### PR TITLE
diag(qk256): pin rank3 row-sensitive dispatch

### DIFF
--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -53,6 +53,33 @@ fn forward_qk256_supports_rank3_input() {
 }
 
 #[test]
+fn forward_qk256_rank3_preserves_varied_token_rows() {
+    let device = Device::Cpu;
+    let mut input_rows = Vec::with_capacity(2 * 2 * 256);
+    for value in [1.0f32, 2.0, -1.0, 0.5] {
+        input_rows.extend(std::iter::repeat_n(value, 256));
+    }
+    let input = Tensor::from_vec(input_rows, (2, 2, 256), &device).unwrap();
+    let qk = Tensor::from_vec(vec![0xAAu8; 64], (1, 64), &device).unwrap();
+
+    let out = forward_qk256(&input, &qk, "layers.0.feed_forward.up_proj.weight.qk256_qs").unwrap();
+    assert_eq!(out.dims(), &[2, 2, 1]);
+
+    let out_vals = out.to_vec3::<f32>().unwrap();
+    let expected = [[[256.0f32], [512.0]], [[-256.0], [128.0]]];
+    for (batch_idx, batch) in out_vals.iter().enumerate() {
+        for (token_idx, token) in batch.iter().enumerate() {
+            assert!(
+                (token[0] - expected[batch_idx][token_idx][0]).abs() < 1e-4,
+                "rank3 QK256 row mismatch at batch {batch_idx}, token {token_idx}: expected {}, actual {}",
+                expected[batch_idx][token_idx][0],
+                token[0]
+            );
+        }
+    }
+}
+
+#[test]
 fn forward_qk256_rejects_dimension_mismatch() {
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 128], (1, 128), &device).unwrap();

--- a/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
+++ b/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
@@ -33,3 +33,47 @@ fn opencl_qk256_matches_cpu_reference_for_known_rows() {
         }
     }
 }
+
+#[test]
+#[ignore = "requires an Intel OpenCL GPU runtime; run manually on the A770 proof station"]
+fn opencl_qk256_rank3_matches_cpu_reference_for_varied_rows() {
+    let device = Device::Cpu;
+    let mut input_rows = Vec::with_capacity(2 * 2 * 256);
+    for value in [1.0f32, 2.0, -1.0, 0.5] {
+        input_rows.extend(std::iter::repeat_n(value, 256));
+    }
+    let input = Tensor::from_vec(input_rows, (2, 2, 256), &device).unwrap();
+
+    let mut qk_bytes = Vec::with_capacity(2 * 64);
+    qk_bytes.extend_from_slice(&[0xAAu8; 64]);
+    qk_bytes.extend_from_slice(&[0x55u8; 64]);
+    let qk = Tensor::from_vec(qk_bytes, (2, 64), &device).unwrap();
+
+    let weight_name = "layers.0.attention.q_proj.weight.qk256_qs";
+    let cpu = forward_qk256(&input, &qk, weight_name).unwrap();
+    let opencl =
+        forward_qk256_with_backend(&input, &qk, weight_name, Qk256DispatchBackend::OpenCl).unwrap();
+
+    let cpu_vals = cpu.to_vec3::<f32>().unwrap();
+    let opencl_vals = opencl.to_vec3::<f32>().unwrap();
+
+    assert_eq!(cpu_vals.len(), opencl_vals.len());
+    for (batch_idx, (expected_batch, actual_batch)) in
+        cpu_vals.iter().zip(opencl_vals.iter()).enumerate()
+    {
+        assert_eq!(expected_batch.len(), actual_batch.len());
+        for (token_idx, (expected_row, actual_row)) in
+            expected_batch.iter().zip(actual_batch.iter()).enumerate()
+        {
+            assert_eq!(expected_row.len(), actual_row.len());
+            for (col_idx, (&expected, &actual)) in
+                expected_row.iter().zip(actual_row.iter()).enumerate()
+            {
+                assert!(
+                    (expected - actual).abs() <= 1e-4,
+                    "OpenCL rank3 QK256 mismatch at batch {batch_idx}, token {token_idx}, col {col_idx}: expected {expected}, actual {actual}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a CPU QK256 rank-3 test with varied token rows to guard against prefill row collapse
- add an ignored A770 OpenCL hardware check that compares rank-3 varied rows against CPU reference
- keep this diagnostic-only; no A770 claim, selected-attention claim, residency claim, or runtime behavior change

## Verification
- rustfmt --edition 2024 --check crates\\bitnet-qk256-dispatch\\tests\\forward_qk256.rs
- rustfmt --edition 2024 --check crates\\bitnet-qk256-dispatch\\tests\\opencl_qk256_hardware.rs
- cargo test --locked -p bitnet-qk256-dispatch --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-qk256-dispatch --features opencl --test forward_qk256 -- --nocapture
- cargo test --locked -p bitnet-qk256-dispatch --features opencl --test opencl_qk256_hardware -- --nocapture
- git diff --check -- crates\\bitnet-qk256-dispatch\\tests\\forward_qk256.rs crates\\bitnet-qk256-dispatch\\tests\\opencl_qk256_hardware.rs

## Not Claims
- selected attention residency
- resident KV decode
- attention scores residency
- softmax residency
- attention value mix residency
- full support-op residency
- full device residency
- completion