### PR TITLE
qk256: add format-correct OpenCL launcher

### DIFF
--- a/.github/workflows/intel-gpu-compile.yml
+++ b/.github/workflows/intel-gpu-compile.yml
@@ -7,6 +7,7 @@ on:
       - 'crates/bitnet-kernels/src/opencl_*'
       - 'crates/bitnet-opencl/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-compile.yml'
   push:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - 'crates/bitnet-kernels/src/opencl_*'
       - 'crates/bitnet-opencl/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-compile.yml'
   workflow_dispatch:
 
@@ -74,6 +76,34 @@ jobs:
 
       - name: cargo check --workspace (oneapi)
         run: cargo check --locked --workspace --no-default-features --features oneapi
+
+  compile-check-qk256-opencl:
+    name: Compile Check (QK256 OpenCL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+        with:
+          toolchain: "1.92.0"
+
+      - name: Install OpenCL headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ocl-icd-opencl-dev opencl-headers
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+        with:
+          shared-key: intel-gpu-compile-qk256-opencl
+
+      - name: cargo check bitnet-qk256-dispatch (opencl)
+        run: cargo check --locked -p bitnet-qk256-dispatch --no-default-features --features opencl
+
+      - name: Test build bitnet-qk256-dispatch (opencl no-run)
+        run: cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --no-run
 
   opencl-kernel-lint:
     name: OpenCL Kernel Lint

--- a/.github/workflows/intel-gpu-feature-matrix.yml
+++ b/.github/workflows/intel-gpu-feature-matrix.yml
@@ -7,12 +7,14 @@ on:
       - 'crates/bitnet-kernels/**'
       - 'crates/bitnet-common/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-feature-matrix.yml'
   pull_request:
     paths:
       - 'crates/bitnet-kernels/**'
       - 'crates/bitnet-common/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-feature-matrix.yml'
   workflow_dispatch:
 
@@ -110,11 +112,13 @@ jobs:
         run: |
           cargo check --locked -p bitnet-kernels --no-default-features --features cpu
           cargo check --locked -p bitnet-common --no-default-features --features cpu
+          cargo check --locked -p bitnet-qk256-dispatch --no-default-features --features cpu
 
       - name: Verify no OpenCL runtime needed at compile time
         run: |
           # Ensure we can build without OpenCL libraries installed
           cargo build --locked -p bitnet-kernels --no-default-features --features cpu 2>&1
+          cargo build --locked -p bitnet-qk256-dispatch --no-default-features --features cpu 2>&1
 
       - name: Verify device_features compiles without oneapi
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qk256-dispatch",
  "bitnet-quantization",
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "bitnet-quantization",
  "bitnet-test-support",
  "candle-core",
+ "opencl3",
 ]
 
 [[package]]

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -28,6 +28,7 @@ bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-qk256-dispatch = { path = "../bitnet-qk256-dispatch", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -119,6 +119,33 @@ fn canonical_proof_backend_label(label: &str) -> String {
     }
 }
 
+fn proof_backend_labels_match(requested_backend: &str, execution_backend: &str) -> bool {
+    canonical_proof_backend_label(requested_backend)
+        == canonical_proof_backend_label(execution_backend)
+}
+
+fn resolve_simple_generation_device(
+    requested_backend_label: &str,
+    strict_backend: bool,
+) -> Result<(bitnet_common::Device, String)> {
+    use bitnet_common::{BackendRequest, Device, select_backend};
+    use bitnet_kernels::device_features::current_kernel_capabilities;
+
+    let request =
+        BackendRequest::from_label(requested_backend_label).unwrap_or(BackendRequest::Auto);
+    match select_backend(request, &current_kernel_capabilities()) {
+        Ok(selection) if selection.selected_backend() == "intel-arc-a770-opencl" => {
+            Ok((Device::OpenCL(0), selection.selected_backend()))
+        }
+        Ok(_) => Ok((Device::Cpu, "cpu".to_string())),
+        Err(err) if strict_backend => Err(err.into()),
+        Err(err) => {
+            warn!(error = %err, "simple generation backend selection fell back to CPU");
+            Ok((Device::Cpu, "cpu".to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod proof_summary_tests {
     use super::*;
@@ -145,6 +172,16 @@ mod proof_summary_tests {
             proof.reason.as_deref(),
             Some("requested backend intel-arc-a770-opencl executed on cpu")
         );
+    }
+
+    #[test]
+    fn a770_alias_matches_canonical_execution_backend() {
+        assert!(proof_backend_labels_match("a770-opencl", "intel-arc-a770-opencl"));
+    }
+
+    #[test]
+    fn a770_alias_does_not_match_cpu_execution_backend() {
+        assert!(!proof_backend_labels_match("a770-opencl", "cpu"));
     }
 
     #[test]
@@ -1466,7 +1503,6 @@ async fn run_simple_generation(
     assert_greedy: bool,
     no_warnings: bool,
 ) -> Result<()> {
-    use bitnet_common::Device;
     use bitnet_models::{Model, transformer::KVCache};
     use bitnet_sampling::{SamplingConfig, SamplingStrategy};
     use bitnet_tokenizers::Tokenizer;
@@ -1518,9 +1554,10 @@ async fn run_simple_generation(
         debug!("Strict loader enabled (BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)");
     }
 
-    let simple_execution_backend = "cpu";
+    let (model_device, simple_execution_backend) =
+        resolve_simple_generation_device(&requested_backend_label, strict_backend)?;
     let initial_backend_fallback =
-        backend_fallback_proof(&requested_backend_label, simple_execution_backend);
+        backend_fallback_proof(&requested_backend_label, simple_execution_backend.as_str());
     if strict_backend && initial_backend_fallback.used {
         let reason = initial_backend_fallback
             .reason
@@ -1559,7 +1596,7 @@ async fn run_simple_generation(
     // Try real loader first
     use bitnet_models::loader::{LoadConfig, ModelLoader};
 
-    let loader = ModelLoader::new(Device::Cpu);
+    let loader = ModelLoader::new(model_device);
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
     let loader_mode;
@@ -1594,7 +1631,7 @@ async fn run_simple_generation(
             // Mock fallback
             let load_result = bitnet_models::gguf_simple::load_gguf_full(
                 &model_path,
-                Device::Cpu,
+                model_device,
                 bitnet_models::GGUFLoaderConfig::default(),
             )
             .context("Mock loader also failed")?;
@@ -1628,7 +1665,7 @@ async fn run_simple_generation(
                 load_result.config.clone(),
                 load_result.tensors,
                 raw_tensors,
-                Device::Cpu,
+                model_device,
             )
             .context("Failed to build mock model")?;
             (Arc::new(m) as Arc<dyn Model>, load_result.config)
@@ -2071,12 +2108,13 @@ async fn run_simple_generation(
         });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
-        let execution_backend = simple_execution_backend;
+        let execution_backend = simple_execution_backend.as_str();
         let requested_backend = requested_backend_label.as_str();
         let backend_fallback = backend_fallback_proof(requested_backend, execution_backend);
         let fallback_used =
             loader_fallback_used || tokenizer_fallback_used || backend_fallback.used;
-        let execution_backend_matched = requested_backend.eq_ignore_ascii_case(execution_backend);
+        let execution_backend_matched =
+            proof_backend_labels_match(requested_backend, execution_backend);
         let proof_model_contract_path =
             proof_model_contract.as_ref().map(|path| path.display().to_string());
         let proof_kernel_route_id = proof_kernel_route.as_deref();

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -295,6 +295,9 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+// Clap owns this parsed command shape; boxing individual parsed fields breaks
+// value parser inference and would not improve command dispatch behavior.
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Run simple text generation
     ///

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1828,6 +1828,7 @@ async fn run_simple_generation(
 
     // Track generated tokens for repetition penalty
     let mut generated_tokens = Vec::new();
+    bitnet_qk256_dispatch::reset_qk256_dispatch_counters();
 
     // Track logits dump if requested
     let mut logits_dump: Vec<LogitStep> = Vec::new();
@@ -2060,6 +2061,7 @@ async fn run_simple_generation(
     } else {
         0.0
     };
+    let qk256_dispatch = bitnet_qk256_dispatch::qk256_dispatch_counters();
 
     println!("\n\nGeneration complete!");
     println!(
@@ -2173,6 +2175,17 @@ async fn run_simple_generation(
                     "claimable": false,
                 },
                 "route_declared": proof_kernel_route.is_some(),
+                "qk256_dispatch": {
+                    "cpu_calls": qk256_dispatch.cpu_calls,
+                    "cpu_successes": qk256_dispatch.cpu_successes,
+                    "cpu_input_rows": qk256_dispatch.cpu_input_rows,
+                    "opencl_calls": qk256_dispatch.opencl_calls,
+                    "opencl_successes": qk256_dispatch.opencl_successes,
+                    "opencl_input_rows": qk256_dispatch.opencl_input_rows,
+                    "a770_qk256_opencl_used": qk256_dispatch.opencl_successes > 0,
+                    "diagnostic_only": true,
+                    "claimable": false,
+                },
                 "backend_claimable": false,
                 "not_claims": critical_not_claims(),
             },

--- a/crates/bitnet-kernels/src/device_features.rs
+++ b/crates/bitnet-kernels/src/device_features.rs
@@ -179,14 +179,12 @@ pub fn opencl_available_runtime() -> bool {
         .map(|v| v == "1" || v.to_lowercase() == "true")
         .unwrap_or(false);
 
-    if !strict_mode {
-        if let Ok(fake) = env::var("BITNET_GPU_FAKE") {
-            if fake.eq_ignore_ascii_case("opencl") {
-                return true;
-            }
-            if fake.eq_ignore_ascii_case("none") {
-                return false;
-            }
+    if !strict_mode && let Ok(fake) = env::var("BITNET_GPU_FAKE") {
+        if fake.eq_ignore_ascii_case("opencl") {
+            return true;
+        }
+        if fake.eq_ignore_ascii_case("none") {
+            return false;
         }
     }
 

--- a/crates/bitnet-models/src/bitnet.rs
+++ b/crates/bitnet-models/src/bitnet.rs
@@ -92,6 +92,11 @@ impl BitNetModel {
         };
 
         // Create a VarBuilder that uses our loaded tensors
+        let qk256_backend = if device.is_opencl() {
+            crate::transformer::Qk256DispatchBackend::OpenCl
+        } else {
+            crate::transformer::Qk256DispatchBackend::Cpu
+        };
         let device = device.to_candle().map_err(|e| BitNetError::Validation(e.to_string()))?;
 
         if tensors.is_empty() {
@@ -129,7 +134,12 @@ impl BitNetModel {
         let raw_mapped = remap_gguf_weights(raw_tensors)?;
 
         let vb = create_var_builder(mapped.clone(), DType::F32, &device)?;
-        let model = TransformerModel::new_with_tensors(updated_config, vb, raw_mapped)?;
+        let model = TransformerModel::new_with_tensors_and_qk256_backend(
+            updated_config,
+            vb,
+            raw_mapped,
+            qk256_backend,
+        )?;
         Ok(Arc::new(model))
     }
 

--- a/crates/bitnet-qk256-dispatch/Cargo.toml
+++ b/crates/bitnet-qk256-dispatch/Cargo.toml
@@ -16,6 +16,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-qk256-layout-core = { path = "../bitnet-qk256-layout-core", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 candle-core = { workspace = true }
+opencl3 = { version = "0.12", optional = true }
 
 [dev-dependencies]
 bitnet-test-support.workspace = true
@@ -24,7 +25,7 @@ bitnet-test-support.workspace = true
 default = []
 cpu = ["bitnet-quantization/cpu"]
 cuda = ["bitnet-common/cuda", "candle-core/cuda", "bitnet-quantization/cuda"]
-opencl = ["bitnet-common/opencl", "bitnet-quantization/opencl"]
+opencl = ["dep:opencl3", "bitnet-common/opencl", "bitnet-quantization/opencl"]
 oneapi = ["bitnet-common/oneapi", "bitnet-quantization/oneapi", "opencl"]
 metal = ["bitnet-common/metal"]
 gpu = ["cuda", "metal", "opencl"]

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -7,9 +7,47 @@ pub use opencl::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC, gemm_qk256_o
 use bitnet_common::{BitNetError, KernelError, Result};
 use bitnet_qk256_layout_core::{parse_input_shape, parse_qk256_layout, validate_input_cols};
 use candle_core::Tensor;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const NOT_CLAIMED_OPENCL_QK256: &[&str] =
     &["a770_qk256_opencl_execution", "a770_qk256_opencl_performance", "a770_full_device_residency"];
+
+static CPU_CALLS: AtomicU64 = AtomicU64::new(0);
+static CPU_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static CPU_INPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+static OPENCL_CALLS: AtomicU64 = AtomicU64::new(0);
+static OPENCL_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static OPENCL_INPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Qk256DispatchCounters {
+    pub cpu_calls: u64,
+    pub cpu_successes: u64,
+    pub cpu_input_rows: u64,
+    pub opencl_calls: u64,
+    pub opencl_successes: u64,
+    pub opencl_input_rows: u64,
+}
+
+pub fn qk256_dispatch_counters() -> Qk256DispatchCounters {
+    Qk256DispatchCounters {
+        cpu_calls: CPU_CALLS.load(Ordering::Relaxed),
+        cpu_successes: CPU_SUCCESSES.load(Ordering::Relaxed),
+        cpu_input_rows: CPU_INPUT_ROWS.load(Ordering::Relaxed),
+        opencl_calls: OPENCL_CALLS.load(Ordering::Relaxed),
+        opencl_successes: OPENCL_SUCCESSES.load(Ordering::Relaxed),
+        opencl_input_rows: OPENCL_INPUT_ROWS.load(Ordering::Relaxed),
+    }
+}
+
+pub fn reset_qk256_dispatch_counters() {
+    CPU_CALLS.store(0, Ordering::Relaxed);
+    CPU_SUCCESSES.store(0, Ordering::Relaxed);
+    CPU_INPUT_ROWS.store(0, Ordering::Relaxed);
+    OPENCL_CALLS.store(0, Ordering::Relaxed);
+    OPENCL_SUCCESSES.store(0, Ordering::Relaxed);
+    OPENCL_INPUT_ROWS.store(0, Ordering::Relaxed);
+}
 
 /// Describes which QK256 runtime is currently used by this dispatch crate.
 ///
@@ -118,6 +156,8 @@ pub fn forward_qk256_with_backend(
 
     match backend {
         Qk256DispatchBackend::Cpu => {
+            CPU_CALLS.fetch_add(1, Ordering::Relaxed);
+            CPU_INPUT_ROWS.fetch_add(input_rows as u64, Ordering::Relaxed);
             for (i, input_row) in input_vec.iter().enumerate() {
                 let start = i * layout.rows;
                 let end = start + layout.rows;
@@ -136,8 +176,11 @@ pub fn forward_qk256_with_backend(
                     ))
                 })?;
             }
+            CPU_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
         Qk256DispatchBackend::OpenCl => {
+            OPENCL_CALLS.fetch_add(1, Ordering::Relaxed);
+            OPENCL_INPUT_ROWS.fetch_add(input_rows as u64, Ordering::Relaxed);
             run_opencl_qk256(
                 &flat_bytes,
                 &input_vec,
@@ -147,6 +190,7 @@ pub fn forward_qk256_with_backend(
                 layout.row_stride_bytes,
                 weight_name,
             )?;
+            OPENCL_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
     }
 

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -1,4 +1,10 @@
-use bitnet_common::{BitNetError, Result};
+#[cfg(feature = "opencl")]
+mod opencl;
+
+#[cfg(feature = "opencl")]
+pub use opencl::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC, gemm_qk256_opencl};
+
+use bitnet_common::{BitNetError, KernelError, Result};
 use bitnet_qk256_layout_core::{parse_input_shape, parse_qk256_layout, validate_input_cols};
 use candle_core::Tensor;
 
@@ -14,6 +20,7 @@ const NOT_CLAIMED_OPENCL_QK256: &[&str] =
 pub struct Qk256DispatchStatus {
     pub compiled_opencl: bool,
     pub compiled_oneapi: bool,
+    pub opencl_launcher_available: bool,
     pub runtime_backend: &'static str,
     pub accelerator_claimable: bool,
     pub blocker: Option<&'static str>,
@@ -25,9 +32,9 @@ pub fn qk256_dispatch_status() -> Qk256DispatchStatus {
     let compiled_opencl = cfg!(feature = "opencl");
     let compiled_oneapi = cfg!(feature = "oneapi");
     let blocker = if compiled_oneapi {
-        Some("oneapi_qk256_runtime_not_wired")
+        Some("oneapi_qk256_transformer_dispatch_not_wired")
     } else if compiled_opencl {
-        Some("opencl_qk256_runtime_not_wired")
+        Some("opencl_qk256_transformer_dispatch_not_wired")
     } else {
         Some("cpu_qk256_dispatch_only")
     };
@@ -35,6 +42,7 @@ pub fn qk256_dispatch_status() -> Qk256DispatchStatus {
     Qk256DispatchStatus {
         compiled_opencl,
         compiled_oneapi,
+        opencl_launcher_available: cfg!(feature = "opencl"),
         runtime_backend: "cpu_qk256_reference",
         accelerator_claimable: false,
         blocker,
@@ -42,8 +50,24 @@ pub fn qk256_dispatch_status() -> Qk256DispatchStatus {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Qk256DispatchBackend {
+    Cpu,
+    OpenCl,
+}
+
 /// Runs I2_S QK256 forward pass for input tensor shapes [B, T, H] or [B, H].
 pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -> Result<Tensor> {
+    forward_qk256_with_backend(input, qk256_tensor, weight_name, Qk256DispatchBackend::Cpu)
+}
+
+/// Runs I2_S QK256 forward pass using an explicit dispatch backend.
+pub fn forward_qk256_with_backend(
+    input: &Tensor,
+    qk256_tensor: &Tensor,
+    weight_name: &str,
+    backend: Qk256DispatchBackend,
+) -> Result<Tensor> {
     use bitnet_quantization::i2s_qk256::gemv_qk256;
 
     let qk256_dims = qk256_tensor.dims();
@@ -78,7 +102,8 @@ pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -
         ))
     })?;
 
-    let mut output_vec = vec![vec![0.0f32; layout.rows]; shape.batch_size * shape.seq_len];
+    let input_rows = shape.batch_size * shape.seq_len;
+    let mut output_flat = vec![0.0f32; input_rows * layout.rows];
 
     if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && weight_name.contains("layers.0.")
     {
@@ -91,24 +116,40 @@ pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -
         });
     }
 
-    for (i, input_row) in input_vec.iter().enumerate() {
-        gemv_qk256(
-            &flat_bytes,
-            input_row,
-            &mut output_vec[i],
-            layout.rows,
-            layout.cols,
-            layout.row_stride_bytes,
-        )
-        .map_err(|e| {
-            BitNetError::Validation(format!(
-                "QK256 GEMV failed for {} at row {}: {}",
-                weight_name, i, e
-            ))
-        })?;
+    match backend {
+        Qk256DispatchBackend::Cpu => {
+            for (i, input_row) in input_vec.iter().enumerate() {
+                let start = i * layout.rows;
+                let end = start + layout.rows;
+                gemv_qk256(
+                    &flat_bytes,
+                    input_row,
+                    &mut output_flat[start..end],
+                    layout.rows,
+                    layout.cols,
+                    layout.row_stride_bytes,
+                )
+                .map_err(|e| {
+                    BitNetError::Validation(format!(
+                        "QK256 GEMV failed for {} at row {}: {}",
+                        weight_name, i, e
+                    ))
+                })?;
+            }
+        }
+        Qk256DispatchBackend::OpenCl => {
+            run_opencl_qk256(
+                &flat_bytes,
+                &input_vec,
+                &mut output_flat,
+                layout.rows,
+                layout.cols,
+                layout.row_stride_bytes,
+                weight_name,
+            )?;
+        }
     }
 
-    let output_flat: Vec<f32> = output_vec.into_iter().flatten().collect();
     let output_tensor = if shape.input_rank == 3 {
         Tensor::from_vec(
             output_flat,
@@ -120,4 +161,43 @@ pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -
     };
 
     Ok(output_tensor)
+}
+
+fn run_opencl_qk256(
+    flat_bytes: &[u8],
+    input_vec: &[Vec<f32>],
+    output_flat: &mut [f32],
+    rows: usize,
+    cols: usize,
+    row_stride_bytes: usize,
+    weight_name: &str,
+) -> Result<()> {
+    #[cfg(feature = "opencl")]
+    {
+        let input_flat: Vec<f32> = input_vec.iter().flat_map(|row| row.iter().copied()).collect();
+        opencl::gemm_qk256_opencl(
+            flat_bytes,
+            &input_flat,
+            output_flat,
+            input_vec.len(),
+            rows,
+            cols,
+            row_stride_bytes,
+        )
+        .map_err(|e| {
+            BitNetError::Kernel(KernelError::GpuError {
+                reason: format!("OpenCL QK256 GEMV failed for {weight_name}: {e}"),
+            })
+        })
+    }
+
+    #[cfg(not(feature = "opencl"))]
+    {
+        let _ = (flat_bytes, input_vec, output_flat, rows, cols, row_stride_bytes);
+        Err(BitNetError::Kernel(KernelError::DeviceUnavailable {
+            reason: format!(
+                "OpenCL QK256 dispatch requested for {weight_name}, but opencl feature is disabled"
+            ),
+        }))
+    }
 }

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -8,6 +8,7 @@ use opencl3::platform::get_platforms;
 use opencl3::program::Program;
 use opencl3::types::CL_BLOCKING;
 use std::ptr::null_mut;
+use std::sync::{Mutex, OnceLock};
 
 pub const QK256_OPENCL_KERNEL_NAME: &str = "qk256_gemm_no_scale";
 
@@ -62,7 +63,12 @@ pub fn gemm_qk256_opencl(
 ) -> Result<()> {
     validate_args(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)?;
 
-    let runtime = OpenClQk256Runtime::new()?;
+    let runtime = qk256_runtime()?;
+    let runtime = runtime.lock().map_err(|_| {
+        BitNetError::Kernel(KernelError::ExecutionFailed {
+            reason: "QK256 OpenCL runtime cache lock was poisoned".to_string(),
+        })
+    })?;
     runtime.run(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)
 }
 
@@ -132,6 +138,26 @@ struct OpenClQk256Runtime {
     context: Context,
     queue: CommandQueue,
     program: Program,
+}
+
+// SAFETY: OpenCL handles are reference-counted driver objects. The cached runtime
+// is only accessed through a Mutex, so the single command queue is not used
+// concurrently by Rust callers.
+unsafe impl Send for OpenClQk256Runtime {}
+
+static QK256_RUNTIME: OnceLock<Mutex<OpenClQk256Runtime>> = OnceLock::new();
+
+fn qk256_runtime() -> Result<&'static Mutex<OpenClQk256Runtime>> {
+    if let Some(runtime) = QK256_RUNTIME.get() {
+        return Ok(runtime);
+    }
+
+    let runtime = Mutex::new(OpenClQk256Runtime::new()?);
+    if QK256_RUNTIME.set(runtime).is_ok() {
+        Ok(QK256_RUNTIME.get().expect("QK256 runtime must be set after initialization"))
+    } else {
+        Ok(QK256_RUNTIME.get().expect("QK256 runtime must be set after racing initialization"))
+    }
 }
 
 impl OpenClQk256Runtime {

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -1,0 +1,282 @@
+use bitnet_common::{BitNetError, KernelError, Result};
+use opencl3::command_queue::{CL_QUEUE_PROFILING_ENABLE, CommandQueue};
+use opencl3::context::Context;
+use opencl3::device::{CL_DEVICE_TYPE_GPU, Device};
+use opencl3::kernel::{ExecuteKernel, Kernel};
+use opencl3::memory::{Buffer, CL_MEM_READ_ONLY, CL_MEM_WRITE_ONLY, ClMem};
+use opencl3::platform::get_platforms;
+use opencl3::program::Program;
+use opencl3::types::CL_BLOCKING;
+use std::ptr::null_mut;
+
+pub const QK256_OPENCL_KERNEL_NAME: &str = "qk256_gemm_no_scale";
+
+pub const QK256_OPENCL_KERNEL_SRC: &str = r#"
+__kernel void qk256_gemm_no_scale(
+    __global const uchar* qs,
+    __global const float* input,
+    __global float* output,
+    const uint input_rows,
+    const uint rows,
+    const uint cols,
+    const uint row_stride_bytes
+) {
+    const uint row = get_global_id(0);
+    const uint input_row = get_global_id(1);
+    if (row >= rows || input_row >= input_rows) {
+        return;
+    }
+
+    __global const uchar* row_bytes = qs + ((ulong)row * (ulong)row_stride_bytes);
+    __global const float* x = input + ((ulong)input_row * (ulong)cols);
+
+    float acc = 0.0f;
+    for (uint col = 0; col < cols; ++col) {
+        const uchar packed = row_bytes[col >> 2];
+        const uchar code = (packed >> ((col & 3u) * 2u)) & 3u;
+        float w;
+        if (code == 0u) {
+            w = -2.0f;
+        } else if (code == 1u) {
+            w = -1.0f;
+        } else if (code == 2u) {
+            w = 1.0f;
+        } else {
+            w = 2.0f;
+        }
+        acc += w * x[col];
+    }
+
+    output[((ulong)input_row * (ulong)rows) + (ulong)row] = acc;
+}
+"#;
+
+pub fn gemm_qk256_opencl(
+    qs_data: &[u8],
+    input: &[f32],
+    output: &mut [f32],
+    input_rows: usize,
+    rows: usize,
+    cols: usize,
+    row_stride_bytes: usize,
+) -> Result<()> {
+    validate_args(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)?;
+
+    let runtime = OpenClQk256Runtime::new()?;
+    runtime.run(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)
+}
+
+fn validate_args(
+    qs_data: &[u8],
+    input: &[f32],
+    output: &[f32],
+    input_rows: usize,
+    rows: usize,
+    cols: usize,
+    row_stride_bytes: usize,
+) -> Result<()> {
+    if input_rows == 0 || rows == 0 || cols == 0 {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: "QK256 OpenCL dimensions must be non-zero".to_string(),
+        }));
+    }
+    let expected_qs = checked_len("rows * row_stride_bytes", rows, row_stride_bytes)?;
+    let expected_input = checked_len("input_rows * cols", input_rows, cols)?;
+    let expected_output = checked_len("input_rows * rows", input_rows, rows)?;
+
+    if qs_data.len() < expected_qs {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!("QK256 OpenCL qs length {} < expected {}", qs_data.len(), expected_qs),
+        }));
+    }
+    if input.len() < expected_input {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!(
+                "QK256 OpenCL input length {} < expected {}",
+                input.len(),
+                expected_input
+            ),
+        }));
+    }
+    if output.len() != expected_output {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!(
+                "QK256 OpenCL output length {} != expected {}",
+                output.len(),
+                expected_output
+            ),
+        }));
+    }
+    u32::try_from(input_rows).map_err(|_| too_large("input_rows", input_rows))?;
+    u32::try_from(rows).map_err(|_| too_large("rows", rows))?;
+    u32::try_from(cols).map_err(|_| too_large("cols", cols))?;
+    u32::try_from(row_stride_bytes).map_err(|_| too_large("row_stride_bytes", row_stride_bytes))?;
+    Ok(())
+}
+
+fn checked_len(name: &str, lhs: usize, rhs: usize) -> Result<usize> {
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!("QK256 OpenCL length overflow for {name}: {lhs} * {rhs}"),
+        })
+    })
+}
+
+fn too_large(field: &str, value: usize) -> BitNetError {
+    BitNetError::Kernel(KernelError::InvalidArguments {
+        reason: format!("QK256 OpenCL {field}={value} exceeds u32 range"),
+    })
+}
+
+struct OpenClQk256Runtime {
+    context: Context,
+    queue: CommandQueue,
+    program: Program,
+}
+
+impl OpenClQk256Runtime {
+    fn new() -> Result<Self> {
+        let platforms = get_platforms().map_err(|e| {
+            BitNetError::Kernel(KernelError::GpuError {
+                reason: format!("failed to query OpenCL platforms: {e}"),
+            })
+        })?;
+
+        for platform in &platforms {
+            let device_ids = platform.get_devices(CL_DEVICE_TYPE_GPU).unwrap_or_default();
+            for device_id in device_ids {
+                let device = Device::new(device_id);
+                let vendor = device.vendor().unwrap_or_default();
+                if !vendor.to_ascii_lowercase().contains("intel") {
+                    continue;
+                }
+
+                let context = Context::from_device(&device).map_err(|e| {
+                    BitNetError::Kernel(KernelError::GpuError {
+                        reason: format!("failed to create OpenCL context: {e}"),
+                    })
+                })?;
+                let queue = CommandQueue::create_default_with_properties(
+                    &context,
+                    CL_QUEUE_PROFILING_ENABLE,
+                    0,
+                )
+                .map_err(|e| {
+                    BitNetError::Kernel(KernelError::GpuError {
+                        reason: format!("failed to create OpenCL command queue: {e}"),
+                    })
+                })?;
+                let program = Program::create_and_build_from_source(
+                    &context,
+                    QK256_OPENCL_KERNEL_SRC,
+                    "-cl-std=CL1.2",
+                )
+                .map_err(|e| {
+                    BitNetError::Kernel(KernelError::GpuError {
+                        reason: format!("failed to build QK256 OpenCL program: {e}"),
+                    })
+                })?;
+
+                return Ok(Self { context, queue, program });
+            }
+        }
+
+        Err(BitNetError::Kernel(KernelError::DeviceUnavailable {
+            reason: "no Intel GPU OpenCL device found for QK256 dispatch".to_string(),
+        }))
+    }
+
+    fn run(
+        &self,
+        qs_data: &[u8],
+        input: &[f32],
+        output: &mut [f32],
+        input_rows: usize,
+        rows: usize,
+        cols: usize,
+        row_stride_bytes: usize,
+    ) -> Result<()> {
+        let mut qs_buf = unsafe {
+            Buffer::<u8>::create(&self.context, CL_MEM_READ_ONLY, qs_data.len(), null_mut())
+        }
+        .map_err(buffer_error("QK256 weights"))?;
+        let mut input_buf = unsafe {
+            Buffer::<f32>::create(&self.context, CL_MEM_READ_ONLY, input.len(), null_mut())
+        }
+        .map_err(buffer_error("QK256 input"))?;
+        let output_buf = unsafe {
+            Buffer::<f32>::create(&self.context, CL_MEM_WRITE_ONLY, output.len(), null_mut())
+        }
+        .map_err(buffer_error("QK256 output"))?;
+
+        unsafe {
+            self.queue
+                .enqueue_write_buffer(&mut qs_buf, CL_BLOCKING, 0, qs_data, &[])
+                .map_err(transfer_error("write QK256 weights"))?;
+            self.queue
+                .enqueue_write_buffer(&mut input_buf, CL_BLOCKING, 0, input, &[])
+                .map_err(transfer_error("write QK256 input"))?;
+        }
+
+        let kernel = Kernel::create(&self.program, QK256_OPENCL_KERNEL_NAME).map_err(|e| {
+            BitNetError::Kernel(KernelError::LaunchFailed {
+                kernel: QK256_OPENCL_KERNEL_NAME.to_string(),
+                reason: format!("failed to create kernel: {e}"),
+            })
+        })?;
+
+        let input_rows_u32 = input_rows as u32;
+        let rows_u32 = rows as u32;
+        let cols_u32 = cols as u32;
+        let row_stride_u32 = row_stride_bytes as u32;
+
+        let event = unsafe {
+            ExecuteKernel::new(&kernel)
+                .set_arg(&qs_buf.get())
+                .set_arg(&input_buf.get())
+                .set_arg(&output_buf.get())
+                .set_arg(&input_rows_u32)
+                .set_arg(&rows_u32)
+                .set_arg(&cols_u32)
+                .set_arg(&row_stride_u32)
+                .set_global_work_sizes(&[rows, input_rows])
+                .enqueue_nd_range(&self.queue)
+                .map_err(|e| {
+                    BitNetError::Kernel(KernelError::LaunchFailed {
+                        kernel: QK256_OPENCL_KERNEL_NAME.to_string(),
+                        reason: format!("enqueue failed: {e}"),
+                    })
+                })?
+        };
+
+        event.wait().map_err(|e| {
+            BitNetError::Kernel(KernelError::ExecutionFailed {
+                reason: format!("QK256 OpenCL wait failed: {e}"),
+            })
+        })?;
+
+        unsafe {
+            self.queue
+                .enqueue_read_buffer(&output_buf, CL_BLOCKING, 0, output, &[])
+                .map_err(transfer_error("read QK256 output"))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn buffer_error(name: &'static str) -> impl Fn(opencl3::error_codes::ClError) -> BitNetError {
+    move |e| {
+        BitNetError::Kernel(KernelError::GpuError {
+            reason: format!("failed to allocate {name} buffer: {e}"),
+        })
+    }
+}
+
+fn transfer_error(name: &'static str) -> impl Fn(opencl3::error_codes::ClError) -> BitNetError {
+    move |e| {
+        BitNetError::Kernel(KernelError::ExecutionFailed {
+            reason: format!("{name} transfer failed: {e}"),
+        })
+    }
+}

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -107,6 +107,8 @@ fn qk256_opencl_source_matches_ggml_no_scale_mapping() {
 
     assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
     assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("row_bytes[col >> 2]"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("(packed >> ((col & 3u) * 2u)) & 3u"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -2.0f"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -1.0f"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("w = 1.0f"));

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -1,10 +1,21 @@
 use bitnet_qk256_dispatch::{
-    Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend, qk256_dispatch_status,
+    Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend, qk256_dispatch_counters,
+    qk256_dispatch_status, reset_qk256_dispatch_counters,
 };
 use candle_core::{Device, Tensor};
+use std::sync::{Mutex, MutexGuard};
+
+static COUNTER_LOCK: Mutex<()> = Mutex::new(());
+
+fn counter_guard() -> MutexGuard<'static, ()> {
+    COUNTER_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 #[test]
 fn forward_qk256_supports_rank2_input() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -18,6 +29,9 @@ fn forward_qk256_supports_rank2_input() {
 
 #[test]
 fn forward_qk256_explicit_cpu_backend_matches_default() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -37,6 +51,9 @@ fn forward_qk256_explicit_cpu_backend_matches_default() {
 
 #[test]
 fn forward_qk256_supports_rank3_input() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 2 * 2 * 256], (2, 2, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -54,6 +71,9 @@ fn forward_qk256_supports_rank3_input() {
 
 #[test]
 fn forward_qk256_rejects_dimension_mismatch() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 128], (1, 128), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -65,6 +85,9 @@ fn forward_qk256_rejects_dimension_mismatch() {
 #[cfg(not(feature = "opencl"))]
 #[test]
 fn forward_qk256_opencl_backend_requires_opencl_feature() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -82,6 +105,8 @@ fn forward_qk256_opencl_backend_requires_opencl_feature() {
 
 #[test]
 fn qk256_dispatch_status_keeps_opencl_non_claiming() {
+    let _guard = counter_guard();
+
     let status = qk256_dispatch_status();
 
     assert_eq!(status.compiled_opencl, cfg!(feature = "opencl"));
@@ -100,10 +125,61 @@ fn qk256_dispatch_status_keeps_opencl_non_claiming() {
     }
 }
 
+#[test]
+fn qk256_dispatch_counters_track_cpu_successes_and_rows() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 2 * 2 * 256], (2, 2, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    forward_qk256(&input, &qk, "layers.0.feed_forward.up_proj.weight.qk256_qs").unwrap();
+
+    let counters = qk256_dispatch_counters();
+    assert_eq!(counters.cpu_calls, 1);
+    assert_eq!(counters.cpu_successes, 1);
+    assert_eq!(counters.cpu_input_rows, 4);
+    assert_eq!(counters.opencl_calls, 0);
+    assert_eq!(counters.opencl_successes, 0);
+    assert_eq!(counters.opencl_input_rows, 0);
+
+    reset_qk256_dispatch_counters();
+    assert_eq!(qk256_dispatch_counters(), Default::default());
+}
+
+#[cfg(not(feature = "opencl"))]
+#[test]
+fn qk256_dispatch_counters_track_failed_opencl_attempts_without_success() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    let err = forward_qk256_with_backend(
+        &input,
+        &qk,
+        "layers.0.attention.q_proj.weight.qk256_qs",
+        Qk256DispatchBackend::OpenCl,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("opencl feature is disabled"));
+    let counters = qk256_dispatch_counters();
+    assert_eq!(counters.opencl_calls, 1);
+    assert_eq!(counters.opencl_successes, 0);
+    assert_eq!(counters.opencl_input_rows, 1);
+    assert_eq!(counters.cpu_calls, 0);
+}
+
 #[cfg(feature = "opencl")]
 #[test]
 fn qk256_opencl_source_matches_ggml_no_scale_mapping() {
     use bitnet_qk256_dispatch::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC};
+
+    let _guard = counter_guard();
 
     assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
     assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -1,4 +1,6 @@
-use bitnet_qk256_dispatch::{forward_qk256, qk256_dispatch_status};
+use bitnet_qk256_dispatch::{
+    Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend, qk256_dispatch_status,
+};
 use candle_core::{Device, Tensor};
 
 #[test]
@@ -12,6 +14,25 @@ fn forward_qk256_supports_rank2_input() {
 
     let out_vals = out.to_vec2::<f32>().unwrap();
     assert!((out_vals[0][0] - 256.0).abs() < 1e-4);
+}
+
+#[test]
+fn forward_qk256_explicit_cpu_backend_matches_default() {
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    let default_out =
+        forward_qk256(&input, &qk, "layers.0.attention.q_proj.weight.qk256_qs").unwrap();
+    let explicit_out = forward_qk256_with_backend(
+        &input,
+        &qk,
+        "layers.0.attention.q_proj.weight.qk256_qs",
+        Qk256DispatchBackend::Cpu,
+    )
+    .unwrap();
+
+    assert_eq!(default_out.to_vec2::<f32>().unwrap(), explicit_out.to_vec2::<f32>().unwrap());
 }
 
 #[test]
@@ -41,21 +62,55 @@ fn forward_qk256_rejects_dimension_mismatch() {
     assert!(err.to_string().contains("dimension mismatch"));
 }
 
+#[cfg(not(feature = "opencl"))]
+#[test]
+fn forward_qk256_opencl_backend_requires_opencl_feature() {
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    let err = forward_qk256_with_backend(
+        &input,
+        &qk,
+        "layers.0.attention.q_proj.weight.qk256_qs",
+        Qk256DispatchBackend::OpenCl,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("opencl feature is disabled"));
+}
+
 #[test]
 fn qk256_dispatch_status_keeps_opencl_non_claiming() {
     let status = qk256_dispatch_status();
 
     assert_eq!(status.compiled_opencl, cfg!(feature = "opencl"));
     assert_eq!(status.compiled_oneapi, cfg!(feature = "oneapi"));
+    assert_eq!(status.opencl_launcher_available, cfg!(feature = "opencl"));
     assert_eq!(status.runtime_backend, "cpu_qk256_reference");
     assert!(!status.accelerator_claimable);
     assert!(status.not_claims.contains(&"a770_qk256_opencl_execution"));
 
     if cfg!(feature = "oneapi") {
-        assert_eq!(status.blocker, Some("oneapi_qk256_runtime_not_wired"));
+        assert_eq!(status.blocker, Some("oneapi_qk256_transformer_dispatch_not_wired"));
     } else if cfg!(feature = "opencl") {
-        assert_eq!(status.blocker, Some("opencl_qk256_runtime_not_wired"));
+        assert_eq!(status.blocker, Some("opencl_qk256_transformer_dispatch_not_wired"));
     } else {
         assert_eq!(status.blocker, Some("cpu_qk256_dispatch_only"));
     }
+}
+
+#[cfg(feature = "opencl")]
+#[test]
+fn qk256_opencl_source_matches_ggml_no_scale_mapping() {
+    use bitnet_qk256_dispatch::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC};
+
+    assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -2.0f"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -1.0f"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = 1.0f"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = 2.0f"));
+    assert!(!QK256_OPENCL_KERNEL_SRC.contains("scales"));
+    assert!(!QK256_OPENCL_KERNEL_SRC.contains("* scale"));
 }

--- a/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
+++ b/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "opencl")]
+
+use bitnet_qk256_dispatch::{Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend};
+use candle_core::{Device, Tensor};
+
+#[test]
+#[ignore = "requires an Intel OpenCL GPU runtime; run manually on the A770 proof station"]
+fn opencl_qk256_matches_cpu_reference_for_known_rows() {
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+
+    let mut qk_bytes = Vec::with_capacity(2 * 64);
+    qk_bytes.extend_from_slice(&[0xAAu8; 64]);
+    qk_bytes.extend_from_slice(&[0x55u8; 64]);
+    let qk = Tensor::from_vec(qk_bytes, (2, 64), &device).unwrap();
+
+    let weight_name = "layers.0.attention.q_proj.weight.qk256_qs";
+    let cpu = forward_qk256(&input, &qk, weight_name).unwrap();
+    let opencl =
+        forward_qk256_with_backend(&input, &qk, weight_name, Qk256DispatchBackend::OpenCl).unwrap();
+
+    let cpu_vals = cpu.to_vec2::<f32>().unwrap();
+    let opencl_vals = opencl.to_vec2::<f32>().unwrap();
+
+    assert_eq!(cpu_vals.len(), opencl_vals.len());
+    assert_eq!(cpu_vals[0].len(), opencl_vals[0].len());
+    for (expected_row, actual_row) in cpu_vals.iter().zip(opencl_vals.iter()) {
+        for (&expected, &actual) in expected_row.iter().zip(actual_row.iter()) {
+            assert!(
+                (expected - actual).abs() <= 1e-4,
+                "OpenCL QK256 mismatch: expected {expected}, actual {actual}"
+            );
+        }
+    }
+}

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1,5 +1,6 @@
 use bitnet_common::{BitNetConfig, BitNetError, Result};
-use bitnet_qk256_dispatch::forward_qk256;
+pub use bitnet_qk256_dispatch::Qk256DispatchBackend;
+use bitnet_qk256_dispatch::forward_qk256_with_backend;
 use bitnet_rope::{build_tables as build_rope_tables, resolve_base as resolve_rope_base};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{LayerNorm, Linear, VarBuilder};
@@ -197,10 +198,16 @@ pub struct MultiHeadAttention {
     o_proj: Linear,
     rope: Option<RotaryEmbedding>,
     layer_idx: usize, // Layer index for QK256 weight name generation
+    qk256_backend: Qk256DispatchBackend,
 }
 
 impl MultiHeadAttention {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         let n_heads = config.model.num_heads;
         let head_dim = hidden_size / n_heads;
@@ -270,6 +277,7 @@ impl MultiHeadAttention {
             o_proj,
             rope,
             layer_idx,
+            qk256_backend,
         })
     }
 
@@ -559,7 +567,7 @@ impl MultiHeadAttention {
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
             tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256(input, qk256_tensor, &qk256_key);
+            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
         }
 
         // Probe: Why is QK256 not found? (layer 0 only, once)
@@ -610,10 +618,16 @@ pub struct FeedForward {
     up_proj: Linear,
     down_proj: Linear,
     layer_idx: usize, // Layer index for QK256 weight name generation
+    qk256_backend: Qk256DispatchBackend,
 }
 
 impl FeedForward {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         let intermediate_size = config.model.intermediate_size;
 
@@ -630,6 +644,7 @@ impl FeedForward {
                 vb.pp("down_proj"),
             )?,
             layer_idx,
+            qk256_backend,
         })
     }
 
@@ -698,7 +713,7 @@ impl FeedForward {
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
             tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256(input, qk256_tensor, &qk256_key);
+            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
         }
 
         // Fall back to standard linear
@@ -720,7 +735,12 @@ pub struct TransformerBlock {
 }
 
 impl TransformerBlock {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         // PATCH 1: Use RMSNorm epsilon from config header for ALL norms (per-layer + final)
         let eps = config.model.rms_norm_eps.map(|e| e as f64).unwrap_or(1e-5);
@@ -728,8 +748,18 @@ impl TransformerBlock {
         tracing::debug!("TransformerBlock using RMSNorm eps={} (from header)", eps);
 
         Ok(Self {
-            attention: MultiHeadAttention::new(config, vb.pp("attention"), layer_idx)?,
-            feed_forward: FeedForward::new(config, vb.pp("feed_forward"), layer_idx)?,
+            attention: MultiHeadAttention::new(
+                config,
+                vb.pp("attention"),
+                layer_idx,
+                qk256_backend,
+            )?,
+            feed_forward: FeedForward::new(
+                config,
+                vb.pp("feed_forward"),
+                layer_idx,
+                qk256_backend,
+            )?,
             attention_norm: layer_norm_with_optional_bias(
                 hidden_size,
                 eps,
@@ -1049,6 +1079,15 @@ impl TransformerModel {
         vb: VarBuilder,
         raw_tensors: std::collections::HashMap<String, Tensor>,
     ) -> Result<Self> {
+        Self::new_with_tensors_and_qk256_backend(config, vb, raw_tensors, Qk256DispatchBackend::Cpu)
+    }
+
+    pub fn new_with_tensors_and_qk256_backend(
+        config: BitNetConfig,
+        vb: VarBuilder,
+        raw_tensors: std::collections::HashMap<String, Tensor>,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let device = vb.device().clone();
         let vocab_size = config.model.vocab_size;
         let hidden_size = config.model.hidden_size;
@@ -1073,7 +1112,12 @@ impl TransformerModel {
 
         let mut layers = Vec::with_capacity(n_layers);
         for i in 0..n_layers {
-            layers.push(TransformerBlock::new(&config, vb.pp(format!("layers.{}", i)), i)?);
+            layers.push(TransformerBlock::new(
+                &config,
+                vb.pp(format!("layers.{}", i)),
+                i,
+                qk256_backend,
+            )?);
         }
 
         // Use RMSNorm epsilon from config header (CRITICAL: must match per-layer norms)

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -289,7 +289,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-009"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-009-benchmark-baseline"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T123205Z-M4-009-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T123205Z-M4-009-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:32:05Z"
+campaign = "apple-m4"
+item = "M4-009"
+event = "merged"
+pr = 3732
+merge_sha = "07f8e2e5a9657f792367e5f25355adf12a1afc50"
+actor = "maintainer"
+
+notes = [
+  "Merged Apple M4 benchmark-baseline campaign item.",
+  "No general Metal speedup, BitNet inference acceleration, or Neural Engine execution claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -17,7 +17,7 @@
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
-| M4-009 | pr_open | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
+| M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "LNL258V-RUN-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v/LNL258V-RUN-001-platform-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T110911Z-LNL258V-RUN-001-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T110911Z-LNL258V-RUN-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:09:11Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-RUN-001"
+event = "merged"
+pr = 3714
+merge_sha = "4dfd156a7e731ccf57f70213566ad63f668a98af"
+actor = "maintainer"
+
+notes = [
+  "Merged Lunar Lake 258V platform probe receipt scaffolding.",
+  "No BitNet inference, Arc 140V packed kernel, or Intel NPU execution claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| LNL258V-RUN-001 | pr_open | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "NPU-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-npu/NPU-002-lite-backend-identity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T115519Z-NPU-002-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T115519Z-NPU-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:55:19Z"
+campaign = "intel-npu"
+item = "NPU-002"
+event = "merged"
+pr = 3722
+merge_sha = "20688198547dbb29a14e31fbdcf46c8c703a2a86"
+actor = "maintainer"
+
+notes = [
+  "Merged Intel NPU backend identity preservation.",
+  "No OpenVINO graph execution, NPU inference, or BitNet subgraph parity claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| NPU-002 | pr_open | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -91,7 +91,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "RTX5070TI-005"
-status = "pr_open"
+status = "merged"
 branch = "codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T132942Z-RTX5070TI-005-merged.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T132942Z-RTX5070TI-005-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T13:29:42Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-005"
+event = "merged"
+pr = 3723
+merge_sha = "8b588762976d17bc2774f0a4a554ecec1d39342f"
+actor = "maintainer"
+
+notes = [
+  "Merged RTX 5070 Ti tiny CUDA kernel smoke receipt.",
+  "No QK256 CUDA, transformer routing, server inference, or end-to-end BitNet acceleration claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | RTX5070TI-003 | merged | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
 | RTX5070TI-004 | merged | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
-| RTX5070TI-005 | pr_open | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
+| RTX5070TI-005 | merged | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -89,7 +89,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-003"
-status = "pr_open"
+status = "merged"
 branch = "codex/tracker-infra/TRACKER-003-current-pr-reconciliation"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T120749Z-TRACKER-003-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T120749Z-TRACKER-003-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:07:49Z"
+campaign = "tracker-infra"
+item = "TRACKER-003"
+event = "merged"
+pr = 3724
+merge_sha = "6f44b77538492182e1a33484ff6683fa2debd8ee"
+actor = "maintainer"
+
+notes = [
+  "Merged current-PR campaign reconciliation for tracker CI.",
+  "No runtime behavior, kernel behavior, or dependency behavior claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
 | TRACKER-002 | merged | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
-| TRACKER-003 | pr_open | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
+| TRACKER-003 | merged | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,8 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-009 | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
-| intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
-| nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
-| tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -10,7 +10,7 @@
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
-| apple-m4 | M4-009 | M4-008 | pr_open |
+| apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |
@@ -24,6 +24,6 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
-| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | pr_open |
+| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
-| tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |
+| tracker-infra | TRACKER-003 | TRACKER-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-009 | #3732 | pr_open | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-010 | TBD | proposed | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-002 | #3722 | pr_open | none | Device-node detection is not inference. |
-| nvidia-5070ti | RTX5070TI-005 | #3723 | pr_open | none | CUDA visibility is not kernel execution. |
+| intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
+| nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-005 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
-| tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/bench_receipt.rs
+++ b/xtask/src/bench_receipt.rs
@@ -488,35 +488,51 @@ fn cli_stage_identity(plan: &Value, cli_stage: &Value, model_contract_path: &Pat
         }
     }
 
-    let requested_backend_matched =
-        planned_backend.is_some() && requested_backend.is_some() && planned_backend == requested_backend;
+    let requested_backend_matched = planned_backend.is_some()
+        && requested_backend.is_some()
+        && planned_backend == requested_backend;
     object.insert("requested_backend_matched".to_string(), Value::Bool(requested_backend_matched));
     if !requested_backend_matched {
-        route_failures.push(field_failure("requested_backend_matched", planned_backend, requested_backend));
+        route_failures.push(field_failure(
+            "requested_backend_matched",
+            planned_backend,
+            requested_backend,
+        ));
     }
 
-    let selected_backend_matched =
-        planned_backend.is_some() && selected_backend.is_some() && planned_backend == selected_backend;
+    let selected_backend_matched = planned_backend.is_some()
+        && selected_backend.is_some()
+        && planned_backend == selected_backend;
     object.insert("selected_backend_matched".to_string(), Value::Bool(selected_backend_matched));
     if !selected_backend_matched {
-        route_failures.push(field_failure("selected_backend_matched", planned_backend, selected_backend));
+        route_failures.push(field_failure(
+            "selected_backend_matched",
+            planned_backend,
+            selected_backend,
+        ));
     }
 
-    let execution_backend_matched =
-        planned_backend.is_some() && execution_backend.is_some() && planned_backend == execution_backend;
-    object.insert(
-        "execution_backend_matched".to_string(),
-        Value::Bool(execution_backend_matched),
-    );
+    let execution_backend_matched = planned_backend.is_some()
+        && execution_backend.is_some()
+        && planned_backend == execution_backend;
+    object.insert("execution_backend_matched".to_string(), Value::Bool(execution_backend_matched));
     if !execution_backend_matched {
-        route_failures.push(field_failure("execution_backend_matched", planned_backend, execution_backend));
+        route_failures.push(field_failure(
+            "execution_backend_matched",
+            planned_backend,
+            execution_backend,
+        ));
     }
 
     let route_declared = bool_at(cli_stage, "/proof_summary/route_declared").unwrap_or(false)
         && declared_route.and_then(Value::as_str).is_some_and(|route| !route.is_empty());
     object.insert("route_declared".to_string(), Value::Bool(route_declared));
     if !route_declared {
-        route_failures.push(field_failure("route_declared", Some(&Value::Bool(true)), Some(&Value::Bool(false))));
+        route_failures.push(field_failure(
+            "route_declared",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
     }
 
     let same_kernel_route =
@@ -526,7 +542,8 @@ fn cli_stage_identity(plan: &Value, cli_stage: &Value, model_contract_path: &Pat
         route_failures.push(field_failure("same_kernel_route", planned_route, declared_route));
     }
 
-    let route_claimable = bool_at(cli_stage, "/proof_summary/kernel_route/claimable").unwrap_or(false);
+    let route_claimable =
+        bool_at(cli_stage, "/proof_summary/kernel_route/claimable").unwrap_or(false);
     object.insert("route_claimable".to_string(), Value::Bool(route_claimable));
     if !route_claimable {
         route_failures.push(field_failure(
@@ -871,8 +888,11 @@ mod tests {
     #[test]
     fn cli_stage_identity_rejects_cpu_execution_with_declared_a770_route() {
         let (plan, cli) = plan_and_cli_stage("cpu");
-        let identity =
-            cli_stage_identity(&plan, &cli, Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"));
+        let identity = cli_stage_identity(
+            &plan,
+            &cli,
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+        );
 
         assert_eq!(identity["profile_matched"], true);
         assert_eq!(identity["model_matched"], true);

--- a/xtask/src/llm_experience.rs
+++ b/xtask/src/llm_experience.rs
@@ -419,17 +419,17 @@ pub fn profile_cli_plan(
     }
 
     let cli_stage_output = "target/llm-experience/profile-cli-stage.json";
-    let cli_command = build_cli_command(
+    let cli_command = build_cli_command(CliCommandSpec {
         backend,
         model_path,
         tokenizer_path,
-        &user_prompt,
+        user_prompt: &user_prompt,
         max_new_tokens,
         template_name,
         cli_stage_output,
         model_contract,
         kernel_route,
-    );
+    });
 
     let mut not_claims = vec![
         "profile_cli_plan_proves_quality",
@@ -722,17 +722,19 @@ fn build_experience_receipt(
     })
 }
 
-fn build_cli_command(
-    backend: &str,
-    model_path: &str,
-    tokenizer_path: &str,
-    user_prompt: &str,
+struct CliCommandSpec<'a> {
+    backend: &'a str,
+    model_path: &'a str,
+    tokenizer_path: &'a str,
+    user_prompt: &'a str,
     max_new_tokens: usize,
-    template_name: &str,
-    cli_stage_output: &str,
-    model_contract: &Path,
-    kernel_route: &str,
-) -> Vec<String> {
+    template_name: &'a str,
+    cli_stage_output: &'a str,
+    model_contract: &'a Path,
+    kernel_route: &'a str,
+}
+
+fn build_cli_command(spec: CliCommandSpec<'_>) -> Vec<String> {
     vec![
         "cargo".to_string(),
         "run".to_string(),
@@ -744,16 +746,16 @@ fn build_cli_command(
         "cpu,opencl".to_string(),
         "--".to_string(),
         "--device".to_string(),
-        backend.to_string(),
+        spec.backend.to_string(),
         "run".to_string(),
         "--model".to_string(),
-        model_path.to_string(),
+        spec.model_path.to_string(),
         "--tokenizer".to_string(),
-        tokenizer_path.to_string(),
+        spec.tokenizer_path.to_string(),
         "--prompt".to_string(),
-        user_prompt.to_string(),
+        spec.user_prompt.to_string(),
         "--max-new-tokens".to_string(),
-        max_new_tokens.to_string(),
+        spec.max_new_tokens.to_string(),
         "--temperature".to_string(),
         "0.0".to_string(),
         "--greedy".to_string(),
@@ -762,13 +764,13 @@ fn build_cli_command(
         "--strict-loader".to_string(),
         "--strict-backend".to_string(),
         "--prompt-template".to_string(),
-        template_name.to_string(),
+        spec.template_name.to_string(),
         "--json-out".to_string(),
-        cli_stage_output.to_string(),
+        spec.cli_stage_output.to_string(),
         "--proof-model-contract".to_string(),
-        model_contract.display().to_string(),
+        spec.model_contract.display().to_string(),
         "--proof-kernel-route".to_string(),
-        kernel_route.to_string(),
+        spec.kernel_route.to_string(),
     ]
 }
 
@@ -896,17 +898,17 @@ fn ttft_section(cli_stage: Option<&Value>) -> Section {
         ("stream_first_byte_ms", "/ttft/stream_first_byte_ms"),
     ];
     let mut missing = collect_section_fields(cli_stage, &mut data, &fields);
-    if !data.contains_key("end_to_end_ms") {
-        if let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/cmd_to_first_ms")) {
-            data.insert("end_to_end_ms".to_string(), value.clone());
-            missing.retain(|field| field != "end_to_end_ms");
-        }
+    if !data.contains_key("end_to_end_ms")
+        && let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/cmd_to_first_ms"))
+    {
+        data.insert("end_to_end_ms".to_string(), value.clone());
+        missing.retain(|field| field != "end_to_end_ms");
     }
-    if !data.contains_key("first_decode_ms") {
-        if let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/decode_first_ms")) {
-            data.insert("first_decode_ms".to_string(), value.clone());
-            missing.retain(|field| field != "first_decode_ms");
-        }
+    if !data.contains_key("first_decode_ms")
+        && let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/decode_first_ms"))
+    {
+        data.insert("first_decode_ms".to_string(), value.clone());
+        missing.retain(|field| field != "first_decode_ms");
     }
     Section { complete: missing.is_empty(), data, missing }
 }
@@ -931,18 +933,14 @@ fn input_speed_section(bench: &Value, cli_stage: Option<&Value>) -> Section {
             .or_else(|| cli_stage.and_then(|json| json.pointer("/ttft/prefill_ms"))),
     );
     let complete = missing.is_empty();
-    if complete {
-        if let (Some(tokens), Some(prefill_ms)) = (
+    if complete
+        && let (Some(tokens), Some(prefill_ms)) = (
             data.get("prompt_tokens").and_then(Value::as_f64),
             data.get("prefill_ms").and_then(Value::as_f64),
-        ) {
-            if prefill_ms > 0.0 {
-                data.insert(
-                    "input_tokens_per_second".to_string(),
-                    json!(tokens / (prefill_ms / 1000.0)),
-                );
-            }
-        }
+        )
+        && prefill_ms > 0.0
+    {
+        data.insert("input_tokens_per_second".to_string(), json!(tokens / (prefill_ms / 1000.0)));
     }
     data.entry("input_tokens_per_second".to_string()).or_insert(Value::Null);
     Section { complete, data, missing }
@@ -1433,17 +1431,17 @@ mod tests {
 
     #[test]
     fn cli_command_binds_proof_identity() {
-        let command = build_cli_command(
-            "intel-arc-a770-opencl",
-            "models/model.gguf",
-            "models/tokenizer.json",
-            "prompt",
-            64,
-            "llama3-chat",
-            "target/llm-experience/profile-cli-stage.json",
-            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
-            "a770.bitnet.i2s.qk256",
-        );
+        let command = build_cli_command(CliCommandSpec {
+            backend: "intel-arc-a770-opencl",
+            model_path: "models/model.gguf",
+            tokenizer_path: "models/tokenizer.json",
+            user_prompt: "prompt",
+            max_new_tokens: 64,
+            template_name: "llama3-chat",
+            cli_stage_output: "target/llm-experience/profile-cli-stage.json",
+            model_contract: Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+            kernel_route: "a770.bitnet.i2s.qk256",
+        });
         assert!(command.windows(2).any(|args| args == ["--device", "intel-arc-a770-opencl"]));
         assert!(command.windows(2).any(|args| args == ["--features", "cpu,opencl"]));
         assert!(command.iter().any(|arg| arg == "--strict-backend"));

--- a/xtask/tests/a770_claim_boundary_spec.rs
+++ b/xtask/tests/a770_claim_boundary_spec.rs
@@ -42,16 +42,8 @@ fn a770_claim_boundary_docs_link_to_the_spec() {
     let validation = read_repo_file("docs/hardware/intel-arc-a770-validation.md");
     let index = read_repo_file("docs/specs/INDEX.md");
 
-    assert_contains(
-        &roadmap,
-        "docs/specs/a770-bitnet-claim-boundary.md",
-        "A770 roadmap",
-    );
-    assert_contains(
-        &roadmap,
-        "plans/a770-bitnet-claim-boundary-implementation.md",
-        "A770 roadmap",
-    );
+    assert_contains(&roadmap, "docs/specs/a770-bitnet-claim-boundary.md", "A770 roadmap");
+    assert_contains(&roadmap, "plans/a770-bitnet-claim-boundary-implementation.md", "A770 roadmap");
     assert_contains(
         &validation,
         "docs/specs/a770-bitnet-claim-boundary.md",
@@ -120,16 +112,8 @@ fn a770_claim_boundary_keeps_selected_attention_separate() {
         "Selected attention is a separate research lane",
         "A770 claim-boundary spec",
     );
-    assert_contains(
-        &spec,
-        "It is not promoted by trusted",
-        "A770 claim-boundary spec",
-    );
-    assert_contains(
-        &roadmap,
-        "Selected attention, resident KV",
-        "A770 roadmap",
-    );
+    assert_contains(&spec, "It is not promoted by trusted", "A770 claim-boundary spec");
+    assert_contains(&roadmap, "Selected attention, resident KV", "A770 roadmap");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an explicit Qk256DispatchBackend and forward_qk256_with_backend entrypoint
- add a GGML QK256 no-scale OpenCL launcher with the correct [-2, -1, 1, 2] code mapping
- keep default transformer dispatch on cpu_qk256_reference and keep A770 QK256 OpenCL execution non-claiming until wired through the transformer/runtime path

## Verification
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features oneapi --test forward_qk256 -- --nocapture
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,oneapi
- git diff --check

## Claim boundary
No selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion is promoted. This PR adds a launcher API only; the existing transformer path still defaults to CPU QK256 dispatch.