### PR TITLE
fix(bitnet): decode i2s qk256 act-parallel layout

### DIFF
--- a/crates/bitnet-models/tests/qk256_error_handling.rs
+++ b/crates/bitnet-models/tests/qk256_error_handling.rs
@@ -406,19 +406,22 @@ fn test_unpack_qk256_block_all_ones() {
 #[test]
 fn test_unpack_qk256_block_alternating_pattern() {
     // Pattern: 0x96 = 0b10010110
-    // Bit extraction order: [1:0], [3:2], [5:4], [7:6]
-    // 0b10010110 unpacks to: [0b10, 0b01, 0b01, 0b10] = [2, 1, 1, 2]
+    // Microsoft BitNet act-parallel order: [7:6], [5:4], [3:2], [1:0]
+    // 0b10010110 unpacks by 32-value lanes to [2, 1, 1, 2].
     let packed = [0x96u8; QK256_PACKED_BYTES];
     let mut codes = [0u8; QK256_BLOCK];
 
     unpack_qk256_block(&packed, &mut codes);
 
-    // Each byte unpacks to [2, 1, 1, 2] based on bit order
-    for chunk_idx in 0..(QK256_BLOCK / 4) {
-        assert_eq!(codes[chunk_idx * 4], 2, "Code {} should be 2", chunk_idx * 4);
-        assert_eq!(codes[chunk_idx * 4 + 1], 1, "Code {} should be 1", chunk_idx * 4 + 1);
-        assert_eq!(codes[chunk_idx * 4 + 2], 1, "Code {} should be 1", chunk_idx * 4 + 2);
-        assert_eq!(codes[chunk_idx * 4 + 3], 2, "Code {} should be 2", chunk_idx * 4 + 3);
+    for (idx, &code) in codes.iter().enumerate() {
+        let lane = (idx % 128) / 32;
+        let expected = match lane {
+            0 => 2,
+            1 => 1,
+            2 => 1,
+            _ => 2,
+        };
+        assert_eq!(code, expected, "Code {idx} should be {expected}");
     }
 }
 

--- a/crates/bitnet-models/tests/qk256_integration.rs
+++ b/crates/bitnet-models/tests/qk256_integration.rs
@@ -22,7 +22,8 @@
 /// - **Tensor shape**: `[rows, row_stride_bytes]` where `row_stride_bytes = ceil(cols/256) * 64`
 /// - **Storage key**: `{original_name}.qk256_qs` (e.g., `layers.0.attention.q_proj.weight.qk256_qs`)
 use bitnet_models::quant::i2s_qk256::{
-    I2SQk256NoScale, QK256_BLOCK, QK256_PACKED_BYTES, gemv_qk256, unpack_qk256_block,
+    I2SQk256NoScale, QK256_BLOCK, QK256_PACKED_BYTES, gemv_qk256, pack_qk256_codes_for_cols,
+    unpack_qk256_block,
 };
 use candle_core::{DType, Device as CDevice, Tensor as CandleTensor};
 
@@ -338,23 +339,20 @@ fn test_qk256_vs_fp32_quantization_error() {
         })
         .collect();
 
-    // Create QK256 quantized version: pack FP32 weights back to codes
+    // Create QK256 quantized version: pack FP32 weights back to Microsoft BitNet codes.
     let mut qs_bytes = Vec::new();
     for row_weights in &fp32_weights {
-        for chunk in row_weights.chunks(4) {
-            let mut byte = 0u8;
-            for (i, &w) in chunk.iter().enumerate() {
-                let code = match w {
-                    x if (x + 1.0).abs() < 1e-6 => 0u8,
-                    x if x.abs() < 1e-6 => 1u8,
-                    x if (x - 1.0).abs() < 1e-6 => 2u8,
-                    x if (x - 2.0).abs() < 1e-6 => 3u8,
-                    _ => panic!("Invalid FP32 value in QK256 space: {}", w),
-                };
-                byte |= code << (i * 2);
-            }
-            qs_bytes.push(byte);
-        }
+        let row_codes: Vec<u8> = row_weights
+            .iter()
+            .map(|&w| match w {
+                x if (x + 1.0).abs() < 1e-6 => 0u8,
+                x if x.abs() < 1e-6 => 1u8,
+                x if (x - 1.0).abs() < 1e-6 => 2u8,
+                x if (x - 2.0).abs() < 1e-6 => 3u8,
+                _ => panic!("Invalid FP32 value in QK256 space: {}", w),
+            })
+            .collect();
+        qs_bytes.extend_from_slice(&pack_qk256_codes_for_cols(&row_codes, cols));
     }
 
     // Create input
@@ -605,10 +603,12 @@ fn test_qk256_unpack_block() {
         assert!(c <= 3, "Codes[{}] = {} exceeds valid range", i, c);
     }
 
-    // 0x00 → [0, 0, 0, 0]
-    // 0xFF → [3, 3, 3, 3]
+    // 0x00 → [0, 0, 0, 0], 0xFF → [3, 3, 3, 3] at the byte's act-parallel positions.
     for (i, &code) in codes.iter().enumerate().take(64) {
-        let byte_idx = i / 4;
+        let group128 = i / 128;
+        let within = i % 128;
+        let pos = within % 32;
+        let byte_idx = group128 * 32 + pos;
         let expected = if byte_idx % 2 == 0 { 0 } else { 3 };
         assert_eq!(code, expected, "Codes[{}] should be {} (alternating pattern)", i, expected);
     }

--- a/crates/bitnet-models/tests/qk256_property_tests.rs
+++ b/crates/bitnet-models/tests/qk256_property_tests.rs
@@ -15,7 +15,7 @@
 
 use bitnet_models::quant::i2s_qk256::{
     I2SQk256NoScale, QK256_BLOCK, QK256_PACKED_BYTES, code_to_f32, gemv_qk256, gemv_qk256_row,
-    unpack_qk256_block,
+    pack_qk256_codes_for_cols, unpack_qk256_block,
 };
 use proptest::prelude::*;
 
@@ -125,15 +125,9 @@ proptest! {
         codes in qk256_codes(QK256_BLOCK),
         input in random_input_vector(QK256_BLOCK),
     ) {
-        // Pack codes into bytes (4 codes per byte)
-        let mut packed = [0u8; QK256_PACKED_BYTES];
-        for (i, chunk) in codes.chunks(4).enumerate() {
-            let mut byte = 0u8;
-            for (j, &code) in chunk.iter().enumerate() {
-                byte |= code << (j * 2);
-            }
-            packed[i] = byte;
-        }
+        let packed: [u8; QK256_PACKED_BYTES] = pack_qk256_codes_for_cols(&codes, QK256_BLOCK)
+            .try_into()
+            .expect("QK256 block packs into 64 bytes");
 
         // Compute QK256 result
         let qk256_result = gemv_qk256_row(&packed, &input, QK256_BLOCK);
@@ -161,15 +155,9 @@ proptest! {
         input in random_input_vector(QK256_BLOCK),
         cols in 1usize..=255, // Tail only (< QK256_BLOCK)
     ) {
-        // Pack codes
-        let mut packed = [0u8; QK256_PACKED_BYTES];
-        for (i, chunk) in codes.chunks(4).enumerate() {
-            let mut byte = 0u8;
-            for (j, &code) in chunk.iter().enumerate() {
-                byte |= code << (j * 2);
-            }
-            packed[i] = byte;
-        }
+        let packed: [u8; QK256_PACKED_BYTES] = pack_qk256_codes_for_cols(&codes, QK256_BLOCK)
+            .try_into()
+            .expect("QK256 block packs into 64 bytes");
 
         // Compute QK256 result with limited cols
         let qk256_result = gemv_qk256_row(&packed, &input, cols);
@@ -223,17 +211,12 @@ proptest! {
 
                 let codes_in_block = QK256_BLOCK.min(cols - block_idx * QK256_BLOCK);
 
-                for byte_idx in 0..QK256_PACKED_BYTES {
-                    let mut byte = 0u8;
-                    for j in 0..4 {
-                        let code_idx = block_start_code + byte_idx * 4 + j;
-                        if byte_idx * 4 + j < codes_in_block {
-                            let code = codes[code_idx];
-                            byte |= code << (j * 2);
-                        }
-                    }
-                    packed_data[block_start_byte + byte_idx] = byte;
-                }
+                let packed_block = pack_qk256_codes_for_cols(
+                    &codes[block_start_code..block_start_code + codes_in_block],
+                    codes_in_block,
+                );
+                packed_data[block_start_byte..block_start_byte + QK256_PACKED_BYTES]
+                    .copy_from_slice(&packed_block[..QK256_PACKED_BYTES]);
             }
         }
 
@@ -425,16 +408,12 @@ proptest! {
 
                 let codes_in_block = QK256_BLOCK.min(cols - block_idx * QK256_BLOCK);
 
-                for byte_idx in 0..QK256_PACKED_BYTES {
-                    let mut byte = 0u8;
-                    for j in 0..4 {
-                        if byte_idx * 4 + j < codes_in_block {
-                            let code_idx = block_start_code + byte_idx * 4 + j;
-                            byte |= codes[code_idx] << (j * 2);
-                        }
-                    }
-                    packed_data[block_start_byte + byte_idx] = byte;
-                }
+                let packed_block = pack_qk256_codes_for_cols(
+                    &codes[block_start_code..block_start_code + codes_in_block],
+                    codes_in_block,
+                );
+                packed_data[block_start_byte..block_start_byte + QK256_PACKED_BYTES]
+                    .copy_from_slice(&packed_block[..QK256_PACKED_BYTES]);
             }
         }
 

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -34,8 +34,12 @@ __kernel void qk256_gemm_no_scale(
 
     float acc = 0.0f;
     for (uint col = 0; col < cols; ++col) {
-        const uchar packed = row_bytes[col >> 2];
-        const uchar code = (packed >> ((col & 3u) * 2u)) & 3u;
+        const uint group128 = col / 128u;
+        const uint within = col - (group128 * 128u);
+        const uint lane = within / 32u;
+        const uint pos = within - (lane * 32u);
+        const uchar packed = row_bytes[(group128 * 32u) + pos];
+        const uchar code = (packed >> (6u - (lane * 2u))) & 3u;
         const float w = ((float)code) - 1.0f;
         acc += w * x[col];
     }

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -134,6 +134,13 @@ fn qk256_opencl_source_matches_microsoft_bitnet_mapping() {
 
     assert_eq!(QK256_OPENCL_KERNEL_NAME, "qk256_gemm_no_scale");
     assert!(QK256_OPENCL_KERNEL_SRC.contains("__kernel void qk256_gemm_no_scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("const uint group128 = col / 128u"));
+    assert!(
+        QK256_OPENCL_KERNEL_SRC.contains("const uchar packed = row_bytes[(group128 * 32u) + pos]")
+    );
+    assert!(
+        QK256_OPENCL_KERNEL_SRC.contains("const uchar code = (packed >> (6u - (lane * 2u))) & 3u")
+    );
     assert!(QK256_OPENCL_KERNEL_SRC.contains("const float w = ((float)code) - 1.0f"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("acc * scale"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("const float scale"));

--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -10,14 +10,15 @@
 //!
 //! ## Memory Layout
 //!
-//! Each block contains 256 elements packed into 64 bytes:
+//! Each block contains two Microsoft BitNet 128-element packing groups. Each
+//! 128-element group uses 32 bytes:
 //! ```text
-//! [byte 0: elem 0..3] [byte 1: elem 4..7] ... [byte 63: elem 252..255]
+//! byte p stores elements p, p+32, p+64, p+96 for p in 0..32
 //! ```
 //!
-//! Each byte packs 4 elements (2 bits each):
+//! Each byte packs four lane-separated elements (2 bits each), MSB first:
 //! ```text
-//! byte = elem0 | (elem1 << 2) | (elem2 << 4) | (elem3 << 6)
+//! byte = (elem_p << 6) | (elem_p+32 << 4) | (elem_p+64 << 2) | elem_p+96
 //! ```
 //!
 //! ## Code Mapping (VERIFIED)
@@ -159,6 +160,40 @@ pub fn code_to_f32(code: u8) -> f32 {
     LUT[code as usize]
 }
 
+/// Extract one logical QK256 code from a Microsoft BitNet-packed row.
+///
+/// Microsoft's `quantize_i2_s` groups each 128 logical values into 32 bytes.
+/// Within that group, byte `p` stores logical positions `p`, `p+32`,
+/// `p+64`, and `p+96` in bits `[7:6]`, `[5:4]`, `[3:2]`, and `[1:0]`.
+#[inline]
+pub fn packed_code_at(qs_row: &[u8], col: usize) -> u8 {
+    let group128 = col / 128;
+    let within = col % 128;
+    let lane = within / 32;
+    let pos = within % 32;
+    let byte = qs_row[group128 * 32 + pos];
+    (byte >> (6 - lane * 2)) & 0x03
+}
+
+/// Pack logical QK256 codes using the Microsoft BitNet act-parallel layout.
+///
+/// This helper is public for tests and diagnostics. Production loading preserves
+/// the GGUF bytes directly.
+pub fn pack_qk256_codes_for_cols(codes: &[u8], cols: usize) -> Vec<u8> {
+    let row_stride = qk256_row_stride_bytes(cols)
+        .expect("QK256: row stride overflow should be impossible for test packing");
+    let mut packed = vec![0u8; row_stride];
+    for (col, &code) in codes.iter().enumerate().take(cols) {
+        debug_assert!(code < 4, "QK256 code must be 0..=3, got {code}");
+        let group128 = col / 128;
+        let within = col % 128;
+        let lane = within / 32;
+        let pos = within % 32;
+        packed[group128 * 32 + pos] |= (code & 0x03) << (6 - lane * 2);
+    }
+    packed
+}
+
 /// Unpack one 64-byte block of 2-bit codes (QK=256) into 256 u8 codes (0..=3)
 ///
 /// # Arguments
@@ -171,13 +206,8 @@ pub fn code_to_f32(code: u8) -> f32 {
 /// Panics if slice lengths don't match expected sizes (debug builds only).
 #[inline]
 pub fn unpack_qk256_block(qs64: &[u8; QK256_PACKED_BYTES], out_codes256: &mut [u8; QK256_BLOCK]) {
-    // Each byte contains 4 codes: bits [1:0], [3:2], [5:4], [7:6]
-    for (i, &b) in qs64.iter().enumerate() {
-        let base = i * 4;
-        out_codes256[base] = b & 0x03;
-        out_codes256[base + 1] = (b >> 2) & 0x03;
-        out_codes256[base + 2] = (b >> 4) & 0x03;
-        out_codes256[base + 3] = (b >> 6) & 0x03;
+    for col in 0..QK256_BLOCK {
+        out_codes256[col] = packed_code_at(qs64, col);
     }
 }
 
@@ -272,9 +302,8 @@ pub fn gemv_qk256_row(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
             }
         }
 
-        // Decode codes and accumulate dot product
         for j in 0..take {
-            let w = code_to_f32(codes[j]);
+            let w = code_to_f32(packed_code_at(blk, j));
             acc += w * x[col + j];
         }
 
@@ -481,13 +510,7 @@ mod tests {
     use super::*;
 
     fn pack_codes_for_cols(codes: &[u8], cols: usize) -> Vec<u8> {
-        let layout = Qk256Layout::from_rows_cols(1, cols).expect("layout");
-        let mut packed = vec![0u8; layout.row_stride_bytes];
-        for (i, &code) in codes.iter().enumerate().take(cols) {
-            assert!(code < 4, "test code must be 0..=3");
-            packed[i / 4] |= code << ((i % 4) * 2);
-        }
-        packed
+        pack_qk256_codes_for_cols(codes, cols)
     }
 
     fn reference_dot(codes: &[u8], x: &[f32], cols: usize) -> f32 {
@@ -502,18 +525,18 @@ mod tests {
 
     #[test]
     fn unpack_block_smoke() {
-        // Pattern: 0b_11_10_01_00 repeated
+        // Logical pattern: 0,1,2,3 repeating in Microsoft BitNet packed layout.
         let mut qs = [0u8; QK256_PACKED_BYTES];
-        for (i, b) in qs.iter_mut().enumerate() {
-            *b = 0b_11_10_01_00u8.wrapping_add(i as u8 & 0x03);
-        }
+        let pattern: Vec<u8> = (0..QK256_BLOCK).map(|i| (i % 4) as u8).collect();
+        let packed = pack_qk256_codes_for_cols(&pattern, QK256_BLOCK);
+        qs.copy_from_slice(&packed);
         let mut codes = [0u8; QK256_BLOCK];
         unpack_qk256_block(&qs, &mut codes);
 
         // Verify codes are in 0..=3
         assert!(codes.iter().all(|&c| c < 4), "All codes must be 0..=3");
 
-        // Verify first few codes match pattern
+        // Verify first few logical codes match pattern.
         assert_eq!(codes[0], 0);
         assert_eq!(codes[1], 1);
         assert_eq!(codes[2], 2);
@@ -795,23 +818,16 @@ mod tests {
     /// Test (B): Block Decode Golden (64B → 256 f32)
     ///
     /// Tests feature spec: i2s-dual-flavor.md#memory-layout
-    /// Pack 256 two-bit codes (LSB-first) cycling 0..3 into 64 bytes.
+    /// Pack 256 two-bit codes cycling 0..3 into Microsoft BitNet act-parallel bytes.
     /// Decode using the unpack path and verify:
     /// - RMS in range [0.1, 5.0]
     /// - First 16 values contain the set {-1, 0, 1, 2}
     #[test]
     fn qk256_block_decode_golden() {
-        // Pack pattern: 0,1,2,3,0,1,2,3,... (cycling through all codes)
-        let mut qs64 = [0u8; QK256_PACKED_BYTES];
-        for (i, byte) in qs64.iter_mut().enumerate() {
-            // Each byte packs 4 codes: elem0 | (elem1 << 2) | (elem2 << 4) | (elem3 << 6)
-            let base = i * 4;
-            let code0 = (base % 4) as u8;
-            let code1 = ((base + 1) % 4) as u8;
-            let code2 = ((base + 2) % 4) as u8;
-            let code3 = ((base + 3) % 4) as u8;
-            *byte = code0 | (code1 << 2) | (code2 << 4) | (code3 << 6);
-        }
+        let logical_codes: Vec<u8> = (0..QK256_BLOCK).map(|i| (i % 4) as u8).collect();
+        let packed = pack_qk256_codes_for_cols(&logical_codes, QK256_BLOCK);
+        let qs64: [u8; QK256_PACKED_BYTES] =
+            packed.try_into().expect("QK256 block packs into 64 bytes");
 
         // Unpack block
         let mut codes = [0u8; QK256_BLOCK];

--- a/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
@@ -6,9 +6,8 @@
 //!
 //! The hot path uses several techniques for throughput:
 //!
-//! - **SIMD variable shift** (`vpsrlvd`): Extracts 8 two-bit codes from 2 packed
-//!   bytes in 3 SIMD ops (broadcast → variable shift → mask), replacing 8 scalar
-//!   bit-extractions + `_mm256_setr_epi32`.
+//! - **SIMD lane extraction**: Extracts 8 two-bit codes from 8 packed lane bytes
+//!   using the Microsoft BitNet act-parallel byte layout.
 //!
 //! - **4-wide accumulator bank**: Hides FMA latency (4–5 cycles on Haswell+) by
 //!   keeping 4 independent dependency chains in flight.
@@ -31,27 +30,21 @@ use std::arch::x86_64::*;
 use crate::i2s_qk256::{QK256_BLOCK, QK256_PACKED_BYTES};
 use anyhow::Result;
 
-/// Decode 8 two-bit codes from 2 packed bytes into 8 f32 weights using SIMD.
+/// Decode 8 two-bit codes from 8 packed lane bytes into 8 f32 weights using SIMD.
 ///
-/// Uses `vpsrlvd` (per-lane variable shift) to extract all 8 codes in parallel:
-///   packed = b0 | (b1 << 16)  →  broadcast to all lanes  →  shift by [0,2,4,6,16,18,20,22]  →  mask 0x03
-///
-/// Then maps codes [0,1,2,3] → weights [-1,0,+1,+2] via `weight = code - 1`.
+/// Microsoft BitNet stores one 128-value group as 32 bytes. Byte `p` stores
+/// values `p`, `p+32`, `p+64`, and `p+96` in bits 7:6, 5:4, 3:2, and 1:0.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
-unsafe fn decode_8_weights_avx2(
-    byte0: u8,
-    byte1: u8,
-    shifts: __m256i,
+unsafe fn decode_8_lane_weights_avx2(
+    bytes: *const u8,
+    lane_shift: __m256i,
     mask_03: __m256i,
     one: __m256i,
 ) -> __m256 {
-    // Pack both bytes so per-lane shifts extract each 2-bit code:
-    //   lanes 0–3 shift byte0 by 0,2,4,6; lanes 4–7 shift byte1 by 0,2,4,6
-    //   (byte1 sits at bit 16, so shifts 16,18,20,22 reach its 2-bit fields).
-    let packed = (byte0 as i32) | ((byte1 as i32) << 16);
-    let broadcast = _mm256_set1_epi32(packed);
-    let codes = _mm256_and_si256(_mm256_srlv_epi32(broadcast, shifts), mask_03);
+    let raw8 = unsafe { _mm_loadl_epi64(bytes as *const __m128i) };
+    let byte_lanes = _mm256_cvtepu8_epi32(raw8);
+    let codes = _mm256_and_si256(_mm256_srlv_epi32(byte_lanes, lane_shift), mask_03);
 
     // codes ∈ {0,1,2,3} → weights ∈ {-1,0,+1,+2}. Code 3 is unused by the
     // Microsoft BitNet quantizer but remains deterministic if encountered.
@@ -62,8 +55,8 @@ unsafe fn decode_8_weights_avx2(
 ///
 /// # Optimizations over the MVP scalar-unpack path
 ///
-/// 1. **SIMD code extraction**: `vpsrlvd` + broadcast replaces 8 scalar shifts per
-///    8-element group, cutting unpack cost from ~16 scalar ops to 3 SIMD ops per group.
+/// 1. **SIMD code extraction**: 8 lane bytes are unpacked to 8 logical weights
+///    for each Microsoft BitNet 32-value lane.
 /// 2. **4-wide accumulator bank**: 4 independent FMA dependency chains hide the
 ///    4-cycle FMA latency on Haswell/Skylake.
 /// 3. **32-element main loop**: 8 packed bytes → 32 codes → 4×FMA per iteration
@@ -91,8 +84,11 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
     debug_assert!(x.len() >= cols, "AVX2: x too short: {} < {}", x.len(), cols);
 
     unsafe {
-        // Hoisted constants shared by every decode_8_weights_avx2 call.
-        let shifts = _mm256_setr_epi32(0, 2, 4, 6, 16, 18, 20, 22);
+        // Hoisted constants shared by every decode_8_lane_weights_avx2 call.
+        let shift_0 = _mm256_set1_epi32(6);
+        let shift_1 = _mm256_set1_epi32(4);
+        let shift_2 = _mm256_set1_epi32(2);
+        let shift_3 = _mm256_set1_epi32(0);
         let mask_03 = _mm256_set1_epi32(0x03);
         let one = _mm256_set1_epi32(1);
 
@@ -120,57 +116,50 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
                 _mm_prefetch(x_ptr.add(col + QK256_BLOCK + 16) as *const i8, _MM_HINT_T0);
             }
 
-            let mut j = 0usize;
+            for group in 0..2usize {
+                let group_col = col + group * 128;
+                if group_col >= cols {
+                    break;
+                }
+                let group_take = 128usize.min(cols - group_col);
+                let group_bytes = blk.add(group * 32);
 
-            // --- 32-element main loop (8 packed bytes → 4 × 8-wide FMA) ---
-            while j + 32 <= take {
-                let pi = j / 4;
+                for lane in 0..4usize {
+                    let lane_col = group_col + lane * 32;
+                    let lane_take = group_take.saturating_sub(lane * 32).min(32);
+                    if lane_take == 0 {
+                        break;
+                    }
 
-                let w0 =
-                    decode_8_weights_avx2(*blk.add(pi), *blk.add(pi + 1), shifts, mask_03, one);
-                let w1 =
-                    decode_8_weights_avx2(*blk.add(pi + 2), *blk.add(pi + 3), shifts, mask_03, one);
-                let w2 =
-                    decode_8_weights_avx2(*blk.add(pi + 4), *blk.add(pi + 5), shifts, mask_03, one);
-                let w3 =
-                    decode_8_weights_avx2(*blk.add(pi + 6), *blk.add(pi + 7), shifts, mask_03, one);
+                    let (shift, acc) = match lane {
+                        0 => (shift_0, &mut acc0),
+                        1 => (shift_1, &mut acc1),
+                        2 => (shift_2, &mut acc2),
+                        _ => (shift_3, &mut acc3),
+                    };
 
-                let xj = col + j;
-                let x0 = _mm256_loadu_ps(x_ptr.add(xj));
-                let x1 = _mm256_loadu_ps(x_ptr.add(xj + 8));
-                let x2 = _mm256_loadu_ps(x_ptr.add(xj + 16));
-                let x3 = _mm256_loadu_ps(x_ptr.add(xj + 24));
+                    let mut pos = 0usize;
+                    while pos + 8 <= lane_take {
+                        let w =
+                            decode_8_lane_weights_avx2(group_bytes.add(pos), shift, mask_03, one);
+                        let xv = _mm256_loadu_ps(x_ptr.add(lane_col + pos));
+                        *acc = _mm256_fmadd_ps(w, xv, *acc);
+                        pos += 8;
+                    }
 
-                acc0 = _mm256_fmadd_ps(w0, x0, acc0);
-                acc1 = _mm256_fmadd_ps(w1, x1, acc1);
-                acc2 = _mm256_fmadd_ps(w2, x2, acc2);
-                acc3 = _mm256_fmadd_ps(w3, x3, acc3);
-
-                j += 32;
-            }
-
-            // --- 8-element cleanup loop ---
-            while j + 8 <= take {
-                let pi = j / 4;
-                let w = decode_8_weights_avx2(*blk.add(pi), *blk.add(pi + 1), shifts, mask_03, one);
-                let xv = _mm256_loadu_ps(x_ptr.add(col + j));
-                acc0 = _mm256_fmadd_ps(w, xv, acc0);
-                j += 8;
-            }
-
-            // --- Scalar tail (< 8 elements) ---
-            while j < take {
-                let packed_byte = *blk.add(j / 4);
-                let shift = (j % 4) * 2;
-                let code = (packed_byte >> shift) & 0x03;
-                let w = match code {
-                    0 => -1.0,
-                    1 => 0.0,
-                    2 => 1.0,
-                    _ => 2.0,
-                };
-                scalar_acc += w * *x_ptr.add(col + j);
-                j += 1;
+                    while pos < lane_take {
+                        let packed_byte = *group_bytes.add(pos);
+                        let code = (packed_byte >> (6 - lane * 2)) & 0x03;
+                        let w = match code {
+                            0 => -1.0,
+                            1 => 0.0,
+                            2 => 1.0,
+                            _ => 2.0,
+                        };
+                        scalar_acc += w * *x_ptr.add(lane_col + pos);
+                        pos += 1;
+                    }
+                }
             }
 
             col += take;

--- a/crates/bitnet-quantization/src/qk256_dispatch.rs
+++ b/crates/bitnet-quantization/src/qk256_dispatch.rs
@@ -49,8 +49,8 @@ pub fn qk256_gemv(
 
 /// Scalar legacy QK256 GEMV (kept for benchmark compatibility).
 ///
-/// This preserves the Microsoft BitNet QK256 code mapping used by the canonical
-/// packed-byte path: `00→-1, 01→0, 10→1, 11→2`, followed by per-block scaling.
+/// This preserves the Microsoft BitNet QK256 act-parallel byte layout and code
+/// mapping used by the canonical packed-byte path, followed by per-block scaling.
 pub fn qk256_gemv_scalar(
     output: &mut [f32],
     rows: usize,
@@ -83,8 +83,12 @@ pub fn qk256_gemv_scalar(
 
             let mut block_sum = 0.0f32;
             for elem in 0..QK256 {
-                let byte_idx = byte_offset + elem / 4;
-                let bit_shift = (elem % 4) * 2;
+                let group128 = elem / 128;
+                let within = elem % 128;
+                let lane = within / 32;
+                let pos = within % 32;
+                let byte_idx = byte_offset + group128 * 32 + pos;
+                let bit_shift = 6 - lane * 2;
                 let two_bit = (packed[byte_idx] >> bit_shift) & 0b11;
 
                 let signed_val = match two_bit {

--- a/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
+++ b/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
@@ -6,17 +6,16 @@
 #![cfg(all(test, feature = "cpu"))]
 
 use bitnet_quantization::i2s_qk256::{
-    QK256_BLOCK, QK256_PACKED_BYTES, code_to_f32, gemv_qk256, gemv_qk256_row, unpack_qk256_block,
+    QK256_BLOCK, QK256_PACKED_BYTES, code_to_f32, gemv_qk256, gemv_qk256_row,
+    pack_qk256_codes_for_cols, unpack_qk256_block,
 };
 use bitnet_quantization::i2s_qk256_avx2::gemv_qk256_avx2;
 
-/// Pack 256 2-bit codes into 64 bytes (4 codes per byte, LSB first).
+/// Pack 256 logical 2-bit codes into Microsoft BitNet act-parallel bytes.
 fn pack_codes(codes: &[u8; 256]) -> [u8; 64] {
-    let mut packed = [0u8; 64];
-    for (i, &code) in codes.iter().enumerate() {
-        packed[i / 4] |= (code & 0x03) << ((i % 4) * 2);
-    }
-    packed
+    pack_qk256_codes_for_cols(codes, QK256_BLOCK)
+        .try_into()
+        .expect("QK256 block packs into 64 bytes")
 }
 
 /// Build contiguous row-major quantized data for multi-row tests.

--- a/crates/bitnet-quantization/tests/quant_property_tests.rs
+++ b/crates/bitnet-quantization/tests/quant_property_tests.rs
@@ -15,7 +15,7 @@
 
 use bitnet_common::QuantizationType;
 use bitnet_quantization::i2s_qk256::{
-    QK256_BLOCK, QK256_PACKED_BYTES, code_to_f32, unpack_qk256_block,
+    QK256_BLOCK, QK256_PACKED_BYTES, code_to_f32, pack_qk256_codes_for_cols, unpack_qk256_block,
 };
 use bitnet_quantization::validation::{
     estimate_quantization_memory, validate_data_shape_consistency, validate_numerical_input,
@@ -28,7 +28,7 @@ use proptest::prelude::*;
 proptest! {
     /// Packing 256 2-bit codes into 64 bytes and unpacking recovers the originals.
     ///
-    /// Each byte stores 4 codes at bit offsets [1:0], [3:2], [5:4], [7:6].
+    /// Microsoft BitNet stores each 128-value group as 32 act-parallel bytes.
     /// This property ensures the bit-shift arithmetic is self-consistent.
     #[test]
     fn prop_qk256_unpack_recovers_packed_codes(
@@ -43,19 +43,8 @@ proptest! {
             prop_assert!(c <= 3, "code[{}] = {} is out of range 0..=3", i, c);
         }
 
-        // Re-pack and compare: byte = c0 | (c1<<2) | (c2<<4) | (c3<<6).
-        for (byte_idx, &original_byte) in qs64.iter().enumerate() {
-            let base = byte_idx * 4;
-            let repacked = codes[base]
-                | (codes[base + 1] << 2)
-                | (codes[base + 2] << 4)
-                | (codes[base + 3] << 6);
-            prop_assert_eq!(
-                repacked, original_byte,
-                "re-packed byte[{}] = {:#04x} != original {:#04x}",
-                byte_idx, repacked, original_byte
-            );
-        }
+        let repacked = pack_qk256_codes_for_cols(&codes, QK256_BLOCK);
+        prop_assert_eq!(&repacked[..], &qs64[..], "re-packed Microsoft BitNet act-parallel bytes differ");
     }
 }
 

--- a/crates/bitnet-transformer/tests/transformer_model_tests.rs
+++ b/crates/bitnet-transformer/tests/transformer_model_tests.rs
@@ -13,6 +13,7 @@
 #![cfg(feature = "cpu")]
 
 use bitnet_common::config::{ActivationType, BitNetConfig, ModelConfig, NormType};
+use bitnet_quantization::i2s_qk256::pack_qk256_codes_for_cols;
 use bitnet_transformer::{KVCache, Qk256DispatchBackend, TransformerModel};
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
@@ -82,11 +83,7 @@ fn qk256_row_with_codes(codes: &[(usize, u8)]) -> Vec<u8> {
         unpacked[idx] = code;
     }
 
-    let mut packed = vec![0u8; 64];
-    for (byte_idx, chunk) in unpacked.chunks_exact(4).enumerate() {
-        packed[byte_idx] = chunk[0] | (chunk[1] << 2) | (chunk[2] << 4) | (chunk[3] << 6);
-    }
-    packed
+    pack_qk256_codes_for_cols(&unpacked, unpacked.len())
 }
 
 fn repeated_qk256_tensor(


### PR DESCRIPTION
## Summary
- decode Microsoft BitNet I2_S QK256 bytes with the official act-parallel 128-value layout
- update scalar, AVX2, legacy scalar dispatch, and OpenCL QK256 paths to share the same byte extraction
- update synthetic QK256 packers/tests so fixtures generate the same layout as official `quantize_i2_s`

## Evidence
Official BitNet `quantize_i2_s` packs each 128-value group into 32 bytes: byte `p` stores logical positions `p`, `p+32`, `p+64`, and `p+96` in bits `[7:6]`, `[5:4]`, `[3:2]`, and `[1:0]`.

## Verification
- `cargo test --locked -p bitnet-quantization qk256 --lib -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test qk256_avx2_parity_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test quant_property_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-quantization --test quantization_extended_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-qk256-dispatch --test forward_qk256 --features opencl -- --nocapture`
- `cargo test --locked -p bitnet-qk256-dispatch --features opencl --test opencl_qk256_hardware -- --ignored --nocapture`
- `cargo test --locked -p bitnet-transformer --test transformer_model_tests --features cpu -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_error_handling -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_avx2_correctness -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_loader_tests -- --nocapture`
- `git diff --check`

Known fixture-only failures remain in:
- `cargo test --locked -p bitnet-models --test qk256_integration -- --nocapture`
- `cargo test --locked -p bitnet-models --test qk256_property_tests -- --nocapture`

Both fail only in `helpers::fixture_loader::*` because `ci/fixtures/qk256/qk256_4x256.gguf` is missing locally; the QK256 integration/property cases themselves pass.

## Diagnostic smoke
Target-local A770 smoke still emits gibberish after this fix, so this does not promote any product claim:

```text
์เพ curved VCριLERİでありclientてるitospara length*self/unit� Sb fich
```

## Claim boundary
Non-promoting. This does not claim selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion.