### PR TITLE
cli: add strict backend proof guard

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -146,6 +146,25 @@ mod proof_summary_tests {
             Some("requested backend intel-arc-a770-opencl executed on cpu")
         );
     }
+
+    #[test]
+    fn run_command_accepts_strict_backend_flag() {
+        let cli = Cli::try_parse_from([
+            "bitnet",
+            "run",
+            "--model",
+            "model.gguf",
+            "--prompt",
+            "hello",
+            "--strict-backend",
+        ])
+        .expect("strict backend flag should parse");
+
+        match cli.command {
+            Some(Commands::Run { strict_backend, .. }) => assert!(strict_backend),
+            _ => panic!("expected run command"),
+        }
+    }
 }
 
 #[cfg(feature = "cli-bench")]
@@ -325,6 +344,10 @@ enum Commands {
         /// Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)
         #[arg(long, default_value_t = false)]
         strict_loader: bool,
+
+        /// Require the requested backend identity to match the actual execution backend
+        #[arg(long, default_value_t = false)]
+        strict_backend: bool,
 
         /// Output JSON results to file
         #[arg(long)]
@@ -640,6 +663,7 @@ async fn main() -> Result<()> {
             strict_mapping,
             strict_tokenizer,
             strict_loader,
+            strict_backend,
             json_out,
             proof_model_contract,
             proof_kernel_route,
@@ -673,6 +697,7 @@ async fn main() -> Result<()> {
                 strict_mapping,
                 strict_tokenizer,
                 strict_loader,
+                strict_backend,
                 json_out,
                 proof_model_contract,
                 proof_kernel_route,
@@ -1422,6 +1447,7 @@ async fn run_simple_generation(
     _strict_mapping: bool,
     strict_tokenizer: bool,
     strict_loader: bool,
+    strict_backend: bool,
     json_out: Option<std::path::PathBuf>,
     proof_model_contract: Option<std::path::PathBuf>,
     proof_kernel_route: Option<String>,
@@ -1490,6 +1516,16 @@ async fn run_simple_generation(
             std::env::set_var("BITNET_STRICT_MODE", "1");
         }
         debug!("Strict loader enabled (BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)");
+    }
+
+    let simple_execution_backend = "cpu";
+    let initial_backend_fallback =
+        backend_fallback_proof(&requested_backend_label, simple_execution_backend);
+    if strict_backend && initial_backend_fallback.used {
+        let reason = initial_backend_fallback
+            .reason
+            .unwrap_or_else(|| "requested backend does not match execution backend".to_string());
+        anyhow::bail!("strict backend check failed: {reason}");
     }
 
     // Override temperature if greedy mode
@@ -2035,7 +2071,7 @@ async fn run_simple_generation(
         });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
-        let execution_backend = "cpu";
+        let execution_backend = simple_execution_backend;
         let requested_backend = requested_backend_label.as_str();
         let backend_fallback = backend_fallback_proof(requested_backend, execution_backend);
         let fallback_used =
@@ -2085,7 +2121,7 @@ async fn run_simple_generation(
                 "backend_fallback_reason": backend_fallback.reason,
                 "loader_fallback_used": loader_fallback_used,
                 "tokenizer_fallback_used": tokenizer_fallback_used,
-                "strict_backend": !allow_mock,
+                "strict_backend": strict_backend,
                 "claim_level": "diagnostic_cli_run",
                 "model_contract": proof_model_contract_path,
                 "model_contract_declared": proof_model_contract.is_some(),

--- a/xtask/src/llm_experience.rs
+++ b/xtask/src/llm_experience.rs
@@ -760,6 +760,7 @@ fn build_cli_command(
         "--deterministic".to_string(),
         "--strict-tokenizer".to_string(),
         "--strict-loader".to_string(),
+        "--strict-backend".to_string(),
         "--prompt-template".to_string(),
         template_name.to_string(),
         "--json-out".to_string(),
@@ -1445,6 +1446,7 @@ mod tests {
         );
         assert!(command.windows(2).any(|args| args == ["--device", "intel-arc-a770-opencl"]));
         assert!(command.windows(2).any(|args| args == ["--features", "cpu,opencl"]));
+        assert!(command.iter().any(|arg| arg == "--strict-backend"));
         assert!(command.iter().any(|arg| arg == "--proof-model-contract"));
         assert!(command.iter().any(|arg| arg == "--proof-kernel-route"));
         assert!(command.iter().any(|arg| arg == "a770.bitnet.i2s.qk256"));


### PR DESCRIPTION
## Summary
- add `bitnet run --strict-backend`
- fail fast when the requested backend identity would execute on a different backend
- make the generated A770 profile CLI plan pass `--strict-backend`

## Claim Boundary
- does not promote A770 execution; it blocks the generated claim-grade A770 run until the runtime can actually execute on A770
- keeps CLI diagnostic runs possible when `--strict-backend` is not used
- keeps selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, and completion unclaimed

## Verification
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu --bin bitnet proof_summary_tests -- --nocapture`
- `cargo test --locked -p xtask --no-default-features --bin xtask llm_experience -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl`
- `cargo run --locked -p xtask --no-default-features -- llm-experience profile-cli-plan --output target/llm-experience-strict-backend/profile-cli-stage-plan.json --format json`
- `git diff --check`