### PR TITLE
tokenizers: avoid duplicate HF prompt specials

### DIFF
--- a/crates/bitnet-tokenizers/src/hf_tokenizer.rs
+++ b/crates/bitnet-tokenizers/src/hf_tokenizer.rs
@@ -110,11 +110,16 @@ impl HfTokenizer {
 }
 
 impl super::Tokenizer for HfTokenizer {
-    fn encode(&self, text: &str, add_bos: bool, add_special: bool) -> Result<Vec<u32>> {
+    fn encode(&self, text: &str, add_bos: bool, _add_special: bool) -> Result<Vec<u32>> {
         use tokenizers::EncodeInput;
 
+        // The Tokenizer trait's third argument is used by prompt templates as
+        // "parse embedded special tokens". Hugging Face tokenizer.json files
+        // still recognize literal AddedToken specials with post-processing
+        // disabled; enabling post-processing here injects template specials
+        // such as BOS/EOS a second time for rendered chat prompts.
         let enc =
-            self.inner.encode(EncodeInput::Single(text.into()), add_special).map_err(|e| {
+            self.inner.encode(EncodeInput::Single(text.into()), false).map_err(|e| {
                 bitnet_common::BitNetError::Model(bitnet_common::ModelError::LoadingFailed {
                     reason: format!("Tokenizer encode error: {}", e),
                 })
@@ -128,14 +133,6 @@ impl super::Tokenizer for HfTokenizer {
             && (ids.is_empty() || ids[0] != bos)
         {
             ids.insert(0, bos);
-        }
-
-        // Add EOS if requested
-        if add_special
-            && let Some(eos) = self.eos_id
-            && (ids.is_empty() || ids[ids.len() - 1] != eos)
-        {
-            ids.push(eos);
         }
 
         Ok(ids)
@@ -174,5 +171,37 @@ impl super::Tokenizer for HfTokenizer {
 impl HfTokenizer {
     pub fn source_name(&self) -> &'static str {
         "hf_json"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tokenizer;
+
+    fn fixture_tokenizer() -> HfTokenizer {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/fixtures/tokenizers/valid_tokenizer_a.json");
+        HfTokenizer::from_file(&path).expect("fixture tokenizer should load")
+    }
+
+    #[test]
+    fn embedded_special_prompt_does_not_get_post_processor_bos() {
+        let tokenizer = fixture_tokenizer();
+
+        let ids = tokenizer.encode("<s>▁t", false, true).expect("encode should succeed");
+
+        assert_eq!(ids.first().copied(), Some(1), "embedded BOS should be parsed");
+        assert_ne!(ids.get(1).copied(), Some(1), "post-processor BOS must not be injected");
+    }
+
+    #[test]
+    fn explicit_bos_policy_still_prepends_single_bos() {
+        let tokenizer = fixture_tokenizer();
+
+        let ids = tokenizer.encode("▁t", true, true).expect("encode should succeed");
+
+        assert_eq!(ids.first().copied(), Some(1), "explicit BOS should be prepended");
+        assert_ne!(ids.get(1).copied(), Some(1), "explicit BOS should not duplicate");
     }
 }


### PR DESCRIPTION
## Summary
- keep Hugging Face tokenizer.json post-processing disabled when the runtime is encoding already-rendered prompts with embedded special tokens
- preserve explicit BOS insertion through the existing `add_bos` policy
- add adapter tests proving embedded BOS is parsed without injecting a second BOS

## Verification
- `cargo test --locked -p bitnet-tokenizers --lib hf_tokenizer -- --nocapture`
- `cargo test --locked -p bitnet-tokenizers --no-default-features --lib hf_tokenizer -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,opencl`
- `git diff --check`
- Diagnostic only: strict A770 smoke now reports `prompt_token_count=20` instead of 21 and still keeps `claim_level=diagnostic_cli_run`

## Claim Boundary
- Does not promote selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion.
- The strict A770 smoke still produces bad text, and CPU previously produced the same bad tokens, so the remaining quality issue is shared above the OpenCL QK256 route.