### PR TITLE
transformer: route QK256 backend from A770 device

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -119,6 +119,11 @@ fn canonical_proof_backend_label(label: &str) -> String {
     }
 }
 
+fn proof_backend_labels_match(requested_backend: &str, execution_backend: &str) -> bool {
+    canonical_proof_backend_label(requested_backend)
+        == canonical_proof_backend_label(execution_backend)
+}
+
 fn resolve_simple_generation_device(
     requested_backend_label: &str,
     strict_backend: bool,
@@ -167,6 +172,16 @@ mod proof_summary_tests {
             proof.reason.as_deref(),
             Some("requested backend intel-arc-a770-opencl executed on cpu")
         );
+    }
+
+    #[test]
+    fn a770_alias_matches_canonical_execution_backend() {
+        assert!(proof_backend_labels_match("a770-opencl", "intel-arc-a770-opencl"));
+    }
+
+    #[test]
+    fn a770_alias_does_not_match_cpu_execution_backend() {
+        assert!(!proof_backend_labels_match("a770-opencl", "cpu"));
     }
 
     #[test]
@@ -2098,7 +2113,8 @@ async fn run_simple_generation(
         let backend_fallback = backend_fallback_proof(requested_backend, execution_backend);
         let fallback_used =
             loader_fallback_used || tokenizer_fallback_used || backend_fallback.used;
-        let execution_backend_matched = requested_backend.eq_ignore_ascii_case(execution_backend);
+        let execution_backend_matched =
+            proof_backend_labels_match(requested_backend, execution_backend);
         let proof_model_contract_path =
             proof_model_contract.as_ref().map(|path| path.display().to_string());
         let proof_kernel_route_id = proof_kernel_route.as_deref();

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -119,6 +119,28 @@ fn canonical_proof_backend_label(label: &str) -> String {
     }
 }
 
+fn resolve_simple_generation_device(
+    requested_backend_label: &str,
+    strict_backend: bool,
+) -> Result<(bitnet_common::Device, String)> {
+    use bitnet_common::{BackendRequest, Device, select_backend};
+    use bitnet_kernels::device_features::current_kernel_capabilities;
+
+    let request =
+        BackendRequest::from_label(requested_backend_label).unwrap_or(BackendRequest::Auto);
+    match select_backend(request, &current_kernel_capabilities()) {
+        Ok(selection) if selection.selected_backend() == "intel-arc-a770-opencl" => {
+            Ok((Device::OpenCL(0), selection.selected_backend()))
+        }
+        Ok(_) => Ok((Device::Cpu, "cpu".to_string())),
+        Err(err) if strict_backend => Err(err.into()),
+        Err(err) => {
+            warn!(error = %err, "simple generation backend selection fell back to CPU");
+            Ok((Device::Cpu, "cpu".to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod proof_summary_tests {
     use super::*;
@@ -1466,7 +1488,6 @@ async fn run_simple_generation(
     assert_greedy: bool,
     no_warnings: bool,
 ) -> Result<()> {
-    use bitnet_common::Device;
     use bitnet_models::{Model, transformer::KVCache};
     use bitnet_sampling::{SamplingConfig, SamplingStrategy};
     use bitnet_tokenizers::Tokenizer;
@@ -1518,9 +1539,10 @@ async fn run_simple_generation(
         debug!("Strict loader enabled (BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)");
     }
 
-    let simple_execution_backend = "cpu";
+    let (model_device, simple_execution_backend) =
+        resolve_simple_generation_device(&requested_backend_label, strict_backend)?;
     let initial_backend_fallback =
-        backend_fallback_proof(&requested_backend_label, simple_execution_backend);
+        backend_fallback_proof(&requested_backend_label, simple_execution_backend.as_str());
     if strict_backend && initial_backend_fallback.used {
         let reason = initial_backend_fallback
             .reason
@@ -1559,7 +1581,7 @@ async fn run_simple_generation(
     // Try real loader first
     use bitnet_models::loader::{LoadConfig, ModelLoader};
 
-    let loader = ModelLoader::new(Device::Cpu);
+    let loader = ModelLoader::new(model_device);
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
     let loader_mode;
@@ -1594,7 +1616,7 @@ async fn run_simple_generation(
             // Mock fallback
             let load_result = bitnet_models::gguf_simple::load_gguf_full(
                 &model_path,
-                Device::Cpu,
+                model_device,
                 bitnet_models::GGUFLoaderConfig::default(),
             )
             .context("Mock loader also failed")?;
@@ -1628,7 +1650,7 @@ async fn run_simple_generation(
                 load_result.config.clone(),
                 load_result.tensors,
                 raw_tensors,
-                Device::Cpu,
+                model_device,
             )
             .context("Failed to build mock model")?;
             (Arc::new(m) as Arc<dyn Model>, load_result.config)
@@ -2071,7 +2093,7 @@ async fn run_simple_generation(
         });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
-        let execution_backend = simple_execution_backend;
+        let execution_backend = simple_execution_backend.as_str();
         let requested_backend = requested_backend_label.as_str();
         let backend_fallback = backend_fallback_proof(requested_backend, execution_backend);
         let fallback_used =

--- a/crates/bitnet-models/src/bitnet.rs
+++ b/crates/bitnet-models/src/bitnet.rs
@@ -92,6 +92,11 @@ impl BitNetModel {
         };
 
         // Create a VarBuilder that uses our loaded tensors
+        let qk256_backend = if device.is_opencl() {
+            crate::transformer::Qk256DispatchBackend::OpenCl
+        } else {
+            crate::transformer::Qk256DispatchBackend::Cpu
+        };
         let device = device.to_candle().map_err(|e| BitNetError::Validation(e.to_string()))?;
 
         if tensors.is_empty() {
@@ -129,7 +134,12 @@ impl BitNetModel {
         let raw_mapped = remap_gguf_weights(raw_tensors)?;
 
         let vb = create_var_builder(mapped.clone(), DType::F32, &device)?;
-        let model = TransformerModel::new_with_tensors(updated_config, vb, raw_mapped)?;
+        let model = TransformerModel::new_with_tensors_and_qk256_backend(
+            updated_config,
+            vb,
+            raw_mapped,
+            qk256_backend,
+        )?;
         Ok(Arc::new(model))
     }
 

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -107,6 +107,8 @@ fn qk256_opencl_source_matches_ggml_no_scale_mapping() {
 
     assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
     assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("row_bytes[col >> 2]"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("(packed >> ((col & 3u) * 2u)) & 3u"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -2.0f"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -1.0f"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("w = 1.0f"));

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1,5 +1,6 @@
 use bitnet_common::{BitNetConfig, BitNetError, Result};
-use bitnet_qk256_dispatch::forward_qk256;
+pub use bitnet_qk256_dispatch::Qk256DispatchBackend;
+use bitnet_qk256_dispatch::forward_qk256_with_backend;
 use bitnet_rope::{build_tables as build_rope_tables, resolve_base as resolve_rope_base};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{LayerNorm, Linear, VarBuilder};
@@ -197,10 +198,16 @@ pub struct MultiHeadAttention {
     o_proj: Linear,
     rope: Option<RotaryEmbedding>,
     layer_idx: usize, // Layer index for QK256 weight name generation
+    qk256_backend: Qk256DispatchBackend,
 }
 
 impl MultiHeadAttention {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         let n_heads = config.model.num_heads;
         let head_dim = hidden_size / n_heads;
@@ -270,6 +277,7 @@ impl MultiHeadAttention {
             o_proj,
             rope,
             layer_idx,
+            qk256_backend,
         })
     }
 
@@ -559,7 +567,7 @@ impl MultiHeadAttention {
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
             tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256(input, qk256_tensor, &qk256_key);
+            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
         }
 
         // Probe: Why is QK256 not found? (layer 0 only, once)
@@ -610,10 +618,16 @@ pub struct FeedForward {
     up_proj: Linear,
     down_proj: Linear,
     layer_idx: usize, // Layer index for QK256 weight name generation
+    qk256_backend: Qk256DispatchBackend,
 }
 
 impl FeedForward {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         let intermediate_size = config.model.intermediate_size;
 
@@ -630,6 +644,7 @@ impl FeedForward {
                 vb.pp("down_proj"),
             )?,
             layer_idx,
+            qk256_backend,
         })
     }
 
@@ -698,7 +713,7 @@ impl FeedForward {
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
             tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256(input, qk256_tensor, &qk256_key);
+            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
         }
 
         // Fall back to standard linear
@@ -720,7 +735,12 @@ pub struct TransformerBlock {
 }
 
 impl TransformerBlock {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         // PATCH 1: Use RMSNorm epsilon from config header for ALL norms (per-layer + final)
         let eps = config.model.rms_norm_eps.map(|e| e as f64).unwrap_or(1e-5);
@@ -728,8 +748,18 @@ impl TransformerBlock {
         tracing::debug!("TransformerBlock using RMSNorm eps={} (from header)", eps);
 
         Ok(Self {
-            attention: MultiHeadAttention::new(config, vb.pp("attention"), layer_idx)?,
-            feed_forward: FeedForward::new(config, vb.pp("feed_forward"), layer_idx)?,
+            attention: MultiHeadAttention::new(
+                config,
+                vb.pp("attention"),
+                layer_idx,
+                qk256_backend,
+            )?,
+            feed_forward: FeedForward::new(
+                config,
+                vb.pp("feed_forward"),
+                layer_idx,
+                qk256_backend,
+            )?,
             attention_norm: layer_norm_with_optional_bias(
                 hidden_size,
                 eps,
@@ -1049,6 +1079,15 @@ impl TransformerModel {
         vb: VarBuilder,
         raw_tensors: std::collections::HashMap<String, Tensor>,
     ) -> Result<Self> {
+        Self::new_with_tensors_and_qk256_backend(config, vb, raw_tensors, Qk256DispatchBackend::Cpu)
+    }
+
+    pub fn new_with_tensors_and_qk256_backend(
+        config: BitNetConfig,
+        vb: VarBuilder,
+        raw_tensors: std::collections::HashMap<String, Tensor>,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let device = vb.device().clone();
         let vocab_size = config.model.vocab_size;
         let hidden_size = config.model.hidden_size;
@@ -1073,7 +1112,12 @@ impl TransformerModel {
 
         let mut layers = Vec::with_capacity(n_layers);
         for i in 0..n_layers {
-            layers.push(TransformerBlock::new(&config, vb.pp(format!("layers.{}", i)), i)?);
+            layers.push(TransformerBlock::new(
+                &config,
+                vb.pp(format!("layers.{}", i)),
+                i,
+                qk256_backend,
+            )?);
         }
 
         // Use RMSNorm epsilon from config header (CRITICAL: must match per-layer norms)

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -289,7 +289,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-009"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-009-benchmark-baseline"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T123205Z-M4-009-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T123205Z-M4-009-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:32:05Z"
+campaign = "apple-m4"
+item = "M4-009"
+event = "merged"
+pr = 3732
+merge_sha = "07f8e2e5a9657f792367e5f25355adf12a1afc50"
+actor = "maintainer"
+
+notes = [
+  "Merged Apple M4 benchmark-baseline campaign item.",
+  "No general Metal speedup, BitNet inference acceleration, or Neural Engine execution claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -17,7 +17,7 @@
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
-| M4-009 | pr_open | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
+| M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "LNL258V-RUN-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v/LNL258V-RUN-001-platform-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T110911Z-LNL258V-RUN-001-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T110911Z-LNL258V-RUN-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:09:11Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-RUN-001"
+event = "merged"
+pr = 3714
+merge_sha = "4dfd156a7e731ccf57f70213566ad63f668a98af"
+actor = "maintainer"
+
+notes = [
+  "Merged Lunar Lake 258V platform probe receipt scaffolding.",
+  "No BitNet inference, Arc 140V packed kernel, or Intel NPU execution claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| LNL258V-RUN-001 | pr_open | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "NPU-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-npu/NPU-002-lite-backend-identity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T115519Z-NPU-002-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T115519Z-NPU-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:55:19Z"
+campaign = "intel-npu"
+item = "NPU-002"
+event = "merged"
+pr = 3722
+merge_sha = "20688198547dbb29a14e31fbdcf46c8c703a2a86"
+actor = "maintainer"
+
+notes = [
+  "Merged Intel NPU backend identity preservation.",
+  "No OpenVINO graph execution, NPU inference, or BitNet subgraph parity claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| NPU-002 | pr_open | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -91,7 +91,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "RTX5070TI-005"
-status = "pr_open"
+status = "merged"
 branch = "codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T132942Z-RTX5070TI-005-merged.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T132942Z-RTX5070TI-005-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T13:29:42Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-005"
+event = "merged"
+pr = 3723
+merge_sha = "8b588762976d17bc2774f0a4a554ecec1d39342f"
+actor = "maintainer"
+
+notes = [
+  "Merged RTX 5070 Ti tiny CUDA kernel smoke receipt.",
+  "No QK256 CUDA, transformer routing, server inference, or end-to-end BitNet acceleration claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | RTX5070TI-003 | merged | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
 | RTX5070TI-004 | merged | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
-| RTX5070TI-005 | pr_open | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
+| RTX5070TI-005 | merged | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -89,7 +89,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-003"
-status = "pr_open"
+status = "merged"
 branch = "codex/tracker-infra/TRACKER-003-current-pr-reconciliation"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T120749Z-TRACKER-003-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T120749Z-TRACKER-003-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:07:49Z"
+campaign = "tracker-infra"
+item = "TRACKER-003"
+event = "merged"
+pr = 3724
+merge_sha = "6f44b77538492182e1a33484ff6683fa2debd8ee"
+actor = "maintainer"
+
+notes = [
+  "Merged current-PR campaign reconciliation for tracker CI.",
+  "No runtime behavior, kernel behavior, or dependency behavior claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
 | TRACKER-002 | merged | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
-| TRACKER-003 | pr_open | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
+| TRACKER-003 | merged | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,8 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-009 | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
-| intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
-| nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
-| tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -10,7 +10,7 @@
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
-| apple-m4 | M4-009 | M4-008 | pr_open |
+| apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |
@@ -24,6 +24,6 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
-| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | pr_open |
+| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
-| tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |
+| tracker-infra | TRACKER-003 | TRACKER-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-009 | #3732 | pr_open | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-010 | TBD | proposed | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-002 | #3722 | pr_open | none | Device-node detection is not inference. |
-| nvidia-5070ti | RTX5070TI-005 | #3723 | pr_open | none | CUDA visibility is not kernel execution. |
+| intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
+| nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-005 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
-| tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/bench_receipt.rs
+++ b/xtask/src/bench_receipt.rs
@@ -488,35 +488,51 @@ fn cli_stage_identity(plan: &Value, cli_stage: &Value, model_contract_path: &Pat
         }
     }
 
-    let requested_backend_matched =
-        planned_backend.is_some() && requested_backend.is_some() && planned_backend == requested_backend;
+    let requested_backend_matched = planned_backend.is_some()
+        && requested_backend.is_some()
+        && planned_backend == requested_backend;
     object.insert("requested_backend_matched".to_string(), Value::Bool(requested_backend_matched));
     if !requested_backend_matched {
-        route_failures.push(field_failure("requested_backend_matched", planned_backend, requested_backend));
+        route_failures.push(field_failure(
+            "requested_backend_matched",
+            planned_backend,
+            requested_backend,
+        ));
     }
 
-    let selected_backend_matched =
-        planned_backend.is_some() && selected_backend.is_some() && planned_backend == selected_backend;
+    let selected_backend_matched = planned_backend.is_some()
+        && selected_backend.is_some()
+        && planned_backend == selected_backend;
     object.insert("selected_backend_matched".to_string(), Value::Bool(selected_backend_matched));
     if !selected_backend_matched {
-        route_failures.push(field_failure("selected_backend_matched", planned_backend, selected_backend));
+        route_failures.push(field_failure(
+            "selected_backend_matched",
+            planned_backend,
+            selected_backend,
+        ));
     }
 
-    let execution_backend_matched =
-        planned_backend.is_some() && execution_backend.is_some() && planned_backend == execution_backend;
-    object.insert(
-        "execution_backend_matched".to_string(),
-        Value::Bool(execution_backend_matched),
-    );
+    let execution_backend_matched = planned_backend.is_some()
+        && execution_backend.is_some()
+        && planned_backend == execution_backend;
+    object.insert("execution_backend_matched".to_string(), Value::Bool(execution_backend_matched));
     if !execution_backend_matched {
-        route_failures.push(field_failure("execution_backend_matched", planned_backend, execution_backend));
+        route_failures.push(field_failure(
+            "execution_backend_matched",
+            planned_backend,
+            execution_backend,
+        ));
     }
 
     let route_declared = bool_at(cli_stage, "/proof_summary/route_declared").unwrap_or(false)
         && declared_route.and_then(Value::as_str).is_some_and(|route| !route.is_empty());
     object.insert("route_declared".to_string(), Value::Bool(route_declared));
     if !route_declared {
-        route_failures.push(field_failure("route_declared", Some(&Value::Bool(true)), Some(&Value::Bool(false))));
+        route_failures.push(field_failure(
+            "route_declared",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
     }
 
     let same_kernel_route =
@@ -526,7 +542,8 @@ fn cli_stage_identity(plan: &Value, cli_stage: &Value, model_contract_path: &Pat
         route_failures.push(field_failure("same_kernel_route", planned_route, declared_route));
     }
 
-    let route_claimable = bool_at(cli_stage, "/proof_summary/kernel_route/claimable").unwrap_or(false);
+    let route_claimable =
+        bool_at(cli_stage, "/proof_summary/kernel_route/claimable").unwrap_or(false);
     object.insert("route_claimable".to_string(), Value::Bool(route_claimable));
     if !route_claimable {
         route_failures.push(field_failure(
@@ -871,8 +888,11 @@ mod tests {
     #[test]
     fn cli_stage_identity_rejects_cpu_execution_with_declared_a770_route() {
         let (plan, cli) = plan_and_cli_stage("cpu");
-        let identity =
-            cli_stage_identity(&plan, &cli, Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"));
+        let identity = cli_stage_identity(
+            &plan,
+            &cli,
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+        );
 
         assert_eq!(identity["profile_matched"], true);
         assert_eq!(identity["model_matched"], true);

--- a/xtask/tests/a770_claim_boundary_spec.rs
+++ b/xtask/tests/a770_claim_boundary_spec.rs
@@ -42,16 +42,8 @@ fn a770_claim_boundary_docs_link_to_the_spec() {
     let validation = read_repo_file("docs/hardware/intel-arc-a770-validation.md");
     let index = read_repo_file("docs/specs/INDEX.md");
 
-    assert_contains(
-        &roadmap,
-        "docs/specs/a770-bitnet-claim-boundary.md",
-        "A770 roadmap",
-    );
-    assert_contains(
-        &roadmap,
-        "plans/a770-bitnet-claim-boundary-implementation.md",
-        "A770 roadmap",
-    );
+    assert_contains(&roadmap, "docs/specs/a770-bitnet-claim-boundary.md", "A770 roadmap");
+    assert_contains(&roadmap, "plans/a770-bitnet-claim-boundary-implementation.md", "A770 roadmap");
     assert_contains(
         &validation,
         "docs/specs/a770-bitnet-claim-boundary.md",
@@ -120,16 +112,8 @@ fn a770_claim_boundary_keeps_selected_attention_separate() {
         "Selected attention is a separate research lane",
         "A770 claim-boundary spec",
     );
-    assert_contains(
-        &spec,
-        "It is not promoted by trusted",
-        "A770 claim-boundary spec",
-    );
-    assert_contains(
-        &roadmap,
-        "Selected attention, resident KV",
-        "A770 roadmap",
-    );
+    assert_contains(&spec, "It is not promoted by trusted", "A770 claim-boundary spec");
+    assert_contains(&roadmap, "Selected attention, resident KV", "A770 roadmap");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- thread Qk256DispatchBackend through TransformerModel, transformer blocks, attention, and FFN QK256 projection calls
- select QK256 OpenCL dispatch when a model is built for Device::OpenCL
- make simple CLI generation resolve the A770 OpenCL device through backend selection instead of hardcoding CPU execution before loading

## Verification
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu --bin bitnet proof_summary_tests -- --nocapture
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,oneapi
- cargo check --locked -p bitnet-transformer --no-default-features --features cpu
- cargo check --locked -p bitnet-transformer --no-default-features --features opencl
- git diff --check

## Claim boundary
No selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion is promoted. This only routes QK256 projection dispatch through the explicit A770/OpenCL device path; support ops remain outside full-residency claims.