### PR TITLE
fix(ci): harden BitNet cpp fetch on Windows

### DIFF
--- a/ci/fetch_bitnet_cpp.ps1
+++ b/ci/fetch_bitnet_cpp.ps1
@@ -6,6 +6,7 @@ param(
     [string]$CachePath = $(if ($env:BITNET_CPP_PATH) { $env:BITNET_CPP_PATH } else { "$env:USERPROFILE\.cache\bitnet_cpp" }),
     [switch]$Force,
     [switch]$Clean,
+    [switch]$SkipPatches,
     [switch]$Help
 )
 
@@ -51,6 +52,7 @@ OPTIONS:
     -CachePath PATH     Specify cache directory (default: $CachePath)
     -Force              Force rebuild even if already built
     -Clean              Clean build directory before building
+    -SkipPatches        Use upstream C++ source as-is without applying local patches
     -Help               Show this help message
 
 ENVIRONMENT VARIABLES:
@@ -62,6 +64,7 @@ EXAMPLES:
     .\fetch_bitnet_cpp.ps1 -Tag v1.1.0         # Use specific version
     .\fetch_bitnet_cpp.ps1 -Force              # Force rebuild
     .\fetch_bitnet_cpp.ps1 -Clean -Force       # Clean rebuild
+    .\fetch_bitnet_cpp.ps1 -SkipPatches        # Build upstream source without patches
 
 After successful build, set environment variables:
     `$env:BITNET_CPP_PATH = "$CachePath"
@@ -222,6 +225,9 @@ function Invoke-ApplyPatches {
     if (Test-Path $PatchScript) {
         Write-Info "Applying patches..."
         & $PatchScript -CppPath $CachePath
+        if ($LASTEXITCODE -ne 0) {
+            throw "Patch application failed"
+        }
     } else {
         Write-Info "No patch application script found - using C++ implementation as-is"
     }
@@ -321,8 +327,12 @@ function Main {
     # Fetch source code
     Get-SourceCode
 
-    # Apply patches
-    Invoke-ApplyPatches
+    # Apply patches, unless explicitly disabled for upstream reference checks.
+    if ($SkipPatches) {
+        Write-Info "Skipping local patches; using upstream C++ implementation as-is"
+    } else {
+        Invoke-ApplyPatches
+    }
 
     # Build
     Invoke-Build

--- a/ci/fetch_bitnet_cpp.ps1
+++ b/ci/fetch_bitnet_cpp.ps1
@@ -13,6 +13,11 @@ $ErrorActionPreference = "Stop"
 
 # Configuration
 $BitNetCppRepo = "https://github.com/microsoft/BitNet.git"
+
+if (-not [System.IO.Path]::IsPathRooted($CachePath)) {
+    $CachePath = Join-Path (Get-Location) $CachePath
+}
+$CachePath = [System.IO.Path]::GetFullPath($CachePath)
 $BuildDir = Join-Path $CachePath "build"
 
 function Write-Info {
@@ -104,18 +109,30 @@ function Get-SourceCode {
             # Fetch latest changes
             git fetch origin
 
-            # Check if we're already on the right tag
+            $OldErrorActionPreference = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
             $CurrentTag = git describe --tags --exact-match 2>$null
-            if ($CurrentTag -eq $Tag) {
+            $DescribeExitCode = $LASTEXITCODE
+            $ErrorActionPreference = $OldErrorActionPreference
+
+            $CurrentBranch = git rev-parse --abbrev-ref HEAD
+
+            # Clean any local changes before moving refs.
+            git reset --hard
+            git clean -fd
+
+            if ($DescribeExitCode -eq 0 -and $CurrentTag -eq $Tag) {
                 Write-Info "Already on correct tag: $Tag"
                 return
             }
 
-            # Clean any local changes
-            git reset --hard
-            git clean -fd
+            if ($CurrentBranch -eq $Tag) {
+                Write-Info "Already on branch $Tag; fast-forwarding to origin/$Tag"
+                git reset --hard "origin/$Tag"
+                return
+            }
 
-            # Checkout the specified tag
+            # Checkout the specified tag or branch.
             git checkout $Tag
         }
         finally {

--- a/ci/fetch_bitnet_cpp.ps1
+++ b/ci/fetch_bitnet_cpp.ps1
@@ -41,6 +41,10 @@ function Write-Debug {
     Write-Host "[DEBUG] $Message" -ForegroundColor Blue
 }
 
+function Test-IsWindows {
+    return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
 function Show-Usage {
     @"
 Usage: .\fetch_bitnet_cpp.ps1 [OPTIONS]
@@ -82,10 +86,21 @@ function Test-Dependencies {
         $MissingDeps += "cmake"
     }
 
-    # Check for Visual Studio or Build Tools
-    $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-    if (-not (Test-Path $VsWhere)) {
-        $MissingDeps += "Visual Studio Build Tools"
+    if (Test-IsWindows) {
+        # Upstream BitNet.cpp uses the Windows ClangCL toolset.
+        if (-not (Get-Command clang -ErrorAction SilentlyContinue)) {
+            $MissingDeps += "clang"
+        }
+
+        if (-not (Get-Command clang++ -ErrorAction SilentlyContinue)) {
+            $MissingDeps += "clang++"
+        }
+
+        # Check for Visual Studio or Build Tools.
+        $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $VsWhere)) {
+            $MissingDeps += "Visual Studio Build Tools"
+        }
     }
 
     if ($MissingDeps.Count -gt 0) {
@@ -94,6 +109,9 @@ function Test-Dependencies {
         Write-Error "  Git: https://git-scm.com/download/win"
         Write-Error "  CMake: https://cmake.org/download/"
         Write-Error "  Visual Studio: https://visualstudio.microsoft.com/downloads/"
+        if (Test-IsWindows) {
+            Write-Error "  Visual Studio components: C++ Clang Compiler for Windows and MS-Build Support for LLVM-Toolset"
+        }
         exit 1
     }
 }
@@ -179,13 +197,26 @@ function Invoke-Build {
                 throw "Visual Studio with C++ tools not found"
             }
 
+            $CMakeArgs = @(
+                "..",
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DCMAKE_INSTALL_PREFIX=$BuildDir\install"
+            )
+
+            if (Test-IsWindows) {
+                $CMakeArgs += @(
+                    "-T",
+                    "ClangCL",
+                    "-DCMAKE_C_COMPILER=clang",
+                    "-DCMAKE_CXX_COMPILER=clang++"
+                )
+            }
+
             # Configure with CMake
             Write-Info "Configuring build with CMake..."
-            cmake .. `
-                -DCMAKE_BUILD_TYPE=Release `
-                -DCMAKE_POSITION_INDEPENDENT_CODE=ON `
-                -DBUILD_SHARED_LIBS=ON `
-                "-DCMAKE_INSTALL_PREFIX=$BuildDir\install"
+            cmake @CMakeArgs
 
             if ($LASTEXITCODE -ne 0) {
                 throw "CMake configuration failed"


### PR DESCRIPTION
## Summary
- normalize `ci/fetch_bitnet_cpp.ps1 -CachePath` to an absolute path before deriving `build`
- avoid treating `git describe --tags --exact-match` as fatal for branch checkouts such as `main`
- fast-forward existing branch checkouts to `origin/<branch>` after cleaning local target-cache changes
- add `-SkipPatches` for upstream-as-is reference setup and stop the parent script if patch application fails
- require `clang`/`clang++` on Windows and configure CMake with upstream BitNet.cpp ClangCL settings instead of falling into MSVC compiler detection

## Why
The A770 reference-readiness path needs a local C++ reference executable before we change more Rust math. On this Windows machine, the fetch script failed before build setup because untagged `main` triggered a PowerShell native-command error, relative cache paths nested under the checkout after `Push-Location`, failed patch policy did not stop the parent script cleanly, and missing Clang let CMake hang in MSVC compiler identification. Reference parity should build upstream source as-is and fail fast when required Windows toolchain components are missing.

## Validation
- `powershell -ExecutionPolicy Bypass -File ci\\fetch_bitnet_cpp.ps1 -Help`
- PowerShell snippet validating untagged `main` checkout no longer throws while collecting `DescribeExitCode=128` and `CurrentBranch=main`
- PowerShell snippet validating relative cache path resolves to an absolute build root
- PowerShell fast-fail check for missing `clang`/`clang++` with `-SkipPatches`
- `git diff --check`

## Claim posture
Setup-script only. Does not run a clean A770 claim sequence and does not promote selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, completion, reference parity, or A770 semantic quality.