### PR TITLE
qk256: cache OpenCL runtime program

### DIFF
--- a/.github/workflows/intel-gpu-compile.yml
+++ b/.github/workflows/intel-gpu-compile.yml
@@ -7,6 +7,7 @@ on:
       - 'crates/bitnet-kernels/src/opencl_*'
       - 'crates/bitnet-opencl/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-compile.yml'
   push:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - 'crates/bitnet-kernels/src/opencl_*'
       - 'crates/bitnet-opencl/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-compile.yml'
   workflow_dispatch:
 
@@ -74,6 +76,34 @@ jobs:
 
       - name: cargo check --workspace (oneapi)
         run: cargo check --locked --workspace --no-default-features --features oneapi
+
+  compile-check-qk256-opencl:
+    name: Compile Check (QK256 OpenCL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+        with:
+          toolchain: "1.92.0"
+
+      - name: Install OpenCL headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ocl-icd-opencl-dev opencl-headers
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+        with:
+          shared-key: intel-gpu-compile-qk256-opencl
+
+      - name: cargo check bitnet-qk256-dispatch (opencl)
+        run: cargo check --locked -p bitnet-qk256-dispatch --no-default-features --features opencl
+
+      - name: Test build bitnet-qk256-dispatch (opencl no-run)
+        run: cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --no-run
 
   opencl-kernel-lint:
     name: OpenCL Kernel Lint

--- a/.github/workflows/intel-gpu-feature-matrix.yml
+++ b/.github/workflows/intel-gpu-feature-matrix.yml
@@ -7,12 +7,14 @@ on:
       - 'crates/bitnet-kernels/**'
       - 'crates/bitnet-common/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-feature-matrix.yml'
   pull_request:
     paths:
       - 'crates/bitnet-kernels/**'
       - 'crates/bitnet-common/**'
       - 'crates/bitnet-device-probe/**'
+      - 'crates/bitnet-qk256-dispatch/**'
       - '.github/workflows/intel-gpu-feature-matrix.yml'
   workflow_dispatch:
 
@@ -110,11 +112,13 @@ jobs:
         run: |
           cargo check --locked -p bitnet-kernels --no-default-features --features cpu
           cargo check --locked -p bitnet-common --no-default-features --features cpu
+          cargo check --locked -p bitnet-qk256-dispatch --no-default-features --features cpu
 
       - name: Verify no OpenCL runtime needed at compile time
         run: |
           # Ensure we can build without OpenCL libraries installed
           cargo build --locked -p bitnet-kernels --no-default-features --features cpu 2>&1
+          cargo build --locked -p bitnet-qk256-dispatch --no-default-features --features cpu 2>&1
 
       - name: Verify device_features compiles without oneapi
         run: |

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -295,6 +295,9 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+// Clap owns this parsed command shape; boxing individual parsed fields breaks
+// value parser inference and would not improve command dispatch behavior.
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Run simple text generation
     ///

--- a/crates/bitnet-kernels/src/device_features.rs
+++ b/crates/bitnet-kernels/src/device_features.rs
@@ -179,14 +179,12 @@ pub fn opencl_available_runtime() -> bool {
         .map(|v| v == "1" || v.to_lowercase() == "true")
         .unwrap_or(false);
 
-    if !strict_mode {
-        if let Ok(fake) = env::var("BITNET_GPU_FAKE") {
-            if fake.eq_ignore_ascii_case("opencl") {
-                return true;
-            }
-            if fake.eq_ignore_ascii_case("none") {
-                return false;
-            }
+    if !strict_mode && let Ok(fake) = env::var("BITNET_GPU_FAKE") {
+        if fake.eq_ignore_ascii_case("opencl") {
+            return true;
+        }
+        if fake.eq_ignore_ascii_case("none") {
+            return false;
         }
     }
 

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -8,6 +8,7 @@ use opencl3::platform::get_platforms;
 use opencl3::program::Program;
 use opencl3::types::CL_BLOCKING;
 use std::ptr::null_mut;
+use std::sync::{Mutex, OnceLock};
 
 pub const QK256_OPENCL_KERNEL_NAME: &str = "qk256_gemm_no_scale";
 
@@ -62,7 +63,12 @@ pub fn gemm_qk256_opencl(
 ) -> Result<()> {
     validate_args(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)?;
 
-    let runtime = OpenClQk256Runtime::new()?;
+    let runtime = qk256_runtime()?;
+    let runtime = runtime.lock().map_err(|_| {
+        BitNetError::Kernel(KernelError::ExecutionFailed {
+            reason: "QK256 OpenCL runtime cache lock was poisoned".to_string(),
+        })
+    })?;
     runtime.run(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)
 }
 
@@ -132,6 +138,26 @@ struct OpenClQk256Runtime {
     context: Context,
     queue: CommandQueue,
     program: Program,
+}
+
+// SAFETY: OpenCL handles are reference-counted driver objects. The cached runtime
+// is only accessed through a Mutex, so the single command queue is not used
+// concurrently by Rust callers.
+unsafe impl Send for OpenClQk256Runtime {}
+
+static QK256_RUNTIME: OnceLock<Mutex<OpenClQk256Runtime>> = OnceLock::new();
+
+fn qk256_runtime() -> Result<&'static Mutex<OpenClQk256Runtime>> {
+    if let Some(runtime) = QK256_RUNTIME.get() {
+        return Ok(runtime);
+    }
+
+    let runtime = Mutex::new(OpenClQk256Runtime::new()?);
+    if QK256_RUNTIME.set(runtime).is_ok() {
+        Ok(QK256_RUNTIME.get().expect("QK256 runtime must be set after initialization"))
+    } else {
+        Ok(QK256_RUNTIME.get().expect("QK256 runtime must be set after racing initialization"))
+    }
 }
 
 impl OpenClQk256Runtime {

--- a/xtask/src/llm_experience.rs
+++ b/xtask/src/llm_experience.rs
@@ -419,17 +419,17 @@ pub fn profile_cli_plan(
     }
 
     let cli_stage_output = "target/llm-experience/profile-cli-stage.json";
-    let cli_command = build_cli_command(
+    let cli_command = build_cli_command(CliCommandSpec {
         backend,
         model_path,
         tokenizer_path,
-        &user_prompt,
+        user_prompt: &user_prompt,
         max_new_tokens,
         template_name,
         cli_stage_output,
         model_contract,
         kernel_route,
-    );
+    });
 
     let mut not_claims = vec![
         "profile_cli_plan_proves_quality",
@@ -722,17 +722,19 @@ fn build_experience_receipt(
     })
 }
 
-fn build_cli_command(
-    backend: &str,
-    model_path: &str,
-    tokenizer_path: &str,
-    user_prompt: &str,
+struct CliCommandSpec<'a> {
+    backend: &'a str,
+    model_path: &'a str,
+    tokenizer_path: &'a str,
+    user_prompt: &'a str,
     max_new_tokens: usize,
-    template_name: &str,
-    cli_stage_output: &str,
-    model_contract: &Path,
-    kernel_route: &str,
-) -> Vec<String> {
+    template_name: &'a str,
+    cli_stage_output: &'a str,
+    model_contract: &'a Path,
+    kernel_route: &'a str,
+}
+
+fn build_cli_command(spec: CliCommandSpec<'_>) -> Vec<String> {
     vec![
         "cargo".to_string(),
         "run".to_string(),
@@ -744,16 +746,16 @@ fn build_cli_command(
         "cpu,opencl".to_string(),
         "--".to_string(),
         "--device".to_string(),
-        backend.to_string(),
+        spec.backend.to_string(),
         "run".to_string(),
         "--model".to_string(),
-        model_path.to_string(),
+        spec.model_path.to_string(),
         "--tokenizer".to_string(),
-        tokenizer_path.to_string(),
+        spec.tokenizer_path.to_string(),
         "--prompt".to_string(),
-        user_prompt.to_string(),
+        spec.user_prompt.to_string(),
         "--max-new-tokens".to_string(),
-        max_new_tokens.to_string(),
+        spec.max_new_tokens.to_string(),
         "--temperature".to_string(),
         "0.0".to_string(),
         "--greedy".to_string(),
@@ -762,13 +764,13 @@ fn build_cli_command(
         "--strict-loader".to_string(),
         "--strict-backend".to_string(),
         "--prompt-template".to_string(),
-        template_name.to_string(),
+        spec.template_name.to_string(),
         "--json-out".to_string(),
-        cli_stage_output.to_string(),
+        spec.cli_stage_output.to_string(),
         "--proof-model-contract".to_string(),
-        model_contract.display().to_string(),
+        spec.model_contract.display().to_string(),
         "--proof-kernel-route".to_string(),
-        kernel_route.to_string(),
+        spec.kernel_route.to_string(),
     ]
 }
 
@@ -896,17 +898,17 @@ fn ttft_section(cli_stage: Option<&Value>) -> Section {
         ("stream_first_byte_ms", "/ttft/stream_first_byte_ms"),
     ];
     let mut missing = collect_section_fields(cli_stage, &mut data, &fields);
-    if !data.contains_key("end_to_end_ms") {
-        if let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/cmd_to_first_ms")) {
-            data.insert("end_to_end_ms".to_string(), value.clone());
-            missing.retain(|field| field != "end_to_end_ms");
-        }
+    if !data.contains_key("end_to_end_ms")
+        && let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/cmd_to_first_ms"))
+    {
+        data.insert("end_to_end_ms".to_string(), value.clone());
+        missing.retain(|field| field != "end_to_end_ms");
     }
-    if !data.contains_key("first_decode_ms") {
-        if let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/decode_first_ms")) {
-            data.insert("first_decode_ms".to_string(), value.clone());
-            missing.retain(|field| field != "first_decode_ms");
-        }
+    if !data.contains_key("first_decode_ms")
+        && let Some(value) = cli_stage.and_then(|json| json.pointer("/latency/decode_first_ms"))
+    {
+        data.insert("first_decode_ms".to_string(), value.clone());
+        missing.retain(|field| field != "first_decode_ms");
     }
     Section { complete: missing.is_empty(), data, missing }
 }
@@ -931,18 +933,14 @@ fn input_speed_section(bench: &Value, cli_stage: Option<&Value>) -> Section {
             .or_else(|| cli_stage.and_then(|json| json.pointer("/ttft/prefill_ms"))),
     );
     let complete = missing.is_empty();
-    if complete {
-        if let (Some(tokens), Some(prefill_ms)) = (
+    if complete
+        && let (Some(tokens), Some(prefill_ms)) = (
             data.get("prompt_tokens").and_then(Value::as_f64),
             data.get("prefill_ms").and_then(Value::as_f64),
-        ) {
-            if prefill_ms > 0.0 {
-                data.insert(
-                    "input_tokens_per_second".to_string(),
-                    json!(tokens / (prefill_ms / 1000.0)),
-                );
-            }
-        }
+        )
+        && prefill_ms > 0.0
+    {
+        data.insert("input_tokens_per_second".to_string(), json!(tokens / (prefill_ms / 1000.0)));
     }
     data.entry("input_tokens_per_second".to_string()).or_insert(Value::Null);
     Section { complete, data, missing }
@@ -1433,17 +1431,17 @@ mod tests {
 
     #[test]
     fn cli_command_binds_proof_identity() {
-        let command = build_cli_command(
-            "intel-arc-a770-opencl",
-            "models/model.gguf",
-            "models/tokenizer.json",
-            "prompt",
-            64,
-            "llama3-chat",
-            "target/llm-experience/profile-cli-stage.json",
-            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
-            "a770.bitnet.i2s.qk256",
-        );
+        let command = build_cli_command(CliCommandSpec {
+            backend: "intel-arc-a770-opencl",
+            model_path: "models/model.gguf",
+            tokenizer_path: "models/tokenizer.json",
+            user_prompt: "prompt",
+            max_new_tokens: 64,
+            template_name: "llama3-chat",
+            cli_stage_output: "target/llm-experience/profile-cli-stage.json",
+            model_contract: Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+            kernel_route: "a770.bitnet.i2s.qk256",
+        });
         assert!(command.windows(2).any(|args| args == ["--device", "intel-arc-a770-opencl"]));
         assert!(command.windows(2).any(|args| args == ["--features", "cpu,opencl"]));
         assert!(command.iter().any(|arg| arg == "--strict-backend"));


### PR DESCRIPTION
## Summary
- cache the QK256 OpenCL context, command queue, and compiled program per process
- avoid rebuilding the OpenCL program for every QK256 projection call
- keep the launcher scoped to QK256 linears only and preserve all residency non-claims

## Verification
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features oneapi --test forward_qk256 -- --nocapture
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl
- git diff --check

## Claim boundary
No selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion is promoted. This only makes the QK256 OpenCL launcher viable for live smoke by caching setup work.