### PR TITLE
fix(cli): gate Apple M4 SLM metadata dead-code lint

### DIFF
--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -410,6 +410,13 @@ pub(crate) struct VerifiedCachedModel {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(
+    not(feature = "full-cli"),
+    expect(
+        dead_code,
+        reason = "Apple M4 SLM receipt metadata is consumed by the full-cli answer-corpus path"
+    )
+)]
 pub(crate) struct AppleM4SlmModelReceiptMetadata {
     pub id: &'static str,
     pub repo: &'static str,
@@ -1989,6 +1996,13 @@ fn supported_model(id: &str) -> Result<&'static SupportedModel> {
     })
 }
 
+#[cfg_attr(
+    not(feature = "full-cli"),
+    expect(
+        dead_code,
+        reason = "Apple M4 SLM receipt metadata is consumed by the full-cli answer-corpus path"
+    )
+)]
 pub(crate) fn apple_m4_slm_model_receipt_metadata(
     id: &str,
 ) -> Result<AppleM4SlmModelReceiptMetadata> {


### PR DESCRIPTION
## Summary

- Fixes the current main BDD grid failure under `--no-default-features --features cpu` and `-D warnings`.
- Marks the Apple M4 SLM model receipt metadata type/helper as expected dead code only when `full-cli` is not enabled.
- Leaves runtime behavior, model metadata, CUDA status, server readiness, and speed claims unchanged.

## Scope

- `crates/bitnet-cli/src/model_cache.rs`

## Claim boundary

This PR only fixes a CI compile/lint surface. It does not claim model answer readiness, CUDA proof, Apple M4 runtime proof, server readiness, or speedup.

## Validation

- [x] `CMAKE_GENERATOR=Ninja; CARGO_TARGET_DIR=C:\bntarget\apple-m4-slm-dead-code; RUSTFLAGS=-Dwarnings; cargo check --locked -p bitnet-cli --no-default-features --features cpu`
- [x] `CMAKE_GENERATOR=Ninja; CARGO_TARGET_DIR=C:\bntarget\apple-m4-slm-dead-code; cargo run --locked --no-default-features -p xtask -- grid-check --cpu-only --verbose`
- [x] `rustfmt --check crates/bitnet-cli/src/model_cache.rs`
- [x] `git diff --check`

## Rollback

Revert this PR; the previous failure mode is a dead-code error for Apple M4 SLM receipt metadata in no-`full-cli` CPU grid cells.