### PR TITLE
claims: gate A770 promotion on experience receipts

### DIFF
--- a/xtask/src/claims.rs
+++ b/xtask/src/claims.rs
@@ -24,20 +24,28 @@ const VALID_STATUSES: &[&str] = &[
     "complete",
 ];
 
-const EVIDENCE_REQUIRED_STATUSES: &[&str] = &[
-    "load_proven",
-    "quality_proven",
-    "performance_proven",
-    "resident_proven",
-    "complete",
-];
+const EVIDENCE_REQUIRED_STATUSES: &[&str] =
+    &["load_proven", "quality_proven", "performance_proven", "resident_proven", "complete"];
 
 const A770_PROMOTED_STATUSES: &[&str] = &["performance_proven", "resident_proven", "complete"];
 
-pub fn verify(ledger_path: &Path, a770_capability_matrix: &Path, format: &str) -> Result<()> {
+pub fn verify(
+    ledger_path: &Path,
+    a770_capability_matrix: &Path,
+    llm_experience_receipt: Option<&Path>,
+    format: &str,
+) -> Result<()> {
     let ledger = read_json(ledger_path)?;
     let matrix = read_json(a770_capability_matrix)?;
-    let report = build_verify_report(ledger_path, &ledger, a770_capability_matrix, &matrix);
+    let experience = llm_experience_receipt.map(read_json).transpose()?;
+    let report = build_verify_report(
+        ledger_path,
+        &ledger,
+        a770_capability_matrix,
+        &matrix,
+        llm_experience_receipt,
+        experience.as_ref(),
+    );
     emit_value(&report, format)?;
     if !report["passed"].as_bool().unwrap_or(false) {
         bail!("claims verify failed: {}", report["failures"].clone());
@@ -87,6 +95,8 @@ fn build_verify_report(
     ledger: &Value,
     matrix_path: &Path,
     matrix: &Value,
+    llm_experience_receipt_path: Option<&Path>,
+    llm_experience_receipt: Option<&Value>,
 ) -> Value {
     let mut failures = Vec::new();
     let claims = ledger.pointer("/claims").and_then(Value::as_array);
@@ -103,7 +113,9 @@ fn build_verify_report(
     };
 
     let a770_claimable_kernel_count = claimable_kernel_count(matrix);
+    let experience_status = experience_status(llm_experience_receipt_path, llm_experience_receipt);
     let mut promoted_a770_claims = Vec::new();
+    let mut promoted_a770_experience_claims = Vec::new();
     for claim in claims {
         let claim_id = str_at(claim, "/claim_id").unwrap_or("");
         let status = str_at(claim, "/status").unwrap_or("");
@@ -141,6 +153,11 @@ fn build_verify_report(
         if claim_id.starts_with("a770.") && A770_PROMOTED_STATUSES.contains(&status) {
             promoted_a770_claims.push(claim_id.to_string());
         }
+        if claim_id == "a770.bitnet.trusted_partial_experience"
+            && A770_PROMOTED_STATUSES.contains(&status)
+        {
+            promoted_a770_experience_claims.push(claim_id.to_string());
+        }
     }
 
     if a770_claimable_kernel_count == 0 && !promoted_a770_claims.is_empty() {
@@ -149,12 +166,21 @@ fn build_verify_report(
             promoted_a770_claims.join(", ")
         ));
     }
+    if !promoted_a770_experience_claims.is_empty()
+        && !bool_at(&experience_status, "/claim_allowed").unwrap_or(false)
+    {
+        failures.push(format!(
+            "A770 trusted experience promotion requires claimable llm_experience_run receipt; promoted={}",
+            promoted_a770_experience_claims.join(", ")
+        ));
+    }
 
     json!({
         "diagnostic": "claims_verify",
         "producer": "cargo xtask claims verify",
         "ledger": ledger_path.display().to_string(),
         "a770_capability_matrix": matrix_path.display().to_string(),
+        "llm_experience_receipt": experience_status,
         "passed": failures.is_empty(),
         "claim_count": claims.len(),
         "a770_claimable_kernel_count": a770_claimable_kernel_count,
@@ -251,6 +277,45 @@ fn claimable_kernel_count(matrix: &Value) -> u64 {
         .unwrap_or(0)
 }
 
+fn experience_status(path: Option<&Path>, receipt: Option<&Value>) -> Value {
+    let Some(receipt) = receipt else {
+        return json!({
+            "present": false,
+            "path": path.map(|path| path.display().to_string()),
+            "claim_allowed": false,
+            "classification": "missing",
+            "receipt_type": Value::Null,
+            "critical_not_claims_present": false,
+        });
+    };
+    let not_claims = array_strings(receipt, "/not_claims");
+    let critical_not_claims_present = CRITICAL_A770_NOT_CLAIMS
+        .iter()
+        .all(|not_claim| not_claims.iter().any(|item| item == not_claim));
+    let receipt_type = str_at(receipt, "/receipt_type").unwrap_or("");
+    let claim_allowed = receipt_type == "llm_experience_run"
+        && bool_at(receipt, "/claim_gate/claim_allowed").unwrap_or(false)
+        && critical_not_claims_present;
+    json!({
+        "present": true,
+        "path": path.map(|path| path.display().to_string()),
+        "receipt_type": receipt_type,
+        "claim_allowed": claim_allowed,
+        "raw_claim_allowed": bool_at(receipt, "/claim_gate/claim_allowed").unwrap_or(false),
+        "classification": str_at(receipt, "/claim_gate/classification").unwrap_or("diagnostic_only"),
+        "quality_passed": bool_at(receipt, "/quality/passed").unwrap_or(false),
+        "fallback_used": bool_at(receipt, "/backend/fallback_used").unwrap_or(true),
+        "route_verified": bool_at(receipt, "/kernel_route/route_verified").unwrap_or(false),
+        "model_contract": str_at(receipt, "/model/contract").unwrap_or(""),
+        "selected_backend": str_at(receipt, "/backend/selected_backend").unwrap_or(""),
+        "critical_not_claims_present": critical_not_claims_present,
+    })
+}
+
+fn bool_at(value: &Value, pointer: &str) -> Option<bool> {
+    value.pointer(pointer).and_then(Value::as_bool)
+}
+
 fn escape_markdown_cell(value: &str) -> String {
     value.replace('|', "\\|").replace('\n', " ")
 }
@@ -287,8 +352,14 @@ mod tests {
 
     #[test]
     fn diagnostic_a770_claim_passes_without_claimable_kernels() {
-        let report =
-            build_verify_report(Path::new("claims.json"), &ledger("diagnostic"), Path::new("matrix.json"), &matrix(0));
+        let report = build_verify_report(
+            Path::new("claims.json"),
+            &ledger("diagnostic"),
+            Path::new("matrix.json"),
+            &matrix(0),
+            None,
+            None,
+        );
         assert_eq!(report["passed"], true);
     }
 
@@ -299,14 +370,75 @@ mod tests {
             &ledger("performance_proven"),
             Path::new("matrix.json"),
             &matrix(0),
+            None,
+            None,
         );
         assert_eq!(report["passed"], false);
         assert!(
-            report["failures"]
-                .as_array()
+            report["failures"].as_array().unwrap().iter().any(|failure| failure
+                .as_str()
                 .unwrap()
-                .iter()
-                .any(|failure| failure.as_str().unwrap().contains("require claimable A770 kernels"))
+                .contains("require claimable A770 kernels"))
         );
+    }
+
+    #[test]
+    fn promoted_a770_experience_requires_claimable_experience_receipt() {
+        let report = build_verify_report(
+            Path::new("claims.json"),
+            &ledger("performance_proven"),
+            Path::new("matrix.json"),
+            &matrix(3),
+            None,
+            None,
+        );
+        assert_eq!(report["passed"], false);
+        assert!(report["failures"].as_array().unwrap().iter().any(|failure| {
+            failure.as_str().unwrap().contains("requires claimable llm_experience_run receipt")
+        }));
+    }
+
+    #[test]
+    fn promoted_a770_experience_accepts_claimable_experience_receipt() {
+        let report = build_verify_report(
+            Path::new("claims.json"),
+            &promoted_ledger_with_evidence(),
+            Path::new("matrix.json"),
+            &matrix(3),
+            Some(Path::new("experience.json")),
+            Some(&experience_receipt(true)),
+        );
+        assert_eq!(report["passed"], true);
+        assert_eq!(report["llm_experience_receipt"]["claim_allowed"], true);
+    }
+
+    fn promoted_ledger_with_evidence() -> Value {
+        let mut ledger = ledger("performance_proven");
+        ledger["claims"][0]["evidence"] = json!(["experience.json"]);
+        ledger
+    }
+
+    fn experience_receipt(claim_allowed: bool) -> Value {
+        json!({
+            "receipt_type": "llm_experience_run",
+            "model": {
+                "contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"
+            },
+            "backend": {
+                "selected_backend": "intel-arc-a770-opencl",
+                "fallback_used": false
+            },
+            "kernel_route": {
+                "route_verified": claim_allowed
+            },
+            "quality": {
+                "passed": claim_allowed
+            },
+            "claim_gate": {
+                "claim_allowed": claim_allowed,
+                "classification": if claim_allowed { "performance_proven" } else { "diagnostic_only" }
+            },
+            "not_claims": CRITICAL_A770_NOT_CLAIMS
+        })
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,19 +36,19 @@ use std::{
 };
 use walkdir::WalkDir;
 
-mod campaign;
 mod bench_receipt;
-mod cpp_setup_auto;
+mod campaign;
 mod claims;
+mod cpp_setup_auto;
 mod crossval;
 pub mod ffi;
 mod gates;
 mod grid_check;
 mod hardware;
-mod llm_experience;
-mod model_contract;
 #[allow(dead_code)]
 mod health_check;
+mod llm_experience;
+mod model_contract;
 #[allow(dead_code)]
 mod model_info;
 mod model_registry;
@@ -1147,6 +1147,9 @@ enum ClaimsCmd {
             default_value = "ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json"
         )]
         a770_capability_matrix: PathBuf,
+        /// Optional LLM experience receipt required for promoted A770 performance claims.
+        #[arg(long)]
+        llm_experience_receipt: Option<PathBuf>,
         /// Output format: human or json.
         #[arg(long, default_value = "human")]
         format: String,
@@ -1419,9 +1422,17 @@ fn real_main() -> Result<()> {
             }
         },
         Cmd::Claims { cmd } => match cmd {
-            ClaimsCmd::Verify { ledger, a770_capability_matrix, format } => {
-                claims::verify(&ledger, &a770_capability_matrix, &format)
-            }
+            ClaimsCmd::Verify {
+                ledger,
+                a770_capability_matrix,
+                llm_experience_receipt,
+                format,
+            } => claims::verify(
+                &ledger,
+                &a770_capability_matrix,
+                llm_experience_receipt.as_deref(),
+                &format,
+            ),
             ClaimsCmd::Docs { ledger, output, check, format } => {
                 claims::docs(&ledger, &output, check, &format)
             }


### PR DESCRIPTION
## Summary
- adds `--llm-experience-receipt` to `claims verify`
- keeps the current diagnostic A770 ledger passing without an experience receipt
- requires promoted `a770.bitnet.trusted_partial_experience` claims to have a claimable `llm_experience_run` receipt
- reports receipt presence, classification, backend, quality/fallback/route status, and critical not-claim coverage in `claims verify`

## Verification
- `cargo test --locked -p xtask --no-default-features --bin xtask claims -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- claims verify --format json`
- `cargo run --locked -p xtask --no-default-features -- claims verify --llm-experience-receipt target/llm-experience-smoke/experience.json --format json`
- `cargo run --locked -p xtask --no-default-features -- claims verify --help | Select-String -Pattern "llm-experience-receipt|claims verify"`
- `cargo run --locked -p xtask --no-default-features -- claims docs --check --format json`
- `cargo test --locked -p xtask --no-default-features --bin xtask llm_experience -- --nocapture`
- `git diff --check a770/llm-experience-history...HEAD`

## Claim boundary
- Does not promote A770 trusted BitNet support
- Current ledger remains diagnostic with `a770_claimable_kernel_count=0`
- Does not run the clean A770 claim sequence
- Does not promote selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion