### PR TITLE
docs(cuda): close CUDA-UX-010 tracker

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -251,7 +251,7 @@ receipt resolves it to `nvidia-rtx-5070-ti-cuda`.
 | CUDA-MODEL-005 | proposed | Add Qwen3 0.6B short-decode and warm-session strict CUDA proof after one-token CUDA lands. |
 | CUDA-UX-008 | merged | PR #4724 added a CUDA model support dashboard sourced from the model coverage matrix. |
 | CUDA-UX-009 | merged | PR #4754 added the strict RTX 5070 Ti BitNet CUDA user guide without changing product claims. |
-| CUDA-UX-010 | pr_open | Add the 9950X3D + RTX 5070 Ti CUDA quickstart after status and core proof surfaces are current. |
+| CUDA-UX-010 | merged | PR #4768 added the 9950X3D + RTX 5070 Ti CUDA quickstart after status and core proof surfaces were current. |
 | CUDA-SERVER-001 | proposed | Add strict CUDA server smoke only after CLI proof and status surfaces are stable. |
 
 ## Review Policy


### PR DESCRIPTION
## Summary

- Correct the NVIDIA 5070 Ti campaign narrative row for `CUDA-UX-010` from `pr_open` to `merged`.
- Keep the closeout tracker-only: `active.toml`, the merged event, and generated dashboards were already current.

## Claim boundary

This PR does not change runtime code, CUDA kernels, receipts, model manifests, server readiness, speedup claims, README badges, Codecov, or Rust 1.95 policy.

## Validation

- [x] `rtk powershell -NoProfile -Command '$env:CMAKE_GENERATOR="Ninja"; $env:CARGO_TARGET_DIR="C:\bntarget\cuda-ux-010-closeout"; rtk cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti'`
- [x] `rtk powershell -NoProfile -Command '$env:CMAKE_GENERATOR="Ninja"; $env:CARGO_TARGET_DIR="C:\bntarget\cuda-ux-010-closeout"; rtk cargo run --locked -p xtask --no-default-features -- campaign generate --check'`
- [x] `rtk powershell -NoProfile -Command '$env:CMAKE_GENERATOR="Ninja"; $env:CARGO_TARGET_DIR="C:\bntarget\cuda-ux-010-closeout"; rtk cargo run --locked -p xtask --no-default-features -- campaign doctor'`
- [x] `rtk git diff --check`

## Notes

The first local campaign-check attempt without `CMAKE_GENERATOR=Ninja` hit the known Windows `sentencepiece-sys` Visual Studio generator path; rerunning with Ninja passed.