### PR TITLE
cli: report QK256 dispatch proof counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qk256-dispatch",
  "bitnet-quantization",
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -28,6 +28,7 @@ bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-qk256-dispatch = { path = "../bitnet-qk256-dispatch", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1828,6 +1828,7 @@ async fn run_simple_generation(
 
     // Track generated tokens for repetition penalty
     let mut generated_tokens = Vec::new();
+    bitnet_qk256_dispatch::reset_qk256_dispatch_counters();
 
     // Track logits dump if requested
     let mut logits_dump: Vec<LogitStep> = Vec::new();
@@ -2060,6 +2061,7 @@ async fn run_simple_generation(
     } else {
         0.0
     };
+    let qk256_dispatch = bitnet_qk256_dispatch::qk256_dispatch_counters();
 
     println!("\n\nGeneration complete!");
     println!(
@@ -2173,6 +2175,17 @@ async fn run_simple_generation(
                     "claimable": false,
                 },
                 "route_declared": proof_kernel_route.is_some(),
+                "qk256_dispatch": {
+                    "cpu_calls": qk256_dispatch.cpu_calls,
+                    "cpu_successes": qk256_dispatch.cpu_successes,
+                    "cpu_input_rows": qk256_dispatch.cpu_input_rows,
+                    "opencl_calls": qk256_dispatch.opencl_calls,
+                    "opencl_successes": qk256_dispatch.opencl_successes,
+                    "opencl_input_rows": qk256_dispatch.opencl_input_rows,
+                    "a770_qk256_opencl_used": qk256_dispatch.opencl_successes > 0,
+                    "diagnostic_only": true,
+                    "claimable": false,
+                },
                 "backend_claimable": false,
                 "not_claims": critical_not_claims(),
             },

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -7,9 +7,47 @@ pub use opencl::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC, gemm_qk256_o
 use bitnet_common::{BitNetError, KernelError, Result};
 use bitnet_qk256_layout_core::{parse_input_shape, parse_qk256_layout, validate_input_cols};
 use candle_core::Tensor;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const NOT_CLAIMED_OPENCL_QK256: &[&str] =
     &["a770_qk256_opencl_execution", "a770_qk256_opencl_performance", "a770_full_device_residency"];
+
+static CPU_CALLS: AtomicU64 = AtomicU64::new(0);
+static CPU_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static CPU_INPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+static OPENCL_CALLS: AtomicU64 = AtomicU64::new(0);
+static OPENCL_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static OPENCL_INPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Qk256DispatchCounters {
+    pub cpu_calls: u64,
+    pub cpu_successes: u64,
+    pub cpu_input_rows: u64,
+    pub opencl_calls: u64,
+    pub opencl_successes: u64,
+    pub opencl_input_rows: u64,
+}
+
+pub fn qk256_dispatch_counters() -> Qk256DispatchCounters {
+    Qk256DispatchCounters {
+        cpu_calls: CPU_CALLS.load(Ordering::Relaxed),
+        cpu_successes: CPU_SUCCESSES.load(Ordering::Relaxed),
+        cpu_input_rows: CPU_INPUT_ROWS.load(Ordering::Relaxed),
+        opencl_calls: OPENCL_CALLS.load(Ordering::Relaxed),
+        opencl_successes: OPENCL_SUCCESSES.load(Ordering::Relaxed),
+        opencl_input_rows: OPENCL_INPUT_ROWS.load(Ordering::Relaxed),
+    }
+}
+
+pub fn reset_qk256_dispatch_counters() {
+    CPU_CALLS.store(0, Ordering::Relaxed);
+    CPU_SUCCESSES.store(0, Ordering::Relaxed);
+    CPU_INPUT_ROWS.store(0, Ordering::Relaxed);
+    OPENCL_CALLS.store(0, Ordering::Relaxed);
+    OPENCL_SUCCESSES.store(0, Ordering::Relaxed);
+    OPENCL_INPUT_ROWS.store(0, Ordering::Relaxed);
+}
 
 /// Describes which QK256 runtime is currently used by this dispatch crate.
 ///
@@ -118,6 +156,8 @@ pub fn forward_qk256_with_backend(
 
     match backend {
         Qk256DispatchBackend::Cpu => {
+            CPU_CALLS.fetch_add(1, Ordering::Relaxed);
+            CPU_INPUT_ROWS.fetch_add(input_rows as u64, Ordering::Relaxed);
             for (i, input_row) in input_vec.iter().enumerate() {
                 let start = i * layout.rows;
                 let end = start + layout.rows;
@@ -136,8 +176,11 @@ pub fn forward_qk256_with_backend(
                     ))
                 })?;
             }
+            CPU_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
         Qk256DispatchBackend::OpenCl => {
+            OPENCL_CALLS.fetch_add(1, Ordering::Relaxed);
+            OPENCL_INPUT_ROWS.fetch_add(input_rows as u64, Ordering::Relaxed);
             run_opencl_qk256(
                 &flat_bytes,
                 &input_vec,
@@ -147,6 +190,7 @@ pub fn forward_qk256_with_backend(
                 layout.row_stride_bytes,
                 weight_name,
             )?;
+            OPENCL_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
     }
 

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -1,10 +1,21 @@
 use bitnet_qk256_dispatch::{
-    Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend, qk256_dispatch_status,
+    Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend, qk256_dispatch_counters,
+    qk256_dispatch_status, reset_qk256_dispatch_counters,
 };
 use candle_core::{Device, Tensor};
+use std::sync::{Mutex, MutexGuard};
+
+static COUNTER_LOCK: Mutex<()> = Mutex::new(());
+
+fn counter_guard() -> MutexGuard<'static, ()> {
+    COUNTER_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 #[test]
 fn forward_qk256_supports_rank2_input() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -18,6 +29,9 @@ fn forward_qk256_supports_rank2_input() {
 
 #[test]
 fn forward_qk256_explicit_cpu_backend_matches_default() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -37,6 +51,9 @@ fn forward_qk256_explicit_cpu_backend_matches_default() {
 
 #[test]
 fn forward_qk256_supports_rank3_input() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 2 * 2 * 256], (2, 2, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -54,6 +71,9 @@ fn forward_qk256_supports_rank3_input() {
 
 #[test]
 fn forward_qk256_rejects_dimension_mismatch() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 128], (1, 128), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -65,6 +85,9 @@ fn forward_qk256_rejects_dimension_mismatch() {
 #[cfg(not(feature = "opencl"))]
 #[test]
 fn forward_qk256_opencl_backend_requires_opencl_feature() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
     let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
@@ -82,6 +105,8 @@ fn forward_qk256_opencl_backend_requires_opencl_feature() {
 
 #[test]
 fn qk256_dispatch_status_keeps_opencl_non_claiming() {
+    let _guard = counter_guard();
+
     let status = qk256_dispatch_status();
 
     assert_eq!(status.compiled_opencl, cfg!(feature = "opencl"));
@@ -100,10 +125,61 @@ fn qk256_dispatch_status_keeps_opencl_non_claiming() {
     }
 }
 
+#[test]
+fn qk256_dispatch_counters_track_cpu_successes_and_rows() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 2 * 2 * 256], (2, 2, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    forward_qk256(&input, &qk, "layers.0.feed_forward.up_proj.weight.qk256_qs").unwrap();
+
+    let counters = qk256_dispatch_counters();
+    assert_eq!(counters.cpu_calls, 1);
+    assert_eq!(counters.cpu_successes, 1);
+    assert_eq!(counters.cpu_input_rows, 4);
+    assert_eq!(counters.opencl_calls, 0);
+    assert_eq!(counters.opencl_successes, 0);
+    assert_eq!(counters.opencl_input_rows, 0);
+
+    reset_qk256_dispatch_counters();
+    assert_eq!(qk256_dispatch_counters(), Default::default());
+}
+
+#[cfg(not(feature = "opencl"))]
+#[test]
+fn qk256_dispatch_counters_track_failed_opencl_attempts_without_success() {
+    let _guard = counter_guard();
+    reset_qk256_dispatch_counters();
+
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    let err = forward_qk256_with_backend(
+        &input,
+        &qk,
+        "layers.0.attention.q_proj.weight.qk256_qs",
+        Qk256DispatchBackend::OpenCl,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("opencl feature is disabled"));
+    let counters = qk256_dispatch_counters();
+    assert_eq!(counters.opencl_calls, 1);
+    assert_eq!(counters.opencl_successes, 0);
+    assert_eq!(counters.opencl_input_rows, 1);
+    assert_eq!(counters.cpu_calls, 0);
+}
+
 #[cfg(feature = "opencl")]
 #[test]
 fn qk256_opencl_source_matches_ggml_no_scale_mapping() {
     use bitnet_qk256_dispatch::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC};
+
+    let _guard = counter_guard();
 
     assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
     assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));


### PR DESCRIPTION
## Summary
- add process-local QK256 dispatch counters for CPU and OpenCL calls/successes/input rows
- reset counters at the start of simple CLI generation
- emit proof_summary.qk256_dispatch in JSON receipts so live A770 runs can prove whether QK256 OpenCL actually executed

## Verification
- cargo check -p bitnet-cli --no-default-features --features cpu
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu --bin bitnet proof_summary_tests -- --nocapture
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,oneapi
- git diff --check

## Claim boundary
No selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion is promoted. The new counters are diagnostic proof fields only and remain claimable=false in the receipt.