### PR TITLE
diag(bitnet): trace layer0 route stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "bitnet-quantization",
  "bitnet-rope",
  "bitnet-test-support",
+ "bitnet-trace",
  "candle-core",
  "candle-nn",
  "insta",

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -82,4 +82,4 @@ tl1 = []  # TL1 quantization for test scaffolding
 tl2 = []  # TL2 quantization for test scaffolding
 test-fixtures = []  # Enable tests that require real GGUF fixtures
 fixtures = []  # Enable GGUF fixture generation for QK256 dual-flavor tests (PR1)
-trace = ["dep:bitnet-trace"]  # Enable tensor activation tracing for cross-validation
+trace = ["dep:bitnet-trace", "bitnet-transformer/trace"]  # Enable tensor activation tracing for cross-validation

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -16,6 +16,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-qk256-dispatch = { path = "../bitnet-qk256-dispatch", version = "0.2.1-dev" }
 bitnet-rope = { path = "../bitnet-rope", version = "0.2.1-dev" }
+bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 anyhow.workspace = true
@@ -36,4 +37,4 @@ opencl = ["bitnet-common/opencl", "bitnet-quantization/opencl", "bitnet-qk256-di
 oneapi = ["bitnet-common/oneapi", "bitnet-quantization/oneapi", "bitnet-qk256-dispatch/oneapi"]
 metal = ["bitnet-common/metal", "bitnet-qk256-dispatch/metal"]
 gpu = ["cuda", "metal", "opencl"]
-trace = []
+trace = ["dep:bitnet-trace"]

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -5,6 +5,25 @@ use bitnet_rope::{build_tables as build_rope_tables, resolve_base as resolve_rop
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{LayerNorm, Linear, VarBuilder};
 
+#[cfg(feature = "trace")]
+fn trace_tensor_record(
+    name: &str,
+    tensor: &Tensor,
+    layer: Option<isize>,
+    stage: &str,
+) -> Result<()> {
+    bitnet_trace::dump_trace(name, tensor, Some(0), layer, Some(stage)).map_err(BitNetError::from)
+}
+
+#[cfg(feature = "trace")]
+fn trace_layer0_tensor(layer_idx: usize, stage: &str, tensor: &Tensor) -> Result<()> {
+    if layer_idx == 0 {
+        let trace_name = format!("t0/blk0/{stage}");
+        trace_tensor_record(&trace_name, tensor, Some(0), stage)?;
+    }
+    Ok(())
+}
+
 /// Debug helper for tensor statistics (only runs if DEBUG_ATTN env var is set)
 fn dbg_stats(tag: &str, t: &Tensor) -> candle_core::Result<()> {
     if std::env::var("DEBUG_ATTN").is_ok() {
@@ -366,6 +385,13 @@ impl MultiHeadAttention {
         let k_proj_out = self.apply_linear(x, &self.k_proj, "k_proj", raw_tensors)?;
         let v_proj_out = self.apply_linear(x, &self.v_proj, "v_proj", raw_tensors)?;
 
+        #[cfg(feature = "trace")]
+        {
+            trace_layer0_tensor(self.layer_idx, "attention_q", &q_proj_out)?;
+            trace_layer0_tensor(self.layer_idx, "attention_k", &k_proj_out)?;
+            trace_layer0_tensor(self.layer_idx, "attention_v", &v_proj_out)?;
+        }
+
         // Probe A3: Q/K/V projection RMS (layer 0, step 0 only)
         if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && self.layer_idx == 0 {
             static PROJ_LOGGED: std::sync::Once = std::sync::Once::new();
@@ -607,10 +633,12 @@ impl MultiHeadAttention {
             eprintln!("[dbg] attn row-sums (first 4): {:?}", take);
         }
 
-        let attn_output = attn_weights.matmul(&v_expanded)?;
+        let attn_value_mix = attn_weights.matmul(&v_expanded)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "attention_value_mix", &attn_value_mix)?;
 
         // Reshape and project output
-        let attn_output = attn_output.transpose(1, 2)?.reshape(&[
+        let attn_output = attn_value_mix.transpose(1, 2)?.reshape(&[
             batch_size,
             seq_len,
             self.n_heads * self.head_dim,
@@ -619,8 +647,13 @@ impl MultiHeadAttention {
             Some(norm) => norm.forward(&attn_output)?,
             None => attn_output,
         };
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_attention_subnorm", &attn_output)?;
 
-        self.apply_linear(&attn_output, &self.o_proj, "o_proj", raw_tensors)
+        let output = self.apply_linear(&attn_output, &self.o_proj, "o_proj", raw_tensors)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_o_proj", &output)?;
+        Ok(output)
     }
 
     /// Apply linear transformation with QK256 dispatch
@@ -742,6 +775,8 @@ impl FeedForward {
         raw_tensors: &std::collections::HashMap<String, Tensor>,
     ) -> Result<Tensor> {
         let gate = self.apply_linear(x, &self.gate_proj, "gate_proj", raw_tensors)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_ffn_gate_proj", &gate)?;
 
         // MLP gating diagnostics (point 3 of user's plan)
         if std::env::var("BITNET_DEBUG_MLP").is_ok()
@@ -751,6 +786,8 @@ impl FeedForward {
         }
 
         let gate = feed_forward_activation(self.activation_type, &gate)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_ffn_gate_activation", &gate)?;
 
         if std::env::var("BITNET_DEBUG_MLP").is_ok()
             && let Ok(activation_norm) = gate.sqr()?.mean_all()?.sqrt()?.to_scalar::<f32>()
@@ -763,6 +800,8 @@ impl FeedForward {
         }
 
         let up = self.apply_linear(x, &self.up_proj, "up_proj", raw_tensors)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_ffn_up_proj", &up)?;
 
         if std::env::var("BITNET_DEBUG_MLP").is_ok()
             && let Ok(v_norm) = up.sqr()?.mean_all()?.sqrt()?.to_scalar::<f32>()
@@ -771,10 +810,15 @@ impl FeedForward {
         }
 
         let hidden = gate.mul(&up)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_swiglu", &hidden)?;
+
         let hidden = match &self.sub_layernorm {
             Some(norm) => norm.forward(&hidden)?,
             None => hidden,
         };
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_ffn_subnorm", &hidden)?;
 
         if std::env::var("BITNET_DEBUG_MLP").is_ok()
             && let Ok(prod_norm) = hidden.sqr()?.mean_all()?.sqrt()?.to_scalar::<f32>()
@@ -787,6 +831,8 @@ impl FeedForward {
         }
 
         let output = self.apply_linear(&hidden, &self.down_proj, "down_proj", raw_tensors)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.layer_idx, "post_down_proj", &output)?;
 
         if std::env::var("BITNET_DEBUG_MLP").is_ok()
             && let Ok(out_norm) = output.sqr()?.mean_all()?.sqrt()?.to_scalar::<f32>()
@@ -979,6 +1025,8 @@ impl TransformerBlock {
 
         let x = self.attention.forward(&x, kv_cache, raw_tensors)?;
         let x = (x + residual)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.attention.layer_idx, "post_attention_residual", &x)?;
 
         // Debug post-attention activation norms
         if std::env::var("DEBUG_ATTN").is_ok() {
@@ -988,6 +1036,8 @@ impl TransformerBlock {
 
         // Pre-norm FFN
         let residual = &x;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.attention.layer_idx, "pre_ffn_norm", &x)?;
 
         // RMSNorm diagnostics (Layer 0 only) - FFN norm
         if std::env::var("BITNET_DEBUG_RMSNORM").is_ok() {
@@ -1010,6 +1060,8 @@ impl TransformerBlock {
         }
 
         let x = self.ffn_norm.forward(&x)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.attention.layer_idx, "post_ffn_norm", &x)?;
 
         // Check norm output
         if std::env::var("BITNET_DEBUG_RMSNORM").is_ok() {
@@ -1031,6 +1083,8 @@ impl TransformerBlock {
 
         let x = self.feed_forward.forward(&x, raw_tensors)?;
         let x = (x + residual)?;
+        #[cfg(feature = "trace")]
+        trace_layer0_tensor(self.attention.layer_idx, "post_layer", &x)?;
 
         // Debug post-FFN activation norms
         if std::env::var("DEBUG_ATTN").is_ok() {
@@ -1514,6 +1568,8 @@ impl TransformerModel {
         }
 
         let normalized = self.norm.forward(&x)?;
+        #[cfg(feature = "trace")]
+        trace_tensor_record("t0/final_norm", &normalized, Some(-1), "final_norm")?;
         if std::env::var("DEBUG_ATTN").is_ok()
             && let Ok(norm) = normalized.sqr()?.mean_all()?.sqrt()?.to_scalar::<f32>()
         {

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -289,7 +289,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-009"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-009-benchmark-baseline"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T123205Z-M4-009-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T123205Z-M4-009-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:32:05Z"
+campaign = "apple-m4"
+item = "M4-009"
+event = "merged"
+pr = 3732
+merge_sha = "07f8e2e5a9657f792367e5f25355adf12a1afc50"
+actor = "maintainer"
+
+notes = [
+  "Apple M4 benchmark baseline item merged.",
+  "No BitNet inference, Neural Engine, or broad Metal performance claim is made by this tracker closeout.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -17,7 +17,7 @@
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
-| M4-009 | pr_open | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
+| M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "LNL258V-RUN-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v/LNL258V-RUN-001-platform-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T110911Z-LNL258V-RUN-001-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T110911Z-LNL258V-RUN-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:09:11Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-RUN-001"
+event = "merged"
+pr = 3714
+merge_sha = "4dfd156a7e731ccf57f70213566ad63f668a98af"
+actor = "maintainer"
+
+notes = [
+  "Lunar Lake 258V platform visibility probe item merged.",
+  "Arc 140V runtime visibility remains separate from Intel NPU inference or A770 claims.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| LNL258V-RUN-001 | pr_open | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "NPU-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-npu/NPU-002-lite-backend-identity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T115519Z-NPU-002-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T115519Z-NPU-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:55:19Z"
+campaign = "intel-npu"
+item = "NPU-002"
+event = "merged"
+pr = 3722
+merge_sha = "20688198547dbb29a14e31fbdcf46c8c703a2a86"
+actor = "maintainer"
+
+notes = [
+  "Intel NPU backend identity item merged.",
+  "This closeout preserves backend identity only and does not claim NPU inference.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| NPU-002 | pr_open | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -91,7 +91,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "RTX5070TI-005"
-status = "pr_open"
+status = "merged"
 branch = "codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T132942Z-RTX5070TI-005-merged.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T132942Z-RTX5070TI-005-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T13:29:42Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-005"
+event = "merged"
+pr = 3723
+merge_sha = "8b588762976d17bc2774f0a4a554ecec1d39342f"
+actor = "maintainer"
+
+notes = [
+  "RTX 5070 Ti tiny CUDA kernel smoke item merged.",
+  "This closeout does not claim BitNet CUDA inference or speedup.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | RTX5070TI-003 | merged | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
 | RTX5070TI-004 | merged | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
-| RTX5070TI-005 | pr_open | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
+| RTX5070TI-005 | merged | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -89,7 +89,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-003"
-status = "pr_open"
+status = "merged"
 branch = "codex/tracker-infra/TRACKER-003-current-pr-reconciliation"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T120749Z-TRACKER-003-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T120749Z-TRACKER-003-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:07:49Z"
+campaign = "tracker-infra"
+item = "TRACKER-003"
+event = "merged"
+pr = 3724
+merge_sha = "6f44b77538492182e1a33484ff6683fa2debd8ee"
+actor = "maintainer"
+
+notes = [
+  "Current-PR-scoped GitHub reconciliation item merged.",
+  "This closeout changes tracker infrastructure only, not runtime behavior.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
 | TRACKER-002 | merged | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
-| TRACKER-003 | pr_open | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
+| TRACKER-003 | merged | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,8 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-009 | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
-| intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
-| nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
-| tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -10,7 +10,7 @@
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
-| apple-m4 | M4-009 | M4-008 | pr_open |
+| apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |
@@ -24,6 +24,6 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
-| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | pr_open |
+| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
-| tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |
+| tracker-infra | TRACKER-003 | TRACKER-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-009 | #3732 | pr_open | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-010 | TBD | proposed | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-002 | #3722 | pr_open | none | Device-node detection is not inference. |
-| nvidia-5070ti | RTX5070TI-005 | #3723 | pr_open | none | CUDA visibility is not kernel execution. |
+| intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
+| nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-005 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
-| tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -366,19 +366,16 @@ enum Cmd {
         emit: String,
     },
 
-    /// Compare Rust vs C++ traces and report first divergence
-    ///
-    /// Wrapper for scripts/trace_diff.py that performs Blake3 hash comparison
-    /// of trace files captured during cross-validation runs.
+    /// Compare two bitnet-trace directories and report first divergence.
     ///
     /// Usage:
-    ///   cargo run -p xtask -- trace-diff /tmp/rs_traces /tmp/cpp_traces
+    ///   cargo run -p xtask -- trace-diff /tmp/cpu_traces /tmp/a770_traces
     #[command(name = "trace-diff")]
     TraceDiff {
-        /// Rust trace directory
-        rs_dir: PathBuf,
-        /// C++ trace directory
-        cpp_dir: PathBuf,
+        /// Left trace directory
+        left_dir: PathBuf,
+        /// Right trace directory
+        right_dir: PathBuf,
     },
 
     /// Check C++ backend availability for cross-validation
@@ -1494,8 +1491,8 @@ fn real_main() -> Result<()> {
             cpp_setup_auto::run(emit_format)?;
             Ok(())
         }
-        Cmd::TraceDiff { rs_dir, cpp_dir } => {
-            trace_diff::run(&rs_dir, &cpp_dir)?;
+        Cmd::TraceDiff { left_dir, right_dir } => {
+            trace_diff::run(&left_dir, &right_dir, "human")?;
             Ok(())
         }
         #[cfg(any(feature = "crossval", feature = "crossval-all"))]

--- a/xtask/src/trace_diff.rs
+++ b/xtask/src/trace_diff.rs
@@ -1,156 +1,271 @@
-//! Trace diff wrapper for cross-validation debugging.
+//! Rust-native trace diffing for activation diagnostics.
 //!
-//! This module provides a Rust wrapper for the Python `scripts/trace_diff.py`
-//! script, which performs Blake3 hash comparison of trace files captured during
-//! Rust vs C++ cross-validation runs.
-//!
-//! # Usage
-//!
-//! ```bash
-//! # Capture traces (example)
-//! BITNET_TRACE_DIR=/tmp/rs cargo run -p bitnet-cli --features cpu,trace -- \
-//!   run --model model.gguf --tokenizer tok.json --prompt "Test" --max-tokens 4
-//!
-//! # (capture C++ trace to /tmp/cpp using C++ inference)
-//!
-//! # Compare traces
-//! cargo run -p xtask -- trace-diff /tmp/rs /tmp/cpp
-//! ```
-//!
-//! # Output
-//!
-//! The tool prints:
-//! - First divergence point: `(seq, layer, stage)` where traces differ
-//! - "All tracepoints match" if traces are identical
-//! - Error diagnostics if trace files are missing or Python is unavailable
+//! Trace files are JSON records produced by `bitnet-trace` when
+//! `BITNET_TRACE_DIR` is set. The diff is diagnostic-only: it never updates
+//! proof manifests or promotes backend/residency claims.
 
 use anyhow::{Context, Result, bail};
-use std::{fs, path::Path, process::Command};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
 
-/// Find available Python interpreter
-///
-/// Tries interpreters in order: python3, python, py
-fn find_python() -> Result<String> {
-    for interp in ["python3", "python", "py"] {
-        if Command::new(interp)
-            .arg("--version")
-            .output()
-            .ok()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-        {
-            return Ok(interp.to_string());
+#[derive(Debug, Clone, Deserialize)]
+struct TraceRecord {
+    name: String,
+    shape: Vec<usize>,
+    dtype: String,
+    blake3: String,
+    rms: f64,
+    num_elements: usize,
+    seq: Option<usize>,
+    layer: Option<isize>,
+    stage: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TraceDiffReport {
+    diagnostic: &'static str,
+    diagnostic_only: bool,
+    promotion_allowed: bool,
+    proof_receipts_written: bool,
+    manifest_updated: bool,
+    left_dir: String,
+    right_dir: String,
+    left_record_count: usize,
+    right_record_count: usize,
+    comparable_record_count: usize,
+    matched_record_count: usize,
+    divergent_record_count: usize,
+    missing_left_count: usize,
+    missing_right_count: usize,
+    first_divergence: Option<TraceDivergence>,
+    not_claims: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TraceDivergence {
+    key: String,
+    kind: String,
+    left: Option<TraceSummary>,
+    right: Option<TraceSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TraceSummary {
+    name: String,
+    shape: Vec<usize>,
+    dtype: String,
+    blake3: String,
+    rms: f64,
+    num_elements: usize,
+    seq: Option<usize>,
+    layer: Option<isize>,
+    stage: Option<String>,
+}
+
+impl From<&TraceRecord> for TraceSummary {
+    fn from(record: &TraceRecord) -> Self {
+        Self {
+            name: record.name.clone(),
+            shape: record.shape.clone(),
+            dtype: record.dtype.clone(),
+            blake3: record.blake3.clone(),
+            rms: record.rms,
+            num_elements: record.num_elements,
+            seq: record.seq,
+            layer: record.layer,
+            stage: record.stage.clone(),
         }
     }
-    bail!(
-        "Python interpreter not found (tried python3, python, py).\n\
-         Install Python 3.7+ to use trace comparison."
+}
+
+fn critical_not_claims() -> Vec<&'static str> {
+    vec![
+        "selected_attention_residency",
+        "resident_kv_decode",
+        "attention_scores_residency",
+        "softmax_residency",
+        "attention_value_mix_residency",
+        "full_support_op_residency",
+        "full_device_residency",
+        "completion",
+    ]
+}
+
+fn trace_key(record: &TraceRecord) -> String {
+    format!(
+        "seq={}|layer={}|stage={}|name={}",
+        record.seq.map(|value| value.to_string()).unwrap_or_else(|| "none".to_string()),
+        record.layer.map(|value| value.to_string()).unwrap_or_else(|| "none".to_string()),
+        record.stage.as_deref().unwrap_or("none"),
+        record.name
     )
 }
 
-/// Check if a directory has trace files
-fn has_trace_files(dir: &Path) -> bool {
-    fs::read_dir(dir).ok().map(|entries| entries.count() > 0).unwrap_or(false)
+fn read_trace_dir(dir: &Path) -> Result<BTreeMap<String, TraceRecord>> {
+    if !dir.exists() {
+        bail!("trace directory not found: {}", dir.display());
+    }
+    if !dir.is_dir() {
+        bail!("trace path is not a directory: {}", dir.display());
+    }
+
+    let mut records = BTreeMap::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("trace") {
+            continue;
+        }
+
+        let json = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let record: TraceRecord = serde_json::from_str(&json)
+            .with_context(|| format!("failed to parse trace JSON {}", path.display()))?;
+        let key = trace_key(&record);
+        if records.insert(key.clone(), record).is_some() {
+            bail!("duplicate trace key {key} in {}", dir.display());
+        }
+    }
+
+    if records.is_empty() {
+        bail!("trace directory is empty: {}", dir.display());
+    }
+
+    Ok(records)
 }
 
-/// Compare Rust vs C++ traces and report first divergence
-///
-/// # Arguments
-///
-/// - `rs_dir`: Path to directory containing Rust trace files
-/// - `cpp_dir`: Path to directory containing C++ trace files
-///
-/// # Workflow
-///
-/// 1. Validates both trace directories exist
-/// 2. Checks `scripts/trace_diff.py` is available in repo
-/// 3. Executes Python script via `python3` subprocess
-/// 4. Propagates exit code from Python script
-///
-/// # Returns
-///
-/// - `Ok(())` if comparison succeeds (traces match or divergence found)
-/// - `Err(_)` if:
-///   - Trace directories don't exist
-///   - `trace_diff.py` script not found
-///   - `python3` not available
-///   - Script execution fails
-pub fn run(rs_dir: &Path, cpp_dir: &Path) -> Result<()> {
-    // 1) Validate trace directories exist
-    if !rs_dir.exists() {
-        eprintln!("❌ Rust trace directory not found: {}", rs_dir.display());
-        eprintln!();
-        eprintln!("How to capture Rust traces:");
-        eprintln!(
-            "  BITNET_TRACE_DIR=/tmp/rs RUST_LOG=warn BITNET_DETERMINISTIC=1 BITNET_SEED=42 \\"
-        );
-        eprintln!("    cargo run -p bitnet-cli --features cpu,trace -- run \\");
-        eprintln!("    --model <model.gguf> --tokenizer <tokenizer.json> \\");
-        eprintln!("    --prompt \"What is 2+2?\" --max-tokens 4 --greedy");
-        anyhow::bail!("Rust trace directory not found: {}", rs_dir.display());
+fn compare_trace_dirs(left_dir: &Path, right_dir: &Path) -> Result<TraceDiffReport> {
+    let left = read_trace_dir(left_dir)?;
+    let right = read_trace_dir(right_dir)?;
+    let keys = left.keys().chain(right.keys()).cloned().collect::<BTreeSet<_>>();
+
+    let mut comparable_record_count = 0usize;
+    let mut matched_record_count = 0usize;
+    let mut divergent_record_count = 0usize;
+    let mut missing_left_count = 0usize;
+    let mut missing_right_count = 0usize;
+    let mut first_divergence = None;
+
+    for key in keys {
+        match (left.get(&key), right.get(&key)) {
+            (Some(left_record), Some(right_record)) => {
+                comparable_record_count += 1;
+                let matches = left_record.shape == right_record.shape
+                    && left_record.dtype == right_record.dtype
+                    && left_record.blake3 == right_record.blake3;
+                if matches {
+                    matched_record_count += 1;
+                } else {
+                    divergent_record_count += 1;
+                    if first_divergence.is_none() {
+                        let kind = if left_record.shape != right_record.shape {
+                            "shape_mismatch"
+                        } else if left_record.dtype != right_record.dtype {
+                            "dtype_mismatch"
+                        } else {
+                            "hash_mismatch"
+                        };
+                        first_divergence = Some(TraceDivergence {
+                            key,
+                            kind: kind.to_string(),
+                            left: Some(left_record.into()),
+                            right: Some(right_record.into()),
+                        });
+                    }
+                }
+            }
+            (None, Some(right_record)) => {
+                missing_left_count += 1;
+                if first_divergence.is_none() {
+                    first_divergence = Some(TraceDivergence {
+                        key,
+                        kind: "missing_left".to_string(),
+                        left: None,
+                        right: Some(right_record.into()),
+                    });
+                }
+            }
+            (Some(left_record), None) => {
+                missing_right_count += 1;
+                if first_divergence.is_none() {
+                    first_divergence = Some(TraceDivergence {
+                        key,
+                        kind: "missing_right".to_string(),
+                        left: Some(left_record.into()),
+                        right: None,
+                    });
+                }
+            }
+            (None, None) => unreachable!("trace key came from at least one input"),
+        }
     }
 
-    if !cpp_dir.exists() {
-        eprintln!("❌ C++ trace directory not found: {}", cpp_dir.display());
-        eprintln!();
-        eprintln!("How to capture C++ traces:");
-        eprintln!("  See docs/howto/cpp-setup.md for C++ instrumentation and trace capture");
-        anyhow::bail!("C++ trace directory not found: {}", cpp_dir.display());
+    Ok(TraceDiffReport {
+        diagnostic: "bitnet_trace_diff",
+        diagnostic_only: true,
+        promotion_allowed: false,
+        proof_receipts_written: false,
+        manifest_updated: false,
+        left_dir: left_dir.display().to_string(),
+        right_dir: right_dir.display().to_string(),
+        left_record_count: left.len(),
+        right_record_count: right.len(),
+        comparable_record_count,
+        matched_record_count,
+        divergent_record_count,
+        missing_left_count,
+        missing_right_count,
+        first_divergence,
+        not_claims: critical_not_claims(),
+    })
+}
+
+fn print_human(report: &TraceDiffReport) {
+    println!("trace diff: diagnostic_only=true promotion_allowed=false");
+    println!("left:  {} records ({})", report.left_record_count, report.left_dir);
+    println!("right: {} records ({})", report.right_record_count, report.right_dir);
+    println!(
+        "matched={} divergent={} missing_left={} missing_right={}",
+        report.matched_record_count,
+        report.divergent_record_count,
+        report.missing_left_count,
+        report.missing_right_count
+    );
+
+    if let Some(divergence) = &report.first_divergence {
+        println!("first_divergence: {} ({})", divergence.key, divergence.kind);
+        if let (Some(left), Some(right)) = (&divergence.left, &divergence.right) {
+            println!(
+                "left:  shape={:?} dtype={} rms={:.8} blake3={}",
+                left.shape, left.dtype, left.rms, left.blake3
+            );
+            println!(
+                "right: shape={:?} dtype={} rms={:.8} blake3={}",
+                right.shape, right.dtype, right.rms, right.blake3
+            );
+        }
+    } else {
+        println!("all tracepoints match");
     }
+}
 
-    // 2) Check if directories are empty
-    if !has_trace_files(rs_dir) {
-        eprintln!("❌ Rust trace directory is empty: {}", rs_dir.display());
-        eprintln!();
-        eprintln!("How to capture Rust traces:");
-        eprintln!(
-            "  BITNET_TRACE_DIR=/tmp/rs RUST_LOG=warn BITNET_DETERMINISTIC=1 BITNET_SEED=42 \\"
-        );
-        eprintln!("    cargo run -p bitnet-cli --features cpu,trace -- run \\");
-        eprintln!("    --model <model.gguf> --tokenizer <tokenizer.json> \\");
-        eprintln!("    --prompt \"What is 2+2?\" --max-tokens 4 --greedy");
-        anyhow::bail!("Rust trace directory is empty: {}", rs_dir.display());
+/// Compare two trace directories and report the first divergence.
+pub fn run(left_dir: &Path, right_dir: &Path, format: &str) -> Result<()> {
+    let report = compare_trace_dirs(left_dir, right_dir)?;
+    match format {
+        "json" => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        "human" => print_human(&report),
+        other => bail!("unsupported trace-diff format: {other}"),
     }
-
-    if !has_trace_files(cpp_dir) {
-        eprintln!("❌ C++ trace directory is empty: {}", cpp_dir.display());
-        eprintln!();
-        eprintln!("How to capture C++ traces:");
-        eprintln!("  See docs/howto/cpp-setup.md for C++ instrumentation and trace capture");
-        anyhow::bail!("C++ trace directory is empty: {}", cpp_dir.display());
-    }
-
-    // 3) Verify trace_diff.py script exists
-    let script = Path::new("scripts/trace_diff.py");
-    if !script.exists() {
-        bail!(
-            "scripts/trace_diff.py not found at {}\n\
-             Are you running from the repository root?",
-            script.display()
-        );
-    }
-
-    // 4) Find Python interpreter
-    let python = find_python()?;
-
-    // 5) Execute Python script
-    eprintln!("[bitnet] Comparing traces:");
-    eprintln!("  Rust:  {}", rs_dir.display());
-    eprintln!("  C++:   {}", cpp_dir.display());
-    eprintln!();
-
-    let status = Command::new(&python)
-        .arg(script)
-        .arg(rs_dir)
-        .arg(cpp_dir)
-        .status()
-        .context(format!("failed to spawn {} for trace_diff.py", python))?;
-
-    // 6) Propagate exit code
-    if !status.success() {
-        bail!("trace_diff.py failed with exit code: {:?}", status.code().unwrap_or(-1));
-    }
-
     Ok(())
 }
 
@@ -158,14 +273,61 @@ pub fn run(rs_dir: &Path, cpp_dir: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn write_trace(dir: &Path, file: &str, name: &str, hash: &str, rms: f64) {
+        let path = dir.join(file);
+        let record = serde_json::json!({
+            "name": name,
+            "shape": [1, 2],
+            "dtype": "F32",
+            "blake3": hash,
+            "rms": rms,
+            "num_elements": 2,
+            "seq": 0,
+            "layer": 0,
+            "stage": name
+        });
+        fs::write(path, serde_json::to_string_pretty(&record).unwrap()).unwrap();
+    }
 
     #[test]
-    fn test_run_missing_dirs() {
-        let rs_dir = PathBuf::from("/nonexistent/rs");
-        let cpp_dir = PathBuf::from("/nonexistent/cpp");
+    fn missing_trace_dir_errors() {
+        let left = PathBuf::from("/nonexistent/left");
+        let right = PathBuf::from("/nonexistent/right");
 
-        let result = run(&rs_dir, &cpp_dir);
+        let result = compare_trace_dirs(&left, &right);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("trace directory not found"));
+    }
+
+    #[test]
+    fn matching_trace_dirs_are_diagnostic_not_promoting() {
+        let left = tempdir().unwrap();
+        let right = tempdir().unwrap();
+        write_trace(left.path(), "a.trace", "attention_q", "abc", 1.0);
+        write_trace(right.path(), "a.trace", "attention_q", "abc", 1.0);
+
+        let report = compare_trace_dirs(left.path(), right.path()).unwrap();
+        assert!(report.diagnostic_only);
+        assert!(!report.promotion_allowed);
+        assert_eq!(report.matched_record_count, 1);
+        assert_eq!(report.divergent_record_count, 0);
+        assert!(report.first_divergence.is_none());
+        assert!(report.not_claims.contains(&"selected_attention_residency"));
+    }
+
+    #[test]
+    fn hash_mismatch_reports_first_divergence() {
+        let left = tempdir().unwrap();
+        let right = tempdir().unwrap();
+        write_trace(left.path(), "a.trace", "attention_q", "abc", 1.0);
+        write_trace(right.path(), "a.trace", "attention_q", "def", 1.25);
+
+        let report = compare_trace_dirs(left.path(), right.path()).unwrap();
+        assert_eq!(report.divergent_record_count, 1);
+        let divergence = report.first_divergence.unwrap();
+        assert_eq!(divergence.kind, "hash_mismatch");
+        assert!(divergence.key.contains("attention_q"));
     }
 }


### PR DESCRIPTION
## Summary

Adds a diagnostic-only layer0 trace rail for the A770/CPU BitNet route diff lane.

- wires `bitnet-transformer/trace` through `bitnet-models/trace`
- adds layer0 tracepoints for Q/K/V, attention value mix, subnorm/o-proj, FFN gate/up/activation/down, residuals, final norm, and logits path coverage
- replaces the old Python-backed `xtask trace-diff` wrapper with a Rust-native trace directory comparator
- keeps trace diff diagnostic-only with critical A770 not-claims and no manifest/receipt promotion

## Validation

- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,trace`
- `cargo check --locked -p bitnet-cli --no-default-features --features opencl,trace`
- `cargo test --locked -p xtask --no-default-features --bin xtask trace_diff -- --nocapture`
- `rustfmt --check --edition 2024 --config skip_children=true crates\\bitnet-transformer\\src\\lib.rs xtask\\src\\trace_diff.rs xtask\\src\\main.rs`
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- trace-diff target\\tmp-trace-left target\\tmp-trace-right`

## Not Claims

This does not promote selected attention, resident KV, attention scores, softmax, value mix, full support-op residency, full device residency, completion, or A770 performance support.

## Notes

A real CPU trace smoke against the official GGUF exceeded a 5-minute local timeout, so I stopped the process. It did materialize target-local trace files and confirmed the new tracepoints are written, but I am not treating that timed-out smoke as proof evidence.