### PR TITLE
backend(a770): accept Arc OpenCL route labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qk256-dispatch",
  "bitnet-quantization",
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",

--- a/crates/bitnet-cli-config-core/src/lib.rs
+++ b/crates/bitnet-cli-config-core/src/lib.rs
@@ -137,7 +137,7 @@ impl CliConfig {
     pub fn validate(&self) -> Result<()> {
         if !is_supported_device_label(&self.default_device) {
             anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, intel-npu, openvino-npu, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto",
+                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, a770-opencl, intel-arc-a770-opencl, npu, intel-npu, openvino-npu, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto",
                 self.default_device
             );
         }
@@ -176,6 +176,8 @@ fn is_supported_device_label(label: &str) -> bool {
             | "vulkan"
             | "opencl"
             | "ocl"
+            | "a770-opencl"
+            | "intel-arc-a770-opencl"
             | "npu"
             | "intel-npu"
             | "openvino-npu"
@@ -266,5 +268,13 @@ mod tests {
     fn builder_preserves_intel_npu_device_label() {
         let config = ConfigBuilder::new().device(Some("intel-npu:2".to_string())).build().unwrap();
         assert_eq!(config.default_device, "intel-npu:2");
+    }
+
+    #[test]
+    fn validates_a770_opencl_route_labels_without_aliasing() {
+        for device in ["a770-opencl", "intel-arc-a770-opencl"] {
+            let config = CliConfig { default_device: device.to_string(), ..CliConfig::default() };
+            config.validate().unwrap();
+        }
     }
 }

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -28,6 +28,7 @@ bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-qk256-dispatch = { path = "../bitnet-qk256-dispatch", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1810,6 +1810,7 @@ async fn run_simple_generation(
 
     // Track generated tokens for repetition penalty
     let mut generated_tokens = Vec::new();
+    bitnet_qk256_dispatch::reset_qk256_dispatch_counters();
 
     // Track logits dump if requested
     let mut logits_dump: Vec<LogitStep> = Vec::new();
@@ -2042,6 +2043,7 @@ async fn run_simple_generation(
     } else {
         0.0
     };
+    let qk256_dispatch = bitnet_qk256_dispatch::qk256_dispatch_counters();
 
     println!("\n\nGeneration complete!");
     println!(
@@ -2154,6 +2156,17 @@ async fn run_simple_generation(
                     "claimable": false,
                 },
                 "route_declared": proof_kernel_route.is_some(),
+                "qk256_dispatch": {
+                    "cpu_calls": qk256_dispatch.cpu_calls,
+                    "cpu_successes": qk256_dispatch.cpu_successes,
+                    "cpu_input_rows": qk256_dispatch.cpu_input_rows,
+                    "opencl_calls": qk256_dispatch.opencl_calls,
+                    "opencl_successes": qk256_dispatch.opencl_successes,
+                    "opencl_input_rows": qk256_dispatch.opencl_input_rows,
+                    "a770_qk256_opencl_used": qk256_dispatch.opencl_successes > 0,
+                    "diagnostic_only": true,
+                    "claimable": false,
+                },
                 "backend_claimable": false,
                 "not_claims": critical_not_claims(),
             },

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -119,6 +119,28 @@ fn canonical_proof_backend_label(label: &str) -> String {
     }
 }
 
+fn resolve_simple_generation_device(
+    requested_backend_label: &str,
+    strict_backend: bool,
+) -> Result<(bitnet_common::Device, String)> {
+    use bitnet_common::{BackendRequest, Device, select_backend};
+    use bitnet_kernels::device_features::current_kernel_capabilities;
+
+    let request =
+        BackendRequest::from_label(requested_backend_label).unwrap_or(BackendRequest::Auto);
+    match select_backend(request, &current_kernel_capabilities()) {
+        Ok(selection) if selection.selected_backend() == "intel-arc-a770-opencl" => {
+            Ok((Device::OpenCL(0), selection.selected_backend()))
+        }
+        Ok(_) => Ok((Device::Cpu, "cpu".to_string())),
+        Err(err) if strict_backend => Err(err.into()),
+        Err(err) => {
+            warn!(error = %err, "simple generation backend selection fell back to CPU");
+            Ok((Device::Cpu, "cpu".to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod proof_summary_tests {
     use super::*;
@@ -1466,7 +1488,6 @@ async fn run_simple_generation(
     assert_greedy: bool,
     no_warnings: bool,
 ) -> Result<()> {
-    use bitnet_common::Device;
     use bitnet_models::{Model, transformer::KVCache};
     use bitnet_sampling::{SamplingConfig, SamplingStrategy};
     use bitnet_tokenizers::Tokenizer;
@@ -1518,9 +1539,10 @@ async fn run_simple_generation(
         debug!("Strict loader enabled (BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)");
     }
 
-    let simple_execution_backend = "cpu";
+    let (model_device, simple_execution_backend) =
+        resolve_simple_generation_device(&requested_backend_label, strict_backend)?;
     let initial_backend_fallback =
-        backend_fallback_proof(&requested_backend_label, simple_execution_backend);
+        backend_fallback_proof(&requested_backend_label, simple_execution_backend.as_str());
     if strict_backend && initial_backend_fallback.used {
         let reason = initial_backend_fallback
             .reason
@@ -1559,7 +1581,7 @@ async fn run_simple_generation(
     // Try real loader first
     use bitnet_models::loader::{LoadConfig, ModelLoader};
 
-    let loader = ModelLoader::new(Device::Cpu);
+    let loader = ModelLoader::new(model_device);
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
     let loader_mode;
@@ -1594,7 +1616,7 @@ async fn run_simple_generation(
             // Mock fallback
             let load_result = bitnet_models::gguf_simple::load_gguf_full(
                 &model_path,
-                Device::Cpu,
+                model_device,
                 bitnet_models::GGUFLoaderConfig::default(),
             )
             .context("Mock loader also failed")?;
@@ -1628,7 +1650,7 @@ async fn run_simple_generation(
                 load_result.config.clone(),
                 load_result.tensors,
                 raw_tensors,
-                Device::Cpu,
+                model_device,
             )
             .context("Failed to build mock model")?;
             (Arc::new(m) as Arc<dyn Model>, load_result.config)
@@ -2071,7 +2093,7 @@ async fn run_simple_generation(
         });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
-        let execution_backend = simple_execution_backend;
+        let execution_backend = simple_execution_backend.as_str();
         let requested_backend = requested_backend_label.as_str();
         let backend_fallback = backend_fallback_proof(requested_backend, execution_backend);
         let fallback_used =

--- a/crates/bitnet-kernels/src/device_features.rs
+++ b/crates/bitnet-kernels/src/device_features.rs
@@ -164,16 +164,16 @@ pub fn opencl_compiled() -> bool {
     cfg!(feature = "opencl")
 }
 
-/// Check if an OpenCL-capable GPU runtime is available.
+/// Check if an OpenCL runtime is available.
 ///
-/// Detection is best-effort via `clinfo`. Tests can force deterministic
-/// outcomes with `BITNET_GPU_FAKE=opencl` / `BITNET_GPU_FAKE=none` unless
-/// strict mode is enabled.
+/// Detection uses the same dynamic OpenCL probe as hardware receipts instead
+/// of requiring a separate `clinfo` executable to be installed. Tests can
+/// force deterministic outcomes with `BITNET_GPU_FAKE=opencl` /
+/// `BITNET_GPU_FAKE=none` unless strict mode is enabled.
 #[cfg(feature = "opencl")]
 #[inline]
 pub fn opencl_available_runtime() -> bool {
     use std::env;
-    use std::process::{Command, Stdio};
 
     let strict_mode = env::var("BITNET_STRICT_MODE")
         .map(|v| v == "1" || v.to_lowercase() == "true")
@@ -190,12 +190,7 @@ pub fn opencl_available_runtime() -> bool {
         }
     }
 
-    Command::new("clinfo")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    bitnet_device_probe::probe_opencl().runtime_available
 }
 
 #[cfg(not(feature = "opencl"))]
@@ -442,6 +437,16 @@ mod intel_tests {
             assert!(info.device_name.contains("simulated"));
             assert_eq!(info.compute_units, 32);
             assert!(intel_gpu_available());
+        });
+    }
+
+    #[cfg(feature = "opencl")]
+    #[test]
+    #[serial(bitnet_env)]
+    fn opencl_runtime_fake_detection_sets_capability() {
+        temp_env::with_var("BITNET_GPU_FAKE", Some("opencl"), || {
+            assert!(opencl_available_runtime());
+            assert!(current_kernel_capabilities().opencl_runtime);
         });
     }
 

--- a/crates/bitnet-models/src/bitnet.rs
+++ b/crates/bitnet-models/src/bitnet.rs
@@ -92,6 +92,11 @@ impl BitNetModel {
         };
 
         // Create a VarBuilder that uses our loaded tensors
+        let qk256_backend = if device.is_opencl() {
+            crate::transformer::Qk256DispatchBackend::OpenCl
+        } else {
+            crate::transformer::Qk256DispatchBackend::Cpu
+        };
         let device = device.to_candle().map_err(|e| BitNetError::Validation(e.to_string()))?;
 
         if tensors.is_empty() {
@@ -129,7 +134,12 @@ impl BitNetModel {
         let raw_mapped = remap_gguf_weights(raw_tensors)?;
 
         let vb = create_var_builder(mapped.clone(), DType::F32, &device)?;
-        let model = TransformerModel::new_with_tensors(updated_config, vb, raw_mapped)?;
+        let model = TransformerModel::new_with_tensors_and_qk256_backend(
+            updated_config,
+            vb,
+            raw_mapped,
+            qk256_backend,
+        )?;
         Ok(Arc::new(model))
     }
 

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -7,9 +7,47 @@ pub use opencl::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC, gemm_qk256_o
 use bitnet_common::{BitNetError, KernelError, Result};
 use bitnet_qk256_layout_core::{parse_input_shape, parse_qk256_layout, validate_input_cols};
 use candle_core::Tensor;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const NOT_CLAIMED_OPENCL_QK256: &[&str] =
     &["a770_qk256_opencl_execution", "a770_qk256_opencl_performance", "a770_full_device_residency"];
+
+static CPU_CALLS: AtomicU64 = AtomicU64::new(0);
+static CPU_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static CPU_INPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+static OPENCL_CALLS: AtomicU64 = AtomicU64::new(0);
+static OPENCL_SUCCESSES: AtomicU64 = AtomicU64::new(0);
+static OPENCL_INPUT_ROWS: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Qk256DispatchCounters {
+    pub cpu_calls: u64,
+    pub cpu_successes: u64,
+    pub cpu_input_rows: u64,
+    pub opencl_calls: u64,
+    pub opencl_successes: u64,
+    pub opencl_input_rows: u64,
+}
+
+pub fn qk256_dispatch_counters() -> Qk256DispatchCounters {
+    Qk256DispatchCounters {
+        cpu_calls: CPU_CALLS.load(Ordering::Relaxed),
+        cpu_successes: CPU_SUCCESSES.load(Ordering::Relaxed),
+        cpu_input_rows: CPU_INPUT_ROWS.load(Ordering::Relaxed),
+        opencl_calls: OPENCL_CALLS.load(Ordering::Relaxed),
+        opencl_successes: OPENCL_SUCCESSES.load(Ordering::Relaxed),
+        opencl_input_rows: OPENCL_INPUT_ROWS.load(Ordering::Relaxed),
+    }
+}
+
+pub fn reset_qk256_dispatch_counters() {
+    CPU_CALLS.store(0, Ordering::Relaxed);
+    CPU_SUCCESSES.store(0, Ordering::Relaxed);
+    CPU_INPUT_ROWS.store(0, Ordering::Relaxed);
+    OPENCL_CALLS.store(0, Ordering::Relaxed);
+    OPENCL_SUCCESSES.store(0, Ordering::Relaxed);
+    OPENCL_INPUT_ROWS.store(0, Ordering::Relaxed);
+}
 
 /// Describes which QK256 runtime is currently used by this dispatch crate.
 ///
@@ -118,6 +156,8 @@ pub fn forward_qk256_with_backend(
 
     match backend {
         Qk256DispatchBackend::Cpu => {
+            CPU_CALLS.fetch_add(1, Ordering::Relaxed);
+            CPU_INPUT_ROWS.fetch_add(input_rows as u64, Ordering::Relaxed);
             for (i, input_row) in input_vec.iter().enumerate() {
                 let start = i * layout.rows;
                 let end = start + layout.rows;
@@ -136,8 +176,11 @@ pub fn forward_qk256_with_backend(
                     ))
                 })?;
             }
+            CPU_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
         Qk256DispatchBackend::OpenCl => {
+            OPENCL_CALLS.fetch_add(1, Ordering::Relaxed);
+            OPENCL_INPUT_ROWS.fetch_add(input_rows as u64, Ordering::Relaxed);
             run_opencl_qk256(
                 &flat_bytes,
                 &input_vec,
@@ -147,6 +190,7 @@ pub fn forward_qk256_with_backend(
                 layout.row_stride_bytes,
                 weight_name,
             )?;
+            OPENCL_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
     }
 

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -8,6 +8,7 @@ use opencl3::platform::get_platforms;
 use opencl3::program::Program;
 use opencl3::types::CL_BLOCKING;
 use std::ptr::null_mut;
+use std::sync::{Arc, OnceLock};
 
 pub const QK256_OPENCL_KERNEL_NAME: &str = "qk256_gemm_no_scale";
 
@@ -62,7 +63,7 @@ pub fn gemm_qk256_opencl(
 ) -> Result<()> {
     validate_args(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)?;
 
-    let runtime = OpenClQk256Runtime::new()?;
+    let runtime = qk256_runtime()?;
     runtime.run(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)
 }
 
@@ -132,6 +133,29 @@ struct OpenClQk256Runtime {
     context: Context,
     queue: CommandQueue,
     program: Program,
+}
+
+// SAFETY: The OpenCL command queue serializes submitted work; the cached runtime
+// owns immutable context/program handles after initialization.
+unsafe impl Send for OpenClQk256Runtime {}
+unsafe impl Sync for OpenClQk256Runtime {}
+
+static QK256_RUNTIME: OnceLock<Arc<OpenClQk256Runtime>> = OnceLock::new();
+
+fn qk256_runtime() -> Result<Arc<OpenClQk256Runtime>> {
+    if let Some(runtime) = QK256_RUNTIME.get() {
+        return Ok(runtime.clone());
+    }
+
+    let runtime = Arc::new(OpenClQk256Runtime::new()?);
+    if QK256_RUNTIME.set(runtime.clone()).is_ok() {
+        Ok(runtime)
+    } else {
+        Ok(QK256_RUNTIME
+            .get()
+            .expect("QK256 runtime must be set after racing initialization")
+            .clone())
+    }
 }
 
 impl OpenClQk256Runtime {

--- a/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
+++ b/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "opencl")]
+
+use bitnet_qk256_dispatch::{Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend};
+use candle_core::{Device, Tensor};
+
+#[test]
+#[ignore = "requires an Intel OpenCL GPU runtime; run manually on the A770 proof station"]
+fn opencl_qk256_matches_cpu_reference_for_known_rows() {
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+
+    let mut qk_bytes = Vec::with_capacity(2 * 64);
+    qk_bytes.extend_from_slice(&[0xAAu8; 64]);
+    qk_bytes.extend_from_slice(&[0x55u8; 64]);
+    let qk = Tensor::from_vec(qk_bytes, (2, 64), &device).unwrap();
+
+    let weight_name = "layers.0.attention.q_proj.weight.qk256_qs";
+    let cpu = forward_qk256(&input, &qk, weight_name).unwrap();
+    let opencl =
+        forward_qk256_with_backend(&input, &qk, weight_name, Qk256DispatchBackend::OpenCl).unwrap();
+
+    let cpu_vals = cpu.to_vec2::<f32>().unwrap();
+    let opencl_vals = opencl.to_vec2::<f32>().unwrap();
+
+    assert_eq!(cpu_vals.len(), opencl_vals.len());
+    assert_eq!(cpu_vals[0].len(), opencl_vals[0].len());
+    for (expected_row, actual_row) in cpu_vals.iter().zip(opencl_vals.iter()) {
+        for (&expected, &actual) in expected_row.iter().zip(actual_row.iter()) {
+            assert!(
+                (expected - actual).abs() <= 1e-4,
+                "OpenCL QK256 mismatch: expected {expected}, actual {actual}"
+            );
+        }
+    }
+}

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1,5 +1,6 @@
 use bitnet_common::{BitNetConfig, BitNetError, Result};
-use bitnet_qk256_dispatch::forward_qk256;
+pub use bitnet_qk256_dispatch::Qk256DispatchBackend;
+use bitnet_qk256_dispatch::forward_qk256_with_backend;
 use bitnet_rope::{build_tables as build_rope_tables, resolve_base as resolve_rope_base};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{LayerNorm, Linear, VarBuilder};
@@ -197,10 +198,16 @@ pub struct MultiHeadAttention {
     o_proj: Linear,
     rope: Option<RotaryEmbedding>,
     layer_idx: usize, // Layer index for QK256 weight name generation
+    qk256_backend: Qk256DispatchBackend,
 }
 
 impl MultiHeadAttention {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         let n_heads = config.model.num_heads;
         let head_dim = hidden_size / n_heads;
@@ -270,6 +277,7 @@ impl MultiHeadAttention {
             o_proj,
             rope,
             layer_idx,
+            qk256_backend,
         })
     }
 
@@ -559,7 +567,7 @@ impl MultiHeadAttention {
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
             tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256(input, qk256_tensor, &qk256_key);
+            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
         }
 
         // Probe: Why is QK256 not found? (layer 0 only, once)
@@ -610,10 +618,16 @@ pub struct FeedForward {
     up_proj: Linear,
     down_proj: Linear,
     layer_idx: usize, // Layer index for QK256 weight name generation
+    qk256_backend: Qk256DispatchBackend,
 }
 
 impl FeedForward {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         let intermediate_size = config.model.intermediate_size;
 
@@ -630,6 +644,7 @@ impl FeedForward {
                 vb.pp("down_proj"),
             )?,
             layer_idx,
+            qk256_backend,
         })
     }
 
@@ -698,7 +713,7 @@ impl FeedForward {
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
             tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256(input, qk256_tensor, &qk256_key);
+            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
         }
 
         // Fall back to standard linear
@@ -720,7 +735,12 @@ pub struct TransformerBlock {
 }
 
 impl TransformerBlock {
-    pub fn new(config: &BitNetConfig, vb: VarBuilder, layer_idx: usize) -> Result<Self> {
+    pub fn new(
+        config: &BitNetConfig,
+        vb: VarBuilder,
+        layer_idx: usize,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let hidden_size = config.model.hidden_size;
         // PATCH 1: Use RMSNorm epsilon from config header for ALL norms (per-layer + final)
         let eps = config.model.rms_norm_eps.map(|e| e as f64).unwrap_or(1e-5);
@@ -728,8 +748,18 @@ impl TransformerBlock {
         tracing::debug!("TransformerBlock using RMSNorm eps={} (from header)", eps);
 
         Ok(Self {
-            attention: MultiHeadAttention::new(config, vb.pp("attention"), layer_idx)?,
-            feed_forward: FeedForward::new(config, vb.pp("feed_forward"), layer_idx)?,
+            attention: MultiHeadAttention::new(
+                config,
+                vb.pp("attention"),
+                layer_idx,
+                qk256_backend,
+            )?,
+            feed_forward: FeedForward::new(
+                config,
+                vb.pp("feed_forward"),
+                layer_idx,
+                qk256_backend,
+            )?,
             attention_norm: layer_norm_with_optional_bias(
                 hidden_size,
                 eps,
@@ -1049,6 +1079,15 @@ impl TransformerModel {
         vb: VarBuilder,
         raw_tensors: std::collections::HashMap<String, Tensor>,
     ) -> Result<Self> {
+        Self::new_with_tensors_and_qk256_backend(config, vb, raw_tensors, Qk256DispatchBackend::Cpu)
+    }
+
+    pub fn new_with_tensors_and_qk256_backend(
+        config: BitNetConfig,
+        vb: VarBuilder,
+        raw_tensors: std::collections::HashMap<String, Tensor>,
+        qk256_backend: Qk256DispatchBackend,
+    ) -> Result<Self> {
         let device = vb.device().clone();
         let vocab_size = config.model.vocab_size;
         let hidden_size = config.model.hidden_size;
@@ -1073,7 +1112,12 @@ impl TransformerModel {
 
         let mut layers = Vec::with_capacity(n_layers);
         for i in 0..n_layers {
-            layers.push(TransformerBlock::new(&config, vb.pp(format!("layers.{}", i)), i)?);
+            layers.push(TransformerBlock::new(
+                &config,
+                vb.pp(format!("layers.{}", i)),
+                i,
+                qk256_backend,
+            )?);
         }
 
         // Use RMSNorm epsilon from config header (CRITICAL: must match per-layer norms)


### PR DESCRIPTION
## Summary
- allows `a770-opencl` / `intel-arc-a770-opencl` through CLI config validation
- makes OpenCL runtime capability detection use the repo's dynamic OpenCL probe instead of requiring a `clinfo` executable
- adds focused tests for the route labels and OpenCL runtime capability path

## Verification
- `cargo test --locked -p bitnet-cli-config-core --lib a770 -- --nocapture`
- `cargo test --locked -p bitnet-kernels --no-default-features --features opencl --lib opencl_runtime_fake_detection_sets_capability -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl`
- `git diff --check`

## Local smoke
- Strict A770 route selection now reaches `selected_backend=intel-arc-a770-opencl` with `fallback_used=false`.
- The run then stops at the existing strict GGUF loader blocker: missing output/lm-head tensor.

## Not claims
- Does not promote selected attention.
- Does not promote resident KV decode.
- Does not promote attention scores, softmax, or value mix residency.
- Does not promote full support-op residency, full device residency, or completion.
- Does not make a benchmark or performance claim.