### PR TITLE
ci: fix main clippy and BDD grid failures

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -433,6 +433,9 @@ jobs:
           toolchain: "1.95.0"
           components: clippy
 
+      - name: Prefer installed Rust toolchain binaries
+        run: echo "$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin" >> "$GITHUB_PATH"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -11458,6 +11458,7 @@ fn allocation_audit_backend_supported(identity: &RunBackendIdentity) -> bool {
         && !identity.fallback_used
 }
 
+#[cfg(feature = "full-cli")]
 fn slm_warm_session_artifact_kind(requested_backend: &str) -> &'static str {
     match requested_backend.trim().to_ascii_lowercase().as_str() {
         "apple-m3-air-cpu-neon" => "slm_apple_m3_air_warm_session",


### PR DESCRIPTION
## Summary

- Gate `slm_warm_session_artifact_kind` behind `full-cli`, matching its only caller and fixing the current-main BDD Grid `dead_code` failure under `-D warnings`.
- Add the same macOS Rust toolchain PATH hardening to CI Core's `clippy-macos-arm64` job that the Apple workflows already use, fixing the current-main `cargo clippy` rustup-init shim failure.

## Failure evidence

- Current main CI Core run `25881338937` failed `BDD Grid Check` because `slm_warm_session_artifact_kind` was unused when `bitnet-cli` builds without `full-cli`.
- The same run failed `Clippy (macOS ARM64)` because `cargo clippy` resolved to the rustup-init shim and exited with `unexpected argument 'clippy'`.

## Claim boundary

This is a main CI fix-forward only. It does not change CUDA runtime behavior, model receipts, server readiness, benchmark qualification, speedup claims, badges, or Rust 1.95 policy.

## Validation

- [x] `rtk git diff --check`
- [x] `rtk powershell -NoProfile -Command '$env:CMAKE_GENERATOR="Ninja"; $env:CARGO_TARGET_DIR="C:\bntarget\fix-main-ci"; rtk cargo check --locked -p bitnet-cli --no-default-features --features cpu'`
- [x] `rtk powershell -NoProfile -Command '$env:CMAKE_GENERATOR="Ninja"; $env:CARGO_TARGET_DIR="C:\bntarget\fix-main-ci"; rtk cargo run --locked --no-default-features -p xtask -- grid-check --cpu-only --verbose'`

## Rollback

Revert this PR. The risk is limited to one CI PATH setup step and one cfg attribute on an otherwise unchanged helper.