### PR TITLE
fix(bitnet): apply i2s trailer scale in qk256 dispatch

### DIFF
--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use tracing::{debug, info};
 
 /// Type alias for tensor load result with optional raw tensor and correction record
-type TensorLoadResult = Result<(Tensor, Option<(String, Tensor)>, Option<CorrectionRecord>)>;
+type TensorLoadResult = Result<(Tensor, Vec<(String, Tensor)>, Option<CorrectionRecord>)>;
 
 /// GGUF format loader
 pub struct GgufLoader;
@@ -1406,7 +1406,7 @@ impl GgufLoader {
             );
 
             // Convert to Candle tensor (now with policy plan and QK256 handling)
-            let (candle_tensor, raw_qk256_opt, correction_opt) = self
+            let (candle_tensor, raw_qk256_tensors, correction_opt) = self
                 .create_candle_tensor_with_policy(
                     tensor_info,
                     tensor_data,
@@ -1416,8 +1416,8 @@ impl GgufLoader {
                 )?;
             tensors.insert(tensor_info.name.clone(), candle_tensor);
 
-            // Store raw QK256 tensor if present
-            if let Some((key, raw_tensor)) = raw_qk256_opt {
+            // Store raw QK256 tensor side-map entries if present.
+            for (key, raw_tensor) in raw_qk256_tensors {
                 raw_tensors.insert(key, raw_tensor);
             }
 
@@ -1454,10 +1454,15 @@ impl GgufLoader {
             }
         }
 
+        let qk256_weight_count =
+            raw_tensors.keys().filter(|key| key.ends_with(".qk256_qs")).count();
+        let qk256_side_entry_count = raw_tensors.len();
+
         info!(
-            "Successfully loaded {} tensors (detected {} QK256 tensors) with fingerprint: {}",
+            "Successfully loaded {} tensors (detected {} QK256 weight tensors, {} raw side-map entries) with fingerprint: {}",
             tensors.len(),
-            raw_tensors.len(),
+            qk256_weight_count,
+            qk256_side_entry_count,
             fingerprint
         );
         Ok((tensors, raw_tensors))
@@ -1505,7 +1510,7 @@ impl GgufLoader {
                     .map_err(|e| BitNetError::Validation(e.to_string()))?;
                 let tensor = Tensor::from_slice(&f32_data, info.shape.as_slice(), &candle_device)
                     .map_err(|e| BitNetError::Validation(e.to_string()))?;
-                return Ok((tensor, None, None));
+                return Ok((tensor, Vec::new(), None));
             }
 
             // For IQ2_S without FFI support, fail with clear message
@@ -1550,22 +1555,46 @@ impl GgufLoader {
                     )));
                 }
                 let i2s_data = &data[..logical_size];
+                let qk256_trailer_scale = if matches!(flavor, I2SFlavor::GgmlQk256NoScale)
+                    && data.len() >= logical_size + std::mem::size_of::<f32>()
+                {
+                    let scale_offset = logical_size;
+                    let scale = f32::from_le_bytes([
+                        data[scale_offset],
+                        data[scale_offset + 1],
+                        data[scale_offset + 2],
+                        data[scale_offset + 3],
+                    ]);
+                    Some(scale)
+                } else {
+                    None
+                };
                 if data.len() > logical_size {
                     tracing::debug!(
-                        "I2_S '{}': trimming {} GGUF alignment padding bytes before decode",
+                        "I2_S '{}': preserving {} logical bytes and leaving {} trailer/alignment bytes outside packed data",
                         info.name,
+                        logical_size,
                         data.len() - logical_size
                     );
                 }
 
                 // If QK256, preserve raw bytes instead of dequantizing
                 if matches!(flavor, I2SFlavor::GgmlQk256NoScale) {
+                    let qk256_scale = qk256_trailer_scale.unwrap_or_else(|| {
+                        tracing::warn!(
+                            "QK256 '{}' has no readable f32 trailer scale; using diagnostic scale 1.0",
+                            info.name
+                        );
+                        1.0
+                    });
+
                     tracing::debug!(
-                        "Detected QK256 tensor '{}' ({}x{}, {} logical bytes) - preserving raw bytes",
+                        "Detected QK256 tensor '{}' ({}x{}, {} logical bytes, scale={}) - preserving raw bytes",
                         info.name,
                         info.shape[0],
                         info.shape[1],
-                        i2s_data.len()
+                        i2s_data.len(),
+                        qk256_scale
                     );
 
                     // Determine correct orientation for QK256 tensors
@@ -1640,6 +1669,9 @@ impl GgufLoader {
 
                     // Generate key for raw_tensors collection
                     let qk256_key = format!("{}.qk256_qs", info.name);
+                    let qk256_scale_key = format!("{}.qk256_scale", info.name);
+                    let scale_tensor = Tensor::from_slice(&[qk256_scale], &[1], &candle_device)
+                        .map_err(|e| BitNetError::Validation(e.to_string()))?;
 
                     // Return placeholder f32 tensor for main collection (will not be used)
                     // We need a valid tensor to satisfy the API, but transformer will use raw_tensors
@@ -1647,12 +1679,17 @@ impl GgufLoader {
                         .map_err(|e| BitNetError::Validation(e.to_string()))?;
 
                     tracing::debug!(
-                        "QK256 raw tensor stored with key '{}' [shape: {:?}]",
+                        "QK256 raw tensor stored with key '{}' [shape: {:?}], scale key '{}'",
                         qk256_key,
-                        raw_tensor.dims()
+                        raw_tensor.dims(),
+                        qk256_scale_key
                     );
 
-                    return Ok((placeholder, Some((qk256_key, raw_tensor)), None));
+                    return Ok((
+                        placeholder,
+                        vec![(qk256_key, raw_tensor), (qk256_scale_key, scale_tensor)],
+                        None,
+                    ));
                 }
 
                 // For other I2_S flavors (Split32, Inline), continue with dequantization
@@ -1677,7 +1714,7 @@ impl GgufLoader {
                     let (rows, cols) = (info.shape[1], info.shape[0]);
                     let tensor = Tensor::from_slice(&f32_data, &[rows, cols], &candle_device)
                         .map_err(|e| BitNetError::Validation(e.to_string()))?;
-                    return Ok((tensor, None, correction_opt));
+                    return Ok((tensor, Vec::new(), correction_opt));
                 } else if Self::is_projection_tensor(&info.name) && info.shape.len() == 2 {
                     // Projection tensors need transposition for linear layer compatibility
                     debug!(
@@ -1705,7 +1742,7 @@ impl GgufLoader {
                         );
                     }
 
-                    return Ok((tensor, None, correction_opt));
+                    return Ok((tensor, Vec::new(), correction_opt));
                 } else {
                     // Normal I2_S dequantization with config
                     let mut f32_data = i2s::dequantize_to_f32_with_cfg(i2s_data, &info.shape, cfg)
@@ -1749,7 +1786,7 @@ impl GgufLoader {
                         );
                     }
 
-                    return Ok((tensor, None, correction_opt));
+                    return Ok((tensor, Vec::new(), correction_opt));
                 }
             }
 
@@ -1757,7 +1794,7 @@ impl GgufLoader {
             // (would need specific dequantizers for Q4_0, Q8_0, etc.)
             let tensor = Tensor::from_raw_buffer(data, dtype, &info.shape, &candle_device)
                 .map_err(|e| BitNetError::Validation(e.to_string()))?;
-            Ok((tensor, None, None))
+            Ok((tensor, Vec::new(), None))
         } else {
             // For regular tensors, interpret the bytes according to the data type
             match dtype {
@@ -1832,7 +1869,7 @@ impl GgufLoader {
 
                         // Prefer correction2 if both are present, otherwise use correction1
                         let final_correction = correction2.or(correction1);
-                        Ok((final_tensor, None, final_correction))
+                        Ok((final_tensor, Vec::new(), final_correction))
                     } else {
                         // Log projection RMS for F32 projections
                         if is_projection_weight(&info.name)
@@ -1845,7 +1882,7 @@ impl GgufLoader {
                                 rms
                             );
                         }
-                        Ok((tensor, None, None))
+                        Ok((tensor, Vec::new(), None))
                     }
                 }
                 DType::F16 => {
@@ -1898,7 +1935,7 @@ impl GgufLoader {
 
                         // Prefer correction2 if both are present, otherwise use correction1
                         let final_correction = correction2.or(correction1);
-                        Ok((final_tensor, None, final_correction))
+                        Ok((final_tensor, Vec::new(), final_correction))
                     } else {
                         // Log projection RMS for F16→F32 projections
                         if is_projection_weight(&info.name)
@@ -1911,7 +1948,7 @@ impl GgufLoader {
                                 rms
                             );
                         }
-                        Ok((tensor, None, None))
+                        Ok((tensor, Vec::new(), None))
                     }
                 }
                 _ => Err(BitNetError::Model(ModelError::InvalidFormat {

--- a/crates/bitnet-models/src/weight_mapper.rs
+++ b/crates/bitnet-models/src/weight_mapper.rs
@@ -179,10 +179,12 @@ pub fn remap_gguf_weights_with_options(
 
     // First pass: map all tensors
     for (name, tensor) in tensors {
-        // Handle raw QK256 tensor keys with .qk256_qs suffix
+        // Handle raw QK256 tensor keys with .qk256_* suffixes
         // Strip suffix -> remap base -> re-append suffix
         let (base_name, suffix) = if let Some(base) = name.strip_suffix(".qk256_qs") {
             (base, Some(".qk256_qs"))
+        } else if let Some(base) = name.strip_suffix(".qk256_scale") {
+            (base, Some(".qk256_scale"))
         } else {
             (name.as_str(), None)
         };

--- a/crates/bitnet-models/tests/qk256_avx2_correctness.rs
+++ b/crates/bitnet-models/tests/qk256_avx2_correctness.rs
@@ -33,12 +33,12 @@ use rand_chacha::ChaCha8Rng;
 
 /// Code-to-weight mapping for QK256 format
 ///
-/// This matches the GGML I2_S specification:
-/// - Code 0 → -2.0
-/// - Code 1 → -1.0
+/// This matches the Microsoft BitNet I2_S QK256 specification:
+/// - Code 0 → -1.0
+/// - Code 1 → 0.0
 /// - Code 2 → +1.0
 /// - Code 3 → +2.0
-const WEIGHTS: [f32; 4] = [-2.0, -1.0, 1.0, 2.0];
+const WEIGHTS: [f32; 4] = [-1.0, 0.0, 1.0, 2.0];
 
 /// Tolerance for floating-point comparison
 ///
@@ -467,13 +467,15 @@ fn test_qk256_avx2_uniform_codes() {
         let expected_diff = (scalar_result - expected).abs();
 
         // Allow larger tolerance for expected value due to summation order differences
+        let expected_rel_diff =
+            if expected.abs() > 1e-6 { expected_diff / expected.abs() } else { expected_diff };
         assert!(
-            expected_diff / expected.abs() < 0.01,
+            expected_rel_diff < 0.01,
             "Uniform code {} sanity check failed: expected={}, got={}, rel_diff={}",
             code,
             expected,
             scalar_result,
-            expected_diff / expected.abs()
+            expected_rel_diff
         );
     }
 

--- a/crates/bitnet-models/tests/qk256_error_handling.rs
+++ b/crates/bitnet-models/tests/qk256_error_handling.rs
@@ -146,9 +146,9 @@ fn test_qk256_zero_weights_effect() {
     let rows = 2;
     let cols = 256;
 
-    // Alternating codes: 0 (-2.0) and 3 (+2.0) should cancel out
-    // Pattern: 0b_11_00_11_00 = 0xCC
-    let qs_data = vec![0xCCu8; rows * QK256_PACKED_BYTES];
+    // Alternating codes: 0 (-1.0) and 2 (+1.0) should cancel out.
+    // LSB-first pattern [0, 2, 0, 2] = 0b_10_00_10_00 = 0x88.
+    let qs_data = vec![0x88u8; rows * QK256_PACKED_BYTES];
 
     let input = vec![1.0f32; cols];
     let mut output = vec![0.0f32; rows];
@@ -156,7 +156,7 @@ fn test_qk256_zero_weights_effect() {
     gemv_qk256(&qs_data, &input, &mut output, rows, cols, QK256_PACKED_BYTES)
         .expect("Alternating weights should succeed");
 
-    // Outputs should be near zero (half -2.0, half +2.0)
+    // Outputs should be near zero (half -1.0, half +1.0)
     for (i, &val) in output.iter().enumerate() {
         assert!(val.abs() < 1e-3, "Row {}: expected ~0.0 (alternating weights), got {}", i, val);
     }
@@ -444,7 +444,7 @@ fn test_gemv_qk256_row_minimum_cols() {
 /// Verify gemv_qk256_row handles exact block size (256 elements)
 #[test]
 fn test_gemv_qk256_row_exact_block() {
-    let qs = [0x55u8; QK256_PACKED_BYTES]; // Code 1 → -1.0
+    let qs = [0x00u8; QK256_PACKED_BYTES]; // Code 0 → -1.0
     let input = vec![2.0f32; QK256_BLOCK];
     let cols = QK256_BLOCK;
 

--- a/crates/bitnet-models/tests/qk256_integration.rs
+++ b/crates/bitnet-models/tests/qk256_integration.rs
@@ -18,7 +18,7 @@
 ///
 /// - **Block size**: 256 elements
 /// - **Packed bytes**: 64 bytes/block (2 bits/element)
-/// - **Code mapping**: 0 → -2.0, 1 → -1.0, 2 → +1.0, 3 → +2.0
+/// - **Code mapping**: 0 → -1.0, 1 → 0.0, 2 → +1.0, 3 → +2.0
 /// - **Tensor shape**: `[rows, row_stride_bytes]` where `row_stride_bytes = ceil(cols/256) * 64`
 /// - **Storage key**: `{original_name}.qk256_qs` (e.g., `layers.0.attention.q_proj.weight.qk256_qs`)
 use bitnet_models::quant::i2s_qk256::{
@@ -63,8 +63,8 @@ fn create_qk256_tensor(rows: usize, cols: usize, code: u8) -> anyhow::Result<Can
 #[inline]
 fn code_to_float(code: u8) -> f32 {
     match code {
-        0 => -2.0,
-        1 => -1.0,
+        0 => -1.0,
+        1 => 0.0,
         2 => 1.0,
         3 => 2.0,
         _ => panic!("Invalid QK256 code: {}", code),
@@ -115,7 +115,7 @@ fn test_qk256_single_block_predictable_output() {
 
 #[test]
 fn test_qk256_single_block_all_codes() {
-    // Test each code mapping (0 → -2.0, 1 → -1.0, 2 → +1.0, 3 → +2.0)
+    // Test each code mapping (0 → -1.0, 1 → 0.0, 2 → +1.0, 3 → +2.0)
     let rows = 1;
     let cols = 256;
 
@@ -196,7 +196,7 @@ fn test_qk256_large_matrix() {
     // Test larger matrix: 512×768 (3 blocks per row)
     let rows = 512;
     let cols: usize = 768;
-    let code = 1u8; // → -1.0
+    let code = 0u8; // → -1.0
 
     let blocks_per_row = cols.div_ceil(QK256_BLOCK); // = 3
     let row_stride_bytes = blocks_per_row * QK256_PACKED_BYTES; // = 192
@@ -324,7 +324,7 @@ fn test_qk256_vs_fp32_quantization_error() {
     let rows = 4;
     let cols = 256;
 
-    // Create FP32 reference weights: deterministic pattern in [-2, -1, 1, 2]
+    // Create FP32 reference weights: deterministic pattern in [-1, 0, 1, 2]
     // Use deterministic pattern instead of random to avoid randomness in tests
     let fp32_weights: Vec<Vec<f32>> = (0..rows)
         .map(|row_idx| {
@@ -345,8 +345,8 @@ fn test_qk256_vs_fp32_quantization_error() {
             let mut byte = 0u8;
             for (i, &w) in chunk.iter().enumerate() {
                 let code = match w {
-                    x if (x + 2.0).abs() < 1e-6 => 0u8,
-                    x if (x + 1.0).abs() < 1e-6 => 1u8,
+                    x if (x + 1.0).abs() < 1e-6 => 0u8,
+                    x if x.abs() < 1e-6 => 1u8,
                     x if (x - 1.0).abs() < 1e-6 => 2u8,
                     x if (x - 2.0).abs() < 1e-6 => 3u8,
                     _ => panic!("Invalid FP32 value in QK256 space: {}", w),
@@ -574,7 +574,7 @@ fn test_qk256_struct_creation() {
 fn test_qk256_unpack_block() {
     // Test unpack_qk256_block with known patterns
 
-    // Pattern 1: All zeros (code 0 → -2.0)
+    // Pattern 1: All zeros (code 0 → -1.0)
     let qs_zeros = [0u8; QK256_PACKED_BYTES];
     let mut codes = [0u8; QK256_BLOCK];
     unpack_qk256_block(&qs_zeros, &mut codes);
@@ -618,13 +618,13 @@ fn test_qk256_unpack_block() {
 
 #[test]
 fn test_qk256_code_to_float_lut() {
-    // Verify code-to-float LUT matches GGML reference
+    // Verify code-to-float LUT matches Microsoft BitNet I2_S trailer-scale reference.
     use bitnet_models::quant::i2s_qk256::code_to_f32;
 
-    assert_eq!(code_to_f32(0), -2.0);
-    assert_eq!(code_to_f32(1), -1.0);
+    assert_eq!(code_to_f32(0), -1.0);
+    assert_eq!(code_to_f32(1), 0.0);
     assert_eq!(code_to_f32(2), 1.0);
     assert_eq!(code_to_f32(3), 2.0);
 
-    println!("✓ Code-to-float LUT verified against GGML reference");
+    println!("✓ Code-to-float LUT verified against Microsoft BitNet I2_S reference");
 }

--- a/crates/bitnet-models/tests/qk256_loader_tests.rs
+++ b/crates/bitnet-models/tests/qk256_loader_tests.rs
@@ -273,8 +273,8 @@ fn test_qk256_multi_layer_integration() -> anyhow::Result<()> {
     let mut layer_weights = Vec::new();
     for layer_idx in 0..num_layers {
         let pattern = match layer_idx % 4 {
-            0 => 0x00u8, // Code 0 → -2.0
-            1 => 0x55u8, // Code 1 → -1.0
+            0 => 0x00u8, // Code 0 → -1.0
+            1 => 0x55u8, // Code 1 → 0.0
             2 => 0xAAu8, // Code 2 → +1.0
             _ => 0xFFu8, // Code 3 → +2.0
         };

--- a/crates/bitnet-models/tests/qk256_property_tests.rs
+++ b/crates/bitnet-models/tests/qk256_property_tests.rs
@@ -8,7 +8,7 @@
 //! ## Coverage
 //!
 //! - Random matrix dimensions (rows, cols with various QK256 block alignments)
-//! - Random code patterns (0..=3 mapping to -2.0, -1.0, 1.0, 2.0)
+//! - Random code patterns (0..=3 mapping to -1.0, 0.0, 1.0, 2.0)
 //! - Random input vectors with various distributions
 //! - Tail handling (cols not multiple of 256)
 //! - Numerical accuracy validation against FP32 reference
@@ -54,12 +54,11 @@ fn random_input_vector(len: usize) -> impl Strategy<Value = Vec<f32>> {
 
 /// Test spec: i2s-dual-flavor.md#code-to-f32-lut-verification
 ///
-/// Verify code_to_f32 LUT values match GGML reference: {-2, -1, 1, 2}
+/// Verify code_to_f32 LUT values match Microsoft BitNet I2_S: {-1, 0, 1, 2}
 #[test]
 fn test_code_to_f32_lut_values() {
-    // Verified against GGML ggml-quants.c:62
-    assert_eq!(code_to_f32(0), -2.0);
-    assert_eq!(code_to_f32(1), -1.0);
+    assert_eq!(code_to_f32(0), -1.0);
+    assert_eq!(code_to_f32(1), 0.0);
     assert_eq!(code_to_f32(2), 1.0);
     assert_eq!(code_to_f32(3), 2.0);
 }

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -106,7 +106,18 @@ pub fn forward_qk256_with_backend(
     weight_name: &str,
     backend: Qk256DispatchBackend,
 ) -> Result<Tensor> {
-    use bitnet_quantization::i2s_qk256::gemv_qk256;
+    forward_qk256_scaled_with_backend(input, qk256_tensor, weight_name, backend, 1.0)
+}
+
+/// Runs I2_S QK256 forward pass with a Microsoft BitNet per-tensor trailer scale.
+pub fn forward_qk256_scaled_with_backend(
+    input: &Tensor,
+    qk256_tensor: &Tensor,
+    weight_name: &str,
+    backend: Qk256DispatchBackend,
+    scale: f32,
+) -> Result<Tensor> {
+    use bitnet_quantization::i2s_qk256::gemv_qk256_scaled;
 
     let qk256_dims = qk256_tensor.dims();
     let layout = parse_qk256_layout(weight_name, qk256_dims)
@@ -161,13 +172,14 @@ pub fn forward_qk256_with_backend(
             for (i, input_row) in input_vec.iter().enumerate() {
                 let start = i * layout.rows;
                 let end = start + layout.rows;
-                gemv_qk256(
+                gemv_qk256_scaled(
                     &flat_bytes,
                     input_row,
                     &mut output_flat[start..end],
                     layout.rows,
                     layout.cols,
                     layout.row_stride_bytes,
+                    scale,
                 )
                 .map_err(|e| {
                     BitNetError::Validation(format!(
@@ -189,6 +201,7 @@ pub fn forward_qk256_with_backend(
                 layout.cols,
                 layout.row_stride_bytes,
                 weight_name,
+                scale,
             )?;
             OPENCL_SUCCESSES.fetch_add(1, Ordering::Relaxed);
         }
@@ -215,6 +228,7 @@ fn run_opencl_qk256(
     cols: usize,
     row_stride_bytes: usize,
     weight_name: &str,
+    scale: f32,
 ) -> Result<()> {
     #[cfg(feature = "opencl")]
     {
@@ -227,6 +241,7 @@ fn run_opencl_qk256(
             rows,
             cols,
             row_stride_bytes,
+            scale,
         )
         .map_err(|e| {
             BitNetError::Kernel(KernelError::GpuError {
@@ -237,7 +252,7 @@ fn run_opencl_qk256(
 
     #[cfg(not(feature = "opencl"))]
     {
-        let _ = (flat_bytes, input_vec, output_flat, rows, cols, row_stride_bytes);
+        let _ = (flat_bytes, input_vec, output_flat, rows, cols, row_stride_bytes, scale);
         Err(BitNetError::Kernel(KernelError::DeviceUnavailable {
             reason: format!(
                 "OpenCL QK256 dispatch requested for {weight_name}, but opencl feature is disabled"

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -20,7 +20,8 @@ __kernel void qk256_gemm_no_scale(
     const uint input_rows,
     const uint rows,
     const uint cols,
-    const uint row_stride_bytes
+    const uint row_stride_bytes,
+    const float scale
 ) {
     const uint row = get_global_id(0);
     const uint input_row = get_global_id(1);
@@ -35,20 +36,11 @@ __kernel void qk256_gemm_no_scale(
     for (uint col = 0; col < cols; ++col) {
         const uchar packed = row_bytes[col >> 2];
         const uchar code = (packed >> ((col & 3u) * 2u)) & 3u;
-        float w;
-        if (code == 0u) {
-            w = -2.0f;
-        } else if (code == 1u) {
-            w = -1.0f;
-        } else if (code == 2u) {
-            w = 1.0f;
-        } else {
-            w = 2.0f;
-        }
+        const float w = ((float)code) - 1.0f;
         acc += w * x[col];
     }
 
-    output[((ulong)input_row * (ulong)rows) + (ulong)row] = acc;
+    output[((ulong)input_row * (ulong)rows) + (ulong)row] = acc * scale;
 }
 "#;
 
@@ -60,11 +52,12 @@ pub fn gemm_qk256_opencl(
     rows: usize,
     cols: usize,
     row_stride_bytes: usize,
+    scale: f32,
 ) -> Result<()> {
     validate_args(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)?;
 
     let runtime = qk256_runtime()?;
-    runtime.run(qs_data, input, output, input_rows, rows, cols, row_stride_bytes)
+    runtime.run(qs_data, input, output, input_rows, rows, cols, row_stride_bytes, scale)
 }
 
 fn validate_args(
@@ -219,6 +212,7 @@ impl OpenClQk256Runtime {
         rows: usize,
         cols: usize,
         row_stride_bytes: usize,
+        scale: f32,
     ) -> Result<()> {
         let mut qs_buf = unsafe {
             Buffer::<u8>::create(&self.context, CL_MEM_READ_ONLY, qs_data.len(), null_mut())
@@ -263,6 +257,7 @@ impl OpenClQk256Runtime {
                 .set_arg(&rows_u32)
                 .set_arg(&cols_u32)
                 .set_arg(&row_stride_u32)
+                .set_arg(&scale)
                 .set_global_work_sizes(&[rows, input_rows])
                 .enqueue_nd_range(&self.queue)
                 .map_err(|e| {

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -129,15 +129,12 @@ fn qk256_dispatch_status_keeps_opencl_non_claiming() {
 
 #[cfg(feature = "opencl")]
 #[test]
-fn qk256_opencl_source_matches_ggml_no_scale_mapping() {
+fn qk256_opencl_source_matches_microsoft_bitnet_mapping() {
     use bitnet_qk256_dispatch::{QK256_OPENCL_KERNEL_NAME, QK256_OPENCL_KERNEL_SRC};
 
     assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
     assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));
-    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -2.0f"));
-    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = -1.0f"));
-    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = 1.0f"));
-    assert!(QK256_OPENCL_KERNEL_SRC.contains("w = 2.0f"));
-    assert!(!QK256_OPENCL_KERNEL_SRC.contains("scales"));
-    assert!(!QK256_OPENCL_KERNEL_SRC.contains("* scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("const float w = ((float)code) - 1.0f"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("acc * scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("const float scale"));
 }

--- a/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
+++ b/crates/bitnet-qk256-dispatch/tests/opencl_qk256_hardware.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "opencl")]
 
-use bitnet_qk256_dispatch::{Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend};
+use bitnet_qk256_dispatch::{
+    Qk256DispatchBackend, forward_qk256, forward_qk256_scaled_with_backend,
+    forward_qk256_with_backend,
+};
 use candle_core::{Device, Tensor};
 
 #[test]
@@ -74,6 +77,50 @@ fn opencl_qk256_rank3_matches_cpu_reference_for_varied_rows() {
                     "OpenCL rank3 QK256 mismatch at batch {batch_idx}, token {token_idx}, col {col_idx}: expected {expected}, actual {actual}"
                 );
             }
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires an Intel OpenCL GPU runtime; run manually on the A770 proof station"]
+fn opencl_qk256_applies_trailer_scale() {
+    let device = Device::Cpu;
+    let input = Tensor::from_vec(vec![1.0f32; 256], (1, 256), &device).unwrap();
+
+    let mut qk_bytes = Vec::with_capacity(2 * 64);
+    qk_bytes.extend_from_slice(&[0xAAu8; 64]); // code 2 -> +1.0
+    qk_bytes.extend_from_slice(&[0x00u8; 64]); // code 0 -> -1.0
+    let qk = Tensor::from_vec(qk_bytes, (2, 64), &device).unwrap();
+
+    let weight_name = "layers.0.attention.q_proj.weight.qk256_qs";
+    let scale = 0.125f32;
+    let cpu = forward_qk256_scaled_with_backend(
+        &input,
+        &qk,
+        weight_name,
+        Qk256DispatchBackend::Cpu,
+        scale,
+    )
+    .unwrap();
+    let opencl = forward_qk256_scaled_with_backend(
+        &input,
+        &qk,
+        weight_name,
+        Qk256DispatchBackend::OpenCl,
+        scale,
+    )
+    .unwrap();
+
+    let cpu_vals = cpu.to_vec2::<f32>().unwrap();
+    let opencl_vals = opencl.to_vec2::<f32>().unwrap();
+    assert_eq!(cpu_vals, vec![vec![32.0, -32.0]]);
+    assert_eq!(opencl_vals.len(), cpu_vals.len());
+    for (expected_row, actual_row) in cpu_vals.iter().zip(opencl_vals.iter()) {
+        for (&expected, &actual) in expected_row.iter().zip(actual_row.iter()) {
+            assert!(
+                (expected - actual).abs() <= 1e-4,
+                "OpenCL scaled QK256 mismatch: expected {expected}, actual {actual}"
+            );
         }
     }
 }

--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -1,9 +1,12 @@
-//! GGML I2_S (QK=256) scalar reference kernels
+//! Microsoft BitNet I2_S (QK=256) scalar reference kernels
 //!
-//! This module implements pure-Rust dequantization and GEMV for GGML's I2_S format:
+//! This module implements pure-Rust dequantization and GEMV for Microsoft BitNet's
+//! GGUF I2_S format:
 //! - Block size: 256 elements
-//! - Packed format: 64 bytes per block (2 bits/element, no embedded scales)
-//! - Code mapping: **VERIFIED** against GGML reference (ggml-quants.c:62)
+//! - Packed format: 64 bytes per block (2 bits/element)
+//! - Per-tensor scale: one little-endian `f32` trailer after the packed bytes
+//! - Code mapping: ternary `0 -> -1`, `1 -> 0`, `2 -> +1`; code `3` is unused by
+//!   the Microsoft BitNet quantizer and is treated as `+2` for deterministic decode
 //!
 //! ## Memory Layout
 //!
@@ -19,19 +22,16 @@
 //!
 //! ## Code Mapping (VERIFIED)
 //!
-//! The 2-bit codes map to signed weights according to GGML's IQ2_S specification
-//! (verified in `crates/bitnet-ggml-ffi/csrc/ggml/src/ggml-quants.c:62`):
+//! The 2-bit codes map to signed weights according to Microsoft BitNet's
+//! `quantize_i2_s` path:
 //!
-//! - Code 0 → -2.0
-//! - Code 1 → -1.0
+//! - Code 0 → -1.0
+//! - Code 1 → 0.0
 //! - Code 2 → +1.0
-//! - Code 3 → +2.0
+//! - Code 3 → +2.0 (unused by the quantizer)
 //!
-//! **Format variants:**
-//! - **GgmlQk256NoScale** (MS BitNet): No per-block scale, use LUT values directly
-//! - **Full GGML IQ2_S** (82B/block): Multiply LUT values by per-block FP16 scale `d`
-//!
-//! This implementation supports the "no-scale" variant used by MS BitNet GGUF models.
+//! The public no-scale entry points use scale `1.0` for fixtures. Real Microsoft
+//! BitNet GGUF loading should call the scaled entry point with the trailer scale.
 
 use anyhow::{Result, bail};
 use bitnet_qk256_layout_core::{
@@ -50,11 +50,13 @@ pub const QK256_SCALAR_GEMV_KERNEL_ID: &str = "qk256-scalar-gemv";
 /// Stable receipt/proof kernel ID for the canonical scalar QK256 prefill GEMM.
 pub const QK256_SCALAR_GEMM_KERNEL_ID: &str = "qk256-scalar-gemm";
 
-/// Storage for GGML I2_S (QK=256) quantized weights without per-block scales
+/// Storage for Microsoft BitNet I2_S (QK=256) quantized weights.
 ///
 /// This structure holds raw packed 2-bit codes for a weight tensor in the
-/// "GgmlQk256NoScale" format used by MS BitNet GGUF models. The data is stored
-/// in row-major order without dequantization.
+/// "GgmlQk256NoScale" format used by MS BitNet GGUF models. The packed data is
+/// stored in row-major order without dequantization. The optional per-tensor scale
+/// is carried separately because the packed row tensor is passed through Candle as
+/// a U8 matrix.
 ///
 /// # Memory Layout
 ///
@@ -76,6 +78,7 @@ pub struct I2SQk256NoScale {
     pub rows: usize,
     pub cols: usize,
     pub row_stride_bytes: usize,
+    pub scale: f32,
     pub qs: Vec<u8>,
 }
 
@@ -92,6 +95,11 @@ impl I2SQk256NoScale {
     ///
     /// `Result<Self>` - The quantized tensor or error if dimensions don't match
     pub fn new(rows: usize, cols: usize, qs: Vec<u8>) -> Result<Self> {
+        Self::new_with_scale(rows, cols, qs, 1.0)
+    }
+
+    /// Create a new QK256 quantized tensor with an explicit per-tensor scale.
+    pub fn new_with_scale(rows: usize, cols: usize, qs: Vec<u8>, scale: f32) -> Result<Self> {
         let layout = Qk256Layout::from_rows_cols(rows, cols)?;
         let row_stride_bytes = layout.row_stride_bytes;
         let expected_bytes = layout.packed_len_bytes;
@@ -111,7 +119,7 @@ impl I2SQk256NoScale {
             );
         }
 
-        Ok(Self { rows, cols, row_stride_bytes, qs })
+        Ok(Self { rows, cols, row_stride_bytes, scale, qs })
     }
 
     /// Get a slice of bytes for a specific row
@@ -138,19 +146,16 @@ impl I2SQk256NoScale {
 
 /// Code-to-float lookup table
 ///
-/// **VERIFIED**: This mapping matches GGML's IQ2_S dequantization (ggml-quants.c:62).
-/// Reference: `const float qmap[4] = { -2.f, -1.f, 1.f, 2.f };`
-///
-/// For MS BitNet "GgmlQk256NoScale" format, these values are used directly
-/// (no per-block scale). For full GGML IQ2_S format (82B/block with FP16 scale),
-/// these would be multiplied by the scale factor.
+/// This mapping matches Microsoft BitNet's `quantize_i2_s` encoding:
+/// `0, 1, 2` represent `-1, 0, +1`, and code `3` is unused by the quantizer.
+/// Real Microsoft BitNet GGUF tensors multiply the dot result by the per-tensor
+/// scale stored after the packed bytes.
 #[inline]
 pub fn code_to_f32(code: u8) -> f32 {
     // SAFETY: code is masked to 0..=3 by caller
     debug_assert!(code < 4, "I2S_QK256: code must be 0..=3, got {}", code);
 
-    // Verified against GGML reference (crates/bitnet-ggml-ffi/csrc/ggml/src/ggml-quants.c:62)
-    const LUT: [f32; 4] = [-2.0, -1.0, 1.0, 2.0];
+    const LUT: [f32; 4] = [-1.0, 0.0, 1.0, 2.0];
     LUT[code as usize]
 }
 
@@ -331,7 +336,7 @@ fn gemv_qk256_scalar_checked(
 
 /// Canonical scalar QK256 GEMV oracle for decode: `y = A x`.
 ///
-/// This path uses the GGML I2_S no-scale mapping from [`code_to_f32`] and the
+/// This path uses the Microsoft BitNet I2_S mapping from [`code_to_f32`] and the
 /// canonical QK256 packed layout. It never dispatches to SIMD.
 pub fn qk256_gemv_scalar(
     qs_data: &[u8],
@@ -452,6 +457,25 @@ pub fn gemv_qk256(
     gemv_qk256_scalar_checked(qs_data, x, y_out, rows, cols, row_stride_bytes)
 }
 
+/// Multi-row GEMV with an explicit Microsoft BitNet per-tensor trailer scale.
+pub fn gemv_qk256_scaled(
+    qs_data: &[u8],
+    x: &[f32],
+    y_out: &mut [f32],
+    rows: usize,
+    cols: usize,
+    row_stride_bytes: usize,
+    scale: f32,
+) -> Result<()> {
+    gemv_qk256(qs_data, x, y_out, rows, cols, row_stride_bytes)?;
+    if scale != 1.0 {
+        for output in y_out {
+            *output *= scale;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -543,7 +567,7 @@ mod tests {
         let cols = 256usize;
         let row_stride_bytes = QK256_PACKED_BYTES;
 
-        // All codes = 1 (→ -1.0)
+        // All codes = 1 (→ 0.0)
         let qs_data = vec![0x55u8; rows * row_stride_bytes]; // 0b_01_01_01_01
 
         let x: Vec<f32> = (0..cols).map(|i| i as f32).collect();
@@ -552,8 +576,8 @@ mod tests {
         gemv_qk256(&qs_data, &x, &mut y_out, rows, cols, row_stride_bytes)
             .expect("gemv_qk256 should succeed");
 
-        // Code 1 → -1.0, so each row = -sum(x)
-        let expected: f32 = -x.iter().sum::<f32>();
+        // Code 1 → 0.0, so each row is zero.
+        let expected: f32 = 0.0;
         for (i, &val) in y_out.iter().enumerate() {
             assert!(
                 (val - expected).abs() < 1e-3,
@@ -567,9 +591,9 @@ mod tests {
 
     #[test]
     fn code_to_f32_lut() {
-        // Verify LUT values (verified against GGML ggml-quants.c:62)
-        assert_eq!(code_to_f32(0), -2.0);
-        assert_eq!(code_to_f32(1), -1.0);
+        // Verify LUT values against Microsoft BitNet quantize_i2_s ternary encoding.
+        assert_eq!(code_to_f32(0), -1.0);
+        assert_eq!(code_to_f32(1), 0.0);
         assert_eq!(code_to_f32(2), 1.0);
         assert_eq!(code_to_f32(3), 2.0);
     }
@@ -755,15 +779,15 @@ mod tests {
     /// Test (A): LUT Sanity (NoScale)
     ///
     /// Tests feature spec: i2s-dual-flavor.md#code-mapping
-    /// Verifies that the code-to-float lookup table matches GGML reference:
-    /// - Code 0 → -2.0
-    /// - Code 1 → -1.0
+    /// Verifies that the code-to-float lookup table matches Microsoft BitNet:
+    /// - Code 0 → -1.0
+    /// - Code 1 → 0.0
     /// - Code 2 → +1.0
-    /// - Code 3 → +2.0
+    /// - Code 3 → +2.0 (unused by the quantizer)
     #[test]
     fn qk256_lut_basic() {
-        assert_eq!(code_to_f32(0), -2.0, "Code 0 should map to -2.0");
-        assert_eq!(code_to_f32(1), -1.0, "Code 1 should map to -1.0");
+        assert_eq!(code_to_f32(0), -1.0, "Code 0 should map to -1.0");
+        assert_eq!(code_to_f32(1), 0.0, "Code 1 should map to 0.0");
         assert_eq!(code_to_f32(2), 1.0, "Code 2 should map to +1.0");
         assert_eq!(code_to_f32(3), 2.0, "Code 3 should map to +2.0");
     }
@@ -774,7 +798,7 @@ mod tests {
     /// Pack 256 two-bit codes (LSB-first) cycling 0..3 into 64 bytes.
     /// Decode using the unpack path and verify:
     /// - RMS in range [0.1, 5.0]
-    /// - First 16 values contain the set {-2, -1, 1, 2}
+    /// - First 16 values contain the set {-1, 0, 1, 2}
     #[test]
     fn qk256_block_decode_golden() {
         // Pack pattern: 0,1,2,3,0,1,2,3,... (cycling through all codes)
@@ -813,13 +837,13 @@ mod tests {
         let sum_sq: f32 = weights.iter().map(|x| x * x).sum();
         let rms = (sum_sq / QK256_BLOCK as f32).sqrt();
 
-        // Verify RMS is reasonable (should be ~1.58 for uniform {-2,-1,1,2})
+        // Verify RMS is reasonable (sqrt(1.5) for uniform {-1,0,1,2})
         assert!((0.1..=5.0).contains(&rms), "RMS {} should be in range [0.1, 5.0]", rms);
 
         // Verify first 16 values contain all expected codes
         let first_16: Vec<f32> = weights[..16].to_vec();
-        assert!(first_16.contains(&-2.0), "First 16 values should contain -2.0");
         assert!(first_16.contains(&-1.0), "First 16 values should contain -1.0");
+        assert!(first_16.contains(&0.0), "First 16 values should contain 0.0");
         assert!(first_16.contains(&1.0), "First 16 values should contain 1.0");
         assert!(first_16.contains(&2.0), "First 16 values should contain 2.0");
     }

--- a/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
@@ -36,7 +36,7 @@ use anyhow::Result;
 /// Uses `vpsrlvd` (per-lane variable shift) to extract all 8 codes in parallel:
 ///   packed = b0 | (b1 << 16)  →  broadcast to all lanes  →  shift by [0,2,4,6,16,18,20,22]  →  mask 0x03
 ///
-/// Then maps codes [0,1,2,3] → weights [-2,-1,+1,+2] via: `weight = code - 2 + (code >> 1) & 1`.
+/// Then maps codes [0,1,2,3] → weights [-1,0,+1,+2] via `weight = code - 1`.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn decode_8_weights_avx2(
@@ -44,7 +44,6 @@ unsafe fn decode_8_weights_avx2(
     byte1: u8,
     shifts: __m256i,
     mask_03: __m256i,
-    two: __m256i,
     one: __m256i,
 ) -> __m256 {
     // Pack both bytes so per-lane shifts extract each 2-bit code:
@@ -54,10 +53,9 @@ unsafe fn decode_8_weights_avx2(
     let broadcast = _mm256_set1_epi32(packed);
     let codes = _mm256_and_si256(_mm256_srlv_epi32(broadcast, shifts), mask_03);
 
-    // codes ∈ {0,1,2,3} → weights ∈ {-2,-1,+1,+2}
-    let shifted = _mm256_sub_epi32(codes, two);
-    let correction = _mm256_and_si256(_mm256_srli_epi32::<1>(codes), one);
-    _mm256_cvtepi32_ps(_mm256_add_epi32(shifted, correction))
+    // codes ∈ {0,1,2,3} → weights ∈ {-1,0,+1,+2}. Code 3 is unused by the
+    // Microsoft BitNet quantizer but remains deterministic if encountered.
+    _mm256_cvtepi32_ps(_mm256_sub_epi32(codes, one))
 }
 
 /// AVX2-accelerated dot product for one QK256 row.
@@ -96,7 +94,6 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
         // Hoisted constants shared by every decode_8_weights_avx2 call.
         let shifts = _mm256_setr_epi32(0, 2, 4, 6, 16, 18, 20, 22);
         let mask_03 = _mm256_set1_epi32(0x03);
-        let two = _mm256_set1_epi32(2);
         let one = _mm256_set1_epi32(1);
 
         // 4 independent FMA accumulators to saturate the FMA pipe.
@@ -129,38 +126,14 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
             while j + 32 <= take {
                 let pi = j / 4;
 
-                let w0 = decode_8_weights_avx2(
-                    *blk.add(pi),
-                    *blk.add(pi + 1),
-                    shifts,
-                    mask_03,
-                    two,
-                    one,
-                );
-                let w1 = decode_8_weights_avx2(
-                    *blk.add(pi + 2),
-                    *blk.add(pi + 3),
-                    shifts,
-                    mask_03,
-                    two,
-                    one,
-                );
-                let w2 = decode_8_weights_avx2(
-                    *blk.add(pi + 4),
-                    *blk.add(pi + 5),
-                    shifts,
-                    mask_03,
-                    two,
-                    one,
-                );
-                let w3 = decode_8_weights_avx2(
-                    *blk.add(pi + 6),
-                    *blk.add(pi + 7),
-                    shifts,
-                    mask_03,
-                    two,
-                    one,
-                );
+                let w0 =
+                    decode_8_weights_avx2(*blk.add(pi), *blk.add(pi + 1), shifts, mask_03, one);
+                let w1 =
+                    decode_8_weights_avx2(*blk.add(pi + 2), *blk.add(pi + 3), shifts, mask_03, one);
+                let w2 =
+                    decode_8_weights_avx2(*blk.add(pi + 4), *blk.add(pi + 5), shifts, mask_03, one);
+                let w3 =
+                    decode_8_weights_avx2(*blk.add(pi + 6), *blk.add(pi + 7), shifts, mask_03, one);
 
                 let xj = col + j;
                 let x0 = _mm256_loadu_ps(x_ptr.add(xj));
@@ -179,14 +152,7 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
             // --- 8-element cleanup loop ---
             while j + 8 <= take {
                 let pi = j / 4;
-                let w = decode_8_weights_avx2(
-                    *blk.add(pi),
-                    *blk.add(pi + 1),
-                    shifts,
-                    mask_03,
-                    two,
-                    one,
-                );
+                let w = decode_8_weights_avx2(*blk.add(pi), *blk.add(pi + 1), shifts, mask_03, one);
                 let xv = _mm256_loadu_ps(x_ptr.add(col + j));
                 acc0 = _mm256_fmadd_ps(w, xv, acc0);
                 j += 8;
@@ -198,8 +164,8 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
                 let shift = (j % 4) * 2;
                 let code = (packed_byte >> shift) & 0x03;
                 let w = match code {
-                    0 => -2.0,
-                    1 => -1.0,
+                    0 => -1.0,
+                    1 => 0.0,
                     2 => 1.0,
                     _ => 2.0,
                 };

--- a/crates/bitnet-quantization/src/qk256_dispatch.rs
+++ b/crates/bitnet-quantization/src/qk256_dispatch.rs
@@ -15,8 +15,8 @@ pub const QK256: usize = QK256_BLOCK_COLS;
 
 /// Legacy QK256 GEMV entry-point.
 ///
-/// The legacy signature exposes an explicit `scales` tensor, but the current
-/// GGML I2_S (QK256 no-scale) format used in BitNet-rs does not consume it.
+/// The legacy signature exposes an explicit `scales` tensor, but this wrapper
+/// delegates to the canonical packed-byte path with scale `1.0`.
 ///
 /// This function validates the legacy input contract and forwards to
 /// [`i2s_qk256::gemv_qk256`], which dispatches AVX2/scalar at runtime.
@@ -49,8 +49,8 @@ pub fn qk256_gemv(
 
 /// Scalar legacy QK256 GEMV (kept for benchmark compatibility).
 ///
-/// This preserves the historical 2-bit mapping used by this legacy interface:
-/// `00→-1, 01→0, 10→1, 11→-1`, followed by per-block scaling.
+/// This preserves the Microsoft BitNet QK256 code mapping used by the canonical
+/// packed-byte path: `00→-1, 01→0, 10→1, 11→2`, followed by per-block scaling.
 pub fn qk256_gemv_scalar(
     output: &mut [f32],
     rows: usize,
@@ -91,7 +91,7 @@ pub fn qk256_gemv_scalar(
                     0b00 => -1.0f32,
                     0b01 => 0.0f32,
                     0b10 => 1.0f32,
-                    0b11 => -1.0f32,
+                    0b11 => 2.0f32,
                     _ => unreachable!(),
                 };
 
@@ -114,15 +114,15 @@ mod tests {
         let rows = 256;
         let cols = 256;
         let mut output = vec![0.0f32; rows];
-        // Code 1 (0b01) maps to -1.0 in i2s_qk256; with activations at 0.5 this
+        // Code 2 (0b10) maps to +1.0 in i2s_qk256; with activations at 0.5 this
         // yields a stable, non-zero smoke assertion.
-        let packed = vec![0x55u8; rows * cols / 4];
+        let packed = vec![0xAAu8; rows * cols / 4];
         let scales = vec![1.0f32; rows * cols / QK256];
         let activations = vec![0.5f32; cols];
 
         qk256_gemv(&mut output, rows, cols, &packed, &scales, &activations);
 
-        assert!(output.iter().all(|&x| x == -128.0));
+        assert!(output.iter().all(|&x| x == 128.0));
     }
 
     #[test]

--- a/crates/bitnet-quantization/tests/proptest_wave15.rs
+++ b/crates/bitnet-quantization/tests/proptest_wave15.rs
@@ -168,13 +168,13 @@ proptest! {
         }
     }
 
-    /// QK256 code_to_f32 maps every valid code to {-2, -1, 1, 2}.
+    /// QK256 code_to_f32 maps every valid code to {-1, 0, 1, 2}.
     #[test]
     fn prop_qk256_code_to_f32_valid(code in 0u8..4) {
         let val = code_to_f32(code);
         prop_assert!(
-            val == -2.0 || val == -1.0 || val == 1.0 || val == 2.0,
-            "code_to_f32({}) = {}, expected {{-2,-1,1,2}}", code, val
+            val == -1.0 || val == 0.0 || val == 1.0 || val == 2.0,
+            "code_to_f32({}) = {}, expected {{-1,0,1,2}}", code, val
         );
     }
 }

--- a/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
+++ b/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
@@ -108,12 +108,12 @@ fn test_gemv_single_row_all_ones() {
     assert_parity(&qs, &x, 1, cols, stride, 1e-5);
 }
 
-// ── Test 2: single row, all codes=1 (-1), uniform x=1.0 ──
+// ── Test 2: single row, all codes=0 (-1), uniform x=1.0 ──
 
 #[test]
 fn test_gemv_single_row_all_neg_ones() {
     let cols = 256;
-    let codes = vec![1u8; cols]; // code 1 → -1.0
+    let codes = vec![0u8; cols]; // code 0 → -1.0
     let x = vec![1.0f32; cols];
     let (qs, stride) = build_qs_data(&[codes], cols);
 
@@ -215,8 +215,8 @@ fn test_unpack_code_roundtrip() {
 
 #[test]
 fn test_code_to_f32_mapping() {
-    assert_eq!(code_to_f32(0), -2.0);
-    assert_eq!(code_to_f32(1), -1.0);
+    assert_eq!(code_to_f32(0), -1.0);
+    assert_eq!(code_to_f32(1), 0.0);
     assert_eq!(code_to_f32(2), 1.0);
     assert_eq!(code_to_f32(3), 2.0);
 }
@@ -265,17 +265,17 @@ fn test_gemv_large_values() {
 fn test_gemv_single_element_rows() {
     let cols = 4; // minimum meaningful size
     let rows = 2;
-    // codes: row0=[0,1,2,3] → weights [-2,-1,+1,+2]
+    // codes: row0=[0,1,2,3] → weights [-1,0,+1,+2]
     // codes: row1=[3,3,3,3] → weights [+2,+2,+2,+2]
     let row_codes = vec![vec![0u8, 1, 2, 3], vec![3u8, 3, 3, 3]];
     let x = vec![1.0f32; cols];
     let (qs, stride) = build_qs_data(&row_codes, cols);
 
-    // Row 0: (-2)*1 + (-1)*1 + 1*1 + 2*1 = 0
+    // Row 0: (-1)*1 + 0*1 + 1*1 + 2*1 = 2
     // Row 1: 2*1 + 2*1 + 2*1 + 2*1 = 8
     let mut y = vec![0.0f32; rows];
     gemv_qk256(&qs, &x, &mut y, rows, cols, stride).expect("gemv_qk256 small");
-    assert!(y[0].abs() < 1e-5, "row 0 expected 0, got {}", y[0]);
+    assert!((y[0] - 2.0).abs() < 1e-5, "row 0 expected 2, got {}", y[0]);
     assert!((y[1] - 8.0).abs() < 1e-5, "row 1 expected 8, got {}", y[1]);
     assert_parity(&qs, &x, rows, cols, stride, 1e-5);
 }

--- a/crates/bitnet-quantization/tests/quant_property_tests.rs
+++ b/crates/bitnet-quantization/tests/quant_property_tests.rs
@@ -3,7 +3,7 @@
 //! These tests cover invariants not already addressed in `property_tests.rs`:
 //!
 //! 1. **QK256 unpack round-trip** – pack→unpack recovers original 2-bit codes.
-//! 2. **QK256 code_to_f32 range** – all valid codes map to {-2, -1, 1, 2}.
+//! 2. **QK256 code_to_f32 range** – all valid codes map to {-1, 0, 1, 2}.
 //! 3. **Quantize-dequantize sign preservation** – non-zero inputs preserve sign.
 //! 4. **Zero vector quantizes to all-zero output** (I2S).
 //! 5. **validate_numerical_input accepts all-finite data**.
@@ -62,11 +62,11 @@ proptest! {
 // ── QK256 code_to_f32 range ─────────────────────────────────────────────────
 
 proptest! {
-    /// `code_to_f32` maps every valid code (0..=3) to exactly one of {-2, -1, 1, 2}.
+    /// `code_to_f32` maps every valid code (0..=3) to exactly one of {-1, 0, 1, 2}.
     #[test]
     fn prop_code_to_f32_maps_to_expected_set(code in 0u8..=3u8) {
         let v = code_to_f32(code);
-        let valid = [-2.0_f32, -1.0, 1.0, 2.0];
+        let valid = [-1.0_f32, 0.0, 1.0, 2.0];
         prop_assert!(
             valid.contains(&v),
             "code_to_f32({}) = {}; expected one of {:?}", code, v, valid

--- a/crates/bitnet-quantization/tests/quantization_extended_tests.rs
+++ b/crates/bitnet-quantization/tests/quantization_extended_tests.rs
@@ -309,11 +309,11 @@ fn test_qk256_constants() {
     );
 }
 
-/// `code_to_f32` maps exactly to the GGML-verified LUT: {-2, -1, +1, +2}.
+/// `code_to_f32` maps exactly to the Microsoft BitNet I2_S LUT: {-1, 0, +1, +2}.
 #[test]
 fn test_qk256_code_to_f32_all_valid_codes() {
-    assert_eq!(code_to_f32(0), -2.0);
-    assert_eq!(code_to_f32(1), -1.0);
+    assert_eq!(code_to_f32(0), -1.0);
+    assert_eq!(code_to_f32(1), 0.0);
     assert_eq!(code_to_f32(2), 1.0);
     assert_eq!(code_to_f32(3), 2.0);
 }

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1,6 +1,6 @@
 use bitnet_common::{ActivationType, BitNetConfig, BitNetError, NormType, Result};
 pub use bitnet_qk256_dispatch::Qk256DispatchBackend;
-use bitnet_qk256_dispatch::forward_qk256_with_backend;
+use bitnet_qk256_dispatch::forward_qk256_scaled_with_backend;
 use bitnet_rope::{build_tables as build_rope_tables, resolve_base as resolve_rope_base};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{LayerNorm, Linear, VarBuilder};
@@ -41,6 +41,25 @@ fn dbg_finite(tag: &str, t: &Tensor) -> candle_core::Result<()> {
         }
     }
     Ok(())
+}
+
+fn qk256_scale_for(
+    raw_tensors: &std::collections::HashMap<String, Tensor>,
+    qk256_key: &str,
+) -> Result<f32> {
+    let scale_key = qk256_key
+        .strip_suffix(".qk256_qs")
+        .map(|base| format!("{base}.qk256_scale"))
+        .unwrap_or_else(|| format!("{qk256_key}.qk256_scale"));
+
+    let Some(scale_tensor) = raw_tensors.get(&scale_key) else {
+        return Ok(1.0);
+    };
+
+    let values = scale_tensor.flatten_all()?.to_vec1::<f32>()?;
+    values.first().copied().ok_or_else(|| {
+        BitNetError::Validation(format!("QK256 scale tensor '{scale_key}' is empty"))
+    })
 }
 
 /// Helper to create linear layers with optional bias tensors (zero-injection)
@@ -619,8 +638,15 @@ impl MultiHeadAttention {
 
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
-            tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
+            let qk256_scale = qk256_scale_for(raw_tensors, &qk256_key)?;
+            tracing::debug!("Using QK256 kernel for {} with scale {}", qk256_key, qk256_scale);
+            return forward_qk256_scaled_with_backend(
+                input,
+                qk256_tensor,
+                &qk256_key,
+                self.qk256_backend,
+                qk256_scale,
+            );
         }
 
         // Probe: Why is QK256 not found? (layer 0 only, once)
@@ -786,8 +812,15 @@ impl FeedForward {
 
         // Check for QK256 data
         if let Some(qk256_tensor) = raw_tensors.get(&qk256_key) {
-            tracing::debug!("Using QK256 kernel for {}", qk256_key);
-            return forward_qk256_with_backend(input, qk256_tensor, &qk256_key, self.qk256_backend);
+            let qk256_scale = qk256_scale_for(raw_tensors, &qk256_key)?;
+            tracing::debug!("Using QK256 kernel for {} with scale {}", qk256_key, qk256_scale);
+            return forward_qk256_scaled_with_backend(
+                input,
+                qk256_tensor,
+                &qk256_key,
+                self.qk256_backend,
+                qk256_scale,
+            );
         }
 
         // Fall back to standard linear

--- a/crates/bitnet-transformer/tests/transformer_model_tests.rs
+++ b/crates/bitnet-transformer/tests/transformer_model_tests.rs
@@ -75,7 +75,7 @@ fn identity_matrix(dim: usize, device: &Device) -> candle_core::Result<Tensor> {
 }
 
 fn qk256_row_with_codes(codes: &[(usize, u8)]) -> Vec<u8> {
-    let mut unpacked = [2u8; 256];
+    let mut unpacked = [1u8; 256];
     for &(idx, code) in codes {
         assert!(idx < unpacked.len(), "QK256 test code index out of range");
         assert!(code <= 3, "QK256 test code must fit in two bits");
@@ -223,19 +223,14 @@ fn qk256_prompt_sensitive_model() -> anyhow::Result<TransformerModel> {
     }
 
     let q_pos_row = qk256_row_with_codes(&[(2, 3)]);
-    let q_neg_row = qk256_row_with_codes(&[(2, 0)]);
     let mut q_rows = Vec::with_capacity(256);
-    for row_idx in 0..256 {
-        if row_idx % 2 == 0 {
-            q_rows.push(q_pos_row.clone());
-        } else {
-            q_rows.push(q_neg_row.clone());
-        }
+    for _ in 0..256 {
+        q_rows.push(q_pos_row.clone());
     }
-    let history_sensitive_row = qk256_row_with_codes(&[(0, 3), (1, 0), (2, 3)]);
-    let v_history_a_row = qk256_row_with_codes(&[(0, 3), (1, 0), (2, 2)]);
-    let v_history_b_row = qk256_row_with_codes(&[(0, 0), (1, 3), (2, 2)]);
-    let v_neutral_row = qk256_row_with_codes(&[(2, 2)]);
+    let history_sensitive_row = qk256_row_with_codes(&[(0, 3), (1, 0), (2, 0)]);
+    let v_history_a_row = qk256_row_with_codes(&[(0, 2)]);
+    let v_history_b_row = qk256_row_with_codes(&[(1, 2)]);
+    let v_neutral_row = qk256_row_with_codes(&[]);
     let mut v_rows = vec![v_neutral_row; 256];
     v_rows[0] = v_history_a_row;
     v_rows[1] = v_history_b_row;


### PR DESCRIPTION
## Summary
- align QK256 decode with Microsoft BitNet I2_S packed semantics: `0 -> -1`, `1 -> 0`, `2 -> +1`, `3 -> +2`
- preserve the per-tensor f32 trailer scale from GGUF as a `.qk256_scale` side-map tensor and apply it through CPU/OpenCL QK256 dispatch
- update transformer QK256 application, model remapping, and QK256 tests to use the scaled path
- add ignored A770/OpenCL hardware coverage proving scaled OpenCL output matches CPU reference

## Claim boundary
- non-promoting diagnostic/runtime correctness slice only
- does not promote selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion
- live A770 smoke still produced unusable text after this fix, so no product-quality or benchmark claim is made here

## Verification
- `cargo test --locked -p bitnet-models --test qk256_error_handling -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_avx2_correctness -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_loader_tests -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_integration -- --nocapture` (34 passed, 2 failed due missing `ci/fixtures/qk256/qk256_4x256.gguf` fixture helpers)
- `cargo test --locked -p bitnet-models --test qk256_property_tests -- --nocapture` (32 passed, 2 failed due same missing fixture helpers)
- `cargo test --locked -p bitnet-quantization qk256 --lib -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test qk256_avx2_parity_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test quant_property_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test quantization_extended_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test proptest_wave15 --features cpu -- --nocapture` (QK256 mapping property passed; unrelated `prop_i2s_roundtrip_preserves_sign` failed)
- `cargo test --locked -p bitnet-qk256-dispatch --test forward_qk256 --features opencl -- --nocapture`
- `cargo test --locked -p bitnet-qk256-dispatch --features opencl --test opencl_qk256_hardware -- --ignored --nocapture`
- `cargo test --locked -p bitnet-transformer --test transformer_model_tests --features cpu -- --nocapture`
- `rustfmt --edition 2024 --check ...`
- `git diff --check`
- diagnostic live A770 smoke wrote `target/a770-diagnostic/cache-16-a770-i2s-scale.json`; output remained gibberish, fallback=false