### PR TITLE
test(cli): pin prefill last-token logit selection

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -213,6 +213,27 @@ mod proof_summary_tests {
     }
 
     #[test]
+    fn extract_last_token_hidden_uses_final_sequence_position() -> Result<()> {
+        let device = candle_core::Device::Cpu;
+        let hidden = candle_core::Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, 4.0, // position 0
+                10.0, 20.0, 30.0, 40.0, // position 1
+                100.0, 200.0, 300.0, 400.0, // position 2
+            ],
+            (1usize, 3usize, 4usize),
+            &device,
+        )?;
+        let tensor =
+            bitnet_common::ConcreteTensor::BitNet(bitnet_common::BitNetTensor::new(hidden));
+
+        let last = extract_last_token_hidden(&tensor)?;
+        assert_eq!(last.shape(), vec![1, 4]);
+        assert_eq!(tensor_to_vec(&last)?, vec![100.0f32, 200.0, 300.0, 400.0]);
+        Ok(())
+    }
+
+    #[test]
     fn run_command_accepts_strict_backend_flag() {
         let cli = Cli::try_parse_from([
             "bitnet",


### PR DESCRIPTION
## Summary
- Add a CLI unit guard proving prefill hidden-state extraction uses the final sequence position.
- Protect the `model.forward(full_prompt) -> extract_last_token_hidden -> logits` path from accidentally sampling an earlier prompt position.
- Keep this as test-only proof hardening: no runtime behavior changes and no claim or residency promotion.

## Verification
- `rustfmt --edition 2024 --check --config skip_children=true crates\\bitnet-cli\\src\\main.rs`
- `cargo test --locked -p bitnet-cli proof_summary_tests --no-default-features --features cpu,opencl -- --nocapture`
- `git diff --check`

## Claim Boundary
- Does not promote selected attention.
- Does not promote resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion.