### PR TITLE
Close apple-m4-local-answer

### DIFF
--- a/docs/tracking/campaigns/apple-m4-local-answer/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-local-answer/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-local-answer`
 
-Status: active
+Status: complete
 
 ## Objective
 

--- a/docs/tracking/campaigns/apple-m4-local-answer/active.toml
+++ b/docs/tracking/campaigns/apple-m4-local-answer/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-local-answer"
 title = "Apple M4 local answer usability"
-status = "active"
+status = "complete"
 
 objective = "Make Apple Silicon useful for a local Mac user by turning the completed proof and operational lanes into prompt-in, intelligible-answer-out behavior with truthful hardware routing and receipts."
 

--- a/docs/tracking/campaigns/apple-m4-local-answer/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-local-answer/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 local answer usability Campaign Status
 
 - Campaign: `apple-m4-local-answer`
-- State: `active`
+- State: `complete`
 - Objective: Make Apple Silicon useful for a local Mac user by turning the completed proof and operational lanes into prompt-in, intelligible-answer-out behavior with truthful hardware routing and receipts.
 
 ## Work Items


### PR DESCRIPTION
Tracker-only closeout. Marks apple-m4-local-answer complete after all work items merged. No runtime, model, Metal, QK256, server, or claim-surface change.

Validation:
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-answer`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
