### PR TITLE
bench: add LLM experience history rails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10037,6 +10037,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "serial_test",
  "sha2",
  "temp-env",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10017,6 +10017,7 @@ dependencies = [
  "bitnet-inference",
  "bitnet-kernels",
  "bitnet-models",
+ "bitnet-prompt-templates",
  "bitnet-sys",
  "bitnet-test-support",
  "bitnet-tokenizers",

--- a/ci/benchmarks/profiles.toml
+++ b/ci/benchmarks/profiles.toml
@@ -1,0 +1,55 @@
+schema_version = 1
+
+[[profile]]
+id = "prefill_128_decode_32"
+prompt_tokens = 128
+decode_tokens = 32
+warmup_runs = 1
+measured_runs = 5
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "prefill_512_decode_64"
+prompt_tokens = 512
+decode_tokens = 64
+warmup_runs = 2
+measured_runs = 7
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "prefill_2048_decode_64"
+prompt_tokens = 2048
+decode_tokens = 64
+warmup_runs = 2
+measured_runs = 5
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "prefill_4096_decode_32"
+prompt_tokens = 4096
+decode_tokens = 32
+warmup_runs = 1
+measured_runs = 5
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "long_decode_128"
+decode_tokens = 128
+warmup_runs = 1
+measured_runs = 5
+quality_required = true
+repetition_guard = true
+resource_envelope_required = true
+
+[[profile]]
+id = "chat_smoke_real_question"
+prompt_suite = "seeded-v1"
+max_new_tokens = 128
+warmup_runs = 1
+measured_runs = 3
+quality_required = true
+resource_envelope_required = true

--- a/ci/benchmarks/schemas/bench-run.schema.json
+++ b/ci/benchmarks/schemas/bench-run.schema.json
@@ -65,9 +65,10 @@
     },
     "kernel_route": {
       "type": "object",
-      "required": ["route_verified", "device_slug", "selected_backend", "kernel_variants"],
+      "required": ["route_verified", "route_claimable", "device_slug", "selected_backend", "kernel_variants"],
       "properties": {
         "route_verified": { "type": "boolean" },
+        "route_claimable": { "type": "boolean" },
         "device_slug": { "type": "string", "minLength": 1 },
         "selected_backend": { "type": "string", "minLength": 1 },
         "kernel_variants": { "type": "array", "items": { "type": "object" } }

--- a/ci/benchmarks/schemas/bench-run.schema.json
+++ b/ci/benchmarks/schemas/bench-run.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bitnet-rs.local/schemas/bench-run.schema.json",
+  "title": "BitNet-rs quality-gated benchmark run receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_type",
+    "run_id",
+    "repo",
+    "device",
+    "model",
+    "backend",
+    "kernel_route",
+    "benchmark_profile",
+    "quality_gate",
+    "claim_gate",
+    "measurements",
+    "not_claims"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "receipt_type": { "const": "bench_run" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "repo": {
+      "type": "object",
+      "required": ["commit", "tree", "dirty", "cargo_lock_hash", "rustc", "features"],
+      "properties": {
+        "commit": { "type": "string", "minLength": 1 },
+        "tree": { "type": "string", "minLength": 1 },
+        "dirty": { "type": "boolean" },
+        "cargo_lock_hash": { "type": "string", "minLength": 1 },
+        "rustc": { "type": "string", "minLength": 1 },
+        "features": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "device": {
+      "type": "object",
+      "required": ["device_slug", "device_instance_hash"],
+      "properties": {
+        "device_slug": { "type": "string", "minLength": 1 },
+        "device_instance_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["contract", "model_id", "weights_sha256", "tokenizer_sha256", "chat_template_hash"],
+      "properties": {
+        "contract": { "type": "string", "minLength": 1 },
+        "model_id": { "type": "string", "minLength": 1 },
+        "weights_sha256": { "type": "string", "minLength": 1 },
+        "tokenizer_sha256": { "type": "string", "minLength": 1 },
+        "chat_template_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "backend": {
+      "type": "object",
+      "required": ["selected_backend", "backend_family", "fallback_used"],
+      "properties": {
+        "selected_backend": { "type": "string", "minLength": 1 },
+        "backend_family": { "type": "string", "minLength": 1 },
+        "fallback_used": { "type": "boolean" }
+      }
+    },
+    "kernel_route": {
+      "type": "object",
+      "required": ["route_verified", "device_slug", "selected_backend", "kernel_variants"],
+      "properties": {
+        "route_verified": { "type": "boolean" },
+        "device_slug": { "type": "string", "minLength": 1 },
+        "selected_backend": { "type": "string", "minLength": 1 },
+        "kernel_variants": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "benchmark_profile": {
+      "type": "object",
+      "required": ["id", "profile_hash"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "profile_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "quality_gate": {
+      "type": "object",
+      "required": ["required", "quality_passed", "quality_receipt"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "quality_passed": { "type": "boolean" },
+        "quality_receipt": { "type": "string" }
+      }
+    },
+    "claim_gate": {
+      "type": "object",
+      "required": ["benchmark_claim_allowed", "classification"],
+      "properties": {
+        "benchmark_claim_allowed": { "type": "boolean" },
+        "classification": {
+          "enum": [
+            "diagnostic_only",
+            "load_proven",
+            "quality_proven",
+            "performance_proven",
+            "resident_proven",
+            "complete"
+          ]
+        }
+      }
+    },
+    "measurements": { "type": "object" },
+    "not_claims": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/ci/benchmarks/schemas/llm-experience-run.schema.json
+++ b/ci/benchmarks/schemas/llm-experience-run.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/BitNet-rs/ci/benchmarks/schemas/llm-experience-run.schema.json",
+  "title": "BitNet-rs LLM experience run receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_type",
+    "producer",
+    "repo",
+    "model",
+    "device",
+    "kernel_route",
+    "backend",
+    "benchmark_profile",
+    "quality",
+    "measurement_supplements",
+    "load",
+    "ttft",
+    "input_speed",
+    "output_speed",
+    "resource_envelope",
+    "claim_gate",
+    "not_claims"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "receipt_type": {
+      "const": "llm_experience_run"
+    },
+    "producer": {
+      "type": "string"
+    },
+    "repo": {
+      "type": "object"
+    },
+    "model": {
+      "type": "object"
+    },
+    "device": {
+      "type": "object"
+    },
+    "kernel_route": {
+      "type": "object"
+    },
+    "backend": {
+      "type": "object"
+    },
+    "benchmark_profile": {
+      "type": "object"
+    },
+    "quality": {
+      "type": "object",
+      "required": ["passed"]
+    },
+    "measurement_supplements": {
+      "type": "object",
+      "required": ["cli_stage_receipt"]
+    },
+    "load": {
+      "$ref": "#/$defs/section"
+    },
+    "ttft": {
+      "$ref": "#/$defs/section"
+    },
+    "input_speed": {
+      "$ref": "#/$defs/section"
+    },
+    "output_speed": {
+      "$ref": "#/$defs/section"
+    },
+    "resource_envelope": {
+      "$ref": "#/$defs/section"
+    },
+    "claim_gate": {
+      "type": "object",
+      "required": ["claim_allowed", "classification", "blocked_reasons"],
+      "properties": {
+        "claim_allowed": {
+          "type": "boolean"
+        },
+        "classification": {
+          "type": "string"
+        },
+        "blocked_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "not_claims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "section": {
+      "type": "object",
+      "required": ["complete", "missing"],
+      "properties": {
+        "complete": {
+          "type": "boolean"
+        },
+        "missing": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ci/benchmarks/schemas/llm-experience-run.schema.json
+++ b/ci/benchmarks/schemas/llm-experience-run.schema.json
@@ -6,6 +6,7 @@
   "required": [
     "schema_version",
     "receipt_type",
+    "run_id",
     "producer",
     "repo",
     "model",
@@ -29,6 +30,9 @@
     },
     "receipt_type": {
       "const": "llm_experience_run"
+    },
+    "run_id": {
+      "type": "string"
     },
     "producer": {
       "type": "string"

--- a/ci/claims/claim-ledger.json
+++ b/ci/claims/claim-ledger.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "producer": "repo-source",
+  "claims": [
+    {
+      "claim_id": "a770.bitnet.trusted_partial_experience",
+      "scope": "BitNet b1.58 i2_s on AMD 5700X + Intel Arc A770",
+      "status": "diagnostic",
+      "evidence": [],
+      "blocker": "clean claim-grade parent benchmark, claimable A770 routes, strict resource envelope, and same-route history are not present",
+      "not_claims": [
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion"
+      ]
+    },
+    {
+      "claim_id": "a770.bitnet.selected_attention",
+      "scope": "BitNet selected attention on AMD 5700X + Intel Arc A770",
+      "status": "diagnostic",
+      "evidence": [],
+      "blocker": "value-level score implementation rule is not available and decode gates are not promoted",
+      "not_claims": [
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion"
+      ]
+    },
+    {
+      "claim_id": "a770.bitnet.full_residency",
+      "scope": "Full BitNet device residency on Intel Arc A770",
+      "status": "unsupported",
+      "evidence": [],
+      "blocker": "resident KV, attention scores, softmax, value mix, full support-op residency, and full device residency are not claimed",
+      "not_claims": [
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion"
+      ]
+    },
+    {
+      "claim_id": "a770.gemma_class.support",
+      "scope": "Gemma-class dense models on Intel Arc A770",
+      "status": "unsupported",
+      "evidence": [],
+      "blocker": "no Gemma-class model contract, dense kernels, tokenizer/template proof, quality proof, or A770 resource receipts are present",
+      "not_claims": [
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion"
+      ]
+    }
+  ]
+}

--- a/ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
+++ b/ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "matrix_id": "amd-5700x-intel-a770.a770-kernel-capability",
+  "device_slug": "amd-5700x-intel-a770",
+  "backend_family": "intel-opencl",
+  "selected_backend": "intel-arc-a770-opencl",
+  "quality_gated_benchmarks_required": true,
+  "claim_policy": {
+    "no_model_family_claim_without_required_kernels": true,
+    "no_benchmark_claim_without_quality_passed": true,
+    "no_fallback_for_claimed_kernels": true,
+    "device_route_must_be_concrete": true
+  },
+  "kernels": [
+    {
+      "kernel": "qk256_i2s_gemv",
+      "model_families": ["bitnet"],
+      "status": "diagnostic",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Trusted-path A770 QK256 receipts are local/target evidence until a clean claim-grade rerun lands."
+    },
+    {
+      "kernel": "embedding_lookup",
+      "model_families": ["bitnet"],
+      "status": "diagnostic",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "A770 embedding route is explicit, but claim-grade receipts are not committed yet."
+    },
+    {
+      "kernel": "lm_head_tied_logits",
+      "model_families": ["bitnet"],
+      "status": "diagnostic",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "A770 lm_head/tied-logits route is explicit, but claim-grade receipts are not committed yet."
+    },
+    {
+      "kernel": "dense_f16_gemv",
+      "model_families": ["gemma", "llama", "qwen"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Dense f16/bf16 A770 kernels are not claim-ready."
+    },
+    {
+      "kernel": "q4_q5_q8_dequant_gemv",
+      "model_families": ["slm", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Dense GGUF dequant A770 kernels are not claim-ready."
+    },
+    {
+      "kernel": "rmsnorm",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "RMSNorm A770 residency is not claimed."
+    },
+    {
+      "kernel": "rope",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "RoPE A770 residency is not claimed."
+    },
+    {
+      "kernel": "selected_attention_scores",
+      "model_families": ["bitnet"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Selected attention score rule is diagnostic-only and not implementation-authorized."
+    },
+    {
+      "kernel": "softmax",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "A770 softmax residency is not claimed."
+    },
+    {
+      "kernel": "attention_value_mix",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "A770 attention value-mix residency is not claimed."
+    },
+    {
+      "kernel": "resident_kv_cache",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Resident KV decode is not claimed."
+    },
+    {
+      "kernel": "full_support_residency",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Full A770 support-op residency is not claimed."
+    },
+    {
+      "kernel": "full_device_residency",
+      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "status": "missing",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": [],
+      "reason": "Full A770 device residency is not claimed."
+    }
+  ],
+  "not_claims": [
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+    "slm_a770_supported",
+    "gemma_a770_supported",
+    "gemma4_a770_supported"
+  ]
+}

--- a/ci/hardware/device-kernel-routing.toml
+++ b/ci/hardware/device-kernel-routing.toml
@@ -1,0 +1,155 @@
+# Device-specific kernel routing policy.
+#
+# Compatibility is not a public claim. A claimable route must name a concrete
+# device, concrete kernel variant, fallback_allowed=false, and proof receipts.
+
+[[route]]
+route_id = "a770.bitnet.i2s.qk256"
+op = "qk256_i2s_gemv"
+model_family = "bitnet"
+quantization = "i2_s"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "a770_opencl_qk256_i2s_route_pending_claim_receipts"
+claim_level = "diagnostic"
+fallback_allowed = false
+proof_receipts = []
+reason = "A770 route is explicit, but claim-grade A770 QK256 receipts are not committed yet."
+not_claims = [
+  "selected_attention_residency",
+  "resident_kv_decode",
+  "attention_scores_residency",
+  "softmax_residency",
+  "attention_value_mix_residency",
+  "full_support_op_residency",
+  "full_device_residency",
+  "completion",
+]
+
+[[route]]
+route_id = "a770.bitnet.i2s.embedding"
+op = "embedding_lookup"
+model_family = "bitnet"
+quantization = "i2_s"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "a770_opencl_embedding_route_pending_claim_receipts"
+claim_level = "diagnostic"
+fallback_allowed = false
+proof_receipts = []
+reason = "A770 embedding route is explicit, but claim-grade receipts are not committed yet."
+not_claims = [
+  "selected_attention_residency",
+  "resident_kv_decode",
+  "attention_scores_residency",
+  "softmax_residency",
+  "attention_value_mix_residency",
+  "full_support_op_residency",
+  "full_device_residency",
+  "completion",
+]
+
+[[route]]
+route_id = "a770.bitnet.i2s.lm_head"
+op = "lm_head_tied_logits"
+model_family = "bitnet"
+quantization = "i2_s"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "a770_opencl_lm_head_route_pending_claim_receipts"
+claim_level = "diagnostic"
+fallback_allowed = false
+proof_receipts = []
+reason = "A770 lm_head route is explicit, but claim-grade receipts are not committed yet."
+not_claims = [
+  "selected_attention_residency",
+  "resident_kv_decode",
+  "attention_scores_residency",
+  "softmax_residency",
+  "attention_value_mix_residency",
+  "full_support_op_residency",
+  "full_device_residency",
+  "completion",
+]
+
+[[route]]
+route_id = "a770.bitnet.selected_attention_scores"
+op = "selected_attention_scores"
+model_family = "bitnet"
+quantization = "i2_s"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "missing"
+claim_level = "unsupported"
+fallback_allowed = false
+proof_receipts = []
+reason = "Selected attention score rule is not implementation-authorized."
+not_claims = [
+  "selected_attention_residency",
+  "resident_kv_decode",
+  "attention_scores_residency",
+  "softmax_residency",
+  "attention_value_mix_residency",
+  "full_support_op_residency",
+  "full_device_residency",
+  "completion",
+]
+
+[[route]]
+route_id = "a770.gemma.dense_f16_gemv"
+op = "dense_f16_gemv"
+model_family = "gemma"
+quantization = "f16"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "missing"
+claim_level = "unsupported"
+fallback_allowed = false
+proof_receipts = []
+reason = "Gemma-class A770 dense kernels, tokenizer/template proof, quality proof, and resource receipts are not present."
+not_claims = [
+  "gemma_a770_supported",
+  "gemma4_a770_supported",
+  "selected_attention_residency",
+  "resident_kv_decode",
+  "full_device_residency",
+  "completion",
+]
+
+[[route]]
+route_id = "a770.slm.q4_dequant_gemv"
+op = "q4_dequant_gemv"
+model_family = "slm"
+quantization = "q4"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "missing"
+claim_level = "unsupported"
+fallback_allowed = false
+proof_receipts = []
+reason = "Small dense SLM A770 support is blocked until model contracts, dense kernels, quality proof, and resources exist."
+not_claims = [
+  "slm_a770_supported",
+  "selected_attention_residency",
+  "resident_kv_decode",
+  "full_device_residency",
+  "completion",
+]

--- a/ci/prompt-suites/seeded-v1.toml
+++ b/ci/prompt-suites/seeded-v1.toml
@@ -1,0 +1,238 @@
+schema_version = 1
+suite_id = "seeded-v1"
+description = "Deterministic prompt breadth suite for BitNet-rs LLM experience receipts."
+template = "llama3-chat"
+add_bos = true
+parse_special = true
+manual_review_allowed_for_claims = false
+required_categories = [
+  "direct_factual_qa",
+  "short_explanation",
+  "structured_json",
+  "context_changes_answer",
+  "long_answer_qa",
+  "summarization",
+  "instruction_following",
+  "simple_code_reasoning",
+  "table_extraction_from_text",
+  "contradiction_handling",
+  "multi_turn_memory_within_prompt",
+  "stop_repetition_stress",
+]
+
+[anti_fakery]
+require_seed_binding = true
+require_answer_binding = true
+require_name_slots = true
+minimum_slot_values = 3
+min_generation_policy_coverage = 1.0
+min_answer_bound_surface_coverage = 1.0
+min_required_surface_category_coverage = 1.0
+
+[[case]]
+id = "seeded-v1-000001"
+seed = 1001
+category = "direct_factual_qa"
+difficulty = "small_model_reasonable"
+oracle = "regex"
+max_new_tokens = 48
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must name the requested capital and avoid unrelated countries"
+required_surface_category = "factual_entity"
+expected_behavior = "Answer the capital directly."
+prompt = "{analyst} asks: What is the capital of Japan? Answer in one short sentence."
+name_slots = [
+  { slot = "analyst", values = ["Mira", "Tomas", "Ilya", "Rhea"] },
+]
+
+[[case]]
+id = "seeded-v1-000002"
+seed = 1002
+category = "short_explanation"
+difficulty = "small_model_reasonable"
+oracle = "semantic_nonempty"
+max_new_tokens = 96
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must explain cache reuse and repeated work"
+required_surface_category = "causal_explanation"
+expected_behavior = "Explain caching in two concise sentences."
+prompt = "{engineer} is reviewing {system}. Explain why caching can speed up repeated work in two short sentences."
+name_slots = [
+  { slot = "engineer", values = ["Nia", "Oren", "Pavel", "Sana"] },
+  { slot = "system", values = ["Atlas", "Beacon", "Cedar", "Delta"] },
+]
+
+[[case]]
+id = "seeded-v1-000003"
+seed = 1003
+category = "structured_json"
+difficulty = "small_model_reasonable"
+oracle = "json_schema"
+max_new_tokens = 128
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must return only JSON with task and priority keys"
+required_surface_category = "format_compliance"
+expected_behavior = "Return valid compact JSON with no prose."
+prompt = "{planner} needs a JSON object with keys task and priority for this request: back up the index before migration. Return only JSON."
+name_slots = [
+  { slot = "planner", values = ["Asha", "Bram", "Cleo", "Dax"] },
+]
+
+[[case]]
+id = "seeded-v1-000004"
+seed = 1004
+category = "context_changes_answer"
+difficulty = "small_model_reasonable"
+oracle = "semantic_pair_difference"
+max_new_tokens = 48
+temperature = 0.0
+requires_pair = true
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "first answer must indicate miss, paired answer must indicate hit"
+required_surface_category = "context_sensitivity"
+expected_behavior = "Answer changes when the cache context changes."
+prompt = "Context for {operator}: The cache is empty. Should the next lookup hit or miss?"
+pair_prompt = "Context for {operator}: The cache already contains the requested key. Should the next lookup hit or miss?"
+name_slots = [
+  { slot = "operator", values = ["Eli", "Faye", "Gita", "Hale"] },
+]
+
+[[case]]
+id = "seeded-v1-000005"
+seed = 1005
+category = "long_answer_qa"
+difficulty = "small_model_reasonable"
+oracle = "semantic_nonempty"
+max_new_tokens = 192
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must include at least three practical setup steps"
+required_surface_category = "procedural_answer"
+expected_behavior = "Give a useful multi-step answer."
+prompt = "{maintainer} is setting up local model evaluation. List three practical steps to make the run repeatable."
+name_slots = [
+  { slot = "maintainer", values = ["Iris", "Jules", "Kavi", "Lena"] },
+]
+
+[[case]]
+id = "seeded-v1-000006"
+seed = 1006
+category = "summarization"
+difficulty = "small_model_reasonable"
+oracle = "structural"
+max_new_tokens = 96
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must preserve cause and result from the source paragraph"
+required_surface_category = "source_grounding"
+expected_behavior = "Summarize the paragraph in one sentence."
+prompt = "Summarize for {reviewer}: The build failed because the tokenizer file was missing. After restoring the tokenizer, the same command loaded the model and produced output."
+name_slots = [
+  { slot = "reviewer", values = ["Marek", "Nora", "Omar", "Priya"] },
+]
+
+[[case]]
+id = "seeded-v1-000007"
+seed = 1007
+category = "instruction_following"
+difficulty = "small_model_reasonable"
+oracle = "structural"
+max_new_tokens = 96
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must produce exactly two bullets"
+required_surface_category = "instruction_constraint"
+expected_behavior = "Return exactly two bullet points."
+prompt = "{lead} asks for exactly two bullet points about why explicit fallback reporting matters."
+name_slots = [
+  { slot = "lead", values = ["Quinn", "Ravi", "Sela", "Tariq"] },
+]
+
+[[case]]
+id = "seeded-v1-000008"
+seed = 1008
+category = "simple_code_reasoning"
+difficulty = "small_model_reasonable"
+oracle = "regex"
+max_new_tokens = 96
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must identify the off-by-one result"
+required_surface_category = "code_reasoning"
+expected_behavior = "Explain the final value."
+prompt = "{developer} runs: let mut total = 0; for i in 0..3 { total += i; } What is total and why?"
+name_slots = [
+  { slot = "developer", values = ["Uma", "Vik", "Wen", "Yara"] },
+]
+
+[[case]]
+id = "seeded-v1-000009"
+seed = 1009
+category = "table_extraction_from_text"
+difficulty = "small_model_reasonable"
+oracle = "structural"
+max_new_tokens = 128
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must extract the owner and status pairs from text"
+required_surface_category = "information_extraction"
+expected_behavior = "Return a compact table or two clear rows."
+prompt = "Extract owner and status for {coordinator}. Item Alpha is owned by Nina and is ready. Item Beta is owned by Omar and is blocked."
+name_slots = [
+  { slot = "coordinator", values = ["Zane", "Ada", "Bela", "Ciro"] },
+]
+
+[[case]]
+id = "seeded-v1-000010"
+seed = 1010
+category = "contradiction_handling"
+difficulty = "small_model_reasonable"
+oracle = "semantic_nonempty"
+max_new_tokens = 96
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must say the notes conflict instead of choosing both"
+required_surface_category = "uncertainty_handling"
+expected_behavior = "Acknowledge contradiction."
+prompt = "{auditor} sees two notes: the package was delivered Monday, and the same package was never delivered. What should be concluded?"
+name_slots = [
+  { slot = "auditor", values = ["Dina", "Enzo", "Farah", "Glen"] },
+]
+
+[[case]]
+id = "seeded-v1-000011"
+seed = 1011
+category = "multi_turn_memory_within_prompt"
+difficulty = "small_model_reasonable"
+oracle = "semantic_nonempty"
+max_new_tokens = 96
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must remember the color stated earlier in the prompt"
+required_surface_category = "in_prompt_memory"
+expected_behavior = "Use the earlier color."
+prompt = "User {user_name}: My deployment tag color is teal. Assistant: Noted. User {user_name}: What color did I say?"
+name_slots = [
+  { slot = "user_name", values = ["Hana", "Ivan", "Jory", "Kira"] },
+]
+
+[[case]]
+id = "seeded-v1-000012"
+seed = 1012
+category = "stop_repetition_stress"
+difficulty = "small_model_reasonable"
+oracle = "repetition_guard"
+max_new_tokens = 128
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must avoid repeating the same sentence more than twice"
+required_surface_category = "stop_repetition"
+expected_behavior = "Give a bounded answer without looping."
+stop_expectation = "stop_token_or_max_new_tokens_without_loop"
+prompt = "{tester} asks for a one-paragraph explanation of why a receipt should include not-claims. Do not repeat sentences."
+name_slots = [
+  { slot = "tester", values = ["Lio", "Mina", "Noel", "Orla"] },
+]

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -58,6 +58,34 @@ fn bitnet_version() -> &'static str {
     })
 }
 
+fn sha256_hex_bytes(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn sha256_text(text: &str) -> String {
+    sha256_hex_bytes(text.as_bytes())
+}
+
+fn sha256_token_ids(tokens: &[u32]) -> Result<String> {
+    Ok(sha256_hex_bytes(&serde_json::to_vec(tokens)?))
+}
+
+fn critical_not_claims() -> Vec<&'static str> {
+    vec![
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion",
+    ]
+}
+
 #[cfg(feature = "cli-bench")]
 use commands::BenchmarkCommand;
 #[cfg(feature = "full-cli")]
@@ -239,6 +267,14 @@ enum Commands {
         /// Output JSON results to file
         #[arg(long)]
         json_out: Option<std::path::PathBuf>,
+
+        /// Declared model contract for diagnostic proof binding.
+        #[arg(long)]
+        proof_model_contract: Option<std::path::PathBuf>,
+
+        /// Declared kernel route id for diagnostic proof binding.
+        #[arg(long)]
+        proof_kernel_route: Option<String>,
 
         /// Dump token IDs to stdout
         #[arg(long, default_value_t = false)]
@@ -543,6 +579,8 @@ async fn main() -> Result<()> {
             strict_tokenizer,
             strict_loader,
             json_out,
+            proof_model_contract,
+            proof_kernel_route,
             dump_ids,
             bos,
             greedy,
@@ -574,6 +612,9 @@ async fn main() -> Result<()> {
                 strict_tokenizer,
                 strict_loader,
                 json_out,
+                proof_model_contract,
+                proof_kernel_route,
+                requested_backend_label.clone(),
                 dump_ids,
                 bos,
                 greedy,
@@ -1320,6 +1361,9 @@ async fn run_simple_generation(
     strict_tokenizer: bool,
     strict_loader: bool,
     json_out: Option<std::path::PathBuf>,
+    proof_model_contract: Option<std::path::PathBuf>,
+    proof_kernel_route: Option<String>,
+    requested_backend_label: String,
     dump_ids: bool,
     bos: bool,
     greedy: bool,
@@ -1421,6 +1465,7 @@ async fn run_simple_generation(
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
     let loader_mode;
+    let mut loader_fallback_used = false;
 
     let (model, config): (Arc<dyn Model>, _) = match loader
         .load_with_config(&model_path, &load_config)
@@ -1439,6 +1484,7 @@ async fn run_simple_generation(
                 );
             }
             tracing::warn!("Real loader failed: {e}. Falling back to MOCK loader (by request).");
+            loader_fallback_used = true;
             if !strict_loader {
                 unsafe {
                     std::env::set_var("BITNET_ALLOW_MINIMAL_LOADER", "1");
@@ -1497,6 +1543,7 @@ async fn run_simple_generation(
     // Track GGUF metadata for JSON output
     let mut gguf_metadata: Option<(usize, usize)> = None;
     let effective_strict_tokenizer = strict_tokenizer || strict_loader;
+    let mut tokenizer_fallback_used = false;
 
     let tokenizer_resolution = match bitnet_tokenizers::auto::resolve_tokenizer(
         &model_path,
@@ -1543,6 +1590,7 @@ async fn run_simple_generation(
                 );
             }
             println!("Warning: Using mock tokenizer due to: {e}");
+            tokenizer_fallback_used = true;
             bitnet_tokenizers::auto::TokenizerResolution {
                 tokenizer: std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new()),
                 source: bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback,
@@ -1553,6 +1601,9 @@ async fn run_simple_generation(
     };
     let tokenizer_source = tokenizer_resolution.source;
     let tokenizer_strict = tokenizer_resolution.strict;
+    if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback {
+        tokenizer_fallback_used = true;
+    }
     let tokenizer: std::sync::Arc<dyn Tokenizer + Send + Sync> = tokenizer_resolution.tokenizer;
 
     if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
@@ -1613,6 +1664,8 @@ async fn run_simple_generation(
     // Tokenize formatted prompt with proper BOS policy and special token parsing
     let parse_special = template_type.parse_special();
     let mut tokens = tokenizer.encode(&formatted_prompt, bos_policy, parse_special)?;
+    let prompt_token_ids = tokens.clone();
+    let prompt_token_ids_sha256 = sha256_token_ids(&prompt_token_ids)?;
     println!("Input tokens ({}): {:?}", tokens.len(), &tokens[..10.min(tokens.len())]);
 
     // Create KV cache
@@ -1920,9 +1973,24 @@ async fn run_simple_generation(
         });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
+        let fallback_used = loader_fallback_used || tokenizer_fallback_used;
+        let execution_backend = "cpu";
+        let requested_backend = requested_backend_label.as_str();
+        let execution_backend_matched = requested_backend.eq_ignore_ascii_case(execution_backend);
+        let proof_model_contract_path =
+            proof_model_contract.as_ref().map(|path| path.display().to_string());
+        let proof_kernel_route_id = proof_kernel_route.as_deref();
         let output = serde_json::json!({
             "prompt": prompt,
             "text": generated_text,
+            "prompt_identity": {
+                "template": template_type.to_string(),
+                "rendered_prompt_sha256": sha256_text(&formatted_prompt),
+                "prompt_token_ids_sha256": prompt_token_ids_sha256,
+                "prompt_token_count": prompt_token_ids.len(),
+                "bos_policy": bos_policy,
+                "parse_special": parse_special,
+            },
             "tokens": {
                 "prompt": prompt_tokens_len,
                 "generated": generated_tokens.len(),
@@ -1942,6 +2010,30 @@ async fn run_simple_generation(
             "tokenizer": tokenizer_info,
             "loader": loader_info,
             "gen_policy": gen_policy,
+            "proof_summary": {
+                "requested_device": requested_backend,
+                "requested_backend": requested_backend,
+                "selected_backend": execution_backend,
+                "execution_backend": execution_backend,
+                "execution_backend_matched": execution_backend_matched,
+                "fallback_used": fallback_used,
+                "loader_fallback_used": loader_fallback_used,
+                "tokenizer_fallback_used": tokenizer_fallback_used,
+                "strict_backend": !allow_mock,
+                "claim_level": "diagnostic_cli_run",
+                "model_contract": proof_model_contract_path,
+                "model_contract_declared": proof_model_contract.is_some(),
+                "kernel_route": {
+                    "route_id": proof_kernel_route_id,
+                    "route_declared": proof_kernel_route.is_some(),
+                    "diagnostic_only": true,
+                    "claimable": false,
+                },
+                "route_declared": proof_kernel_route.is_some(),
+                "backend_claimable": false,
+                "not_claims": critical_not_claims(),
+            },
+            "not_claims": critical_not_claims(),
             "logits_dump": if !logits_dump.is_empty() {
                 Some(logits_dump.iter().map(|step| {
                     serde_json::json!({

--- a/docs/claims.md
+++ b/docs/claims.md
@@ -1,0 +1,21 @@
+# Claim Ledger
+
+Generated from `ci/claims/claim-ledger.json`.
+
+| Claim | Status | Scope | Blocker |
+| --- | --- | --- | --- |
+| `a770.bitnet.trusted_partial_experience` | `diagnostic` | BitNet b1.58 i2_s on AMD 5700X + Intel Arc A770 | clean claim-grade parent benchmark, claimable A770 routes, strict resource envelope, and same-route history are not present |
+| `a770.bitnet.selected_attention` | `diagnostic` | BitNet selected attention on AMD 5700X + Intel Arc A770 | value-level score implementation rule is not available and decode gates are not promoted |
+| `a770.bitnet.full_residency` | `unsupported` | Full BitNet device residency on Intel Arc A770 | resident KV, attention scores, softmax, value mix, full support-op residency, and full device residency are not claimed |
+| `a770.gemma_class.support` | `unsupported` | Gemma-class dense models on Intel Arc A770 | no Gemma-class model contract, dense kernels, tokenizer/template proof, quality proof, or A770 resource receipts are present |
+
+## A770 Not Claims
+
+- `selected_attention_residency`
+- `resident_kv_decode`
+- `attention_scores_residency`
+- `softmax_residency`
+- `attention_value_mix_residency`
+- `full_support_op_residency`
+- `full_device_residency`
+- `completion`

--- a/docs/hardware/HARDWARE_MATRIX.md
+++ b/docs/hardware/HARDWARE_MATRIX.md
@@ -189,6 +189,8 @@ Do not jump from docs or detection directly to benchmark claims.
 
 BitNet-specific proof also requires:
 
+- `docs/specs/a770-bitnet-claim-boundary.md` for A770 trusted BitNet product claims.
+- `plans/a770-bitnet-claim-boundary-implementation.md` for the PR-by-PR A770 implementation sequence.
 - `docs/bitnet/BITNET_MODEL_CONTRACT.md`
 - `docs/bitnet/BITNET_QUANTIZATION_CONTRACT.md`
 - `docs/bitnet/BITNET_KERNEL_MATRIX.md`

--- a/docs/hardware/intel-arc-a770-validation.md
+++ b/docs/hardware/intel-arc-a770-validation.md
@@ -10,6 +10,12 @@ Roadmap:
 docs/specs/intel-arc-a770-gpu-roadmap.md
 ```
 
+BitNet claim boundary:
+
+```text
+docs/specs/a770-bitnet-claim-boundary.md
+```
+
 ## Required Machine Facts
 
 Record these before moving A770 beyond `scaffold`:
@@ -37,6 +43,9 @@ Record these before moving A770 beyond `scaffold`:
 - CPU/OpenCL parity is parity only.
 - CPU fallback cannot count as A770 execution.
 - Performance claims require benchmark artifacts and receipts.
+- BitNet trusted partial acceleration does not imply selected-attention
+  residency, resident KV decode, attention scores, softmax, attention value
+  mix, full support-op residency, full device residency, or completion.
 
 ## Linux Bundle
 

--- a/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
+++ b/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+model_id: microsoft/bitnet-b1.58-2B-4T-gguf
+family: bitnet
+source: huggingface
+official_repo: microsoft/bitnet-b1.58-2B-4T-gguf
+format: gguf
+quantization: i2_s
+architecture: bitnet_b1_58
+parameters: approx_2b
+training_tokens: 4t
+local_path: models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf
+sha256: 4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162
+max_context: 4096
+
+tokenizer:
+  kind: llama3_tokenizer_json
+  path: models/BitNet-b1.58-2B-4T/tokenizer.json
+  sha256: e134af98b985517b4f068e3755ae90d4e9cd2d45d328325dc503f1c6b2d06cc7
+  vocab_size: 128256
+
+chat_template:
+  name: llama3-chat
+  source: model_contract
+  bos_token_id: 128000
+  eos_token_id: 128001
+
+stop_tokens:
+  eos_token_id: 128001
+  policy: stop_on_eos
+
+cpu:
+  support: required
+  quality_gate: required
+
+a770:
+  support: trusted_partial
+  selected_backend: intel-arc-a770-opencl
+  required_claimed_ops:
+    - qk256_linears
+    - embedding
+    - lm_head_tied_logits
+  not_claims:
+    - selected_attention_residency
+    - resident_kv_decode
+    - attention_scores_residency
+    - softmax_residency
+    - attention_value_mix_residency
+    - full_support_op_residency
+    - full_device_residency
+    - completion

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,3 +1,21 @@
+# Specs Index
+
+## A770 BitNet Productization
+
+Use these specs before implementing or claiming A770 BitNet product support:
+
+1. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+   - Defines claim levels, required evidence, current not-claims, and the
+     selected-attention boundary for real BitNet question-answer usage on
+     A770.
+2. [Intel Arc A770 GPU Roadmap](intel-arc-a770-gpu-roadmap.md)
+   - Defines the A770 hardware/runtime lane and native OpenCL proof path.
+3. [A770 BitNet Productization Plan](../../plans/a770-bitnet-claim-boundary-implementation.md)
+   - Defines the PR-by-PR implementation sequence and acceptance gates.
+
+Do not proceed from A770 detection or a single benchmark to product claims.
+Claims must pass through the claim boundary and productization plan first.
+
 # BitNet.cpp API Discovery - Documentation Index
 
 **Discovery Date**: October 25, 2025

--- a/docs/specs/a770-bitnet-claim-boundary.md
+++ b/docs/specs/a770-bitnet-claim-boundary.md
@@ -1,0 +1,233 @@
+# A770 BitNet Claim Boundary
+
+## Purpose
+
+This spec defines what BitNet-rs may claim for real BitNet question-answer
+usage on an Intel Arc A770. It is narrower than generic "GPU support" and
+narrower than full device residency.
+
+The goal is a useful, reproducible product path:
+
+```text
+official BitNet model contract
+real tokenizer and prompt template
+real question-answer prompts
+CPU reference behavior
+explicit A770 route
+fallback_used=false where A770 is claimed
+load, TTFT, prefill, decode, and resource receipts
+same-device history
+clear not-claims
+```
+
+## First Claim Target
+
+The first A770 product claim is:
+
+```text
+BitNet b1.58 i2_s trusted partial A770 acceleration
+```
+
+This means:
+
+- The official BitNet GGUF weights load through the strict model path.
+- The tokenizer and prompt template are authoritative and hashable.
+- Real prompts produce useful, intelligible answers.
+- CPU reference behavior is correct enough to be the comparison baseline.
+- The A770 route is concrete: `intel-arc-a770-opencl`.
+- Claimed A770 operations run on the A770 with `fallback_used=false`.
+- Timings and resources are measured under a named profile.
+- The receipt says exactly what is not claimed.
+
+This does not mean:
+
+- All Intel GPUs are supported.
+- All OpenCL devices inherit the A770 claim.
+- Dense SLM or Gemma-class models are A770-supported.
+- Selected attention is resident on A770.
+- KV cache decode is resident on A770.
+- Attention scores, softmax, or value mix are resident on A770.
+- Full support-op residency or full device residency is complete.
+
+## Claim Levels
+
+Use these levels for A770 BitNet support.
+
+| Level | Meaning | Public claim allowed |
+|---|---|---|
+| `unsupported` | No valid model, route, or kernel evidence. | No |
+| `diagnostic` | Local evidence exists but is dirty, incomplete, or not claim-grade. | No |
+| `load_proven` | Official weights and tokenizer/template load with hashes. | Limited load claim |
+| `quality_proven` | Prompt suite and CPU/A770 behavior gates pass. | Quality claim only |
+| `performance_proven` | Quality-gated benchmark and same-route history are claim-grade. | Trusted partial performance claim |
+| `resident_proven` | A named resident operation is proved with transfer and fallback receipts. | Resident claim for that operation only |
+| `complete` | All required support ops and residency gates are proved. | Full A770 completion claim |
+
+Do not collapse `performance_proven`, `resident_proven`, and `complete`.
+
+## Required Evidence
+
+### Model Contract
+
+Every claimable A770 BitNet run must identify:
+
+- model ID
+- official weight file
+- weight hash
+- tokenizer hash or embedded tokenizer identity
+- chat template or prompt template
+- quantization format
+- max context
+- stop-token policy
+
+No model contract means no model support claim.
+
+### Prompt and Answer Quality
+
+Every claimable run must include prompt evidence that is hard to fake by
+memorizing fixed names or fixed answers:
+
+- rendered prompt hash
+- token ID hash
+- deterministic sampling configuration
+- seeded prompt identities
+- randomized surface names or slots where the prompt suite supports them
+- category coverage
+- paired context checks where the expected answer must change
+- stop and repetition checks
+
+Manual review cases may be stored as diagnostic evidence, but they cannot by
+themselves promote an automated quality claim.
+
+### Route Identity
+
+A claimable A770 route must record:
+
+```json
+{
+  "requested_backend": "intel-arc-a770",
+  "selected_backend": "intel-arc-a770-opencl",
+  "runtime_api": "opencl",
+  "fallback_used": false,
+  "resolved_device": {
+    "name": "Intel(R) Arc(TM) A770 Graphics",
+    "pci_device_id": "0x56A0",
+    "vram_bytes": 17179869184
+  }
+}
+```
+
+A route for A750, Arc 140V, OpenVINO GPU, CUDA, Metal, or CPU is a different
+route and needs its own evidence.
+
+### Experience Measurements
+
+A claimable A770 BitNet experience receipt must include:
+
+- cold load timing
+- warm load timing, when a load-speed claim is made
+- time to first token
+- prefill/input throughput
+- decode/output throughput
+- inter-token latency when claiming streaming quality
+- peak RSS
+- peak VRAM when available
+- host/device transfer bytes when available
+- kernel invocation counts for claimed A770 operations
+- fallback status
+
+Benchmarks may be stored even when incomplete. They are diagnostic until the
+quality, route, model, resource, and history gates pass.
+
+## Parent Benchmark and History
+
+A performance claim requires a parent benchmark receipt with:
+
+```text
+repo.dirty=false
+quality_passed=true
+route_verified=true
+model_contract_matched=true
+fallback_used=false
+claim_allowed=true
+```
+
+Same-device history requires two distinct receipts:
+
+- distinct non-empty run IDs
+- distinct receipt paths
+- same device instance
+- same model contract
+- same backend
+- same benchmark profile
+- same kernel route
+
+Comparing a receipt to itself is not history. Cross-vendor or cross-device
+comparisons are useful diagnostics, not regression evidence.
+
+## Current Not-Claims
+
+Until separate receipts prove them, every A770 trusted-path receipt must keep
+these explicit not-claims:
+
+```text
+selected_attention_residency
+resident_kv_decode
+attention_scores_residency
+softmax_residency
+attention_value_mix_residency
+full_support_op_residency
+full_device_residency
+completion
+```
+
+## Selected Attention Boundary
+
+Selected attention is a separate research lane. It is not promoted by trusted
+partial A770 acceleration.
+
+Before selected attention can be promoted, the repo needs:
+
+- a production-shaped selected-attention score rule
+- decode parity at short and long decode lengths
+- semantic quality unchanged
+- stop behavior unchanged
+- fallback_used=false
+- selected attention actually used
+- no replacement maps, output bias, CPU attention island, or diagnostic knobs
+
+Resident KV, attention scores, softmax, and value mix must wait until selected
+attention itself is claim-grade.
+
+## PR Sequence
+
+Build this path in small PRs:
+
+1. Claim-boundary specs and docs.
+2. Model contract and local asset hash verification.
+3. A770 device route and kernel capability matrix.
+4. Seeded prompt suite and anti-fakery validation.
+5. Quality-gated benchmark receipt schema.
+6. LLM experience receipt generation and verification.
+7. Clean A770 parent benchmark rerun.
+8. Two distinct same-device, same-route history receipts.
+9. Claim ledger and generated dashboard.
+10. Selected-attention fork decision, still non-promoting unless its gates pass.
+
+Each PR must preserve the not-claims unless it is specifically the promotion PR
+for one named capability.
+
+The detailed implementation plan is:
+
+```text
+plans/a770-bitnet-claim-boundary-implementation.md
+```
+
+## Related Specs
+
+- `docs/specs/intel-arc-a770-gpu-roadmap.md`
+- `docs/hardware/intel-arc-a770-validation.md`
+- `docs/hardware/HARDWARE_MATRIX.md`
+- `docs/hardware/BENCHMARK_PROTOCOL.md`
+- `docs/bitnet/BITNET_MODEL_CONTRACT.md`
+- `docs/bitnet/BITNET_RECEIPT_FIELDS.md`

--- a/docs/specs/intel-arc-a770-gpu-roadmap.md
+++ b/docs/specs/intel-arc-a770-gpu-roadmap.md
@@ -18,6 +18,19 @@ intel-arc-a770-openvino-gpu
 
 The first useful milestone is native OpenCL kernel smoke with CPU parity and a receipt proving the selected A770 backend with `fallback_used=false`.
 
+BitNet product claims for real question-answer usage are governed by the
+stricter claim boundary in:
+
+```text
+docs/specs/a770-bitnet-claim-boundary.md
+```
+
+The PR-by-PR implementation plan is:
+
+```text
+plans/a770-bitnet-claim-boundary-implementation.md
+```
+
 ## Hardware Profile
 
 The expected target is Intel Arc A770 16GB:
@@ -57,6 +70,11 @@ Do not claim A770 execution from detection alone.
 OpenVINO GPU graph smoke is reference-runtime evidence. It is not native BitNet OpenCL kernel proof.
 
 CPU fallback cannot count as A770 execution.
+
+For BitNet b1.58, the first product claim is trusted partial A770
+acceleration, not full A770 residency. Selected attention, resident KV,
+attention scores, softmax, attention value mix, full support-op residency, and
+full device residency require separate promotion receipts.
 
 ## Backend Labels
 

--- a/plans/a770-bitnet-claim-boundary-implementation.md
+++ b/plans/a770-bitnet-claim-boundary-implementation.md
@@ -1,0 +1,475 @@
+# A770 BitNet Productization Plan
+
+## Goal
+
+Make the A770 path usable for real BitNet question-answer workloads without
+overclaiming hardware residency.
+
+The target product claim is:
+
+```text
+BitNet b1.58 i2_s trusted partial A770 acceleration
+```
+
+The final full-residency claim is explicitly out of scope until separate gates
+prove selected attention, resident KV, attention scores, softmax, attention
+value mix, full support-op residency, and full device residency.
+
+## Required End State
+
+The trusted A770 BitNet lane is product-ready only when the repo can prove:
+
+- official BitNet GGUF weights load through a strict model contract
+- tokenizer and prompt template are authoritative
+- real prompts produce useful answers
+- CPU reference behavior is correct
+- A770 route identity is concrete and device-specific
+- fallback is false where A770 is claimed
+- claimed A770 operations are named
+- load, time-to-first-token, input throughput, output throughput, and resources
+  are measured
+- benchmark claims are quality-gated
+- two distinct same-device, same-route history receipts exist
+- generated docs and CLI summaries preserve not-claims
+
+## Non-Claims Until Promoted
+
+Every PR in this plan must preserve these not-claims unless it is the explicit
+promotion PR for that named capability:
+
+```text
+selected_attention_residency
+resident_kv_decode
+attention_scores_residency
+softmax_residency
+attention_value_mix_residency
+full_support_op_residency
+full_device_residency
+completion
+```
+
+## Stop Rules
+
+- Do not add selected-attention kernels before a reviewed selected-attention
+  score rule exists.
+- Do not treat a CLI smoke as a benchmark claim.
+- Do not treat a dirty-worktree run as claim-grade.
+- Do not treat a same-receipt comparison as history.
+- Do not inherit A770 proof to A750, Arc 140V, OpenVINO GPU, CUDA, Metal, or
+  CPU lanes.
+- Do not benchmark unsupported model families as A770 support.
+
+## PR 0 - Specs and Plan
+
+Purpose: make the lane followable before implementation.
+
+Files:
+
+```text
+docs/specs/a770-bitnet-claim-boundary.md
+docs/specs/intel-arc-a770-gpu-roadmap.md
+docs/hardware/intel-arc-a770-validation.md
+plans/a770-bitnet-claim-boundary-implementation.md
+```
+
+Acceptance:
+
+```text
+the spec defines claim levels
+the spec defines required evidence
+the spec defines current not-claims
+the plan lists PR-by-PR work
+no runtime behavior changes
+```
+
+Verification:
+
+```powershell
+git diff --check -- docs/specs/a770-bitnet-claim-boundary.md docs/specs/intel-arc-a770-gpu-roadmap.md docs/hardware/intel-arc-a770-validation.md plans/a770-bitnet-claim-boundary-implementation.md
+```
+
+## PR 1 - Model Contract and Asset Proof
+
+Purpose: make the official BitNet model identity claimable.
+
+Files:
+
+```text
+docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
+xtask/src/model_contract.rs
+xtask/src/main.rs
+```
+
+Required command:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- model-contract lint --format json
+```
+
+Required evidence:
+
+```text
+model_id matches the official BitNet GGUF model
+local GGUF hash verified
+local tokenizer hash verified
+chat template recorded
+stop-token policy recorded
+max context recorded
+asset_hashes_verified=true
+```
+
+Not enough:
+
+```text
+model file exists
+tokenizer file exists
+download command succeeded
+```
+
+## PR 2 - A770 Route and Kernel Capability Matrix
+
+Purpose: prevent broad or inherited A770 claims.
+
+Files:
+
+```text
+ci/hardware/device-kernel-routing.toml
+ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
+xtask/src/hardware.rs or equivalent
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- hardware a770 kernel-capability-check --format json
+cargo run --locked -p xtask --no-default-features -- hardware route resolve --format json
+```
+
+Required evidence:
+
+```text
+A770 route names a concrete device
+route has a concrete kernel variant
+fallback_allowed=false for claimable routes
+proof receipts listed for claimable kernels
+unsupported dense/Gemma routes fail closed
+```
+
+Not enough:
+
+```text
+runtime says OpenCL exists
+device name contains Intel
+kernel is compatible with same-family hardware
+```
+
+## PR 3 - Seeded Prompt Suite and Anti-Fakery Validation
+
+Purpose: prove broad prompt behavior without fixed-name overfitting.
+
+Files:
+
+```text
+ci/prompt-suites/seeded-v1.toml
+xtask/src/prompt_suite.rs or equivalent
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- prompt-suite verify --suite ci/prompt-suites/seeded-v1.toml --format json
+cargo run --locked -p xtask --no-default-features -- prompt-suite render --suite ci/prompt-suites/seeded-v1.toml --model-contract docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml --format json
+```
+
+Required evidence:
+
+```text
+required categories present
+deterministic sampling for claimable cases
+prompt hashes present
+token ID hashes present
+seeded surface-name slots present
+answer-bound surfaces present
+paired context cases check answer changes
+manual-review cases cannot promote automated quality claims
+```
+
+Not enough:
+
+```text
+one real question
+one benchmark prompt
+prompt strings without token hashes
+manual review only
+```
+
+## PR 4 - Quality-Gated Benchmark Receipt
+
+Purpose: ensure speed evidence cannot promote without answer quality.
+
+Files:
+
+```text
+ci/benchmarks/schemas/bench-run.schema.json
+ci/benchmarks/profiles.toml
+xtask/src/bench.rs or equivalent
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- bench verify-receipt --receipt target/bench-runs/profile-cli-stage.json --format json
+cargo run --locked -p xtask --no-default-features -- bench compare --require-same-route --require-claim-ready --format json
+```
+
+Required evidence:
+
+```text
+quality_passed=true before benchmark_claim_allowed=true
+repo.dirty=false for claim-grade runs
+fallback_used=false for A770 claims
+model contract matched
+kernel route matched
+profile matched
+resource fields present
+```
+
+Not enough:
+
+```text
+tokens per second only
+single smoke timing
+dirty workspace benchmark
+```
+
+## PR 5 - CLI Stage Receipts and Proof Summary
+
+Purpose: let normal user runs expose the claim boundary.
+
+Files:
+
+```text
+crates/bitnet-cli/src/main.rs or command modules
+```
+
+Required evidence:
+
+```text
+backend printed
+model contract printed
+fallback status printed
+claimed A770 ops printed
+not-claims printed
+prompt/token hash identity available in JSON
+load and TTFT stages available in JSON
+```
+
+Not enough:
+
+```text
+human text says A770
+no JSON receipt
+no fallback status
+```
+
+## PR 6 - LLM Experience Receipt
+
+Purpose: combine model, route, quality, timing, resource, and not-claim evidence.
+
+Files:
+
+```text
+ci/benchmarks/schemas/llm-experience-run.schema.json
+xtask/src/llm_experience.rs or equivalent
+docs/benchmarks/llm-experience.md
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- llm-experience run --format json
+cargo run --locked -p xtask --no-default-features -- llm-experience verify --receipt target/llm-experience/a770-bitnet-profile-stage.json --format json
+```
+
+Required evidence:
+
+```text
+model contract matched
+asset hashes verified
+route verified
+quality passed
+fallback=false
+load complete
+TTFT complete
+input speed complete
+output speed complete
+resource envelope complete
+critical not-claims present
+```
+
+Not enough:
+
+```text
+benchmark receipt alone
+CLI smoke alone
+diagnostic supplement alone
+```
+
+## PR 7 - Clean A770 Parent Benchmark
+
+Purpose: produce the first claim-grade parent benchmark.
+
+Required sequence:
+
+```powershell
+git status --short
+cargo run --locked -p xtask --no-default-features -- llm-experience profile-cli-plan --format json
+# run generated CLI command
+cargo run --locked -p xtask --no-default-features -- bench from-cli-stage --format json
+cargo run --locked -p xtask --no-default-features -- bench verify-receipt --receipt target/bench-runs/profile-cli-stage.json --format json
+```
+
+Required evidence:
+
+```text
+git status is empty before run
+parent benchmark claim_allowed=true
+repo.dirty=false
+quality_passed=true
+fallback_used=false
+route_verified=true
+profile matched
+```
+
+Not enough:
+
+```text
+claim_allowed_if_repo_clean=true
+dirty diagnostic run
+```
+
+## PR 8 - Same-Device Same-Route History
+
+Purpose: prove stability and prevent self-comparison.
+
+Required sequence:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- llm-experience publish --format json
+# repeat full clean run for second distinct receipt
+cargo run --locked -p xtask --no-default-features -- llm-experience compare --require-same-route --require-claim-ready --format json
+```
+
+Required evidence:
+
+```text
+two distinct run IDs
+two distinct receipt paths
+same device instance
+same model contract
+same backend
+same profile
+same kernel route
+classification=same_device_regression_signal
+history_scope_ready=true
+```
+
+Not enough:
+
+```text
+same receipt compared to itself
+same route but diagnostic parent benchmark
+cross-device comparison
+```
+
+## PR 9 - Claim Ledger and Generated Dashboard
+
+Purpose: turn verified receipts into public claims.
+
+Files:
+
+```text
+ci/claims/claim-ledger.json
+ci/claims/correctness-ledger.json
+ci/claims/efficiency-ledger.json
+docs/claims.md
+docs/model-support.md
+docs/benchmarks.md
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- claims verify --format json
+cargo run --locked -p xtask --no-default-features -- claims docs --check --format json
+```
+
+Required evidence:
+
+```text
+trusted partial A770 BitNet claim is ledger-derived
+not-claims are present in docs
+unsupported model families stay unsupported
+benchmark claims point to quality-gated receipts
+```
+
+Not enough:
+
+```text
+README prose
+manual claim table
+receipt exists but ledger ignores it
+```
+
+## PR 10 - Selected Attention Decision
+
+Purpose: keep selected attention separate from the trusted product path.
+
+Allowed outcomes:
+
+```text
+defer selected attention
+continue research with a reviewed score-rule design
+```
+
+Promotion requires:
+
+```text
+production-shaped selected-attention score rule
+decode_32 exact
+decode_64 exact
+decode_128 exact
+semantic quality unchanged
+stop behavior unchanged
+fallback_used=false
+selected attention actually used
+no diagnostic knobs
+```
+
+Not enough:
+
+```text
+captured value target without implementation rule
+dirty diagnostic decode
+another score-row variant
+replacement map or output bias
+```
+
+## Done Criteria
+
+The A770 trusted BitNet path is done only when:
+
+```text
+model contract verified
+prompt suite claim-ready
+route verified
+quality passed
+fallback=false
+parent benchmark claim_allowed=true
+two same-device same-route history receipts exist
+claim ledger consumes the evidence
+docs and CLI expose claim boundary
+selected attention and full residency remain explicit not-claims
+```
+
+If any line is missing, the lane is still in progress.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -21,6 +21,7 @@ fs2 = "0.4.3"
 is-terminal = "0.4.17"
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 toml = "0.9.8"
 httpdate = "1.0.3"
 tempfile = "3.23.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -31,6 +31,7 @@ bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev", def
 bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev", default-features = false }
 bitnet-download = { path = "../crates/bitnet-download", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev", default-features = false, features = ["spm"] }
+bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.1-dev" }
 bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, optional = true }
 bitnet = { path = "..", version = "0.2.1-dev", default-features = false, features = ["cpu"], optional = true }
 tokio = { version = "1.48.0", features = ["rt"], optional = true }

--- a/xtask/src/bench_receipt.rs
+++ b/xtask/src/bench_receipt.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "selected_attention_residency",
@@ -36,6 +38,7 @@ const REQUIRED_POINTERS: &[&str] = &[
     "/backend/backend_family",
     "/backend/fallback_used",
     "/kernel_route/route_verified",
+    "/kernel_route/route_claimable",
     "/kernel_route/device_slug",
     "/kernel_route/selected_backend",
     "/kernel_route/kernel_variants",
@@ -62,6 +65,7 @@ struct BenchReceiptVerifyReport {
     repo_dirty: bool,
     fallback_used: bool,
     route_verified: bool,
+    route_claimable: bool,
     model_contract_matched: Option<bool>,
     resource_envelope_complete: Option<bool>,
     run_id: Option<String>,
@@ -79,6 +83,200 @@ pub fn verify_receipt(receipt_path: &Path, format: &str, require_claimable: bool
         bail!("bench receipt verification failed: {}", report.failures.join(", "));
     }
     Ok(())
+}
+
+pub fn from_cli_stage(
+    plan_path: &Path,
+    cli_stage_receipt: &Path,
+    model_contract: &Path,
+    quality_receipt: &Path,
+    quality_passed: bool,
+    output: &Path,
+    format: &str,
+) -> Result<()> {
+    let plan = read_json(plan_path)?;
+    let cli_stage = read_json(cli_stage_receipt)?;
+    let contract = read_yaml(model_contract)?;
+    let receipt = build_from_cli_stage_receipt(
+        plan_path,
+        &plan,
+        cli_stage_receipt,
+        &cli_stage,
+        model_contract,
+        &contract,
+        quality_receipt,
+        quality_passed,
+    )?;
+
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(output, serde_json::to_vec_pretty(&receipt)?)
+        .with_context(|| format!("writing {}", output.display()))?;
+    emit_json_or_human(&receipt, format)?;
+    Ok(())
+}
+
+fn build_from_cli_stage_receipt(
+    plan_path: &Path,
+    plan: &Value,
+    cli_stage_path: &Path,
+    cli_stage: &Value,
+    model_contract_path: &Path,
+    contract: &Value,
+    quality_receipt: &Path,
+    quality_passed: bool,
+) -> Result<Value> {
+    let identity = cli_stage_identity(plan, cli_stage, model_contract_path);
+    let repo = repo_identity()?;
+    let planned_backend = str_at(plan, "/backend").unwrap_or("unknown-backend");
+    let actual_selected_backend = str_at(cli_stage, "/proof_summary/selected_backend")
+        .or_else(|| str_at(cli_stage, "/proof_summary/execution_backend"))
+        .unwrap_or("unknown-backend");
+    let actual_execution_backend =
+        str_at(cli_stage, "/proof_summary/execution_backend").unwrap_or(actual_selected_backend);
+    let fallback_used = bool_at(cli_stage, "/proof_summary/fallback_used").unwrap_or(true);
+    let route_declared = bool_at(&identity, "/route_declared").unwrap_or(false);
+    let execution_backend_matched =
+        bool_at(&identity, "/execution_backend_matched").unwrap_or(false);
+    let route_claimable = bool_at(&identity, "/route_claimable").unwrap_or(false);
+    let route_verified = route_declared && execution_backend_matched && !fallback_used;
+    let model_contract_matched = bool_at(&identity, "/model_matched").unwrap_or(false);
+    let profile_identity_matched = bool_at(&identity, "/profile_matched").unwrap_or(false);
+    let resource_envelope_complete = false;
+
+    let mut blocked_reasons = Vec::new();
+    if !quality_passed {
+        blocked_reasons.push("quality_not_passed");
+    }
+    if bool_at(&repo, "/dirty").unwrap_or(true) {
+        blocked_reasons.push("repo_dirty");
+    }
+    if fallback_used {
+        blocked_reasons.push("fallback_used");
+    }
+    if !profile_identity_matched {
+        blocked_reasons.push("profile_identity_mismatch");
+    }
+    if !model_contract_matched {
+        blocked_reasons.push("model_contract_not_matched");
+    }
+    if !route_declared {
+        blocked_reasons.push("route_not_declared");
+    }
+    if !execution_backend_matched {
+        blocked_reasons.push("execution_backend_mismatch");
+        if planned_backend.contains("a770") {
+            blocked_reasons.push("execution_backend_not_a770");
+        }
+    }
+    if !route_verified {
+        blocked_reasons.push("route_not_verified");
+    }
+    if !route_claimable {
+        blocked_reasons.push("route_not_claimable");
+    }
+    if !resource_envelope_complete {
+        blocked_reasons.push("resource_envelope_incomplete");
+    }
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+
+    let benchmark_claim_allowed = quality_passed
+        && !bool_at(&repo, "/dirty").unwrap_or(true)
+        && !fallback_used
+        && route_verified
+        && route_claimable
+        && resource_envelope_complete
+        && profile_identity_matched
+        && model_contract_matched;
+
+    let profile_id = str_at(plan, "/profile/id").unwrap_or("unknown-profile");
+    let run_id = format!(
+        "{}_{}_{}",
+        chrono::Utc::now().format("%Y%m%dT%H%M%SZ"),
+        str_at(plan, "/device_slug").unwrap_or("unknown-device"),
+        profile_id
+    );
+    let prompt_tokens = number_at(cli_stage, "/tokens/prompt")
+        .or_else(|| number_at(plan, "/profile/target_prompt_tokens"));
+    let generated_tokens = number_at(cli_stage, "/tokens/generated");
+    let tokens_per_second = number_at(cli_stage, "/throughput/tokens_per_second");
+    let prefill_ms = number_at(cli_stage, "/ttft/first_decode_ms")
+        .or_else(|| number_at(cli_stage, "/latency/decode_first_ms"));
+
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "receipt_type": "bench_run",
+        "run_id": run_id,
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "source_receipts": {
+            "profile_cli_plan": plan_path.display().to_string(),
+            "cli_stage_receipt": cli_stage_path.display().to_string()
+        },
+        "repo": repo,
+        "device": {
+            "device_slug": str_at(plan, "/device_slug").unwrap_or("unknown-device"),
+            "device_instance_hash": "sha256:local-unverified"
+        },
+        "model": {
+            "contract": model_contract_path.display().to_string(),
+            "model_id": str_at(contract, "/model_id").unwrap_or("unknown-model"),
+            "weights_sha256": str_at(contract, "/sha256").unwrap_or(""),
+            "tokenizer_sha256": str_at(contract, "/tokenizer/sha256").unwrap_or(""),
+            "chat_template_hash": sha256_text(str_at(contract, "/chat_template/name").unwrap_or(""))
+        },
+        "backend": {
+            "requested_backend": str_at(cli_stage, "/proof_summary/requested_backend").unwrap_or(planned_backend),
+            "planned_backend": planned_backend,
+            "selected_backend": actual_selected_backend,
+            "execution_backend": actual_execution_backend,
+            "backend_family": backend_family(actual_selected_backend),
+            "fallback_used": fallback_used
+        },
+        "kernel_route": {
+            "route_verified": route_verified,
+            "route_claimable": route_claimable,
+            "route_declared": route_declared,
+            "device_slug": str_at(plan, "/device_slug").unwrap_or("unknown-device"),
+            "selected_backend": planned_backend,
+            "declared_route_id": str_at(cli_stage, "/proof_summary/kernel_route/route_id"),
+            "kernel_variants": [],
+            "not_claims": CRITICAL_NOT_CLAIMS
+        },
+        "benchmark_profile": {
+            "id": profile_id,
+            "profile_hash": sha256_text(&serde_json::to_string(&plan["profile"])?),
+            "profile_identity": identity
+        },
+        "cli_stage_identity_validation": identity,
+        "quality_gate": {
+            "required": true,
+            "quality_passed": quality_passed,
+            "quality_receipt": quality_receipt.display().to_string()
+        },
+        "claim_gate": {
+            "benchmark_claim_allowed": benchmark_claim_allowed,
+            "classification": if benchmark_claim_allowed { "performance_proven" } else { "diagnostic_only" },
+            "model_contract_matched": model_contract_matched,
+            "resource_envelope_complete": resource_envelope_complete,
+            "blocked_reasons": blocked_reasons
+        },
+        "measurements": {
+            "summary": {
+                "prompt_tokens": prompt_tokens,
+                "generated_tokens": generated_tokens,
+                "prefill_ms": prefill_ms,
+                "steady_state_output_tok_s": tokens_per_second,
+                "end_to_end_output_tok_s": tokens_per_second,
+                "peak_rss_bytes": number_at(cli_stage, "/resource_envelope/peak_rss_bytes"),
+                "peak_vram_bytes": Value::Null,
+                "host_device_transfer_bytes": Value::Null,
+                "kernel_invocations": Value::Null
+            }
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS
+    }))
 }
 
 fn build_verify_report(
@@ -107,6 +305,7 @@ fn build_verify_report(
     let repo_dirty = bool_at(&value, "/repo/dirty").unwrap_or(true);
     let fallback_used = bool_at(&value, "/backend/fallback_used").unwrap_or(true);
     let route_verified = bool_at(&value, "/kernel_route/route_verified").unwrap_or(false);
+    let route_claimable = bool_at(&value, "/kernel_route/route_claimable").unwrap_or(false);
     let model_contract_matched = bool_at(&value, "/claim_gate/model_contract_matched");
     let resource_envelope_complete = bool_at(&value, "/claim_gate/resource_envelope_complete");
     let claimable = bool_at(&value, "/claim_gate/benchmark_claim_allowed")
@@ -138,6 +337,9 @@ fn build_verify_report(
     if claimable && !route_verified {
         failures.push("benchmark claim allowed while route_verified=false".to_string());
     }
+    if claimable && !route_claimable {
+        failures.push("benchmark claim allowed while route_claimable=false".to_string());
+    }
     if claimable && model_contract_matched == Some(false) {
         failures.push("benchmark claim allowed while model_contract_matched=false".to_string());
     }
@@ -159,6 +361,9 @@ fn build_verify_report(
     }
     if !route_verified {
         blocked_reasons.push("route_not_verified".to_string());
+    }
+    if !route_claimable {
+        blocked_reasons.push("route_not_claimable".to_string());
     }
     if model_contract_matched == Some(false) {
         blocked_reasons.push("model_contract_not_matched".to_string());
@@ -182,6 +387,7 @@ fn build_verify_report(
         repo_dirty,
         fallback_used,
         route_verified,
+        route_claimable,
         model_contract_matched,
         resource_envelope_complete,
         run_id: str_at(&value, "/run_id").map(ToOwned::to_owned),
@@ -229,6 +435,270 @@ fn array_strings(value: &Value, pointer: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn cli_stage_identity(plan: &Value, cli_stage: &Value, model_contract_path: &Path) -> Value {
+    let deterministic_temperature = Value::from(0.0);
+    let prompt_profile_checks = [
+        (
+            "same_prompt_token_count",
+            plan.pointer("/prompt_identity/prompt_token_count"),
+            cli_stage.pointer("/prompt_identity/prompt_token_count"),
+        ),
+        (
+            "same_rendered_prompt_hash",
+            plan.pointer("/prompt_identity/rendered_prompt_sha256"),
+            cli_stage.pointer("/prompt_identity/rendered_prompt_sha256"),
+        ),
+        (
+            "same_token_ids_hash",
+            plan.pointer("/prompt_identity/prompt_token_ids_sha256"),
+            cli_stage.pointer("/prompt_identity/prompt_token_ids_sha256"),
+        ),
+        (
+            "same_generated_token_count",
+            plan.pointer("/profile/max_new_tokens"),
+            cli_stage.pointer("/tokens/generated"),
+        ),
+        (
+            "same_sampling_temperature",
+            Some(&deterministic_temperature),
+            cli_stage.pointer("/gen_policy/temperature"),
+        ),
+    ];
+
+    let planned_backend = plan.pointer("/backend");
+    let requested_backend = cli_stage.pointer("/proof_summary/requested_backend");
+    let selected_backend = cli_stage.pointer("/proof_summary/selected_backend");
+    let execution_backend = cli_stage.pointer("/proof_summary/execution_backend");
+    let planned_route = plan.pointer("/kernel_route/route_id");
+    let declared_route = cli_stage.pointer("/proof_summary/kernel_route/route_id");
+    let expected_contract_text = model_contract_path.display().to_string();
+    let expected_contract = Value::String(expected_contract_text.clone());
+    let declared_contract = cli_stage.pointer("/proof_summary/model_contract");
+
+    let mut object = serde_json::Map::new();
+    let mut profile_failures = Vec::new();
+    let mut route_failures = Vec::new();
+    let mut model_failures = Vec::new();
+
+    for (name, expected, actual) in prompt_profile_checks {
+        let passed = expected.is_some() && expected == actual;
+        object.insert(name.to_string(), Value::Bool(passed));
+        if !passed {
+            profile_failures.push(field_failure(name, expected, actual));
+        }
+    }
+
+    let requested_backend_matched =
+        planned_backend.is_some() && requested_backend.is_some() && planned_backend == requested_backend;
+    object.insert("requested_backend_matched".to_string(), Value::Bool(requested_backend_matched));
+    if !requested_backend_matched {
+        route_failures.push(field_failure("requested_backend_matched", planned_backend, requested_backend));
+    }
+
+    let selected_backend_matched =
+        planned_backend.is_some() && selected_backend.is_some() && planned_backend == selected_backend;
+    object.insert("selected_backend_matched".to_string(), Value::Bool(selected_backend_matched));
+    if !selected_backend_matched {
+        route_failures.push(field_failure("selected_backend_matched", planned_backend, selected_backend));
+    }
+
+    let execution_backend_matched =
+        planned_backend.is_some() && execution_backend.is_some() && planned_backend == execution_backend;
+    object.insert(
+        "execution_backend_matched".to_string(),
+        Value::Bool(execution_backend_matched),
+    );
+    if !execution_backend_matched {
+        route_failures.push(field_failure("execution_backend_matched", planned_backend, execution_backend));
+    }
+
+    let route_declared = bool_at(cli_stage, "/proof_summary/route_declared").unwrap_or(false)
+        && declared_route.and_then(Value::as_str).is_some_and(|route| !route.is_empty());
+    object.insert("route_declared".to_string(), Value::Bool(route_declared));
+    if !route_declared {
+        route_failures.push(field_failure("route_declared", Some(&Value::Bool(true)), Some(&Value::Bool(false))));
+    }
+
+    let same_kernel_route =
+        planned_route.is_some() && declared_route.is_some() && planned_route == declared_route;
+    object.insert("same_kernel_route".to_string(), Value::Bool(same_kernel_route));
+    if !same_kernel_route {
+        route_failures.push(field_failure("same_kernel_route", planned_route, declared_route));
+    }
+
+    let route_claimable = bool_at(cli_stage, "/proof_summary/kernel_route/claimable").unwrap_or(false);
+    object.insert("route_claimable".to_string(), Value::Bool(route_claimable));
+    if !route_claimable {
+        route_failures.push(field_failure(
+            "route_claimable",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
+    }
+
+    let model_matched = declared_contract
+        .and_then(Value::as_str)
+        .is_some_and(|actual| same_path_string(&expected_contract_text, actual));
+    object.insert("model_matched".to_string(), Value::Bool(model_matched));
+    object.insert("same_model_contract".to_string(), Value::Bool(model_matched));
+    if !model_matched {
+        model_failures.push(field_failure(
+            "model_matched",
+            Some(&expected_contract),
+            declared_contract,
+        ));
+    }
+
+    let fallback_false = !bool_at(cli_stage, "/proof_summary/fallback_used").unwrap_or(true);
+    object.insert("fallback_false".to_string(), Value::Bool(fallback_false));
+    if !fallback_false {
+        route_failures.push(field_failure(
+            "fallback_false",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
+    }
+
+    let profile_matched = profile_failures.is_empty();
+    let route_identity_matched = requested_backend_matched && same_kernel_route && route_declared;
+    let matched = profile_matched
+        && model_matched
+        && route_identity_matched
+        && execution_backend_matched
+        && fallback_false
+        && route_claimable;
+
+    object.insert("profile_matched".to_string(), Value::Bool(profile_matched));
+    object.insert("route_identity_matched".to_string(), Value::Bool(route_identity_matched));
+    object.insert("matched".to_string(), Value::Bool(matched));
+    object.insert("profile_failures".to_string(), Value::Array(profile_failures));
+    object.insert("route_failures".to_string(), Value::Array(route_failures));
+    object.insert("model_failures".to_string(), Value::Array(model_failures));
+    let failures = object
+        .get("profile_failures")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .chain(object.get("route_failures").and_then(Value::as_array).into_iter().flatten())
+        .chain(object.get("model_failures").and_then(Value::as_array).into_iter().flatten())
+        .cloned()
+        .collect();
+    object.insert("failures".to_string(), Value::Array(failures));
+    Value::Object(object)
+}
+
+fn field_failure(name: &str, expected: Option<&Value>, actual: Option<&Value>) -> Value {
+    serde_json::json!({
+        "field": name,
+        "expected": expected.cloned().unwrap_or(Value::Null),
+        "actual": actual.cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn same_path_string(expected: &str, actual: &str) -> bool {
+    normalize_path_string(expected) == normalize_path_string(actual)
+}
+
+fn normalize_path_string(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+fn repo_identity() -> Result<Value> {
+    Ok(serde_json::json!({
+        "commit": git_output(&["rev-parse", "HEAD"]).unwrap_or_else(|_| "unknown".to_string()),
+        "tree": git_output(&["rev-parse", "HEAD^{tree}"]).unwrap_or_else(|_| "unknown".to_string()),
+        "dirty": repo_dirty(),
+        "cargo_lock_hash": format!("sha256:{}", sha256_file(Path::new("Cargo.lock")).unwrap_or_else(|_| "unknown".to_string())),
+        "rustc": command_output("rustc", &["--version"]).unwrap_or_else(|_| "unknown".to_string()),
+        "features": ["cpu"],
+    }))
+}
+
+fn repo_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=all"])
+        .output()
+        .map(|output| !output.status.success() || !output.stdout.is_empty())
+        .unwrap_or(true)
+}
+
+fn git_output(args: &[&str]) -> Result<String> {
+    command_output("git", args)
+}
+
+fn command_output(program: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("running {program} {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!("{program} {} failed", args.join(" "));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn read_yaml(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_yaml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn emit_json_or_human(value: &Value, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(value)?),
+        "human" => {
+            println!("bench from-cli-stage: {}", str_at(value, "/run_id").unwrap_or("unknown"));
+            println!(
+                "benchmark_claim_allowed: {}",
+                bool_at(value, "/claim_gate/benchmark_claim_allowed").unwrap_or(false)
+            );
+            println!(
+                "classification: {}",
+                str_at(value, "/claim_gate/classification").unwrap_or("diagnostic_only")
+            );
+            println!(
+                "blocked_reasons: {}",
+                value.pointer("/claim_gate/blocked_reasons").unwrap_or(&Value::Null)
+            );
+        }
+        other => bail!("unsupported bench output format: {other}"),
+    }
+    Ok(())
+}
+
+fn number_at(value: &Value, pointer: &str) -> Option<Value> {
+    value.pointer(pointer).filter(|value| value.is_number()).cloned()
+}
+
+fn backend_family(selected_backend: &str) -> &'static str {
+    if selected_backend == "cpu" {
+        "cpu"
+    } else if selected_backend.contains("a770") || selected_backend.contains("opencl") {
+        "intel-opencl"
+    } else {
+        "unknown"
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(sha256_bytes(&bytes))
+}
+
+fn sha256_text(value: &str) -> String {
+    sha256_bytes(value.as_bytes())
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,6 +734,7 @@ mod tests {
             },
             "kernel_route": {
                 "route_verified": true,
+                "route_claimable": claim_allowed,
                 "device_slug": "amd-5700x-intel-a770",
                 "selected_backend": "intel-arc-a770-opencl",
                 "kernel_variants": [
@@ -306,6 +777,72 @@ mod tests {
         (dir, path)
     }
 
+    fn plan_and_cli_stage(execution_backend: &str) -> (Value, Value) {
+        let plan = serde_json::json!({
+            "backend": "intel-arc-a770-opencl",
+            "device_slug": "amd-5700x-intel-a770",
+            "kernel_route": {
+                "route_id": "a770.bitnet.i2s.qk256"
+            },
+            "profile": {
+                "id": "prefill_512_decode_64",
+                "target_prompt_tokens": 512,
+                "max_new_tokens": 64
+            },
+            "prompt_identity": {
+                "prompt_token_count": 512,
+                "rendered_prompt_sha256": "rendered",
+                "prompt_token_ids_sha256": "tokens"
+            }
+        });
+        let cli = serde_json::json!({
+            "prompt_identity": {
+                "prompt_token_count": 512,
+                "rendered_prompt_sha256": "rendered",
+                "prompt_token_ids_sha256": "tokens"
+            },
+            "tokens": {
+                "prompt": 512,
+                "generated": 64
+            },
+            "gen_policy": {
+                "temperature": 0.0
+            },
+            "proof_summary": {
+                "requested_backend": "intel-arc-a770-opencl",
+                "selected_backend": execution_backend,
+                "execution_backend": execution_backend,
+                "fallback_used": false,
+                "model_contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
+                "route_declared": true,
+                "kernel_route": {
+                    "route_id": "a770.bitnet.i2s.qk256",
+                    "claimable": false
+                }
+            },
+            "throughput": {
+                "tokens_per_second": 12.5
+            },
+            "ttft": {
+                "first_decode_ms": 100.0
+            }
+        });
+        (plan, cli)
+    }
+
+    fn contract() -> Value {
+        serde_json::json!({
+            "model_id": "microsoft/bitnet-b1.58-2B-4T-gguf",
+            "sha256": "sha256:weights",
+            "tokenizer": {
+                "sha256": "sha256:tokenizer"
+            },
+            "chat_template": {
+                "name": "llama3-chat"
+            }
+        })
+    }
+
     #[test]
     fn diagnostic_receipt_can_verify_without_claim() {
         let (_dir, path) = write_receipt(&receipt(false, false, true));
@@ -329,5 +866,47 @@ mod tests {
         let report = build_verify_report(&path, false).unwrap();
         assert!(!report.passed);
         assert!(report.failures.iter().any(|failure| failure.contains("dirty repo")));
+    }
+
+    #[test]
+    fn cli_stage_identity_rejects_cpu_execution_with_declared_a770_route() {
+        let (plan, cli) = plan_and_cli_stage("cpu");
+        let identity =
+            cli_stage_identity(&plan, &cli, Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"));
+
+        assert_eq!(identity["profile_matched"], true);
+        assert_eq!(identity["model_matched"], true);
+        assert_eq!(identity["route_declared"], true);
+        assert_eq!(identity["same_kernel_route"], true);
+        assert_eq!(identity["requested_backend_matched"], true);
+        assert_eq!(identity["execution_backend_matched"], false);
+        assert_eq!(identity["route_claimable"], false);
+        assert_eq!(identity["matched"], false);
+    }
+
+    #[test]
+    fn from_cli_stage_blocks_cpu_as_a770_evidence() {
+        let (plan, cli) = plan_and_cli_stage("cpu");
+        let receipt = build_from_cli_stage_receipt(
+            Path::new("plan.json"),
+            &plan,
+            Path::new("cli.json"),
+            &cli,
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+            &contract(),
+            Path::new("quality.json"),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(receipt["backend"]["selected_backend"], "cpu");
+        assert_eq!(receipt["backend"]["execution_backend"], "cpu");
+        assert_eq!(receipt["kernel_route"]["route_declared"], true);
+        assert_eq!(receipt["kernel_route"]["route_verified"], false);
+        assert_eq!(receipt["claim_gate"]["benchmark_claim_allowed"], false);
+        let blocked = receipt["claim_gate"]["blocked_reasons"].as_array().unwrap();
+        assert!(blocked.iter().any(|reason| reason == "execution_backend_not_a770"));
+        assert!(blocked.iter().any(|reason| reason == "route_not_claimable"));
+        assert!(blocked.iter().any(|reason| reason == "resource_envelope_incomplete"));
     }
 }

--- a/xtask/src/bench_receipt.rs
+++ b/xtask/src/bench_receipt.rs
@@ -1,0 +1,333 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+];
+
+const REQUIRED_POINTERS: &[&str] = &[
+    "/schema_version",
+    "/receipt_type",
+    "/run_id",
+    "/repo/commit",
+    "/repo/tree",
+    "/repo/dirty",
+    "/repo/cargo_lock_hash",
+    "/repo/rustc",
+    "/repo/features",
+    "/device/device_slug",
+    "/device/device_instance_hash",
+    "/model/contract",
+    "/model/model_id",
+    "/model/weights_sha256",
+    "/model/tokenizer_sha256",
+    "/model/chat_template_hash",
+    "/backend/selected_backend",
+    "/backend/backend_family",
+    "/backend/fallback_used",
+    "/kernel_route/route_verified",
+    "/kernel_route/device_slug",
+    "/kernel_route/selected_backend",
+    "/kernel_route/kernel_variants",
+    "/benchmark_profile/id",
+    "/benchmark_profile/profile_hash",
+    "/quality_gate/required",
+    "/quality_gate/quality_passed",
+    "/quality_gate/quality_receipt",
+    "/claim_gate/classification",
+    "/measurements",
+    "/not_claims",
+];
+
+#[derive(Debug, Serialize)]
+struct BenchReceiptVerifyReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    receipt_path: String,
+    passed: bool,
+    claimable: bool,
+    classification: String,
+    quality_required: bool,
+    quality_passed: bool,
+    repo_dirty: bool,
+    fallback_used: bool,
+    route_verified: bool,
+    model_contract_matched: Option<bool>,
+    resource_envelope_complete: Option<bool>,
+    run_id: Option<String>,
+    benchmark_profile: Option<String>,
+    selected_backend: Option<String>,
+    failures: Vec<String>,
+    blocked_reasons: Vec<String>,
+    not_claims: Vec<String>,
+}
+
+pub fn verify_receipt(receipt_path: &Path, format: &str, require_claimable: bool) -> Result<()> {
+    let report = build_verify_report(receipt_path, require_claimable)?;
+    emit_report(&report, format)?;
+    if !report.passed {
+        bail!("bench receipt verification failed: {}", report.failures.join(", "));
+    }
+    Ok(())
+}
+
+fn build_verify_report(
+    receipt_path: &Path,
+    require_claimable: bool,
+) -> Result<BenchReceiptVerifyReport> {
+    let raw = fs::read_to_string(receipt_path)
+        .with_context(|| format!("reading {}", receipt_path.display()))?;
+    let value: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing {}", receipt_path.display()))?;
+
+    let mut failures = Vec::new();
+    let mut blocked_reasons = Vec::new();
+    for pointer in REQUIRED_POINTERS {
+        if value.pointer(pointer).is_none_or(Value::is_null) {
+            failures.push(format!("missing required field {pointer}"));
+        }
+    }
+
+    if str_at(&value, "/receipt_type") != Some("bench_run") {
+        failures.push("receipt_type must be bench_run".to_string());
+    }
+
+    let quality_required = bool_at(&value, "/quality_gate/required").unwrap_or(false);
+    let quality_passed = bool_at(&value, "/quality_gate/quality_passed").unwrap_or(false);
+    let repo_dirty = bool_at(&value, "/repo/dirty").unwrap_or(true);
+    let fallback_used = bool_at(&value, "/backend/fallback_used").unwrap_or(true);
+    let route_verified = bool_at(&value, "/kernel_route/route_verified").unwrap_or(false);
+    let model_contract_matched = bool_at(&value, "/claim_gate/model_contract_matched");
+    let resource_envelope_complete = bool_at(&value, "/claim_gate/resource_envelope_complete");
+    let claimable = bool_at(&value, "/claim_gate/benchmark_claim_allowed")
+        .or_else(|| bool_at(&value, "/claim_gate/claim_allowed"))
+        .unwrap_or(false);
+    let classification =
+        str_at(&value, "/claim_gate/classification").unwrap_or("diagnostic_only").to_string();
+
+    let not_claims = array_strings(&value, "/not_claims");
+    for not_claim in CRITICAL_NOT_CLAIMS {
+        if !not_claims.iter().any(|value| value == not_claim) {
+            failures.push(format!("missing critical not-claim {not_claim}"));
+        }
+    }
+
+    if quality_required && str_at(&value, "/quality_gate/quality_receipt").unwrap_or("").is_empty()
+    {
+        failures.push("quality is required but quality_receipt is empty".to_string());
+    }
+    if claimable && !quality_passed {
+        failures.push("benchmark claim allowed while quality_passed=false".to_string());
+    }
+    if claimable && repo_dirty {
+        failures.push("benchmark claim allowed from dirty repo".to_string());
+    }
+    if claimable && fallback_used {
+        failures.push("benchmark claim allowed while fallback_used=true".to_string());
+    }
+    if claimable && !route_verified {
+        failures.push("benchmark claim allowed while route_verified=false".to_string());
+    }
+    if claimable && model_contract_matched == Some(false) {
+        failures.push("benchmark claim allowed while model_contract_matched=false".to_string());
+    }
+    if claimable && resource_envelope_complete == Some(false) {
+        failures.push("benchmark claim allowed while resource_envelope_complete=false".to_string());
+    }
+    if claimable && classification == "diagnostic_only" {
+        failures.push("benchmark claim allowed with diagnostic_only classification".to_string());
+    }
+
+    if !quality_passed {
+        blocked_reasons.push("quality_not_passed".to_string());
+    }
+    if repo_dirty {
+        blocked_reasons.push("repo_dirty".to_string());
+    }
+    if fallback_used {
+        blocked_reasons.push("fallback_used".to_string());
+    }
+    if !route_verified {
+        blocked_reasons.push("route_not_verified".to_string());
+    }
+    if model_contract_matched == Some(false) {
+        blocked_reasons.push("model_contract_not_matched".to_string());
+    }
+    if resource_envelope_complete == Some(false) {
+        blocked_reasons.push("resource_envelope_incomplete".to_string());
+    }
+    if require_claimable && !claimable {
+        failures.push("receipt is not claimable but --require-claimable was set".to_string());
+    }
+
+    Ok(BenchReceiptVerifyReport {
+        diagnostic: "bench_receipt_verify",
+        producer: "cargo xtask bench verify-receipt",
+        receipt_path: receipt_path.display().to_string(),
+        passed: failures.is_empty(),
+        claimable,
+        classification,
+        quality_required,
+        quality_passed,
+        repo_dirty,
+        fallback_used,
+        route_verified,
+        model_contract_matched,
+        resource_envelope_complete,
+        run_id: str_at(&value, "/run_id").map(ToOwned::to_owned),
+        benchmark_profile: str_at(&value, "/benchmark_profile/id").map(ToOwned::to_owned),
+        selected_backend: str_at(&value, "/backend/selected_backend").map(ToOwned::to_owned),
+        failures,
+        blocked_reasons,
+        not_claims,
+    })
+}
+
+fn emit_report(report: &BenchReceiptVerifyReport, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(report)?),
+        "human" => {
+            println!("bench receipt verify: passed={}", report.passed);
+            println!("claimable: {}", report.claimable);
+            println!("classification: {}", report.classification);
+            if !report.blocked_reasons.is_empty() {
+                println!("blocked_reasons: {}", report.blocked_reasons.join(", "));
+            }
+            if !report.failures.is_empty() {
+                println!("failures: {}", report.failures.join(", "));
+            }
+            println!("not_claims: {}", report.not_claims.join(", "));
+        }
+        other => bail!("unsupported bench receipt output format: {other}"),
+    }
+    Ok(())
+}
+
+fn bool_at(value: &Value, pointer: &str) -> Option<bool> {
+    value.pointer(pointer).and_then(Value::as_bool)
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn array_strings(value: &Value, pointer: &str) -> Vec<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn receipt(claim_allowed: bool, quality_passed: bool, dirty: bool) -> Value {
+        serde_json::json!({
+            "schema_version": 1,
+            "receipt_type": "bench_run",
+            "run_id": "run-1",
+            "repo": {
+                "commit": "abc",
+                "tree": "def",
+                "dirty": dirty,
+                "cargo_lock_hash": "sha256:lock",
+                "rustc": "rustc 1.95.0",
+                "features": ["cpu"]
+            },
+            "device": {
+                "device_slug": "amd-5700x-intel-a770",
+                "device_instance_hash": "sha256:device"
+            },
+            "model": {
+                "contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
+                "model_id": "microsoft/bitnet-b1.58-2B-4T-gguf",
+                "weights_sha256": "sha256:weights",
+                "tokenizer_sha256": "sha256:tokenizer",
+                "chat_template_hash": "sha256:template"
+            },
+            "backend": {
+                "selected_backend": "intel-arc-a770-opencl",
+                "backend_family": "intel-opencl",
+                "fallback_used": false
+            },
+            "kernel_route": {
+                "route_verified": true,
+                "device_slug": "amd-5700x-intel-a770",
+                "selected_backend": "intel-arc-a770-opencl",
+                "kernel_variants": [
+                    { "op": "qk256_i2s_gemv", "kernel_variant_id": "a770_opencl_qk256_i2s_route_pending_claim_receipts" }
+                ]
+            },
+            "benchmark_profile": {
+                "id": "prefill_512_decode_64",
+                "profile_hash": "sha256:profile"
+            },
+            "quality_gate": {
+                "required": true,
+                "quality_passed": quality_passed,
+                "quality_receipt": "quality.json"
+            },
+            "claim_gate": {
+                "benchmark_claim_allowed": claim_allowed,
+                "classification": if claim_allowed { "performance_proven" } else { "diagnostic_only" },
+                "model_contract_matched": true,
+                "resource_envelope_complete": true
+            },
+            "measurements": { "summary": {} },
+            "not_claims": [
+                "selected_attention_residency",
+                "resident_kv_decode",
+                "attention_scores_residency",
+                "softmax_residency",
+                "attention_value_mix_residency",
+                "full_support_op_residency",
+                "full_device_residency",
+                "completion"
+            ]
+        })
+    }
+
+    fn write_receipt(value: &Value) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("receipt.json");
+        fs::write(&path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn diagnostic_receipt_can_verify_without_claim() {
+        let (_dir, path) = write_receipt(&receipt(false, false, true));
+        let report = build_verify_report(&path, false).unwrap();
+        assert!(report.passed);
+        assert!(!report.claimable);
+        assert!(report.blocked_reasons.iter().any(|reason| reason == "quality_not_passed"));
+    }
+
+    #[test]
+    fn rejects_quality_failed_claim() {
+        let (_dir, path) = write_receipt(&receipt(true, false, false));
+        let report = build_verify_report(&path, false).unwrap();
+        assert!(!report.passed);
+        assert!(report.failures.iter().any(|failure| failure.contains("quality_passed=false")));
+    }
+
+    #[test]
+    fn rejects_dirty_claim() {
+        let (_dir, path) = write_receipt(&receipt(true, true, true));
+        let report = build_verify_report(&path, false).unwrap();
+        assert!(!report.passed);
+        assert!(report.failures.iter().any(|failure| failure.contains("dirty repo")));
+    }
+}

--- a/xtask/src/claims.rs
+++ b/xtask/src/claims.rs
@@ -1,0 +1,312 @@
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+
+const CRITICAL_A770_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+];
+
+const VALID_STATUSES: &[&str] = &[
+    "unsupported",
+    "diagnostic",
+    "load_proven",
+    "quality_proven",
+    "performance_proven",
+    "resident_proven",
+    "complete",
+];
+
+const EVIDENCE_REQUIRED_STATUSES: &[&str] = &[
+    "load_proven",
+    "quality_proven",
+    "performance_proven",
+    "resident_proven",
+    "complete",
+];
+
+const A770_PROMOTED_STATUSES: &[&str] = &["performance_proven", "resident_proven", "complete"];
+
+pub fn verify(ledger_path: &Path, a770_capability_matrix: &Path, format: &str) -> Result<()> {
+    let ledger = read_json(ledger_path)?;
+    let matrix = read_json(a770_capability_matrix)?;
+    let report = build_verify_report(ledger_path, &ledger, a770_capability_matrix, &matrix);
+    emit_value(&report, format)?;
+    if !report["passed"].as_bool().unwrap_or(false) {
+        bail!("claims verify failed: {}", report["failures"].clone());
+    }
+    Ok(())
+}
+
+pub fn docs(ledger_path: &Path, output: &Path, check: bool, format: &str) -> Result<()> {
+    let ledger = read_json(ledger_path)?;
+    let markdown = render_docs(&ledger);
+    if check {
+        let existing =
+            fs::read_to_string(output).with_context(|| format!("reading {}", output.display()))?;
+        if normalize_newlines(&existing) != normalize_newlines(&markdown) {
+            let report = json!({
+                "diagnostic": "claims_docs",
+                "producer": "cargo xtask claims docs",
+                "passed": false,
+                "check": true,
+                "output": output.display().to_string(),
+                "failures": ["claim docs are stale"],
+            });
+            emit_value(&report, format)?;
+            bail!("claim docs are stale: {}", output.display());
+        }
+    } else {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(output, markdown).with_context(|| format!("writing {}", output.display()))?;
+    }
+    let report = json!({
+        "diagnostic": "claims_docs",
+        "producer": "cargo xtask claims docs",
+        "passed": true,
+        "check": check,
+        "ledger": ledger_path.display().to_string(),
+        "output": output.display().to_string(),
+        "claim_count": ledger.pointer("/claims").and_then(Value::as_array).map_or(0, Vec::len),
+    });
+    emit_value(&report, format)?;
+    Ok(())
+}
+
+fn build_verify_report(
+    ledger_path: &Path,
+    ledger: &Value,
+    matrix_path: &Path,
+    matrix: &Value,
+) -> Value {
+    let mut failures = Vec::new();
+    let claims = ledger.pointer("/claims").and_then(Value::as_array);
+    let Some(claims) = claims else {
+        return json!({
+            "diagnostic": "claims_verify",
+            "producer": "cargo xtask claims verify",
+            "ledger": ledger_path.display().to_string(),
+            "a770_capability_matrix": matrix_path.display().to_string(),
+            "passed": false,
+            "claim_count": 0,
+            "failures": ["ledger missing /claims array"],
+        });
+    };
+
+    let a770_claimable_kernel_count = claimable_kernel_count(matrix);
+    let mut promoted_a770_claims = Vec::new();
+    for claim in claims {
+        let claim_id = str_at(claim, "/claim_id").unwrap_or("");
+        let status = str_at(claim, "/status").unwrap_or("");
+        let scope = str_at(claim, "/scope").unwrap_or("");
+        if claim_id.is_empty() {
+            failures.push("claim missing claim_id".to_string());
+        }
+        if !VALID_STATUSES.contains(&status) {
+            failures.push(format!("{claim_id}: invalid status {status}"));
+        }
+        let evidence = claim.pointer("/evidence").and_then(Value::as_array);
+        if EVIDENCE_REQUIRED_STATUSES.contains(&status)
+            && evidence.is_none_or(|items| items.is_empty())
+        {
+            failures.push(format!("{claim_id}: status {status} requires evidence"));
+        }
+
+        let not_claims = array_strings(claim, "/not_claims");
+        if claim_id.starts_with("a770.") || scope.to_ascii_lowercase().contains("a770") {
+            for not_claim in CRITICAL_A770_NOT_CLAIMS {
+                if !not_claims.iter().any(|item| item == not_claim) {
+                    failures.push(format!("{claim_id}: missing critical not-claim {not_claim}"));
+                }
+            }
+        }
+
+        if claim_id.contains("selected_attention")
+            && !matches!(status, "unsupported" | "diagnostic")
+        {
+            failures.push(format!("{claim_id}: selected attention cannot be promoted by ledger"));
+        }
+        if claim_id.contains("full_residency") && !matches!(status, "unsupported" | "diagnostic") {
+            failures.push(format!("{claim_id}: full residency cannot be promoted by ledger"));
+        }
+        if claim_id.starts_with("a770.") && A770_PROMOTED_STATUSES.contains(&status) {
+            promoted_a770_claims.push(claim_id.to_string());
+        }
+    }
+
+    if a770_claimable_kernel_count == 0 && !promoted_a770_claims.is_empty() {
+        failures.push(format!(
+            "A770 promoted claims require claimable A770 kernels; promoted={}",
+            promoted_a770_claims.join(", ")
+        ));
+    }
+
+    json!({
+        "diagnostic": "claims_verify",
+        "producer": "cargo xtask claims verify",
+        "ledger": ledger_path.display().to_string(),
+        "a770_capability_matrix": matrix_path.display().to_string(),
+        "passed": failures.is_empty(),
+        "claim_count": claims.len(),
+        "a770_claimable_kernel_count": a770_claimable_kernel_count,
+        "promoted_a770_claims": promoted_a770_claims,
+        "failures": failures,
+    })
+}
+
+fn render_docs(ledger: &Value) -> String {
+    let mut output = String::new();
+    output.push_str("# Claim Ledger\n\n");
+    output.push_str("Generated from `ci/claims/claim-ledger.json`.\n\n");
+    output.push_str("| Claim | Status | Scope | Blocker |\n");
+    output.push_str("| --- | --- | --- | --- |\n");
+    if let Some(claims) = ledger.pointer("/claims").and_then(Value::as_array) {
+        for claim in claims {
+            output.push_str(&format!(
+                "| `{}` | `{}` | {} | {} |\n",
+                str_at(claim, "/claim_id").unwrap_or("unknown"),
+                str_at(claim, "/status").unwrap_or("unknown"),
+                escape_markdown_cell(str_at(claim, "/scope").unwrap_or("")),
+                escape_markdown_cell(str_at(claim, "/blocker").unwrap_or(""))
+            ));
+        }
+    }
+    output.push_str("\n## A770 Not Claims\n\n");
+    for not_claim in CRITICAL_A770_NOT_CLAIMS {
+        output.push_str(&format!("- `{not_claim}`\n"));
+    }
+    output
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn emit_value(value: &Value, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(value)?),
+        "human" => {
+            println!("diagnostic: {}", str_at(value, "/diagnostic").unwrap_or("claims"));
+            if let Some(passed) = value.pointer("/passed").and_then(Value::as_bool) {
+                println!("passed: {passed}");
+            }
+            if let Some(claim_count) = value.pointer("/claim_count").and_then(Value::as_u64) {
+                println!("claim_count: {claim_count}");
+            }
+            if let Some(failures) = value.pointer("/failures") {
+                println!("failures: {failures}");
+            }
+        }
+        other => bail!("unsupported claims output format: {other}"),
+    }
+    Ok(())
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn array_strings(value: &Value, pointer: &str) -> Vec<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect())
+        .unwrap_or_default()
+}
+
+fn claimable_kernel_count(matrix: &Value) -> u64 {
+    if let Some(count) = matrix.pointer("/claimable_kernel_count").and_then(Value::as_u64) {
+        return count;
+    }
+
+    matrix
+        .pointer("/kernels")
+        .and_then(Value::as_array)
+        .map(|kernels| {
+            kernels
+                .iter()
+                .filter(|kernel| {
+                    str_at(kernel, "/status").is_some_and(|status| {
+                        matches!(
+                            status,
+                            "quality_proven"
+                                | "performance_proven"
+                                | "resident_proven"
+                                | "complete"
+                        )
+                    })
+                })
+                .count() as u64
+        })
+        .unwrap_or(0)
+}
+
+fn escape_markdown_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', " ")
+}
+
+fn normalize_newlines(value: &str) -> String {
+    value.replace("\r\n", "\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ledger(status: &str) -> Value {
+        json!({
+            "schema_version": 1,
+            "claims": [
+                {
+                    "claim_id": "a770.bitnet.trusted_partial_experience",
+                    "scope": "BitNet b1.58 i2_s on AMD 5700X + Intel Arc A770",
+                    "status": status,
+                    "evidence": [],
+                    "blocker": "clean claim-grade parent benchmark and history are not present",
+                    "not_claims": CRITICAL_A770_NOT_CLAIMS
+                }
+            ]
+        })
+    }
+
+    fn matrix(claimable_kernel_count: u64) -> Value {
+        json!({
+            "claimable_kernel_count": claimable_kernel_count
+        })
+    }
+
+    #[test]
+    fn diagnostic_a770_claim_passes_without_claimable_kernels() {
+        let report =
+            build_verify_report(Path::new("claims.json"), &ledger("diagnostic"), Path::new("matrix.json"), &matrix(0));
+        assert_eq!(report["passed"], true);
+    }
+
+    #[test]
+    fn performance_a770_claim_requires_claimable_kernels() {
+        let report = build_verify_report(
+            Path::new("claims.json"),
+            &ledger("performance_proven"),
+            Path::new("matrix.json"),
+            &matrix(0),
+        );
+        assert_eq!(report["passed"], false);
+        assert!(
+            report["failures"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|failure| failure.as_str().unwrap().contains("require claimable A770 kernels"))
+        );
+    }
+}

--- a/xtask/src/hardware.rs
+++ b/xtask/src/hardware.rs
@@ -1,0 +1,534 @@
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+];
+
+#[derive(Debug, Deserialize)]
+struct CapabilityMatrix {
+    schema_version: u32,
+    matrix_id: String,
+    device_slug: String,
+    backend_family: String,
+    selected_backend: String,
+    quality_gated_benchmarks_required: bool,
+    kernels: Vec<KernelCapability>,
+    not_claims: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KernelCapability {
+    kernel: String,
+    model_families: Vec<String>,
+    status: String,
+    fallback_allowed_when_claimed: bool,
+    proof_receipts: Vec<String>,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct KernelSummary {
+    kernel: String,
+    model_families: Vec<String>,
+    status: String,
+    claimable: bool,
+    fallback_allowed_when_claimed: bool,
+    proof_receipt_count: usize,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CapabilityCheckReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    matrix_path: String,
+    schema_version: u32,
+    matrix_id: String,
+    device_slug: String,
+    backend_family: String,
+    selected_backend: String,
+    quality_gated_benchmarks_required: bool,
+    passed: bool,
+    kernel_count: usize,
+    claimable_kernel_count: usize,
+    status_counts: BTreeMap<String, usize>,
+    kernels: Vec<KernelSummary>,
+    missing: Vec<String>,
+    not_claims: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RouteTable {
+    #[serde(default)]
+    route: Vec<RouteEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct RouteEntry {
+    route_id: String,
+    op: String,
+    model_family: String,
+    quantization: String,
+    backend_family: String,
+    selected_backend: String,
+    device_slug: String,
+    device_family: String,
+    device_models: Vec<String>,
+    kernel_variant: String,
+    claim_level: String,
+    fallback_allowed: bool,
+    proof_receipts: Vec<String>,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    not_claims: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RouteQuery {
+    device_slug: String,
+    selected_backend: String,
+    backend_family: String,
+    model_family: String,
+    quantization: String,
+    op: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RouteResolveReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    routing_table: String,
+    query: RouteQuery,
+    passed: bool,
+    route_found: bool,
+    route_verified: bool,
+    claimable: bool,
+    classification: String,
+    route: Option<RouteEntry>,
+    failures: Vec<String>,
+    not_claims: Vec<String>,
+}
+
+pub fn kernel_capability_check(matrix_path: &Path, format: &str) -> Result<()> {
+    let report = build_capability_check_report(matrix_path)?;
+    emit_capability_report(&report, format)?;
+    if !report.passed {
+        bail!("kernel capability check failed: {}", report.missing.join(", "));
+    }
+    Ok(())
+}
+
+pub fn route_resolve(
+    routing_table: &Path,
+    device_slug: &str,
+    selected_backend: &str,
+    backend_family: &str,
+    model_family: &str,
+    quantization: &str,
+    op: &str,
+    format: &str,
+) -> Result<()> {
+    let report = build_route_resolve_report(
+        routing_table,
+        RouteQuery {
+            device_slug: device_slug.to_string(),
+            selected_backend: selected_backend.to_string(),
+            backend_family: backend_family.to_string(),
+            model_family: model_family.to_string(),
+            quantization: quantization.to_string(),
+            op: op.to_string(),
+        },
+    )?;
+    emit_route_report(&report, format)?;
+    if !report.passed {
+        bail!("kernel route resolve failed: {}", report.failures.join(", "));
+    }
+    Ok(())
+}
+
+fn build_capability_check_report(matrix_path: &Path) -> Result<CapabilityCheckReport> {
+    let raw = fs::read_to_string(matrix_path)
+        .with_context(|| format!("reading {}", matrix_path.display()))?;
+    let matrix: CapabilityMatrix =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", matrix_path.display()))?;
+
+    let mut missing = Vec::new();
+    if matrix.kernels.is_empty() {
+        missing.push("matrix has no kernels".to_string());
+    }
+    if !matrix.quality_gated_benchmarks_required {
+        missing.push("quality_gated_benchmarks_required must be true".to_string());
+    }
+    for not_claim in CRITICAL_NOT_CLAIMS {
+        if !matrix.not_claims.iter().any(|value| value == not_claim) {
+            missing.push(format!("missing critical not-claim {not_claim}"));
+        }
+    }
+
+    let mut status_counts = BTreeMap::new();
+    let mut kernels = Vec::new();
+    let mut claimable_kernel_count = 0;
+    for kernel in matrix.kernels {
+        if kernel.kernel.trim().is_empty() {
+            missing.push("kernel entry has empty kernel name".to_string());
+        }
+        if kernel.model_families.is_empty() {
+            missing.push(format!("{} has no model_families", kernel.kernel));
+        }
+        if !is_known_status(&kernel.status) {
+            missing.push(format!("{} has unknown status {}", kernel.kernel, kernel.status));
+        }
+        *status_counts.entry(kernel.status.clone()).or_insert(0) += 1;
+        let claimable = is_claimable_status(&kernel.status);
+        if claimable {
+            claimable_kernel_count += 1;
+        }
+        if status_requires_receipts(&kernel.status) && kernel.proof_receipts.is_empty() {
+            missing.push(format!(
+                "{} status {} requires proof_receipts",
+                kernel.kernel, kernel.status
+            ));
+        }
+        if claimable && kernel.fallback_allowed_when_claimed {
+            missing.push(format!(
+                "{} is claimable but fallback_allowed_when_claimed=true",
+                kernel.kernel
+            ));
+        }
+        kernels.push(KernelSummary {
+            kernel: kernel.kernel,
+            model_families: kernel.model_families,
+            status: kernel.status,
+            claimable,
+            fallback_allowed_when_claimed: kernel.fallback_allowed_when_claimed,
+            proof_receipt_count: kernel.proof_receipts.len(),
+            reason: kernel.reason,
+        });
+    }
+
+    Ok(CapabilityCheckReport {
+        diagnostic: "a770_kernel_capability_check",
+        producer: "cargo xtask hardware a770 kernel-capability-check",
+        matrix_path: matrix_path.display().to_string(),
+        schema_version: matrix.schema_version,
+        matrix_id: matrix.matrix_id,
+        device_slug: matrix.device_slug,
+        backend_family: matrix.backend_family,
+        selected_backend: matrix.selected_backend,
+        quality_gated_benchmarks_required: matrix.quality_gated_benchmarks_required,
+        passed: missing.is_empty(),
+        kernel_count: kernels.len(),
+        claimable_kernel_count,
+        status_counts,
+        kernels,
+        missing,
+        not_claims: matrix.not_claims,
+    })
+}
+
+fn build_route_resolve_report(
+    routing_table: &Path,
+    query: RouteQuery,
+) -> Result<RouteResolveReport> {
+    let raw = fs::read_to_string(routing_table)
+        .with_context(|| format!("reading {}", routing_table.display()))?;
+    let table: RouteTable =
+        toml::from_str(&raw).with_context(|| format!("parsing {}", routing_table.display()))?;
+
+    let route = table.route.into_iter().find(|route| {
+        route.device_slug == query.device_slug
+            && route.selected_backend == query.selected_backend
+            && route.backend_family == query.backend_family
+            && route.model_family == query.model_family
+            && route.quantization == query.quantization
+            && route.op == query.op
+    });
+
+    let mut failures = Vec::new();
+    let mut not_claims = CRITICAL_NOT_CLAIMS.iter().map(|value| (*value).to_string()).collect();
+    let mut route_verified = false;
+    let mut claimable = false;
+    let classification;
+
+    if let Some(route) = &route {
+        claimable = is_claimable_status(&route.claim_level);
+        route_verified = true;
+        if route.device_slug == "*" {
+            failures.push(format!("{} uses wildcard device_slug", route.route_id));
+            route_verified = false;
+        }
+        if route.device_models.iter().any(|model| model == "*") {
+            failures.push(format!("{} uses wildcard device_models", route.route_id));
+            route_verified = false;
+        }
+        if route.kernel_variant.trim().is_empty() {
+            failures.push(format!("{} has empty kernel_variant", route.route_id));
+            route_verified = false;
+        }
+        if route.kernel_variant == "missing" && route.claim_level != "unsupported" {
+            failures.push(format!(
+                "{} uses missing kernel_variant but claim_level={}",
+                route.route_id, route.claim_level
+            ));
+            route_verified = false;
+        }
+        if !is_known_status(&route.claim_level) {
+            failures
+                .push(format!("{} has unknown claim_level {}", route.route_id, route.claim_level));
+            route_verified = false;
+        }
+        if claimable && route.fallback_allowed {
+            failures.push(format!("{} is claimable but fallback_allowed=true", route.route_id));
+            route_verified = false;
+        }
+        if status_requires_receipts(&route.claim_level) && route.proof_receipts.is_empty() {
+            failures.push(format!(
+                "{} claim_level {} requires proof_receipts",
+                route.route_id, route.claim_level
+            ));
+            route_verified = false;
+        }
+        if !route.not_claims.is_empty() {
+            not_claims = route.not_claims.clone();
+        }
+        classification = if claimable {
+            "claimable_route"
+        } else if route.claim_level == "unsupported" {
+            "unsupported_route"
+        } else {
+            "diagnostic_route"
+        }
+        .to_string();
+    } else {
+        failures.push("no matching route".to_string());
+        classification = "route_missing".to_string();
+    }
+
+    Ok(RouteResolveReport {
+        diagnostic: "kernel_route_resolve",
+        producer: "cargo xtask hardware route resolve",
+        routing_table: routing_table.display().to_string(),
+        query,
+        passed: failures.is_empty(),
+        route_found: route.is_some(),
+        route_verified,
+        claimable,
+        classification,
+        route,
+        failures,
+        not_claims,
+    })
+}
+
+fn is_known_status(status: &str) -> bool {
+    matches!(
+        status,
+        "unsupported"
+            | "missing"
+            | "diagnostic"
+            | "load_proven"
+            | "parity_proven"
+            | "quality_proven"
+            | "performance_proven"
+            | "resident_proven"
+            | "complete"
+    )
+}
+
+fn is_claimable_status(status: &str) -> bool {
+    matches!(status, "quality_proven" | "performance_proven" | "resident_proven" | "complete")
+}
+
+fn status_requires_receipts(status: &str) -> bool {
+    !matches!(status, "unsupported" | "missing" | "diagnostic")
+}
+
+fn emit_capability_report(report: &CapabilityCheckReport, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(report)?),
+        "human" => {
+            println!("a770 kernel capability check: passed={}", report.passed);
+            println!("matrix: {}", report.matrix_path);
+            println!("device: {}", report.device_slug);
+            println!("backend: {}", report.selected_backend);
+            println!("kernels: {}", report.kernel_count);
+            println!("claimable kernels: {}", report.claimable_kernel_count);
+            if !report.missing.is_empty() {
+                println!("missing: {}", report.missing.join(", "));
+            }
+            println!("not_claims: {}", report.not_claims.join(", "));
+        }
+        other => bail!("unsupported hardware output format: {other}"),
+    }
+    Ok(())
+}
+
+fn emit_route_report(report: &RouteResolveReport, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(report)?),
+        "human" => {
+            println!("kernel route resolve: passed={}", report.passed);
+            println!("classification: {}", report.classification);
+            println!("route_found: {}", report.route_found);
+            println!("route_verified: {}", report.route_verified);
+            println!("claimable: {}", report.claimable);
+            if let Some(route) = &report.route {
+                println!("route_id: {}", route.route_id);
+                println!("kernel_variant: {}", route.kernel_variant);
+                println!("claim_level: {}", route.claim_level);
+            }
+            if !report.failures.is_empty() {
+                println!("failures: {}", report.failures.join(", "));
+            }
+            println!("not_claims: {}", report.not_claims.join(", "));
+        }
+        other => bail!("unsupported hardware output format: {other}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_rejects_claimable_kernel_without_receipts() {
+        let dir = tempfile::tempdir().unwrap();
+        let matrix = dir.path().join("matrix.json");
+        fs::write(
+            &matrix,
+            r#"
+{
+  "schema_version": 1,
+  "matrix_id": "test",
+  "device_slug": "amd-5700x-intel-a770",
+  "backend_family": "intel-opencl",
+  "selected_backend": "intel-arc-a770-opencl",
+  "quality_gated_benchmarks_required": true,
+  "kernels": [
+    {
+      "kernel": "qk256_i2s_gemv",
+      "model_families": ["bitnet"],
+      "status": "performance_proven",
+      "fallback_allowed_when_claimed": false,
+      "proof_receipts": []
+    }
+  ],
+  "not_claims": [
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion"
+  ]
+}
+"#,
+        )
+        .unwrap();
+
+        let report = build_capability_check_report(&matrix).unwrap();
+        assert!(!report.passed);
+        assert!(report.missing.iter().any(|failure| failure.contains("requires proof_receipts")));
+    }
+
+    #[test]
+    fn route_rejects_wildcard_device_inheritance() {
+        let dir = tempfile::tempdir().unwrap();
+        let table = dir.path().join("routes.toml");
+        fs::write(
+            &table,
+            r#"
+[[route]]
+route_id = "bad.wildcard"
+op = "qk256_i2s_gemv"
+model_family = "bitnet"
+quantization = "i2_s"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "*"
+device_family = "arc_alchemist"
+device_models = ["*"]
+kernel_variant = "some_kernel"
+claim_level = "diagnostic"
+fallback_allowed = false
+proof_receipts = []
+"#,
+        )
+        .unwrap();
+
+        let report = build_route_resolve_report(
+            &table,
+            RouteQuery {
+                device_slug: "*".to_string(),
+                selected_backend: "intel-arc-a770-opencl".to_string(),
+                backend_family: "intel-opencl".to_string(),
+                model_family: "bitnet".to_string(),
+                quantization: "i2_s".to_string(),
+                op: "qk256_i2s_gemv".to_string(),
+            },
+        )
+        .unwrap();
+        assert!(!report.passed);
+        assert!(!report.route_verified);
+        assert!(report.failures.iter().any(|failure| failure.contains("wildcard")));
+    }
+
+    #[test]
+    fn diagnostic_a770_route_resolves_without_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let table = dir.path().join("routes.toml");
+        fs::write(
+            &table,
+            r#"
+[[route]]
+route_id = "a770.bitnet.i2s.qk256"
+op = "qk256_i2s_gemv"
+model_family = "bitnet"
+quantization = "i2_s"
+backend_family = "intel-opencl"
+selected_backend = "intel-arc-a770-opencl"
+device_slug = "amd-5700x-intel-a770"
+device_family = "arc_alchemist"
+device_models = ["arc-a770-16gb"]
+kernel_variant = "a770_opencl_qk256_i2s_route_pending_claim_receipts"
+claim_level = "diagnostic"
+fallback_allowed = false
+proof_receipts = []
+"#,
+        )
+        .unwrap();
+
+        let report = build_route_resolve_report(
+            &table,
+            RouteQuery {
+                device_slug: "amd-5700x-intel-a770".to_string(),
+                selected_backend: "intel-arc-a770-opencl".to_string(),
+                backend_family: "intel-opencl".to_string(),
+                model_family: "bitnet".to_string(),
+                quantization: "i2_s".to_string(),
+                op: "qk256_i2s_gemv".to_string(),
+            },
+        )
+        .unwrap();
+        assert!(report.passed);
+        assert!(report.route_verified);
+        assert!(!report.claimable);
+        assert_eq!(report.classification, "diagnostic_route");
+    }
+}

--- a/xtask/src/llm_experience.rs
+++ b/xtask/src/llm_experience.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result, bail};
 use bitnet_prompt_templates::TemplateType;
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "selected_attention_residency",
@@ -16,6 +16,35 @@ const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "full_device_residency",
     "completion",
 ];
+
+const REQUIRED_EXPERIENCE_POINTERS: &[&str] = &[
+    "/schema_version",
+    "/receipt_type",
+    "/producer",
+    "/repo",
+    "/model",
+    "/device",
+    "/kernel_route",
+    "/backend",
+    "/benchmark_profile",
+    "/quality/passed",
+    "/measurement_supplements/cli_stage_receipt/present",
+    "/load/complete",
+    "/ttft/complete",
+    "/input_speed/complete",
+    "/output_speed/complete",
+    "/resource_envelope/complete",
+    "/claim_gate/claim_allowed",
+    "/claim_gate/classification",
+    "/not_claims",
+];
+
+#[derive(Debug, Clone)]
+struct Section {
+    complete: bool,
+    data: Map<String, Value>,
+    missing: Vec<String>,
+}
 
 #[derive(Debug, Deserialize)]
 struct ProfileTable {
@@ -31,6 +60,141 @@ struct BenchProfile {
     decode_tokens: Option<usize>,
     #[serde(default)]
     max_new_tokens: Option<usize>,
+}
+
+pub fn maybe_dispatch_from_env() -> Result<bool> {
+    let args = std::env::args().collect::<Vec<_>>();
+    maybe_dispatch(&args)
+}
+
+fn maybe_dispatch(args: &[String]) -> Result<bool> {
+    if args.get(1).map(String::as_str) != Some("llm-experience") {
+        return Ok(false);
+    }
+    match args.get(2).map(String::as_str) {
+        Some("run") => {
+            if args[3..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_run_help();
+                return Ok(true);
+            }
+            let opts = parse_run_args(&args[3..])?;
+            run(
+                &opts.bench_receipt,
+                opts.cli_stage_receipt.as_deref(),
+                Some(&opts.output),
+                &opts.format,
+            )?;
+            Ok(true)
+        }
+        Some("verify") => {
+            if args[3..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_verify_help();
+                return Ok(true);
+            }
+            let opts = parse_verify_args(&args[3..])?;
+            verify(&opts.receipt, &opts.format, opts.require_claimable)?;
+            Ok(true)
+        }
+        Some("profile-cli-plan") | Some("-h") | Some("--help") | None => Ok(false),
+        Some(other) => bail!(
+            "unknown llm-experience subcommand {other}; supported manual subcommands: run, verify"
+        ),
+    }
+}
+
+#[derive(Debug)]
+struct RunArgs {
+    bench_receipt: PathBuf,
+    cli_stage_receipt: Option<PathBuf>,
+    output: PathBuf,
+    format: String,
+}
+
+#[derive(Debug)]
+struct VerifyArgs {
+    receipt: PathBuf,
+    require_claimable: bool,
+    format: String,
+}
+
+fn parse_run_args(args: &[String]) -> Result<RunArgs> {
+    let mut opts = RunArgs {
+        bench_receipt: PathBuf::from("target/bench-runs/profile-cli-stage.json"),
+        cli_stage_receipt: None,
+        output: PathBuf::from("target/llm-experience/a770-bitnet-profile-stage.json"),
+        format: "human".to_string(),
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--bench-receipt" => {
+                index += 1;
+                opts.bench_receipt = PathBuf::from(required_value(args, index, "--bench-receipt")?);
+            }
+            "--cli-stage-receipt" => {
+                index += 1;
+                opts.cli_stage_receipt =
+                    Some(PathBuf::from(required_value(args, index, "--cli-stage-receipt")?));
+            }
+            "--output" => {
+                index += 1;
+                opts.output = PathBuf::from(required_value(args, index, "--output")?);
+            }
+            "--format" => {
+                index += 1;
+                opts.format = required_value(args, index, "--format")?.to_string();
+            }
+            other => bail!("unknown llm-experience run option {other}"),
+        }
+        index += 1;
+    }
+    Ok(opts)
+}
+
+fn parse_verify_args(args: &[String]) -> Result<VerifyArgs> {
+    let mut opts = VerifyArgs {
+        receipt: PathBuf::from("target/llm-experience/a770-bitnet-profile-stage.json"),
+        require_claimable: false,
+        format: "human".to_string(),
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--receipt" => {
+                index += 1;
+                opts.receipt = PathBuf::from(required_value(args, index, "--receipt")?);
+            }
+            "--require-claimable" => {
+                opts.require_claimable = true;
+            }
+            "--format" => {
+                index += 1;
+                opts.format = required_value(args, index, "--format")?.to_string();
+            }
+            other => bail!("unknown llm-experience verify option {other}"),
+        }
+        index += 1;
+    }
+    Ok(opts)
+}
+
+fn required_value<'a>(args: &'a [String], index: usize, flag: &str) -> Result<&'a str> {
+    args.get(index)
+        .map(String::as_str)
+        .filter(|value| !value.starts_with("--"))
+        .with_context(|| format!("{flag} requires a value"))
+}
+
+fn print_run_help() {
+    println!(
+        "Build a canonical LLM experience receipt\n\nUsage: xtask.exe llm-experience run [OPTIONS]\n\nOptions:\n      --bench-receipt <PATH>       Parent benchmark receipt [default: target/bench-runs/profile-cli-stage.json]\n      --cli-stage-receipt <PATH>   Optional CLI-stage measurement supplement\n      --output <PATH>              Output receipt [default: target/llm-experience/a770-bitnet-profile-stage.json]\n      --format <FORMAT>            human or json [default: human]\n  -h, --help                       Print help"
+    );
+}
+
+fn print_verify_help() {
+    println!(
+        "Verify an LLM experience receipt\n\nUsage: xtask.exe llm-experience verify [OPTIONS]\n\nOptions:\n      --receipt <PATH>             Experience receipt [default: target/llm-experience/a770-bitnet-profile-stage.json]\n      --require-claimable          Fail if receipt is diagnostic-only\n      --format <FORMAT>            human or json [default: human]\n  -h, --help                       Print help"
+    );
 }
 
 pub fn profile_cli_plan(
@@ -141,6 +305,154 @@ pub fn profile_cli_plan(
             .with_context(|| format!("writing {}", output.display()))?;
     }
     emit_value(&plan, format)
+}
+
+pub fn run(
+    bench_receipt: &Path,
+    cli_stage_receipt: Option<&Path>,
+    output: Option<&Path>,
+    format: &str,
+) -> Result<()> {
+    let bench = read_json(bench_receipt)?;
+    let cli_stage = cli_stage_receipt.map(read_json).transpose()?;
+    let receipt =
+        build_experience_receipt(bench_receipt, &bench, cli_stage_receipt, cli_stage.as_ref());
+    if let Some(output) = output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(output, serde_json::to_vec_pretty(&receipt)?)
+            .with_context(|| format!("writing {}", output.display()))?;
+    }
+    emit_value(&receipt, format)
+}
+
+pub fn verify(receipt: &Path, format: &str, require_claimable: bool) -> Result<()> {
+    let value = read_json(receipt)?;
+    let report = build_verify_report(receipt, &value, require_claimable);
+    emit_value(&report, format)?;
+    if !report["passed"].as_bool().unwrap_or(false) {
+        bail!("llm-experience verify failed: {}", report["failures"]);
+    }
+    Ok(())
+}
+
+fn build_experience_receipt(
+    bench_path: &Path,
+    bench: &Value,
+    cli_stage_path: Option<&Path>,
+    cli_stage: Option<&Value>,
+) -> Value {
+    let load = load_section(cli_stage);
+    let ttft = ttft_section(cli_stage);
+    let input_speed = input_speed_section(bench, cli_stage);
+    let output_speed = output_speed_section(bench, cli_stage);
+    let resource_envelope = resource_section(bench, cli_stage);
+    let quality_passed = bool_at(bench, "/quality_gate/quality_passed").unwrap_or(false);
+    let fallback_used = bool_at(bench, "/backend/fallback_used").unwrap_or(true);
+    let route_verified = bool_at(bench, "/kernel_route/route_verified").unwrap_or(false);
+    let benchmark_claim_allowed =
+        bool_at(bench, "/claim_gate/benchmark_claim_allowed").unwrap_or(false);
+    let model_contract_matched =
+        bool_at(bench, "/claim_gate/model_contract_matched").unwrap_or(false);
+    let parent_classification =
+        str_at(bench, "/claim_gate/classification").unwrap_or("diagnostic_only");
+    let cli_present = cli_stage.is_some();
+    let cli_profile_matched =
+        bool_at(bench, "/benchmark_profile/profile_identity/profile_matched").unwrap_or(false);
+
+    let mut blocked_reasons = Vec::new();
+    if !benchmark_claim_allowed {
+        blocked_reasons.push("parent_benchmark_not_claim_allowed");
+    }
+    if !quality_passed {
+        blocked_reasons.push("quality_not_passed");
+    }
+    if fallback_used {
+        blocked_reasons.push("fallback_used");
+    }
+    if !route_verified {
+        blocked_reasons.push("route_not_verified");
+    }
+    if !model_contract_matched {
+        blocked_reasons.push("model_contract_not_matched");
+    }
+    if !load.complete {
+        blocked_reasons.push("load_incomplete");
+    }
+    if !ttft.complete {
+        blocked_reasons.push("ttft_incomplete");
+    }
+    if !input_speed.complete {
+        blocked_reasons.push("input_speed_incomplete");
+    }
+    if !output_speed.complete {
+        blocked_reasons.push("output_speed_incomplete");
+    }
+    if !resource_envelope.complete {
+        blocked_reasons.push("resource_envelope_incomplete");
+    }
+    if cli_present {
+        blocked_reasons.push("cli_stage_receipt_diagnostic_only");
+    }
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+
+    let claim_allowed = blocked_reasons.is_empty();
+    let classification = if claim_allowed { parent_classification } else { "diagnostic_only" };
+
+    json!({
+        "schema_version": 1,
+        "receipt_type": "llm_experience_run",
+        "producer": "cargo xtask llm-experience run",
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "source_receipts": {
+            "bench_receipt": bench_path.display().to_string(),
+            "cli_stage_receipt": cli_stage_path.map(|path| path.display().to_string()),
+        },
+        "repo": bench.pointer("/repo").cloned().unwrap_or_else(|| json!({})),
+        "model": bench.pointer("/model").cloned().unwrap_or_else(|| json!({})),
+        "device": bench.pointer("/device").cloned().unwrap_or_else(|| json!({})),
+        "kernel_route": bench.pointer("/kernel_route").cloned().unwrap_or_else(|| json!({})),
+        "backend": bench.pointer("/backend").cloned().unwrap_or_else(|| json!({})),
+        "benchmark_profile": bench.pointer("/benchmark_profile").cloned().unwrap_or_else(|| json!({})),
+        "quality": {
+            "required": bool_at(bench, "/quality_gate/required").unwrap_or(false),
+            "passed": quality_passed,
+            "receipt": str_at(bench, "/quality_gate/quality_receipt").unwrap_or(""),
+        },
+        "measurement_supplements": {
+            "cli_stage_receipt": {
+                "present": cli_present,
+                "path": cli_stage_path.map(|path| path.display().to_string()),
+                "diagnostic_only": cli_present,
+                "claimable": false,
+                "profile_matched": cli_profile_matched,
+                "fields_filled": cli_stage_fields_filled(cli_stage),
+                "not_claims": [
+                    "cli_stage_receipt_proves_quality",
+                    "cli_stage_receipt_promotes_benchmark_claim",
+                    "cli_stage_receipt_promotes_residency"
+                ],
+            }
+        },
+        "load": section_value(load),
+        "ttft": section_value(ttft),
+        "input_speed": section_value(input_speed),
+        "output_speed": section_value(output_speed),
+        "resource_envelope": section_value(resource_envelope),
+        "claim_gate": {
+            "claim_allowed": claim_allowed,
+            "classification": classification,
+            "quality_passed": quality_passed,
+            "fallback_used": fallback_used,
+            "route_verified": route_verified,
+            "model_contract_matched": model_contract_matched,
+            "benchmark_claim_allowed": benchmark_claim_allowed,
+            "blocked_reasons": blocked_reasons,
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    })
 }
 
 fn build_cli_command(
@@ -280,6 +592,288 @@ fn count_template_tokens(
         .len())
 }
 
+fn load_section(cli_stage: Option<&Value>) -> Section {
+    let mut data = Map::new();
+    let fields = [
+        ("cold_total_ms", "/load_timing/cold_total_ms"),
+        ("warm_total_ms", "/load_timing/warm_total_ms"),
+        ("model_open_ms", "/load_timing/model_open_ms"),
+        ("tokenizer_load_ms", "/load_timing/tokenizer_load_ms"),
+        ("backend_init_ms", "/load_timing/backend_init_ms"),
+        ("kernel_compile_ms", "/load_timing/kernel_compile_ms"),
+        ("weight_upload_ms", "/load_timing/weight_upload_ms"),
+        ("ready_to_generate_ms", "/load_timing/ready_to_generate_ms"),
+    ];
+    let missing = collect_section_fields(cli_stage, &mut data, &fields);
+    data.insert(
+        "status".to_string(),
+        json!(if missing.is_empty() {
+            "stage_breakdown_present"
+        } else {
+            "stage_breakdown_incomplete"
+        }),
+    );
+    Section { complete: missing.is_empty(), data, missing }
+}
+
+fn ttft_section(cli_stage: Option<&Value>) -> Section {
+    let mut data = Map::new();
+    let fields = [
+        ("end_to_end_ms", "/ttft/end_to_end_ms"),
+        ("prompt_render_ms", "/ttft/prompt_render_ms"),
+        ("tokenization_ms", "/ttft/tokenization_ms"),
+        ("prefill_ms", "/ttft/prefill_ms"),
+        ("first_decode_ms", "/ttft/first_decode_ms"),
+        ("sampler_ms", "/ttft/sampler_ms"),
+        ("stream_first_byte_ms", "/ttft/stream_first_byte_ms"),
+    ];
+    let mut missing = collect_section_fields(cli_stage, &mut data, &fields);
+    if !data.contains_key("end_to_end_ms") {
+        if let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/cmd_to_first_ms")) {
+            data.insert("end_to_end_ms".to_string(), value.clone());
+            missing.retain(|field| field != "end_to_end_ms");
+        }
+    }
+    if !data.contains_key("first_decode_ms") {
+        if let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/decode_first_ms")) {
+            data.insert("first_decode_ms".to_string(), value.clone());
+            missing.retain(|field| field != "first_decode_ms");
+        }
+    }
+    Section { complete: missing.is_empty(), data, missing }
+}
+
+fn input_speed_section(bench: &Value, cli_stage: Option<&Value>) -> Section {
+    let mut data = Map::new();
+    let mut missing = Vec::new();
+    push_number(
+        &mut data,
+        &mut missing,
+        "prompt_tokens",
+        bench
+            .pointer("/measurements/summary/prompt_tokens")
+            .or_else(|| cli_stage.and_then(|json| json.pointer("/tokens/prompt"))),
+    );
+    push_number(
+        &mut data,
+        &mut missing,
+        "prefill_ms",
+        bench
+            .pointer("/measurements/summary/prefill_ms")
+            .or_else(|| cli_stage.and_then(|json| json.pointer("/ttft/prefill_ms"))),
+    );
+    let complete = missing.is_empty();
+    if complete {
+        if let (Some(tokens), Some(prefill_ms)) = (
+            data.get("prompt_tokens").and_then(Value::as_f64),
+            data.get("prefill_ms").and_then(Value::as_f64),
+        ) {
+            if prefill_ms > 0.0 {
+                data.insert(
+                    "input_tokens_per_second".to_string(),
+                    json!(tokens / (prefill_ms / 1000.0)),
+                );
+            }
+        }
+    }
+    data.entry("input_tokens_per_second".to_string()).or_insert(Value::Null);
+    Section { complete, data, missing }
+}
+
+fn output_speed_section(bench: &Value, cli_stage: Option<&Value>) -> Section {
+    let mut data = Map::new();
+    let mut missing = Vec::new();
+    push_number(
+        &mut data,
+        &mut missing,
+        "generated_tokens",
+        bench
+            .pointer("/measurements/summary/generated_tokens")
+            .or_else(|| cli_stage.and_then(|json| json.pointer("/tokens/generated"))),
+    );
+    push_number(
+        &mut data,
+        &mut missing,
+        "steady_state_output_tok_s",
+        bench
+            .pointer("/measurements/summary/steady_state_output_tok_s")
+            .or_else(|| cli_stage.and_then(|json| json.pointer("/throughput/tokens_per_second"))),
+    );
+    push_number(
+        &mut data,
+        &mut missing,
+        "end_to_end_output_tok_s",
+        bench
+            .pointer("/measurements/summary/end_to_end_output_tok_s")
+            .or_else(|| cli_stage.and_then(|json| json.pointer("/throughput/tokens_per_second"))),
+    );
+    push_number(
+        &mut data,
+        &mut missing,
+        "p50_inter_token_latency_ms",
+        bench.pointer("/measurements/summary/p50_inter_token_latency_ms"),
+    );
+    push_number(
+        &mut data,
+        &mut missing,
+        "p95_inter_token_latency_ms",
+        bench.pointer("/measurements/summary/p95_inter_token_latency_ms"),
+    );
+    data.insert(
+        "stop_reason".to_string(),
+        cli_stage.and_then(|json| json.pointer("/stop_reason")).cloned().unwrap_or(Value::Null),
+    );
+    Section { complete: missing.is_empty(), data, missing }
+}
+
+fn resource_section(bench: &Value, cli_stage: Option<&Value>) -> Section {
+    let mut data = Map::new();
+    let mut missing = Vec::new();
+    for field in
+        ["peak_rss_bytes", "peak_vram_bytes", "host_device_transfer_bytes", "kernel_invocations"]
+    {
+        push_number(
+            &mut data,
+            &mut missing,
+            field,
+            bench.pointer(&format!("/measurements/summary/{field}")).or_else(|| {
+                cli_stage.and_then(|json| json.pointer(&format!("/resource_envelope/{field}")))
+            }),
+        );
+    }
+    data.insert(
+        "resident_ops".to_string(),
+        bench
+            .pointer("/measurements/summary/resident_ops")
+            .or_else(|| cli_stage.and_then(|json| json.pointer("/resource_envelope/resident_ops")))
+            .cloned()
+            .unwrap_or_else(|| {
+                json!({
+                    "qk256_linears": true,
+                    "embedding": true,
+                    "lm_head_tied_logits": true,
+                    "selected_attention": false,
+                    "resident_kv_decode": false
+                })
+            }),
+    );
+    Section { complete: missing.is_empty(), data, missing }
+}
+
+fn collect_section_fields(
+    source: Option<&Value>,
+    data: &mut Map<String, Value>,
+    fields: &[(&str, &str)],
+) -> Vec<String> {
+    let mut missing = Vec::new();
+    for (field, pointer) in fields {
+        if let Some(value) = source.and_then(|json| json.pointer(pointer)).cloned() {
+            data.insert((*field).to_string(), value);
+        } else {
+            missing.push((*field).to_string());
+        }
+    }
+    missing
+}
+
+fn push_number(
+    data: &mut Map<String, Value>,
+    missing: &mut Vec<String>,
+    field: &str,
+    value: Option<&Value>,
+) {
+    if let Some(value) = value.filter(|value| !value.is_null()) {
+        data.insert(field.to_string(), value.clone());
+    } else {
+        data.insert(field.to_string(), Value::Null);
+        missing.push(field.to_string());
+    }
+}
+
+fn section_value(section: Section) -> Value {
+    let mut data = section.data;
+    data.insert("complete".to_string(), Value::Bool(section.complete));
+    data.insert(
+        "missing".to_string(),
+        Value::Array(section.missing.into_iter().map(Value::String).collect()),
+    );
+    Value::Object(data)
+}
+
+fn cli_stage_fields_filled(cli_stage: Option<&Value>) -> Vec<String> {
+    let Some(cli_stage) = cli_stage else {
+        return Vec::new();
+    };
+    [
+        ("tokenizer_load_ms", "/load_timing/tokenizer_load_ms"),
+        ("prompt_render_ms", "/ttft/prompt_render_ms"),
+        ("first_decode_ms", "/ttft/first_decode_ms"),
+        ("latency_decode_first_ms", "/latency/decode_first_ms"),
+        ("peak_rss_bytes", "/resource_envelope/peak_rss_bytes"),
+        ("tokens", "/tokens"),
+        ("throughput", "/throughput"),
+    ]
+    .into_iter()
+    .filter_map(|(field, pointer)| cli_stage.pointer(pointer).map(|_| field.to_string()))
+    .collect()
+}
+
+fn build_verify_report(receipt_path: &Path, value: &Value, require_claimable: bool) -> Value {
+    let mut failures = Vec::new();
+    for pointer in REQUIRED_EXPERIENCE_POINTERS {
+        if value.pointer(pointer).is_none_or(Value::is_null) {
+            failures.push(format!("missing required field {pointer}"));
+        }
+    }
+    if str_at(value, "/receipt_type") != Some("llm_experience_run") {
+        failures.push("receipt_type must be llm_experience_run".to_string());
+    }
+    let not_claims = array_strings(value, "/not_claims");
+    for not_claim in CRITICAL_NOT_CLAIMS {
+        if !not_claims.iter().any(|value| value == not_claim) {
+            failures.push(format!("missing critical not-claim {not_claim}"));
+        }
+    }
+
+    let claim_allowed = bool_at(value, "/claim_gate/claim_allowed").unwrap_or(false);
+    let classification = str_at(value, "/claim_gate/classification").unwrap_or("diagnostic_only");
+    if claim_allowed && classification == "diagnostic_only" {
+        failures.push("claim_allowed=true with diagnostic_only classification".to_string());
+    }
+    if claim_allowed && !bool_at(value, "/quality/passed").unwrap_or(false) {
+        failures.push("claim_allowed=true while quality passed=false".to_string());
+    }
+    if claim_allowed && bool_at(value, "/backend/fallback_used").unwrap_or(true) {
+        failures.push("claim_allowed=true while fallback_used=true".to_string());
+    }
+    if claim_allowed && !bool_at(value, "/kernel_route/route_verified").unwrap_or(false) {
+        failures.push("claim_allowed=true while route_verified=false".to_string());
+    }
+    if require_claimable && !claim_allowed {
+        failures.push("receipt is not claimable but --require-claimable was set".to_string());
+    }
+
+    json!({
+        "diagnostic": "llm_experience_verify",
+        "producer": "cargo xtask llm-experience verify",
+        "receipt_path": receipt_path.display().to_string(),
+        "passed": failures.is_empty(),
+        "claim_allowed": claim_allowed,
+        "classification": classification,
+        "blocked_reasons": value
+            .pointer("/claim_gate/blocked_reasons")
+            .cloned()
+            .unwrap_or_else(|| json!([])),
+        "failures": failures,
+        "not_claims": not_claims,
+    })
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
 fn read_yaml(path: &Path) -> Result<Value> {
     let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     serde_yaml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
@@ -292,6 +886,18 @@ fn read_profiles(path: &Path) -> Result<ProfileTable> {
 
 fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
     value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn bool_at(value: &Value, pointer: &str) -> Option<bool> {
+    value.pointer(pointer).and_then(Value::as_bool)
+}
+
+fn array_strings(value: &Value, pointer: &str) -> Vec<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect())
+        .unwrap_or_default()
 }
 
 fn sha256_text(value: &str) -> String {
@@ -313,8 +919,17 @@ fn emit_value(value: &Value, format: &str) -> Result<()> {
         "json" => println!("{}", serde_json::to_string_pretty(value)?),
         "human" => {
             println!("diagnostic: {}", str_at(value, "/diagnostic").unwrap_or("llm_experience"));
-            if let Some(claimable) = value.pointer("/claimable").and_then(Value::as_bool) {
+            if let Some(claimable) = value
+                .pointer("/claimable")
+                .and_then(Value::as_bool)
+                .or_else(|| value.pointer("/claim_gate/claim_allowed").and_then(Value::as_bool))
+            {
                 println!("claimable: {claimable}");
+            }
+            if let Some(classification) = str_at(value, "/claim_gate/classification")
+                .or_else(|| str_at(value, "/classification"))
+            {
+                println!("classification: {classification}");
             }
             if let Some(profile) = str_at(value, "/profile/id") {
                 println!("profile: {profile}");
@@ -322,7 +937,15 @@ fn emit_value(value: &Value, format: &str) -> Result<()> {
             if let Some(count) = value.pointer("/prompt_identity/prompt_token_count") {
                 println!("prompt_token_count: {count}");
             }
-            println!("not_claims: {}", serde_json::to_string(&value["not_claims"])?);
+            if let Some(blocked) = value
+                .pointer("/claim_gate/blocked_reasons")
+                .or_else(|| value.pointer("/blocked_reasons"))
+            {
+                println!("blocked_reasons: {blocked}");
+            }
+            if let Some(not_claims) = value.pointer("/not_claims") {
+                println!("not_claims: {}", serde_json::to_string(not_claims)?);
+            }
         }
         other => bail!("unsupported llm-experience output format: {other}"),
     }
@@ -363,6 +986,124 @@ mod tests {
         let count =
             count_template_tokens(&prompt, TemplateType::Raw, &tokenizer).expect("prompt count");
         assert_eq!(count, target);
+    }
+
+    #[test]
+    fn manual_dispatch_leaves_profile_plan_to_clap() {
+        let args = vec![
+            "xtask".to_string(),
+            "llm-experience".to_string(),
+            "profile-cli-plan".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        assert!(!maybe_dispatch(&args).expect("dispatch"));
+    }
+
+    #[test]
+    fn diagnostic_parent_keeps_experience_diagnostic() {
+        let receipt = build_experience_receipt(
+            Path::new("bench.json"),
+            &bench_receipt(false),
+            Some(Path::new("cli.json")),
+            Some(&cli_stage()),
+        );
+        assert_eq!(receipt["claim_gate"]["claim_allowed"], false);
+        assert_eq!(receipt["claim_gate"]["classification"], "diagnostic_only");
+        assert!(
+            receipt["claim_gate"]["blocked_reasons"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|reason| reason == "parent_benchmark_not_claim_allowed")
+        );
+    }
+
+    #[test]
+    fn verify_requires_critical_not_claims() {
+        let mut receipt =
+            build_experience_receipt(Path::new("bench.json"), &bench_receipt(false), None, None);
+        receipt["not_claims"] = json!([]);
+        let report = build_verify_report(Path::new("experience.json"), &receipt, false);
+        assert_eq!(report["passed"], false);
+        assert!(
+            report["failures"].as_array().unwrap().iter().any(|failure| {
+                failure.as_str().unwrap().contains("selected_attention_residency")
+            })
+        );
+    }
+
+    fn bench_receipt(parent_claimable: bool) -> Value {
+        json!({
+            "repo": { "commit": "abc", "tree": "def", "dirty": !parent_claimable },
+            "model": { "contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml" },
+            "device": { "device_slug": "amd-5700x-intel-a770" },
+            "kernel_route": {
+                "route_verified": parent_claimable,
+                "device_slug": "amd-5700x-intel-a770"
+            },
+            "backend": {
+                "selected_backend": "intel-arc-a770-opencl",
+                "fallback_used": false
+            },
+            "benchmark_profile": {
+                "id": "prefill_512_decode_64",
+                "profile_hash": "sha256:profile",
+                "profile_identity": { "profile_matched": true }
+            },
+            "quality_gate": {
+                "required": true,
+                "quality_passed": true,
+                "quality_receipt": "quality.json"
+            },
+            "claim_gate": {
+                "benchmark_claim_allowed": parent_claimable,
+                "classification": if parent_claimable { "performance_proven" } else { "diagnostic_only" },
+                "model_contract_matched": true
+            },
+            "measurements": {
+                "summary": {
+                    "prompt_tokens": 512,
+                    "prefill_ms": 4000.0,
+                    "generated_tokens": 64,
+                    "steady_state_output_tok_s": 10.0,
+                    "end_to_end_output_tok_s": 9.0,
+                    "p50_inter_token_latency_ms": 100.0,
+                    "p95_inter_token_latency_ms": 120.0,
+                    "peak_rss_bytes": 100,
+                    "peak_vram_bytes": 200,
+                    "host_device_transfer_bytes": 300,
+                    "kernel_invocations": 4
+                }
+            },
+            "not_claims": CRITICAL_NOT_CLAIMS
+        })
+    }
+
+    fn cli_stage() -> Value {
+        json!({
+            "load_timing": {
+                "cold_total_ms": 1.0,
+                "warm_total_ms": 1.0,
+                "model_open_ms": 1.0,
+                "tokenizer_load_ms": 1.0,
+                "backend_init_ms": 1.0,
+                "kernel_compile_ms": 1.0,
+                "weight_upload_ms": 1.0,
+                "ready_to_generate_ms": 1.0
+            },
+            "ttft": {
+                "end_to_end_ms": 4.0,
+                "prompt_render_ms": 0.1,
+                "tokenization_ms": 0.2,
+                "prefill_ms": 3.0,
+                "first_decode_ms": 0.0,
+                "sampler_ms": 0.1,
+                "stream_first_byte_ms": 4.0
+            },
+            "tokens": { "prompt": 512, "generated": 64 },
+            "throughput": { "tokens_per_second": 10.0 }
+        })
     }
 
     struct CountingTokenizer;

--- a/xtask/src/llm_experience.rs
+++ b/xtask/src/llm_experience.rs
@@ -1,0 +1,397 @@
+use anyhow::{Context, Result, bail};
+use bitnet_prompt_templates::TemplateType;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::Path;
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+];
+
+#[derive(Debug, Deserialize)]
+struct ProfileTable {
+    profile: Vec<BenchProfile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BenchProfile {
+    id: String,
+    #[serde(default)]
+    prompt_tokens: Option<usize>,
+    #[serde(default)]
+    decode_tokens: Option<usize>,
+    #[serde(default)]
+    max_new_tokens: Option<usize>,
+}
+
+pub fn profile_cli_plan(
+    model_contract: &Path,
+    profiles: &Path,
+    profile_id: &str,
+    backend: &str,
+    device_slug: &str,
+    kernel_route: &str,
+    output: Option<&Path>,
+    format: &str,
+) -> Result<()> {
+    let contract = read_yaml(model_contract)?;
+    let profile_table = read_profiles(profiles)?;
+    let profile = profile_table
+        .profile
+        .iter()
+        .find(|profile| profile.id == profile_id)
+        .with_context(|| format!("profile {profile_id} not found in {}", profiles.display()))?;
+    let target_prompt_tokens = profile.prompt_tokens.with_context(|| {
+        format!("profile {profile_id} does not define prompt_tokens for CLI plan synthesis")
+    })?;
+    let max_new_tokens = profile.decode_tokens.or(profile.max_new_tokens).unwrap_or(64);
+    let model_path = str_at(&contract, "/local_path").context("contract missing /local_path")?;
+    let tokenizer_path =
+        str_at(&contract, "/tokenizer/path").context("contract missing /tokenizer/path")?;
+    let template_name = str_at(&contract, "/chat_template/name").unwrap_or("llama3-chat");
+    let template = template_name
+        .parse::<TemplateType>()
+        .with_context(|| format!("parsing chat template {template_name}"))?;
+    let tokenizer = bitnet_tokenizers::load_tokenizer(Path::new(tokenizer_path))
+        .with_context(|| format!("loading tokenizer {}", tokenizer_path))?;
+
+    let user_prompt =
+        synthesize_profile_prompt(target_prompt_tokens, template, tokenizer.as_ref())?;
+    let formatted_prompt = template.apply(&user_prompt, None);
+    let add_bos = template.should_add_bos();
+    let parse_special = template.parse_special();
+    let token_ids = tokenizer
+        .encode(&formatted_prompt, add_bos, parse_special)
+        .with_context(|| "tokenizing synthesized profile prompt")?;
+    if token_ids.len() != target_prompt_tokens {
+        bail!(
+            "profile prompt synthesis produced {} tokens, expected {}",
+            token_ids.len(),
+            target_prompt_tokens
+        );
+    }
+
+    let cli_stage_output = "target/llm-experience/profile-cli-stage.json";
+    let cli_command = build_cli_command(
+        backend,
+        model_path,
+        tokenizer_path,
+        &user_prompt,
+        max_new_tokens,
+        template_name,
+        cli_stage_output,
+        model_contract,
+        kernel_route,
+    );
+
+    let mut not_claims = vec![
+        "profile_cli_plan_proves_quality",
+        "profile_cli_plan_promotes_benchmark_claim",
+        "profile_cli_plan_promotes_residency",
+    ];
+    not_claims.extend_from_slice(CRITICAL_NOT_CLAIMS);
+
+    let plan = json!({
+        "diagnostic": "llm_experience_profile_cli_plan",
+        "producer": "cargo xtask llm-experience profile-cli-plan",
+        "diagnostic_only": true,
+        "claimable": false,
+        "model_contract": model_contract.display().to_string(),
+        "model_path": model_path,
+        "tokenizer_path": tokenizer_path,
+        "backend": backend,
+        "device_slug": device_slug,
+        "kernel_route": {
+            "route_id": kernel_route,
+            "diagnostic_only": true,
+            "claimable": false
+        },
+        "profile": {
+            "id": profile.id.as_str(),
+            "target_prompt_tokens": target_prompt_tokens,
+            "max_new_tokens": max_new_tokens,
+        },
+        "prompt_identity": {
+            "prompt_template": template_name,
+            "add_bos": add_bos,
+            "parse_special": parse_special,
+            "rendered_prompt_sha256": sha256_text(&formatted_prompt),
+            "prompt_token_ids_sha256": sha256_token_ids(&token_ids)?,
+            "prompt_token_count": token_ids.len(),
+        },
+        "prompt": user_prompt,
+        "cli_command": cli_command,
+        "not_claims": not_claims,
+    });
+
+    if let Some(output) = output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(output, serde_json::to_vec_pretty(&plan)?)
+            .with_context(|| format!("writing {}", output.display()))?;
+    }
+    emit_value(&plan, format)
+}
+
+fn build_cli_command(
+    backend: &str,
+    model_path: &str,
+    tokenizer_path: &str,
+    user_prompt: &str,
+    max_new_tokens: usize,
+    template_name: &str,
+    cli_stage_output: &str,
+    model_contract: &Path,
+    kernel_route: &str,
+) -> Vec<String> {
+    vec![
+        "cargo".to_string(),
+        "run".to_string(),
+        "--locked".to_string(),
+        "-p".to_string(),
+        "bitnet-cli".to_string(),
+        "--no-default-features".to_string(),
+        "--features".to_string(),
+        "cpu".to_string(),
+        "--".to_string(),
+        "--device".to_string(),
+        backend.to_string(),
+        "run".to_string(),
+        "--model".to_string(),
+        model_path.to_string(),
+        "--tokenizer".to_string(),
+        tokenizer_path.to_string(),
+        "--prompt".to_string(),
+        user_prompt.to_string(),
+        "--max-new-tokens".to_string(),
+        max_new_tokens.to_string(),
+        "--temperature".to_string(),
+        "0.0".to_string(),
+        "--greedy".to_string(),
+        "--deterministic".to_string(),
+        "--strict-tokenizer".to_string(),
+        "--strict-loader".to_string(),
+        "--prompt-template".to_string(),
+        template_name.to_string(),
+        "--json-out".to_string(),
+        cli_stage_output.to_string(),
+        "--proof-model-contract".to_string(),
+        model_contract.display().to_string(),
+        "--proof-kernel-route".to_string(),
+        kernel_route.to_string(),
+    ]
+}
+
+fn synthesize_profile_prompt(
+    target_prompt_tokens: usize,
+    template: TemplateType,
+    tokenizer: &(dyn bitnet_tokenizers::Tokenizer + Send + Sync),
+) -> Result<String> {
+    let mut prompt = "Answer this real local model check question in a concise paragraph. Explain why receipt-backed model contracts, route identity, quality gates, and explicit not-claims make a local LLM benchmark trustworthy.".to_string();
+    let mut current = count_template_tokens(&prompt, template, tokenizer)?;
+    if current > target_prompt_tokens {
+        bail!(
+            "base profile prompt has {current} tokens, target profile has {target_prompt_tokens}"
+        );
+    }
+    let fillers = [
+        " Include the model contract.",
+        " Include the tokenizer hash.",
+        " Include the prompt token hash.",
+        " Include the A770 route.",
+        " Include fallback status.",
+        " Include quality evidence.",
+        " Include load timing.",
+        " Include TTFT.",
+        " Include input speed.",
+        " Include output speed.",
+        " Include RSS.",
+        " Include VRAM.",
+        " Include transfer bytes.",
+        " Include kernel counts.",
+        " Include history.",
+        " Include not-claims.",
+        " State the claim boundary.",
+        " Keep selected attention deferred.",
+        " Keep resident KV unclaimed.",
+        " Keep full residency unclaimed.",
+        " receipt",
+        " route",
+        " token",
+        " model",
+        " proof",
+        " quality",
+        " benchmark",
+        " history",
+        " resource",
+        " fallback",
+        ".",
+        " a",
+        " the",
+        " and",
+    ];
+
+    let mut cursor = 0usize;
+    while current < target_prompt_tokens {
+        let mut chosen: Option<(&str, usize, usize)> = None;
+        for offset in 0..fillers.len() {
+            let index = (cursor + offset) % fillers.len();
+            let filler = fillers[index];
+            let candidate = format!("{prompt}{filler}");
+            let count = count_template_tokens(&candidate, template, tokenizer)?;
+            if count > current && count <= target_prompt_tokens {
+                chosen = Some((filler, count, index));
+                break;
+            }
+        }
+        if let Some((filler, count, index)) = chosen {
+            prompt.push_str(filler);
+            current = count;
+            cursor = index + 1;
+        } else {
+            bail!(
+                "could not synthesize exact {target_prompt_tokens}-token prompt; stopped at {current}"
+            );
+        }
+    }
+
+    Ok(prompt)
+}
+
+fn count_template_tokens(
+    user_prompt: &str,
+    template: TemplateType,
+    tokenizer: &(dyn bitnet_tokenizers::Tokenizer + Send + Sync),
+) -> Result<usize> {
+    let formatted = template.apply(user_prompt, None);
+    Ok(tokenizer
+        .encode(&formatted, template.should_add_bos(), template.parse_special())
+        .with_context(|| "tokenizing profile prompt candidate")?
+        .len())
+}
+
+fn read_yaml(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_yaml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn read_profiles(path: &Path) -> Result<ProfileTable> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn sha256_text(value: &str) -> String {
+    sha256_bytes(value.as_bytes())
+}
+
+fn sha256_token_ids(tokens: &[u32]) -> Result<String> {
+    Ok(sha256_bytes(&serde_json::to_vec(tokens)?))
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
+fn emit_value(value: &Value, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(value)?),
+        "human" => {
+            println!("diagnostic: {}", str_at(value, "/diagnostic").unwrap_or("llm_experience"));
+            if let Some(claimable) = value.pointer("/claimable").and_then(Value::as_bool) {
+                println!("claimable: {claimable}");
+            }
+            if let Some(profile) = str_at(value, "/profile/id") {
+                println!("profile: {profile}");
+            }
+            if let Some(count) = value.pointer("/prompt_identity/prompt_token_count") {
+                println!("prompt_token_count: {count}");
+            }
+            println!("not_claims: {}", serde_json::to_string(&value["not_claims"])?);
+        }
+        other => bail!("unsupported llm-experience output format: {other}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_command_binds_proof_identity() {
+        let command = build_cli_command(
+            "intel-arc-a770-opencl",
+            "models/model.gguf",
+            "models/tokenizer.json",
+            "prompt",
+            64,
+            "llama3-chat",
+            "target/llm-experience/profile-cli-stage.json",
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+            "a770.bitnet.i2s.qk256",
+        );
+        assert!(command.windows(2).any(|args| args == ["--device", "intel-arc-a770-opencl"]));
+        assert!(command.iter().any(|arg| arg == "--proof-model-contract"));
+        assert!(command.iter().any(|arg| arg == "--proof-kernel-route"));
+        assert!(command.iter().any(|arg| arg == "a770.bitnet.i2s.qk256"));
+    }
+
+    #[test]
+    fn synthesizes_exact_target_when_base_matches() {
+        let tokenizer = CountingTokenizer;
+        let base = "Answer this real local model check question in a concise paragraph. Explain why receipt-backed model contracts, route identity, quality gates, and explicit not-claims make a local LLM benchmark trustworthy.";
+        let target =
+            count_template_tokens(base, TemplateType::Raw, &tokenizer).expect("base token count");
+        let prompt = synthesize_profile_prompt(target, TemplateType::Raw, &tokenizer)
+            .expect("synthesize prompt");
+        let count =
+            count_template_tokens(&prompt, TemplateType::Raw, &tokenizer).expect("prompt count");
+        assert_eq!(count, target);
+    }
+
+    struct CountingTokenizer;
+
+    impl bitnet_tokenizers::Tokenizer for CountingTokenizer {
+        fn encode(
+            &self,
+            text: &str,
+            add_bos: bool,
+            _add_special: bool,
+        ) -> bitnet_common::Result<Vec<u32>> {
+            let mut tokens = Vec::new();
+            if add_bos {
+                tokens.push(1);
+            }
+            tokens.extend((0..text.split_whitespace().count()).map(|index| index as u32 + 2));
+            Ok(tokens)
+        }
+
+        fn decode(&self, tokens: &[u32]) -> bitnet_common::Result<String> {
+            Ok(tokens.iter().map(u32::to_string).collect::<Vec<_>>().join(" "))
+        }
+
+        fn vocab_size(&self) -> usize {
+            1024
+        }
+
+        fn token_to_piece(&self, token: u32) -> Option<String> {
+            Some(token.to_string())
+        }
+    }
+}

--- a/xtask/src/llm_experience.rs
+++ b/xtask/src/llm_experience.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
 
 const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "selected_attention_residency",
@@ -20,6 +21,7 @@ const CRITICAL_NOT_CLAIMS: &[&str] = &[
 const REQUIRED_EXPERIENCE_POINTERS: &[&str] = &[
     "/schema_version",
     "/receipt_type",
+    "/run_id",
     "/producer",
     "/repo",
     "/model",
@@ -95,9 +97,43 @@ fn maybe_dispatch(args: &[String]) -> Result<bool> {
             verify(&opts.receipt, &opts.format, opts.require_claimable)?;
             Ok(true)
         }
+        Some("publish") => {
+            if args[3..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_publish_help();
+                return Ok(true);
+            }
+            let opts = parse_publish_args(&args[3..])?;
+            publish(&opts.receipt, &opts.history_root, &opts.format)?;
+            Ok(true)
+        }
+        Some("compare") => {
+            if args[3..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_compare_help();
+                return Ok(true);
+            }
+            let opts = parse_compare_args(&args[3..])?;
+            compare(
+                &opts.history_root,
+                &opts.device,
+                &opts.profile,
+                opts.require_same_route,
+                opts.require_claim_ready,
+                &opts.format,
+            )?;
+            Ok(true)
+        }
+        Some("docs") => {
+            if args[3..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_docs_help();
+                return Ok(true);
+            }
+            let opts = parse_docs_args(&args[3..])?;
+            docs(&opts.history_root, &opts.output, opts.check, &opts.format)?;
+            Ok(true)
+        }
         Some("profile-cli-plan") | Some("-h") | Some("--help") | None => Ok(false),
         Some(other) => bail!(
-            "unknown llm-experience subcommand {other}; supported manual subcommands: run, verify"
+            "unknown llm-experience subcommand {other}; supported manual subcommands: run, verify, publish, compare, docs"
         ),
     }
 }
@@ -114,6 +150,31 @@ struct RunArgs {
 struct VerifyArgs {
     receipt: PathBuf,
     require_claimable: bool,
+    format: String,
+}
+
+#[derive(Debug)]
+struct PublishArgs {
+    receipt: PathBuf,
+    history_root: PathBuf,
+    format: String,
+}
+
+#[derive(Debug)]
+struct CompareArgs {
+    history_root: PathBuf,
+    device: String,
+    profile: String,
+    require_same_route: bool,
+    require_claim_ready: bool,
+    format: String,
+}
+
+#[derive(Debug)]
+struct DocsArgs {
+    history_root: PathBuf,
+    output: PathBuf,
+    check: bool,
     format: String,
 }
 
@@ -178,6 +239,101 @@ fn parse_verify_args(args: &[String]) -> Result<VerifyArgs> {
     Ok(opts)
 }
 
+fn parse_publish_args(args: &[String]) -> Result<PublishArgs> {
+    let mut opts = PublishArgs {
+        receipt: PathBuf::from("target/llm-experience/a770-bitnet-profile-stage.json"),
+        history_root: PathBuf::from("target/llm-experience-history"),
+        format: "human".to_string(),
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--receipt" => {
+                index += 1;
+                opts.receipt = PathBuf::from(required_value(args, index, "--receipt")?);
+            }
+            "--history-root" => {
+                index += 1;
+                opts.history_root = PathBuf::from(required_value(args, index, "--history-root")?);
+            }
+            "--format" => {
+                index += 1;
+                opts.format = required_value(args, index, "--format")?.to_string();
+            }
+            other => bail!("unknown llm-experience publish option {other}"),
+        }
+        index += 1;
+    }
+    Ok(opts)
+}
+
+fn parse_compare_args(args: &[String]) -> Result<CompareArgs> {
+    let mut opts = CompareArgs {
+        history_root: PathBuf::from("target/llm-experience-history"),
+        device: "amd-5700x-intel-a770".to_string(),
+        profile: "prefill_512_decode_64".to_string(),
+        require_same_route: false,
+        require_claim_ready: false,
+        format: "human".to_string(),
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--history-root" => {
+                index += 1;
+                opts.history_root = PathBuf::from(required_value(args, index, "--history-root")?);
+            }
+            "--device" => {
+                index += 1;
+                opts.device = required_value(args, index, "--device")?.to_string();
+            }
+            "--profile" => {
+                index += 1;
+                opts.profile = required_value(args, index, "--profile")?.to_string();
+            }
+            "--require-same-route" => opts.require_same_route = true,
+            "--require-claim-ready" => opts.require_claim_ready = true,
+            "--format" => {
+                index += 1;
+                opts.format = required_value(args, index, "--format")?.to_string();
+            }
+            other => bail!("unknown llm-experience compare option {other}"),
+        }
+        index += 1;
+    }
+    Ok(opts)
+}
+
+fn parse_docs_args(args: &[String]) -> Result<DocsArgs> {
+    let mut opts = DocsArgs {
+        history_root: PathBuf::from("target/llm-experience-history"),
+        output: PathBuf::from("docs/benchmarks/llm-experience.md"),
+        check: false,
+        format: "human".to_string(),
+    };
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--history-root" => {
+                index += 1;
+                opts.history_root = PathBuf::from(required_value(args, index, "--history-root")?);
+            }
+            "--output" => {
+                index += 1;
+                opts.output = PathBuf::from(required_value(args, index, "--output")?);
+            }
+            "--check" => opts.check = true,
+            "--format" => {
+                index += 1;
+                opts.format = required_value(args, index, "--format")?.to_string();
+            }
+            other => bail!("unknown llm-experience docs option {other}"),
+        }
+        index += 1;
+    }
+    Ok(opts)
+}
+
 fn required_value<'a>(args: &'a [String], index: usize, flag: &str) -> Result<&'a str> {
     args.get(index)
         .map(String::as_str)
@@ -194,6 +350,24 @@ fn print_run_help() {
 fn print_verify_help() {
     println!(
         "Verify an LLM experience receipt\n\nUsage: xtask.exe llm-experience verify [OPTIONS]\n\nOptions:\n      --receipt <PATH>             Experience receipt [default: target/llm-experience/a770-bitnet-profile-stage.json]\n      --require-claimable          Fail if receipt is diagnostic-only\n      --format <FORMAT>            human or json [default: human]\n  -h, --help                       Print help"
+    );
+}
+
+fn print_publish_help() {
+    println!(
+        "Publish an LLM experience receipt to local history\n\nUsage: xtask.exe llm-experience publish [OPTIONS]\n\nOptions:\n      --receipt <PATH>             Experience receipt [default: target/llm-experience/a770-bitnet-profile-stage.json]\n      --history-root <PATH>        History root [default: target/llm-experience-history]\n      --format <FORMAT>            human or json [default: human]\n  -h, --help                       Print help"
+    );
+}
+
+fn print_compare_help() {
+    println!(
+        "Compare LLM experience history for same-device/same-route readiness\n\nUsage: xtask.exe llm-experience compare [OPTIONS]\n\nOptions:\n      --history-root <PATH>        History root [default: target/llm-experience-history]\n      --device <SLUG>              Device slug [default: amd-5700x-intel-a770]\n      --profile <ID>               Benchmark profile [default: prefill_512_decode_64]\n      --require-same-route         Fail unless the latest pair is same-route comparable\n      --require-claim-ready        Fail unless both receipts are claim-ready\n      --format <FORMAT>            human or json [default: human]\n  -h, --help                       Print help"
+    );
+}
+
+fn print_docs_help() {
+    println!(
+        "Generate LLM experience dashboard docs from local history\n\nUsage: xtask.exe llm-experience docs [OPTIONS]\n\nOptions:\n      --history-root <PATH>        History root [default: target/llm-experience-history]\n      --output <PATH>              Markdown output [default: docs/benchmarks/llm-experience.md]\n      --check                      Fail if output is stale\n      --format <FORMAT>            human or json [default: human]\n  -h, --help                       Print help"
     );
 }
 
@@ -337,6 +511,98 @@ pub fn verify(receipt: &Path, format: &str, require_claimable: bool) -> Result<(
     Ok(())
 }
 
+pub fn publish(receipt: &Path, history_root: &Path, format: &str) -> Result<()> {
+    let value = read_json(receipt)?;
+    let commit = str_at(&value, "/repo/commit").unwrap_or("unknown-commit");
+    let device = str_at(&value, "/device/device_slug").unwrap_or("unknown-device");
+    let profile = str_at(&value, "/benchmark_profile/id").unwrap_or("unknown-profile");
+    let run_id = run_id(&value);
+    let output = history_root
+        .join("runs")
+        .join(sanitize_path_component(commit))
+        .join(sanitize_path_component(device))
+        .join(sanitize_path_component(profile))
+        .join(format!("{}.json", sanitize_path_component(&run_id)));
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::copy(receipt, &output)
+        .with_context(|| format!("copying {} to {}", receipt.display(), output.display()))?;
+    let report = json!({
+        "diagnostic": "llm_experience_publish",
+        "producer": "cargo xtask llm-experience publish",
+        "receipt": receipt.display().to_string(),
+        "history_root": history_root.display().to_string(),
+        "published_path": output.display().to_string(),
+        "run_id": run_id,
+        "claim_allowed": bool_at(&value, "/claim_gate/claim_allowed").unwrap_or(false),
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    });
+    emit_value(&report, format)
+}
+
+pub fn compare(
+    history_root: &Path,
+    device: &str,
+    profile: &str,
+    require_same_route: bool,
+    require_claim_ready: bool,
+    format: &str,
+) -> Result<()> {
+    let mut receipts = history_receipts(history_root, device, profile)?;
+    receipts.sort_by(|left, right| left.path.cmp(&right.path));
+    let report = build_compare_report(
+        history_root,
+        device,
+        profile,
+        require_same_route,
+        require_claim_ready,
+        &receipts,
+    );
+    emit_value(&report, format)?;
+    if !report["passed"].as_bool().unwrap_or(false) {
+        bail!("llm-experience compare failed: {}", report["failures"]);
+    }
+    Ok(())
+}
+
+pub fn docs(history_root: &Path, output: &Path, check: bool, format: &str) -> Result<()> {
+    let receipts = all_history_receipts(history_root)?;
+    let rendered = render_history_docs(history_root, &receipts);
+    if check {
+        let existing = fs::read_to_string(output).unwrap_or_default();
+        let passed = existing == rendered;
+        let report = json!({
+            "diagnostic": "llm_experience_docs",
+            "producer": "cargo xtask llm-experience docs",
+            "check": true,
+            "passed": passed,
+            "output": output.display().to_string(),
+            "history_root": history_root.display().to_string(),
+            "receipt_count": receipts.len(),
+        });
+        emit_value(&report, format)?;
+        if !passed {
+            bail!("LLM experience docs are stale: {}", output.display());
+        }
+        return Ok(());
+    }
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(output, rendered).with_context(|| format!("writing {}", output.display()))?;
+    let report = json!({
+        "diagnostic": "llm_experience_docs",
+        "producer": "cargo xtask llm-experience docs",
+        "check": false,
+        "passed": true,
+        "output": output.display().to_string(),
+        "history_root": history_root.display().to_string(),
+        "receipt_count": receipts.len(),
+    });
+    emit_value(&report, format)
+}
+
 fn build_experience_receipt(
     bench_path: &Path,
     bench: &Value,
@@ -404,6 +670,7 @@ fn build_experience_receipt(
     json!({
         "schema_version": 1,
         "receipt_type": "llm_experience_run",
+        "run_id": str_at(bench, "/run_id").unwrap_or("unknown-run"),
         "producer": "cargo xtask llm-experience run",
         "created_at": chrono::Utc::now().to_rfc3339(),
         "source_receipts": {
@@ -869,6 +1136,213 @@ fn build_verify_report(receipt_path: &Path, value: &Value, require_claimable: bo
     })
 }
 
+#[derive(Debug, Clone)]
+struct HistoryReceipt {
+    path: PathBuf,
+    value: Value,
+}
+
+fn history_receipts(
+    history_root: &Path,
+    device: &str,
+    profile: &str,
+) -> Result<Vec<HistoryReceipt>> {
+    let root = history_root.join("runs");
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut receipts = Vec::new();
+    for entry in WalkDir::new(&root).into_iter().filter_map(|entry| entry.ok()) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let value = read_json(entry.path())?;
+        if str_at(&value, "/device/device_slug") == Some(device)
+            && str_at(&value, "/benchmark_profile/id") == Some(profile)
+        {
+            receipts.push(HistoryReceipt { path: entry.path().to_path_buf(), value });
+        }
+    }
+    Ok(receipts)
+}
+
+fn all_history_receipts(history_root: &Path) -> Result<Vec<HistoryReceipt>> {
+    let root = history_root.join("runs");
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut receipts = Vec::new();
+    for entry in WalkDir::new(&root).into_iter().filter_map(|entry| entry.ok()) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        receipts.push(HistoryReceipt {
+            path: entry.path().to_path_buf(),
+            value: read_json(entry.path())?,
+        });
+    }
+    receipts.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(receipts)
+}
+
+fn build_compare_report(
+    history_root: &Path,
+    device: &str,
+    profile: &str,
+    require_same_route: bool,
+    require_claim_ready: bool,
+    receipts: &[HistoryReceipt],
+) -> Value {
+    let mut failures = Vec::new();
+    if receipts.len() < 2 {
+        failures.push("history_pair_missing".to_string());
+        return json!({
+            "diagnostic": "llm_experience_compare",
+            "producer": "cargo xtask llm-experience compare",
+            "history_root": history_root.display().to_string(),
+            "device": device,
+            "profile": profile,
+            "passed": false,
+            "comparison_classification": "diagnostic_only",
+            "receipt_count": receipts.len(),
+            "failures": failures,
+            "not_claims": CRITICAL_NOT_CLAIMS,
+        });
+    }
+
+    let left = &receipts[receipts.len() - 2];
+    let right = &receipts[receipts.len() - 1];
+    let left_run_id = run_id(&left.value);
+    let right_run_id = run_id(&right.value);
+    let distinct_paths = left.path != right.path;
+    let distinct_run_ids = !left_run_id.is_empty()
+        && !right_run_id.is_empty()
+        && left_run_id != "unknown-run"
+        && right_run_id != "unknown-run"
+        && left_run_id != right_run_id;
+    let same_device =
+        str_at(&left.value, "/device/device_slug") == str_at(&right.value, "/device/device_slug");
+    let same_backend = str_at(&left.value, "/backend/selected_backend")
+        == str_at(&right.value, "/backend/selected_backend");
+    let same_route = route_key(&left.value) == route_key(&right.value);
+    let left_claim_ready = bool_at(&left.value, "/claim_gate/claim_allowed").unwrap_or(false);
+    let right_claim_ready = bool_at(&right.value, "/claim_gate/claim_allowed").unwrap_or(false);
+    let claim_ready_pair = left_claim_ready && right_claim_ready;
+
+    let comparison_classification = if !distinct_paths || !distinct_run_ids {
+        "self_comparison_not_regression_comparable"
+    } else if same_device && same_backend && same_route && claim_ready_pair {
+        "same_device_same_route_regression"
+    } else if same_device && same_backend && same_route {
+        "same_device_same_route_diagnostic"
+    } else if same_device && same_backend {
+        "same_device_route_changed"
+    } else {
+        "diagnostic_only"
+    };
+
+    if require_same_route
+        && !(same_device && same_backend && same_route && distinct_paths && distinct_run_ids)
+    {
+        failures.push("same_route_history_not_ready".to_string());
+    }
+    if require_claim_ready && !claim_ready_pair {
+        failures.push("claim_ready_history_not_ready".to_string());
+    }
+    if !distinct_paths {
+        failures.push("history_receipt_paths_not_distinct".to_string());
+    }
+    if !distinct_run_ids {
+        failures.push("history_run_ids_not_distinct".to_string());
+    }
+
+    json!({
+        "diagnostic": "llm_experience_compare",
+        "producer": "cargo xtask llm-experience compare",
+        "history_root": history_root.display().to_string(),
+        "device": device,
+        "profile": profile,
+        "passed": failures.is_empty(),
+        "comparison_classification": comparison_classification,
+        "receipt_count": receipts.len(),
+        "left": {
+            "path": left.path.display().to_string(),
+            "run_id": left_run_id,
+            "claim_allowed": left_claim_ready,
+            "route_key": route_key(&left.value),
+        },
+        "right": {
+            "path": right.path.display().to_string(),
+            "run_id": right_run_id,
+            "claim_allowed": right_claim_ready,
+            "route_key": route_key(&right.value),
+        },
+        "same_device": same_device,
+        "same_backend": same_backend,
+        "same_route": same_route,
+        "distinct_paths": distinct_paths,
+        "distinct_run_ids": distinct_run_ids,
+        "claim_ready_pair": claim_ready_pair,
+        "failures": failures,
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    })
+}
+
+fn render_history_docs(history_root: &Path, receipts: &[HistoryReceipt]) -> String {
+    let mut out = String::new();
+    out.push_str("# LLM Experience History\n\n");
+    out.push_str(&format!("History root: `{}`\n\n", history_root.display()));
+    out.push_str("| Device | Profile | Backend | Claim | Run ID | Receipt |\n");
+    out.push_str("| --- | --- | --- | --- | --- | --- |\n");
+    for receipt in receipts {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} |\n",
+            str_at(&receipt.value, "/device/device_slug").unwrap_or("unknown-device"),
+            str_at(&receipt.value, "/benchmark_profile/id").unwrap_or("unknown-profile"),
+            str_at(&receipt.value, "/backend/selected_backend").unwrap_or("unknown-backend"),
+            bool_at(&receipt.value, "/claim_gate/claim_allowed").unwrap_or(false),
+            run_id(&receipt.value),
+            receipt.path.display()
+        ));
+    }
+    out.push_str("\nNot claimed: selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, completion.\n");
+    out
+}
+
+fn run_id(value: &Value) -> String {
+    str_at(value, "/run_id")
+        .or_else(|| str_at(value, "/source_receipts/parent_run_id"))
+        .or_else(|| str_at(value, "/source_receipts/bench_run_id"))
+        .or_else(|| str_at(value, "/benchmark_profile/run_id"))
+        .unwrap_or("unknown-run")
+        .to_string()
+}
+
+fn route_key(value: &Value) -> String {
+    str_at(value, "/kernel_route/declared_route_id")
+        .or_else(|| str_at(value, "/kernel_route/route_id"))
+        .or_else(|| str_at(value, "/kernel_route/selected_backend"))
+        .or_else(|| str_at(value, "/backend/selected_backend"))
+        .unwrap_or("unknown-route")
+        .to_string()
+}
+
+fn sanitize_path_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '_',
+        })
+        .collect()
+}
+
 fn read_json(path: &Path) -> Result<Value> {
     let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
@@ -1033,8 +1507,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn compare_rejects_self_history() {
+        let receipt = build_experience_receipt(
+            Path::new("bench.json"),
+            &bench_receipt(false),
+            Some(Path::new("cli.json")),
+            Some(&cli_stage()),
+        );
+        let receipts = vec![
+            HistoryReceipt { path: PathBuf::from("same.json"), value: receipt.clone() },
+            HistoryReceipt { path: PathBuf::from("same.json"), value: receipt },
+        ];
+        let report = build_compare_report(
+            Path::new("history"),
+            "amd-5700x-intel-a770",
+            "prefill_512_decode_64",
+            true,
+            true,
+            &receipts,
+        );
+        assert_eq!(
+            report["comparison_classification"],
+            "self_comparison_not_regression_comparable"
+        );
+        assert_eq!(report["passed"], false);
+        assert!(
+            report["failures"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|failure| { failure == "history_receipt_paths_not_distinct" })
+        );
+    }
+
     fn bench_receipt(parent_claimable: bool) -> Value {
         json!({
+            "run_id": if parent_claimable { "claimable-run" } else { "diagnostic-run" },
             "repo": { "commit": "abc", "tree": "def", "dirty": !parent_claimable },
             "model": { "contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml" },
             "device": { "device_slug": "amd-5700x-intel-a770" },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,6 +45,7 @@ pub mod ffi;
 mod gates;
 mod grid_check;
 mod hardware;
+mod llm_experience;
 mod model_contract;
 #[allow(dead_code)]
 mod health_check;
@@ -308,6 +309,13 @@ enum Cmd {
     Claims {
         #[command(subcommand)]
         cmd: ClaimsCmd,
+    },
+
+    /// Generate and verify LLM experience proof artifacts.
+    #[command(name = "llm-experience")]
+    LlmExperience {
+        #[command(subcommand)]
+        cmd: LlmExperienceCmd,
     },
 
     /// Verify hardware claim rails and resolve device-specific kernel routes.
@@ -1161,6 +1169,38 @@ enum ClaimsCmd {
 }
 
 #[derive(Subcommand)]
+enum LlmExperienceCmd {
+    /// Generate an exact-token CLI-stage plan for an experience benchmark profile.
+    #[command(name = "profile-cli-plan")]
+    ProfileCliPlan {
+        /// Model contract YAML file.
+        #[arg(long, default_value = "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml")]
+        model_contract: PathBuf,
+        /// Benchmark profiles TOML file.
+        #[arg(long, default_value = "ci/benchmarks/profiles.toml")]
+        profiles: PathBuf,
+        /// Benchmark profile ID to synthesize.
+        #[arg(long, default_value = "prefill_512_decode_64")]
+        profile: String,
+        /// Planned backend for the generated CLI command.
+        #[arg(long, default_value = "intel-arc-a770-opencl")]
+        backend: String,
+        /// Concrete device slug for the generated proof plan.
+        #[arg(long, default_value = "amd-5700x-intel-a770")]
+        device_slug: String,
+        /// Declared kernel route ID for diagnostic proof binding.
+        #[arg(long, default_value = "a770.bitnet.i2s.qk256")]
+        kernel_route: String,
+        /// Output plan JSON file.
+        #[arg(long, default_value = "target/llm-experience/profile-cli-stage-plan.json")]
+        output: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum HardwareCmd {
     /// Intel Arc A770 hardware claim checks.
     A770 {
@@ -1382,6 +1422,27 @@ fn real_main() -> Result<()> {
             ClaimsCmd::Docs { ledger, output, check, format } => {
                 claims::docs(&ledger, &output, check, &format)
             }
+        },
+        Cmd::LlmExperience { cmd } => match cmd {
+            LlmExperienceCmd::ProfileCliPlan {
+                model_contract,
+                profiles,
+                profile,
+                backend,
+                device_slug,
+                kernel_route,
+                output,
+                format,
+            } => llm_experience::profile_cli_plan(
+                &model_contract,
+                &profiles,
+                &profile,
+                &backend,
+                &device_slug,
+                &kernel_route,
+                Some(&output),
+                &format,
+            ),
         },
         Cmd::Hardware { cmd } => match cmd {
             HardwareCmd::A770 { cmd } => match cmd {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,6 +37,7 @@ use std::{
 use walkdir::WalkDir;
 
 mod campaign;
+mod bench_receipt;
 mod cpp_setup_auto;
 mod crossval;
 pub mod ffi;
@@ -294,6 +295,12 @@ enum Cmd {
     PromptSuite {
         #[command(subcommand)]
         cmd: PromptSuiteCmd,
+    },
+
+    /// Verify quality-gated benchmark receipts.
+    Bench {
+        #[command(subcommand)]
+        cmd: BenchCmd,
     },
 
     /// Verify hardware claim rails and resolve device-specific kernel routes.
@@ -1070,6 +1077,23 @@ enum PromptSuiteCmd {
 }
 
 #[derive(Subcommand)]
+enum BenchCmd {
+    /// Verify a quality-gated benchmark receipt.
+    #[command(name = "verify-receipt")]
+    VerifyReceipt {
+        /// Benchmark receipt JSON file.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Require the receipt to be claimable, not merely well-formed diagnostic evidence.
+        #[arg(long, default_value_t = false)]
+        require_claimable: bool,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum HardwareCmd {
     /// Intel Arc A770 hardware claim checks.
     A770 {
@@ -1260,6 +1284,11 @@ fn real_main() -> Result<()> {
             PromptSuiteCmd::Verify { suite, format } => prompt_suite::verify_suite(&suite, &format),
             PromptSuiteCmd::Render { suite, model_contract, format } => {
                 prompt_suite::render_suite(&suite, model_contract.as_deref(), &format)
+            }
+        },
+        Cmd::Bench { cmd } => match cmd {
+            BenchCmd::VerifyReceipt { receipt, require_claimable, format } => {
+                bench_receipt::verify_receipt(&receipt, &format, require_claimable)
             }
         },
         Cmd::Hardware { cmd } => match cmd {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,6 +39,7 @@ use walkdir::WalkDir;
 mod campaign;
 mod bench_receipt;
 mod cpp_setup_auto;
+mod claims;
 mod crossval;
 pub mod ffi;
 mod gates;
@@ -301,6 +302,12 @@ enum Cmd {
     Bench {
         #[command(subcommand)]
         cmd: BenchCmd,
+    },
+
+    /// Verify public claim ledgers and generated claim docs.
+    Claims {
+        #[command(subcommand)]
+        cmd: ClaimsCmd,
     },
 
     /// Verify hardware claim rails and resolve device-specific kernel routes.
@@ -1094,6 +1101,40 @@ enum BenchCmd {
 }
 
 #[derive(Subcommand)]
+enum ClaimsCmd {
+    /// Verify the claim ledger against capability matrices and claim policy.
+    Verify {
+        /// Claim ledger JSON file.
+        #[arg(long, default_value = "ci/claims/claim-ledger.json")]
+        ledger: PathBuf,
+        /// A770 kernel capability matrix JSON file.
+        #[arg(
+            long,
+            default_value = "ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json"
+        )]
+        a770_capability_matrix: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+    /// Render or check generated claim documentation.
+    Docs {
+        /// Claim ledger JSON file.
+        #[arg(long, default_value = "ci/claims/claim-ledger.json")]
+        ledger: PathBuf,
+        /// Output Markdown path.
+        #[arg(long, default_value = "docs/claims.md")]
+        output: PathBuf,
+        /// Check mode: fail if docs are stale.
+        #[arg(long, default_value_t = false)]
+        check: bool,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum HardwareCmd {
     /// Intel Arc A770 hardware claim checks.
     A770 {
@@ -1289,6 +1330,14 @@ fn real_main() -> Result<()> {
         Cmd::Bench { cmd } => match cmd {
             BenchCmd::VerifyReceipt { receipt, require_claimable, format } => {
                 bench_receipt::verify_receipt(&receipt, &format, require_claimable)
+            }
+        },
+        Cmd::Claims { cmd } => match cmd {
+            ClaimsCmd::Verify { ledger, a770_capability_matrix, format } => {
+                claims::verify(&ledger, &a770_capability_matrix, &format)
+            }
+            ClaimsCmd::Docs { ledger, output, check, format } => {
+                claims::docs(&ledger, &output, check, &format)
             }
         },
         Cmd::Hardware { cmd } => match cmd {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -49,6 +49,7 @@ mod health_check;
 #[allow(dead_code)]
 mod model_info;
 mod model_registry;
+mod prompt_suite;
 mod tokenizers;
 mod trace_diff;
 
@@ -286,6 +287,13 @@ enum Cmd {
     ModelContract {
         #[command(subcommand)]
         cmd: ModelContractCmd,
+    },
+
+    /// Verify and render deterministic prompt-suite artifacts.
+    #[command(name = "prompt-suite")]
+    PromptSuite {
+        #[command(subcommand)]
+        cmd: PromptSuiteCmd,
     },
 
     /// Verify hardware claim rails and resolve device-specific kernel routes.
@@ -1037,6 +1045,31 @@ enum ModelContractCmd {
 }
 
 #[derive(Subcommand)]
+enum PromptSuiteCmd {
+    /// Verify deterministic prompt-suite policy.
+    Verify {
+        /// Prompt suite TOML file.
+        #[arg(long, default_value = "ci/prompt-suites/seeded-v1.toml")]
+        suite: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+    /// Render prompt-suite cases and emit stable prompt/token hashes.
+    Render {
+        /// Prompt suite TOML file.
+        #[arg(long, default_value = "ci/prompt-suites/seeded-v1.toml")]
+        suite: PathBuf,
+        /// Optional model contract for tokenizer-backed token ID hashes.
+        #[arg(long)]
+        model_contract: Option<PathBuf>,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum HardwareCmd {
     /// Intel Arc A770 hardware claim checks.
     A770 {
@@ -1221,6 +1254,12 @@ fn real_main() -> Result<()> {
         Cmd::ModelContract { cmd } => match cmd {
             ModelContractCmd::Lint { contract_dir, format, allow_missing_assets } => {
                 model_contract::lint_contracts(&contract_dir, &format, allow_missing_assets)
+            }
+        },
+        Cmd::PromptSuite { cmd } => match cmd {
+            PromptSuiteCmd::Verify { suite, format } => prompt_suite::verify_suite(&suite, &format),
+            PromptSuiteCmd::Render { suite, model_contract, format } => {
+                prompt_suite::render_suite(&suite, model_contract.as_deref(), &format)
             }
         },
         Cmd::Hardware { cmd } => match cmd {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,6 +42,7 @@ mod crossval;
 pub mod ffi;
 mod gates;
 mod grid_check;
+mod hardware;
 mod model_contract;
 #[allow(dead_code)]
 mod health_check;
@@ -285,6 +286,12 @@ enum Cmd {
     ModelContract {
         #[command(subcommand)]
         cmd: ModelContractCmd,
+    },
+
+    /// Verify hardware claim rails and resolve device-specific kernel routes.
+    Hardware {
+        #[command(subcommand)]
+        cmd: HardwareCmd,
     },
 
     /// Fetch & build microsoft/BitNet C++ for cross-validation
@@ -1030,6 +1037,68 @@ enum ModelContractCmd {
 }
 
 #[derive(Subcommand)]
+enum HardwareCmd {
+    /// Intel Arc A770 hardware claim checks.
+    A770 {
+        #[command(subcommand)]
+        cmd: A770HardwareCmd,
+    },
+    /// Resolve a device-specific kernel route.
+    Route {
+        #[command(subcommand)]
+        cmd: HardwareRouteCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum A770HardwareCmd {
+    /// Check the A770 kernel capability matrix.
+    #[command(name = "kernel-capability-check")]
+    KernelCapabilityCheck {
+        /// Capability matrix JSON file.
+        #[arg(
+            long,
+            default_value = "ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json"
+        )]
+        matrix: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum HardwareRouteCmd {
+    /// Resolve the kernel route for a model/backend/device operation.
+    Resolve {
+        /// Device kernel routing table.
+        #[arg(long, default_value = "ci/hardware/device-kernel-routing.toml")]
+        routing_table: PathBuf,
+        /// Concrete device slug.
+        #[arg(long, default_value = "amd-5700x-intel-a770")]
+        device_slug: String,
+        /// Selected backend identifier.
+        #[arg(long, default_value = "intel-arc-a770-opencl")]
+        selected_backend: String,
+        /// Backend family identifier.
+        #[arg(long, default_value = "intel-opencl")]
+        backend_family: String,
+        /// Model family.
+        #[arg(long, default_value = "bitnet")]
+        model_family: String,
+        /// Model quantization.
+        #[arg(long, default_value = "i2_s")]
+        quantization: String,
+        /// Operation to route.
+        #[arg(long, default_value = "qk256_i2s_gemv")]
+        op: String,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum GateWhich {
     /// Dry-run tensor-name mapper gate → JSON
     Mapper {
@@ -1153,6 +1222,34 @@ fn real_main() -> Result<()> {
             ModelContractCmd::Lint { contract_dir, format, allow_missing_assets } => {
                 model_contract::lint_contracts(&contract_dir, &format, allow_missing_assets)
             }
+        },
+        Cmd::Hardware { cmd } => match cmd {
+            HardwareCmd::A770 { cmd } => match cmd {
+                A770HardwareCmd::KernelCapabilityCheck { matrix, format } => {
+                    hardware::kernel_capability_check(&matrix, &format)
+                }
+            },
+            HardwareCmd::Route { cmd } => match cmd {
+                HardwareRouteCmd::Resolve {
+                    routing_table,
+                    device_slug,
+                    selected_backend,
+                    backend_family,
+                    model_family,
+                    quantization,
+                    op,
+                    format,
+                } => hardware::route_resolve(
+                    &routing_table,
+                    &device_slug,
+                    &selected_backend,
+                    &backend_family,
+                    &model_family,
+                    &quantization,
+                    &op,
+                    &format,
+                ),
+            },
         },
         Cmd::FetchCpp { tag, force, clean, backend, cmake_flags, repo } => {
             fetch_cpp_cmd(&tag, force, clean, &backend, &cmake_flags, &repo)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,6 +42,7 @@ mod crossval;
 pub mod ffi;
 mod gates;
 mod grid_check;
+mod model_contract;
 #[allow(dead_code)]
 mod health_check;
 #[allow(dead_code)]
@@ -277,6 +278,13 @@ enum Cmd {
         /// Verbose output for debugging
         #[arg(short, long)]
         verbose: bool,
+    },
+
+    /// Verify model contract files and local model/tokenizer hashes.
+    #[command(name = "model-contract")]
+    ModelContract {
+        #[command(subcommand)]
+        cmd: ModelContractCmd,
     },
 
     /// Fetch & build microsoft/BitNet C++ for cross-validation
@@ -1006,6 +1014,22 @@ enum Cmd {
 }
 
 #[derive(Subcommand)]
+enum ModelContractCmd {
+    /// Lint model contracts and verify local assets.
+    Lint {
+        /// Directory containing model contract YAML files.
+        #[arg(long, default_value = "docs/model-contracts")]
+        contract_dir: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+        /// Allow missing local model/tokenizer assets for diagnostic-only environments.
+        #[arg(long, default_value_t = false)]
+        allow_missing_assets: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum GateWhich {
     /// Dry-run tensor-name mapper gate → JSON
     Mapper {
@@ -1125,6 +1149,11 @@ fn real_main() -> Result<()> {
             println!("✓ Downloaded tokenizer to: {}", output_path.display());
             Ok(())
         }
+        Cmd::ModelContract { cmd } => match cmd {
+            ModelContractCmd::Lint { contract_dir, format, allow_missing_assets } => {
+                model_contract::lint_contracts(&contract_dir, &format, allow_missing_assets)
+            }
+        },
         Cmd::FetchCpp { tag, force, clean, backend, cmake_flags, repo } => {
             fetch_cpp_cmd(&tag, force, clean, &backend, &cmake_flags, &repo)
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1323,6 +1323,9 @@ fn classify_exit(e: &anyhow::Error) -> i32 {
 }
 
 fn real_main() -> Result<()> {
+    if llm_experience::maybe_dispatch_from_env()? {
+        return Ok(());
+    }
     let cli = Cli::parse();
     match cli.cmd {
         Cmd::DownloadModel {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1085,6 +1085,32 @@ enum PromptSuiteCmd {
 
 #[derive(Subcommand)]
 enum BenchCmd {
+    /// Convert a profile CLI-stage receipt into a quality-gated benchmark receipt.
+    #[command(name = "from-cli-stage")]
+    FromCliStage {
+        /// Profile CLI plan emitted by a profile planner.
+        #[arg(long, default_value = "target/llm-experience/profile-cli-stage-plan.json")]
+        plan: PathBuf,
+        /// CLI-stage JSON receipt emitted by bitnet run --json-out.
+        #[arg(long, default_value = "target/llm-experience/profile-cli-stage.json")]
+        cli_stage_receipt: PathBuf,
+        /// Model contract YAML file.
+        #[arg(long, default_value = "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml")]
+        model_contract: PathBuf,
+        /// Quality receipt path this benchmark depends on.
+        #[arg(long, default_value = "target/quality/a770-bitnet-quality.json")]
+        quality_receipt: PathBuf,
+        /// Whether the referenced quality receipt passed.
+        #[arg(long, default_value_t = false)]
+        quality_passed: bool,
+        /// Output benchmark receipt JSON file.
+        #[arg(long, default_value = "target/bench-runs/profile-cli-stage.json")]
+        output: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+
     /// Verify a quality-gated benchmark receipt.
     #[command(name = "verify-receipt")]
     VerifyReceipt {
@@ -1328,6 +1354,23 @@ fn real_main() -> Result<()> {
             }
         },
         Cmd::Bench { cmd } => match cmd {
+            BenchCmd::FromCliStage {
+                plan,
+                cli_stage_receipt,
+                model_contract,
+                quality_receipt,
+                quality_passed,
+                output,
+                format,
+            } => bench_receipt::from_cli_stage(
+                &plan,
+                &cli_stage_receipt,
+                &model_contract,
+                &quality_receipt,
+                quality_passed,
+                &output,
+                &format,
+            ),
             BenchCmd::VerifyReceipt { receipt, require_claimable, format } => {
                 bench_receipt::verify_receipt(&receipt, &format, require_claimable)
             }

--- a/xtask/src/model_contract.rs
+++ b/xtask/src/model_contract.rs
@@ -1,0 +1,376 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "all_bitnet_models_supported",
+    "all_supported_models_a770_accelerated",
+    "llama_a770_supported",
+    "qwen_a770_supported",
+    "gemma_a770_supported",
+    "gemma4_a770_supported",
+    "slm_a770_supported",
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+];
+
+const REQUIRED_POINTERS: &[&str] = &[
+    "/model_id",
+    "/family",
+    "/source",
+    "/format",
+    "/quantization",
+    "/architecture",
+    "/local_path",
+    "/sha256",
+    "/tokenizer/path",
+    "/tokenizer/sha256",
+    "/chat_template/name",
+    "/stop_tokens/eos_token_id",
+    "/max_context",
+];
+
+#[derive(Debug, Serialize)]
+struct AssetReport {
+    label: &'static str,
+    asset_path: String,
+    resolved_path: String,
+    expected_sha256: String,
+    actual_sha256: Option<String>,
+    passed: bool,
+    missing: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ContractReport {
+    path: String,
+    model_id: Option<String>,
+    passed: bool,
+    asset_hashes_verified: bool,
+    missing: Vec<String>,
+    asset_hashes: Vec<AssetReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct LintReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    contract_dir: String,
+    contract_count: usize,
+    passed: bool,
+    missing: Vec<String>,
+    contracts: Vec<ContractReport>,
+    not_claims: &'static [&'static str],
+}
+
+pub fn lint_contracts(contract_dir: &Path, format: &str, allow_missing_assets: bool) -> Result<()> {
+    let report = build_lint_report(contract_dir, allow_missing_assets)?;
+    match format {
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        "human" => print_human_report(&report),
+        other => bail!("unsupported model-contract lint format: {other}"),
+    }
+
+    if !report.passed {
+        bail!("model contract lint failed: {}", report.missing.join(", "));
+    }
+
+    Ok(())
+}
+
+fn build_lint_report(contract_dir: &Path, allow_missing_assets: bool) -> Result<LintReport> {
+    let mut paths = Vec::new();
+    if contract_dir.exists() {
+        for entry in fs::read_dir(contract_dir)
+            .with_context(|| format!("reading {}", contract_dir.display()))?
+        {
+            let path = entry?.path();
+            if matches!(path.extension().and_then(|ext| ext.to_str()), Some("yaml" | "yml")) {
+                paths.push(path);
+            }
+        }
+    }
+    paths.sort();
+
+    let mut missing = Vec::new();
+    if paths.is_empty() {
+        missing.push(format!("no model contracts found under {}", contract_dir.display()));
+    }
+
+    let mut contracts = Vec::new();
+    for path in paths {
+        contracts.push(lint_one_contract(&path, allow_missing_assets)?);
+    }
+
+    for contract in &contracts {
+        if !contract.passed {
+            missing.push(format!("{} failed", contract.path));
+        }
+    }
+
+    Ok(LintReport {
+        diagnostic: "model_contract_lint",
+        producer: "cargo xtask model-contract lint",
+        contract_dir: contract_dir.display().to_string(),
+        contract_count: contracts.len(),
+        passed: missing.is_empty(),
+        missing,
+        contracts,
+        not_claims: CRITICAL_NOT_CLAIMS,
+    })
+}
+
+fn lint_one_contract(path: &Path, allow_missing_assets: bool) -> Result<ContractReport> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let value: Value =
+        serde_yaml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+
+    let mut missing = Vec::new();
+    for pointer in REQUIRED_POINTERS {
+        if value.pointer(pointer).is_none_or(Value::is_null) {
+            missing.push((*pointer).to_string());
+        }
+    }
+
+    let root = Path::new(".");
+    let mut asset_hashes = Vec::new();
+    if let (Some(model_path), Some(model_sha)) =
+        (str_at(&value, "/local_path"), str_at(&value, "/sha256"))
+    {
+        asset_hashes.push(verify_asset(
+            "model weights",
+            root,
+            model_path,
+            model_sha,
+            allow_missing_assets,
+        )?);
+    }
+    if let (Some(tokenizer_path), Some(tokenizer_sha)) =
+        (str_at(&value, "/tokenizer/path"), str_at(&value, "/tokenizer/sha256"))
+    {
+        asset_hashes.push(verify_asset(
+            "tokenizer",
+            root,
+            tokenizer_path,
+            tokenizer_sha,
+            allow_missing_assets,
+        )?);
+    }
+
+    for asset in &asset_hashes {
+        if !asset.passed {
+            missing.push(format!("{} hash", asset.label));
+        }
+    }
+
+    let asset_hashes_verified = !asset_hashes.is_empty() && asset_hashes.iter().all(|a| a.passed);
+    let passed = missing.is_empty() && asset_hashes_verified;
+
+    Ok(ContractReport {
+        path: path.display().to_string(),
+        model_id: str_at(&value, "/model_id").map(ToOwned::to_owned),
+        passed,
+        asset_hashes_verified,
+        missing,
+        asset_hashes,
+    })
+}
+
+fn verify_asset(
+    label: &'static str,
+    root: &Path,
+    asset_path: &str,
+    expected_sha256: &str,
+    allow_missing_assets: bool,
+) -> Result<AssetReport> {
+    let resolved = root.join(PathBuf::from(asset_path));
+    if !resolved.exists() {
+        return Ok(AssetReport {
+            label,
+            asset_path: asset_path.to_string(),
+            resolved_path: resolved.display().to_string(),
+            expected_sha256: normalize_sha(expected_sha256),
+            actual_sha256: None,
+            passed: allow_missing_assets,
+            missing: true,
+        });
+    }
+
+    let actual = sha256_file(&resolved)?;
+    let expected = normalize_sha(expected_sha256);
+    Ok(AssetReport {
+        label,
+        asset_path: asset_path.to_string(),
+        resolved_path: resolved.display().to_string(),
+        expected_sha256: expected.clone(),
+        actual_sha256: Some(actual.clone()),
+        passed: actual == expected,
+        missing: false,
+    })
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn normalize_sha(value: &str) -> String {
+    value.trim().trim_start_matches("sha256:").to_ascii_lowercase()
+}
+
+fn print_human_report(report: &LintReport) {
+    println!("model contract lint: passed={}", report.passed);
+    println!("contract dir: {}", report.contract_dir);
+    for contract in &report.contracts {
+        println!(
+            "- {}: passed={} asset_hashes_verified={}",
+            contract.path, contract.passed, contract.asset_hashes_verified
+        );
+        if let Some(model_id) = &contract.model_id {
+            println!("  model_id: {model_id}");
+        }
+        for asset in &contract.asset_hashes {
+            println!(
+                "  {}: passed={} missing={} path={}",
+                asset.label, asset.passed, asset.missing, asset.asset_path
+            );
+        }
+        if !contract.missing.is_empty() {
+            println!("  missing: {}", contract.missing.join(", "));
+        }
+    }
+    if !report.missing.is_empty() {
+        println!("missing: {}", report.missing.join(", "));
+    }
+    println!("not_claims: {}", report.not_claims.join(", "));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_sha_accepts_prefixed_or_plain_values() {
+        assert_eq!(normalize_sha("sha256:ABCD"), "abcd");
+        assert_eq!(normalize_sha(" abcd "), "abcd");
+    }
+
+    #[test]
+    fn missing_assets_are_not_verified_by_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let contract = dir.path().join("model.yaml");
+        fs::write(
+            &contract,
+            r#"
+model_id: example/model
+family: bitnet
+source: test
+format: gguf
+quantization: i2_s
+architecture: bitnet_b1_58
+local_path: missing.gguf
+sha256: 00
+tokenizer:
+  path: missing-tokenizer.json
+  sha256: 11
+chat_template:
+  name: llama3-chat
+stop_tokens:
+  eos_token_id: 128001
+max_context: 4096
+"#,
+        )
+        .unwrap();
+
+        let report = build_lint_report(dir.path(), false).unwrap();
+        assert!(!report.passed);
+        assert_eq!(report.contract_count, 1);
+        assert!(!report.contracts[0].asset_hashes_verified);
+    }
+
+    #[test]
+    fn verifies_local_asset_hashes() {
+        let dir = tempfile::tempdir().unwrap();
+        let model = dir.path().join("model.gguf");
+        let tokenizer = dir.path().join("tokenizer.json");
+        fs::write(&model, b"model").unwrap();
+        fs::write(&tokenizer, b"tokenizer").unwrap();
+        let model_sha = sha256_file(&model).unwrap();
+        let tokenizer_sha = sha256_file(&tokenizer).unwrap();
+        let contract = dir.path().join("model.yaml");
+        fs::write(
+            &contract,
+            format!(
+                r#"
+model_id: example/model
+family: bitnet
+source: test
+format: gguf
+quantization: i2_s
+architecture: bitnet_b1_58
+local_path: {}
+sha256: {}
+tokenizer:
+  path: {}
+  sha256: {}
+chat_template:
+  name: llama3-chat
+stop_tokens:
+  eos_token_id: 128001
+max_context: 4096
+"#,
+                model.display(),
+                model_sha,
+                tokenizer.display(),
+                tokenizer_sha
+            ),
+        )
+        .unwrap();
+
+        let report = build_lint_report(dir.path(), false).unwrap();
+        assert!(report.passed);
+        assert_eq!(report.contracts[0].asset_hashes.len(), 2);
+        assert!(report.contracts[0].asset_hashes_verified);
+    }
+
+    #[test]
+    fn json_shape_contains_policy_not_claims() {
+        let report = LintReport {
+            diagnostic: "model_contract_lint",
+            producer: "cargo xtask model-contract lint",
+            contract_dir: "docs/model-contracts".to_string(),
+            contract_count: 0,
+            passed: false,
+            missing: vec!["no model contracts".to_string()],
+            contracts: vec![],
+            not_claims: CRITICAL_NOT_CLAIMS,
+        };
+        let value = serde_json::json!(report);
+        assert_eq!(value["diagnostic"], "model_contract_lint");
+        assert!(
+            value["not_claims"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| v == "selected_attention_residency")
+        );
+        assert!(value["not_claims"].as_array().unwrap().iter().any(|v| v == "completion"));
+    }
+}

--- a/xtask/src/prompt_suite.rs
+++ b/xtask/src/prompt_suite.rs
@@ -1,0 +1,560 @@
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const REQUIRED_NOT_CLAIMS: &[&str] = &[
+    "prompt_suite_quality_claim",
+    "benchmark_speed_claim",
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "full_device_residency",
+    "completion",
+];
+
+#[derive(Debug, Deserialize)]
+struct PromptSuite {
+    schema_version: u32,
+    suite_id: String,
+    #[serde(default)]
+    description: Option<String>,
+    template: String,
+    #[serde(default = "default_true")]
+    add_bos: bool,
+    #[serde(default = "default_true")]
+    parse_special: bool,
+    #[serde(default)]
+    manual_review_allowed_for_claims: bool,
+    required_categories: Vec<String>,
+    anti_fakery: AntiFakeryPolicy,
+    #[serde(default)]
+    case: Vec<PromptCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AntiFakeryPolicy {
+    require_seed_binding: bool,
+    require_answer_binding: bool,
+    require_name_slots: bool,
+    minimum_slot_values: usize,
+    min_generation_policy_coverage: f64,
+    min_answer_bound_surface_coverage: f64,
+    min_required_surface_category_coverage: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PromptCase {
+    id: String,
+    seed: u64,
+    category: String,
+    #[serde(default)]
+    difficulty: Option<String>,
+    oracle: String,
+    max_new_tokens: u32,
+    temperature: f64,
+    #[serde(default)]
+    requires_pair: bool,
+    generation_policy: String,
+    answer_bound_surface: String,
+    required_surface_category: String,
+    expected_behavior: String,
+    prompt: String,
+    #[serde(default)]
+    pair_prompt: Option<String>,
+    #[serde(default)]
+    stop_expectation: Option<String>,
+    #[serde(default)]
+    name_slots: Vec<NameSlot>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct NameSlot {
+    slot: String,
+    values: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptSuiteVerifyReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    suite_path: String,
+    schema_version: u32,
+    suite_id: String,
+    description: Option<String>,
+    template: String,
+    passed: bool,
+    case_count: usize,
+    required_category_count: usize,
+    covered_category_count: usize,
+    generation_policy_coverage: f64,
+    answer_bound_surface_coverage: f64,
+    required_surface_category_coverage: f64,
+    seeded_name_slot_case_count: usize,
+    manual_review_case_count: usize,
+    categories_missing: Vec<String>,
+    failures: Vec<String>,
+    not_claims: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PromptSuiteRenderReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    suite_path: String,
+    suite_id: String,
+    template: String,
+    model_contract: Option<String>,
+    tokenizer_authority: bool,
+    tokenizer_path: Option<String>,
+    add_bos: bool,
+    parse_special: bool,
+    case_count: usize,
+    cases: Vec<RenderedCase>,
+    not_claims: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RenderedCase {
+    id: String,
+    category: String,
+    difficulty: Option<String>,
+    oracle: String,
+    max_new_tokens: u32,
+    temperature: f64,
+    slot_bindings: BTreeMap<String, String>,
+    rendered_prompt_sha256: String,
+    prompt_token_ids_sha256: Option<String>,
+    prompt_token_count: Option<usize>,
+    pair_rendered_prompt_sha256: Option<String>,
+    pair_token_ids_sha256: Option<String>,
+    pair_prompt_token_count: Option<usize>,
+}
+
+pub fn verify_suite(suite_path: &Path, format: &str) -> Result<()> {
+    let suite = read_suite(suite_path)?;
+    let report = build_verify_report(suite_path, &suite);
+    emit_verify_report(&report, format)?;
+    if !report.passed {
+        bail!("prompt-suite verify failed: {}", report.failures.join(", "));
+    }
+    Ok(())
+}
+
+pub fn render_suite(suite_path: &Path, model_contract: Option<&Path>, format: &str) -> Result<()> {
+    let suite = read_suite(suite_path)?;
+    let tokenizer = if let Some(contract) = model_contract {
+        Some(load_contract_tokenizer(contract)?)
+    } else {
+        None
+    };
+    let report = build_render_report(suite_path, &suite, model_contract, tokenizer)?;
+    emit_render_report(&report, format)?;
+    Ok(())
+}
+
+fn read_suite(path: &Path) -> Result<PromptSuite> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn build_verify_report(suite_path: &Path, suite: &PromptSuite) -> PromptSuiteVerifyReport {
+    let mut failures = Vec::new();
+    if suite.case.is_empty() {
+        failures.push("suite has no cases".to_string());
+    }
+    if suite.required_categories.is_empty() {
+        failures.push("suite has no required_categories".to_string());
+    }
+    if suite.manual_review_allowed_for_claims {
+        failures.push("manual_review_allowed_for_claims must be false".to_string());
+    }
+    if suite.anti_fakery.minimum_slot_values < 3 {
+        failures.push("anti_fakery.minimum_slot_values must be at least 3".to_string());
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut categories = BTreeSet::new();
+    let mut surface_categories = BTreeSet::new();
+    let mut generation_policy_count = 0;
+    let mut answer_bound_surface_count = 0;
+    let mut seeded_name_slot_case_count = 0;
+    let mut manual_review_case_count = 0;
+
+    for case in &suite.case {
+        if !ids.insert(case.id.clone()) {
+            failures.push(format!("duplicate case id {}", case.id));
+        }
+        if case.seed == 0 && suite.anti_fakery.require_seed_binding {
+            failures.push(format!("{} has zero seed", case.id));
+        }
+        if case.prompt.trim().is_empty() {
+            failures.push(format!("{} has empty prompt", case.id));
+        }
+        if case.expected_behavior.trim().is_empty() && suite.anti_fakery.require_answer_binding {
+            failures.push(format!("{} missing expected_behavior", case.id));
+        }
+        if case.max_new_tokens == 0 {
+            failures.push(format!("{} has max_new_tokens=0", case.id));
+        }
+        if case.temperature != 0.0 {
+            failures.push(format!(
+                "{} has non-deterministic temperature {}",
+                case.id, case.temperature
+            ));
+        }
+        if case.oracle == "manual_review_needed" {
+            manual_review_case_count += 1;
+            failures.push(format!("{} uses manual_review_needed", case.id));
+        }
+        if (case.requires_pair || case.oracle == "semantic_pair_difference")
+            && case.pair_prompt.as_deref().is_none_or(str::is_empty)
+        {
+            failures.push(format!("{} requires pair_prompt", case.id));
+        }
+        if (case.oracle == "repetition_guard"
+            || case.oracle == "stop_condition"
+            || case.category == "stop_repetition_stress")
+            && case.stop_expectation.as_deref().is_none_or(str::is_empty)
+        {
+            failures.push(format!("{} missing stop_expectation", case.id));
+        }
+        if !case.generation_policy.trim().is_empty() {
+            generation_policy_count += 1;
+        }
+        if !case.answer_bound_surface.trim().is_empty() {
+            answer_bound_surface_count += 1;
+        }
+        if !case.required_surface_category.trim().is_empty() {
+            surface_categories.insert(case.required_surface_category.clone());
+        }
+        categories.insert(case.category.clone());
+
+        if case.name_slots.is_empty() && suite.anti_fakery.require_name_slots {
+            failures.push(format!("{} missing seeded name_slots", case.id));
+        }
+        if !case.name_slots.is_empty() {
+            seeded_name_slot_case_count += 1;
+        }
+        for slot in &case.name_slots {
+            if slot.values.len() < suite.anti_fakery.minimum_slot_values {
+                failures.push(format!(
+                    "{} slot {} has fewer than {} values",
+                    case.id, slot.slot, suite.anti_fakery.minimum_slot_values
+                ));
+            }
+            let needle = format!("{{{}}}", slot.slot);
+            let prompt_has_slot = case.prompt.contains(&needle)
+                || case.pair_prompt.as_deref().is_some_and(|pair| pair.contains(&needle));
+            if !prompt_has_slot {
+                failures.push(format!("{} slot {} is not used in prompt text", case.id, slot.slot));
+            }
+        }
+    }
+
+    let categories_missing = suite
+        .required_categories
+        .iter()
+        .filter(|category| !categories.contains(*category))
+        .cloned()
+        .collect::<Vec<_>>();
+    for category in &categories_missing {
+        failures.push(format!("missing required category {category}"));
+    }
+
+    let case_count = suite.case.len();
+    let denominator = case_count.max(1) as f64;
+    let generation_policy_coverage = generation_policy_count as f64 / denominator;
+    let answer_bound_surface_coverage = answer_bound_surface_count as f64 / denominator;
+    let required_surface_category_coverage =
+        surface_categories.len() as f64 / suite.required_categories.len().max(1) as f64;
+    if generation_policy_coverage < suite.anti_fakery.min_generation_policy_coverage {
+        failures.push("generation policy coverage below minimum".to_string());
+    }
+    if answer_bound_surface_coverage < suite.anti_fakery.min_answer_bound_surface_coverage {
+        failures.push("answer-bound surface coverage below minimum".to_string());
+    }
+    if required_surface_category_coverage < suite.anti_fakery.min_required_surface_category_coverage
+    {
+        failures.push("required surface category coverage below minimum".to_string());
+    }
+
+    PromptSuiteVerifyReport {
+        diagnostic: "prompt_suite_verify",
+        producer: "cargo xtask prompt-suite verify",
+        suite_path: suite_path.display().to_string(),
+        schema_version: suite.schema_version,
+        suite_id: suite.suite_id.clone(),
+        description: suite.description.clone(),
+        template: suite.template.clone(),
+        passed: failures.is_empty(),
+        case_count,
+        required_category_count: suite.required_categories.len(),
+        covered_category_count: categories.len(),
+        generation_policy_coverage,
+        answer_bound_surface_coverage,
+        required_surface_category_coverage,
+        seeded_name_slot_case_count,
+        manual_review_case_count,
+        categories_missing,
+        failures,
+        not_claims: REQUIRED_NOT_CLAIMS.iter().map(|value| (*value).to_string()).collect(),
+    }
+}
+
+fn build_render_report(
+    suite_path: &Path,
+    suite: &PromptSuite,
+    model_contract: Option<&Path>,
+    tokenizer: Option<(String, Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>)>,
+) -> Result<PromptSuiteRenderReport> {
+    let tokenizer_path = tokenizer.as_ref().map(|(path, _)| path.clone());
+    let tokenizer_ref = tokenizer.as_ref().map(|(_, tokenizer)| tokenizer.as_ref());
+    let mut cases = Vec::new();
+    for case in &suite.case {
+        cases.push(render_case(case, tokenizer_ref, suite.add_bos, suite.parse_special)?);
+    }
+
+    Ok(PromptSuiteRenderReport {
+        diagnostic: "prompt_suite_render",
+        producer: "cargo xtask prompt-suite render",
+        suite_path: suite_path.display().to_string(),
+        suite_id: suite.suite_id.clone(),
+        template: suite.template.clone(),
+        model_contract: model_contract.map(|path| path.display().to_string()),
+        tokenizer_authority: tokenizer_ref.is_some(),
+        tokenizer_path,
+        add_bos: suite.add_bos,
+        parse_special: suite.parse_special,
+        case_count: cases.len(),
+        cases,
+        not_claims: REQUIRED_NOT_CLAIMS.iter().map(|value| (*value).to_string()).collect(),
+    })
+}
+
+fn render_case(
+    case: &PromptCase,
+    tokenizer: Option<&(dyn bitnet_tokenizers::Tokenizer + Send + Sync)>,
+    add_bos: bool,
+    parse_special: bool,
+) -> Result<RenderedCase> {
+    let slot_bindings = bind_slots(case.seed, &case.name_slots);
+    let rendered = apply_slots(&case.prompt, &slot_bindings);
+    let (prompt_token_ids_sha256, prompt_token_count) =
+        tokenize_hash(tokenizer, &rendered, add_bos, parse_special)?;
+    let pair_rendered = case.pair_prompt.as_ref().map(|prompt| apply_slots(prompt, &slot_bindings));
+    let (pair_token_ids_sha256, pair_prompt_token_count) = if let Some(pair) = &pair_rendered {
+        tokenize_hash(tokenizer, pair, add_bos, parse_special)?
+    } else {
+        (None, None)
+    };
+
+    Ok(RenderedCase {
+        id: case.id.clone(),
+        category: case.category.clone(),
+        difficulty: case.difficulty.clone(),
+        oracle: case.oracle.clone(),
+        max_new_tokens: case.max_new_tokens,
+        temperature: case.temperature,
+        slot_bindings,
+        rendered_prompt_sha256: sha256_text(&rendered),
+        prompt_token_ids_sha256,
+        prompt_token_count,
+        pair_rendered_prompt_sha256: pair_rendered.as_deref().map(sha256_text),
+        pair_token_ids_sha256,
+        pair_prompt_token_count,
+    })
+}
+
+fn bind_slots(seed: u64, slots: &[NameSlot]) -> BTreeMap<String, String> {
+    let mut bindings = BTreeMap::new();
+    for slot in slots {
+        if slot.values.is_empty() {
+            continue;
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(seed.to_le_bytes());
+        hasher.update(slot.slot.as_bytes());
+        let digest = hasher.finalize();
+        let index = usize::from(digest[0]) % slot.values.len();
+        bindings.insert(slot.slot.clone(), slot.values[index].clone());
+    }
+    bindings
+}
+
+fn apply_slots(prompt: &str, bindings: &BTreeMap<String, String>) -> String {
+    let mut rendered = prompt.to_string();
+    for (slot, value) in bindings {
+        rendered = rendered.replace(&format!("{{{slot}}}"), value);
+    }
+    rendered
+}
+
+fn tokenize_hash(
+    tokenizer: Option<&(dyn bitnet_tokenizers::Tokenizer + Send + Sync)>,
+    rendered: &str,
+    add_bos: bool,
+    parse_special: bool,
+) -> Result<(Option<String>, Option<usize>)> {
+    let Some(tokenizer) = tokenizer else {
+        return Ok((None, None));
+    };
+    let tokens = tokenizer
+        .encode(rendered, add_bos, parse_special)
+        .with_context(|| "tokenizing rendered prompt")?;
+    let encoded = serde_json::to_vec(&tokens)?;
+    Ok((Some(sha256_bytes(&encoded)), Some(tokens.len())))
+}
+
+fn load_contract_tokenizer(
+    contract_path: &Path,
+) -> Result<(String, Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>)> {
+    let raw = fs::read_to_string(contract_path)
+        .with_context(|| format!("reading {}", contract_path.display()))?;
+    let value: Value = serde_yaml::from_str(&raw)
+        .with_context(|| format!("parsing {}", contract_path.display()))?;
+    let tokenizer_path = value
+        .pointer("/tokenizer/path")
+        .and_then(Value::as_str)
+        .context("model contract missing /tokenizer/path")?;
+    let path = PathBuf::from(tokenizer_path);
+    let tokenizer = bitnet_tokenizers::load_tokenizer(&path)
+        .with_context(|| format!("loading tokenizer {}", path.display()))?;
+    Ok((tokenizer_path.to_string(), tokenizer))
+}
+
+fn sha256_text(value: &str) -> String {
+    sha256_bytes(value.as_bytes())
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
+fn emit_verify_report(report: &PromptSuiteVerifyReport, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(report)?),
+        "human" => {
+            println!("prompt-suite verify: passed={}", report.passed);
+            println!("suite: {}", report.suite_id);
+            println!("cases: {}", report.case_count);
+            println!(
+                "coverage: generation_policy={:.2} answer_bound_surface={:.2} surface_category={:.2}",
+                report.generation_policy_coverage,
+                report.answer_bound_surface_coverage,
+                report.required_surface_category_coverage
+            );
+            if !report.failures.is_empty() {
+                println!("failures: {}", report.failures.join(", "));
+            }
+            println!("not_claims: {}", report.not_claims.join(", "));
+        }
+        other => bail!("unsupported prompt-suite output format: {other}"),
+    }
+    Ok(())
+}
+
+fn emit_render_report(report: &PromptSuiteRenderReport, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(report)?),
+        "human" => {
+            println!("prompt-suite render: suite={}", report.suite_id);
+            println!("cases: {}", report.case_count);
+            println!("tokenizer_authority: {}", report.tokenizer_authority);
+            println!("not_claims: {}", report.not_claims.join(", "));
+        }
+        other => bail!("unsupported prompt-suite output format: {other}"),
+    }
+    Ok(())
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_suite(extra_case: &str) -> String {
+        format!(
+            r#"
+schema_version = 1
+suite_id = "test-suite"
+template = "llama3-chat"
+required_categories = ["short_explanation"]
+manual_review_allowed_for_claims = false
+
+[anti_fakery]
+require_seed_binding = true
+require_answer_binding = true
+require_name_slots = true
+minimum_slot_values = 3
+min_generation_policy_coverage = 1.0
+min_answer_bound_surface_coverage = 1.0
+min_required_surface_category_coverage = 1.0
+
+{extra_case}
+"#
+        )
+    }
+
+    fn valid_case(id: &str) -> String {
+        format!(
+            r#"
+[[case]]
+id = "{id}"
+seed = 7
+category = "short_explanation"
+oracle = "semantic_nonempty"
+max_new_tokens = 16
+temperature = 0.0
+generation_policy = "deterministic_greedy"
+answer_bound_surface = "must mention reuse"
+required_surface_category = "short_explanation"
+expected_behavior = "explain briefly"
+prompt = "{{name}} asks why caching helps."
+name_slots = [
+  {{ slot = "name", values = ["Ava", "Bo", "Cy"] }},
+]
+"#
+        )
+    }
+
+    #[test]
+    fn verify_rejects_duplicate_ids() {
+        let raw = minimal_suite(&format!("{}\n{}", valid_case("same"), valid_case("same")));
+        let suite: PromptSuite = toml::from_str(&raw).unwrap();
+        let report = build_verify_report(Path::new("suite.toml"), &suite);
+        assert!(!report.passed);
+        assert!(report.failures.iter().any(|failure| failure.contains("duplicate case id")));
+    }
+
+    #[test]
+    fn verify_rejects_manual_review_oracle() {
+        let mut case = valid_case("manual");
+        case = case.replace("semantic_nonempty", "manual_review_needed");
+        let raw = minimal_suite(&case);
+        let suite: PromptSuite = toml::from_str(&raw).unwrap();
+        let report = build_verify_report(Path::new("suite.toml"), &suite);
+        assert!(!report.passed);
+        assert!(report.failures.iter().any(|failure| failure.contains("manual_review_needed")));
+    }
+
+    #[test]
+    fn render_binds_seeded_slots_and_hashes_prompt() {
+        let raw = minimal_suite(&valid_case("render"));
+        let suite: PromptSuite = toml::from_str(&raw).unwrap();
+        let report = build_render_report(Path::new("suite.toml"), &suite, None, None).unwrap();
+        assert_eq!(report.case_count, 1);
+        let case = &report.cases[0];
+        assert!(case.slot_bindings.contains_key("name"));
+        assert_eq!(case.rendered_prompt_sha256.len(), 64);
+        assert!(case.prompt_token_ids_sha256.is_none());
+    }
+}

--- a/xtask/tests/a770_claim_boundary_spec.rs
+++ b/xtask/tests/a770_claim_boundary_spec.rs
@@ -1,0 +1,166 @@
+//! Guards for the A770 BitNet claim-boundary spec.
+//!
+//! These tests keep the product boundary from drifting while the implementation
+//! rails land PR by PR. They intentionally check only documentation/source
+//! policy, not runtime receipts.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate should live under the workspace root")
+        .to_path_buf()
+}
+
+fn read_repo_file(path: &str) -> String {
+    let full_path = repo_root().join(path);
+    std::fs::read_to_string(&full_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {}", full_path.display(), err))
+}
+
+fn assert_contains(contents: &str, needle: &str, context: &str) {
+    assert!(contents.contains(needle), "{} must contain `{}`", context, needle);
+}
+
+fn assert_file_exists(path: &str) {
+    let full_path = repo_root().join(path);
+    assert!(Path::new(&full_path).exists(), "missing required file {}", full_path.display());
+}
+
+#[test]
+fn a770_claim_boundary_spec_files_exist() {
+    assert_file_exists("docs/specs/a770-bitnet-claim-boundary.md");
+    assert_file_exists("docs/specs/intel-arc-a770-gpu-roadmap.md");
+    assert_file_exists("docs/hardware/intel-arc-a770-validation.md");
+    assert_file_exists("plans/a770-bitnet-claim-boundary-implementation.md");
+}
+
+#[test]
+fn a770_claim_boundary_docs_link_to_the_spec() {
+    let roadmap = read_repo_file("docs/specs/intel-arc-a770-gpu-roadmap.md");
+    let validation = read_repo_file("docs/hardware/intel-arc-a770-validation.md");
+    let index = read_repo_file("docs/specs/INDEX.md");
+
+    assert_contains(
+        &roadmap,
+        "docs/specs/a770-bitnet-claim-boundary.md",
+        "A770 roadmap",
+    );
+    assert_contains(
+        &roadmap,
+        "plans/a770-bitnet-claim-boundary-implementation.md",
+        "A770 roadmap",
+    );
+    assert_contains(
+        &validation,
+        "docs/specs/a770-bitnet-claim-boundary.md",
+        "A770 validation profile",
+    );
+    assert_contains(&index, "a770-bitnet-claim-boundary.md", "spec index");
+}
+
+#[test]
+fn a770_claim_boundary_preserves_first_claim_target() {
+    let spec = read_repo_file("docs/specs/a770-bitnet-claim-boundary.md");
+    let plan = read_repo_file("plans/a770-bitnet-claim-boundary-implementation.md");
+
+    for contents in [&spec, &plan] {
+        assert_contains(
+            contents,
+            "BitNet b1.58 i2_s trusted partial A770 acceleration",
+            "A770 claim boundary",
+        );
+    }
+}
+
+#[test]
+fn a770_claim_boundary_preserves_critical_not_claims() {
+    let spec = read_repo_file("docs/specs/a770-bitnet-claim-boundary.md");
+    let plan = read_repo_file("plans/a770-bitnet-claim-boundary-implementation.md");
+    let validation = read_repo_file("docs/hardware/intel-arc-a770-validation.md");
+
+    let required = [
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion",
+    ];
+
+    for not_claim in required {
+        assert_contains(&spec, not_claim, "A770 claim-boundary spec");
+        assert_contains(&plan, not_claim, "A770 implementation plan");
+    }
+
+    for not_claim in [
+        "selected-attention",
+        "resident KV decode",
+        "attention scores",
+        "softmax",
+        "attention value",
+        "full support-op residency",
+        "full device residency",
+        "completion",
+    ] {
+        assert_contains(&validation, not_claim, "A770 validation profile");
+    }
+}
+
+#[test]
+fn a770_claim_boundary_keeps_selected_attention_separate() {
+    let spec = read_repo_file("docs/specs/a770-bitnet-claim-boundary.md");
+    let roadmap = read_repo_file("docs/specs/intel-arc-a770-gpu-roadmap.md");
+
+    assert_contains(
+        &spec,
+        "Selected attention is a separate research lane",
+        "A770 claim-boundary spec",
+    );
+    assert_contains(
+        &spec,
+        "It is not promoted by trusted",
+        "A770 claim-boundary spec",
+    );
+    assert_contains(
+        &roadmap,
+        "Selected attention, resident KV",
+        "A770 roadmap",
+    );
+}
+
+#[test]
+fn a770_claim_boundary_requires_clean_parent_benchmark_and_real_history() {
+    let spec = read_repo_file("docs/specs/a770-bitnet-claim-boundary.md");
+    let plan = read_repo_file("plans/a770-bitnet-claim-boundary-implementation.md");
+
+    for contents in [&spec, &plan] {
+        assert_contains(contents, "repo.dirty=false", "A770 claim boundary");
+    }
+
+    for needle in [
+        "two distinct receipts",
+        "distinct non-empty run IDs",
+        "distinct receipt paths",
+        "same device",
+        "same backend",
+        "same benchmark profile",
+        "same kernel route",
+    ] {
+        assert_contains(&spec, needle, "A770 claim-boundary spec");
+    }
+
+    assert_contains(
+        &spec,
+        "Comparing a receipt to itself is not history",
+        "A770 claim-boundary spec",
+    );
+    assert_contains(
+        &plan,
+        "two distinct same-device, same-route history receipts",
+        "A770 implementation plan",
+    );
+}


### PR DESCRIPTION
## Summary
- adds manual `llm-experience publish`, `compare`, and `docs` rails without widening the xtask clap enum
- publishes experience receipts into `history-root/runs/<commit>/<device>/<profile>/<run_id>.json`
- compares the latest two same-device/profile receipts and distinguishes diagnostic same-route history from claim-ready regression history
- rejects self-history through distinct receipt path and distinct run_id checks
- generates a compact Markdown dashboard from local history receipts

## Verification
- `cargo test --locked -p xtask --no-default-features --bin xtask llm_experience -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- llm-experience publish --help`
- `cargo run --locked -p xtask --no-default-features -- llm-experience compare --help`
- `cargo run --locked -p xtask --no-default-features -- llm-experience docs --help`
- generated-target smoke: published two diagnostic receipts to `target/llm-experience-history-smoke`
- generated-target smoke: `llm-experience compare` returned `same_device_same_route_diagnostic`, `passed=true`, `claim_ready_pair=false`
- generated-target smoke: `llm-experience docs` and `docs --check` passed for two receipts
- expected negative smoke: `llm-experience compare --require-claim-ready` failed with `claim_ready_history_not_ready`
- `cargo test --locked -p xtask --no-default-features --bin xtask bench_receipt -- --nocapture`
- `cargo test --locked -p xtask --no-default-features --bin xtask claims -- --nocapture`
- `git diff --check a770/llm-experience-run-verify...HEAD`

## Claim boundary
- Does not run the clean A770 claim sequence
- Diagnostic same-route history is not claim-ready history
- Does not promote selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion
- Does not make the A770 route claimable