### PR TITLE
loader(gguf): trim strict I2S padding

### DIFF
--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -1535,15 +1535,33 @@ impl GgufLoader {
                 let has_scale_sibling = false; // QK256 has no sibling scale tensor (scales are inline or absent)
 
                 let flavor = detect_i2s_flavor(info, has_scale_sibling, nelems)?;
+                let logical_size = flavor.logical_size_bytes(nelems);
+                if data.len() < logical_size {
+                    return Err(BitNetError::Validation(format!(
+                        "I2_S '{}': available bytes {} shorter than logical {} for {:?}",
+                        info.name,
+                        data.len(),
+                        logical_size,
+                        flavor
+                    )));
+                }
+                let i2s_data = &data[..logical_size];
+                if data.len() > logical_size {
+                    tracing::debug!(
+                        "I2_S '{}': trimming {} GGUF alignment padding bytes before decode",
+                        info.name,
+                        data.len() - logical_size
+                    );
+                }
 
                 // If QK256, preserve raw bytes instead of dequantizing
                 if matches!(flavor, I2SFlavor::GgmlQk256NoScale) {
                     tracing::debug!(
-                        "Detected QK256 tensor '{}' ({}x{}, {} bytes) - preserving raw bytes",
+                        "Detected QK256 tensor '{}' ({}x{}, {} logical bytes) - preserving raw bytes",
                         info.name,
                         info.shape[0],
                         info.shape[1],
-                        data.len()
+                        i2s_data.len()
                     );
 
                     // Determine correct orientation for QK256 tensors
@@ -1591,7 +1609,7 @@ impl GgufLoader {
                                 detect_qk256_orientation_by_bytes(
                                     shape_as_is,
                                     shape_transposed,
-                                    data.len(),
+                                    i2s_data.len(),
                                 )
                             }
                         } else {
@@ -1599,7 +1617,7 @@ impl GgufLoader {
                             detect_qk256_orientation_by_bytes(
                                 shape_as_is,
                                 shape_transposed,
-                                data.len(),
+                                i2s_data.len(),
                             )
                         }
                     };
@@ -1609,7 +1627,7 @@ impl GgufLoader {
 
                     // Store raw bytes as U8 tensor [rows, row_stride_bytes]
                     let raw_tensor = Tensor::from_raw_buffer(
-                        data,
+                        i2s_data,
                         DType::U8,
                         &[rows, row_stride_bytes],
                         &candle_device,
@@ -1636,7 +1654,7 @@ impl GgufLoader {
                 // For other I2_S flavors (Split32, Inline), continue with dequantization
                 // Select per-tensor I2_S config (policy → heuristic → default)
                 let (inv, k, correction_opt) =
-                    Self::select_i2s_config(&info.name, Some(data), policy_plan);
+                    Self::select_i2s_config(&info.name, Some(i2s_data), policy_plan);
                 let cfg = I2SDequantCfg { inv, k };
 
                 // Log projection weight RMS after dequant for diagnosis
@@ -1648,7 +1666,7 @@ impl GgufLoader {
                 {
                     info!("Embedding appears transposed ({:?}) -> decoding transposed", info.shape);
                     let f32_data =
-                        i2s::dequantize_to_f32_transposed_with_cfg(data, &info.shape, cfg)
+                        i2s::dequantize_to_f32_transposed_with_cfg(i2s_data, &info.shape, cfg)
                             .map_err(|e| BitNetError::Validation(e.to_string()))?;
 
                     // Now dims become [vocab, hidden]
@@ -1665,7 +1683,7 @@ impl GgufLoader {
                         [info.shape[1], info.shape[0]]
                     );
                     let tensor = Self::create_transposed_i2s_tensor_with_cfg(
-                        data,
+                        i2s_data,
                         &info.shape,
                         &candle_device,
                         cfg,
@@ -1686,7 +1704,7 @@ impl GgufLoader {
                     return Ok((tensor, None, correction_opt));
                 } else {
                     // Normal I2_S dequantization with config
-                    let mut f32_data = i2s::dequantize_to_f32_with_cfg(data, &info.shape, cfg)
+                    let mut f32_data = i2s::dequantize_to_f32_with_cfg(i2s_data, &info.shape, cfg)
                         .map_err(|e| BitNetError::Validation(e.to_string()))?;
 
                     // Transpose once to [out,in] if this is a projection weight

--- a/crates/bitnet-models/src/formats/gguf/types.rs
+++ b/crates/bitnet-models/src/formats/gguf/types.rs
@@ -834,6 +834,12 @@ impl I2SFlavor {
         }
     }
 
+    /// Get the logical tensor byte count for this flavor, excluding GGUF
+    /// alignment padding between tensors.
+    pub fn logical_size_bytes(&self, nelems: usize) -> usize {
+        nelems.div_ceil(self.block_size()) * self.total_bytes_per_block()
+    }
+
     /// Convert to legacy I2SLayoutKind for backward compatibility
     pub fn to_layout_kind(&self) -> I2SLayoutKind {
         match self {
@@ -878,11 +884,12 @@ pub fn detect_i2s_flavor(
     let available = info.size as usize;
 
     // AC2: Centralized tolerance
-    // - Strict mode: tight 8 bytes (fail-fast)
+    // - Strict mode: allow one GGUF alignment interval of padding, but loader
+    //   code must still trim to the flavor's logical byte count before decode.
     // - Default: size-proportional (~0.1%) using quantization helper
     let strict = std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1");
     let tolerance = if strict {
-        8usize
+        64usize
     } else {
         // pick a representative expected size (qk256/split) to compute tolerance bytes
         let expected_any = core::cmp::min(split_need, qk256_need);
@@ -1319,5 +1326,29 @@ mod tests {
         assert_eq!(align_up(31, 32), 32);
         assert_eq!(align_up(32, 32), 32);
         assert_eq!(align_up(33, 32), 64);
+    }
+
+    #[test]
+    fn i2s_flavor_accepts_strict_gguf_alignment_padding() {
+        let nelems = 256 * 256;
+        let logical = I2SFlavor::GgmlQk256NoScale.logical_size_bytes(nelems);
+        let info = TensorInfo {
+            name: "blk.0.ffn_down.weight".to_string(),
+            shape: vec![256, 256],
+            tensor_type: GgufTensorType::I2_S,
+            offset: 0,
+            size: (logical + 32) as u64,
+        };
+
+        temp_env::with_var("BITNET_STRICT_MODE", Some("1"), || {
+            let flavor = detect_i2s_flavor(&info, false, nelems).expect("alignment padding");
+            assert_eq!(flavor, I2SFlavor::GgmlQk256NoScale);
+        });
+    }
+
+    #[test]
+    fn i2s_logical_size_excludes_padding() {
+        let nelems = 256 * 256;
+        assert_eq!(I2SFlavor::GgmlQk256NoScale.logical_size_bytes(nelems), 16_384);
     }
 }


### PR DESCRIPTION
## Summary
- allows bounded GGUF alignment padding during strict I2_S flavor detection
- trims I2_S data to the detected flavor's logical byte count before raw preservation or dequantization
- adds tests for strict QK256 padding detection and logical-size accounting

## Verification
- `cargo test --locked -p bitnet-models --lib i2s_ -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl`
- `git diff --check`

## Local smoke
- Strict A770 diagnostic run loaded the official BitNet GGUF and generated 8 tokens.
- Receipt reports `execution_backend=intel-arc-a770-opencl`, `fallback_used=false`, and QK256 OpenCL dispatch counters at 1680 calls / 1680 successes.
- Generated text was not semantically useful, so this remains diagnostic-only and does not support a quality or benchmark claim.

## Not claims
- Does not promote selected attention.
- Does not promote resident KV decode.
- Does not promote attention scores, softmax, or value mix residency.
- Does not promote full support-op residency, full device residency, or completion.
- Does not make a quality, benchmark, performance, or product-support claim.