### PR TITLE
diag(bitnet): detect Windows Clang for reference setup

### DIFF
--- a/ci/fetch_bitnet_cpp.ps1
+++ b/ci/fetch_bitnet_cpp.ps1
@@ -45,6 +45,73 @@ function Test-IsWindows {
     return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
 }
 
+function Get-VisualStudioBuildToolsPath {
+    if (-not (Test-IsWindows)) {
+        return $null
+    }
+
+    $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path $VsWhere)) {
+        return $null
+    }
+
+    $VsPath = & $VsWhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if ($VsPath) {
+        return $VsPath.Trim()
+    }
+    return $null
+}
+
+function Find-WindowsClangTool {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    $Command = Get-Command $Name -ErrorAction SilentlyContinue
+    if ($Command) {
+        return $Command.Source
+    }
+
+    $Executable = if ($Name.EndsWith(".exe")) { $Name } else { "$Name.exe" }
+    $Candidates = @()
+
+    if ($env:ProgramFiles) {
+        $Candidates += (Join-Path $env:ProgramFiles "LLVM\bin\$Executable")
+    }
+
+    $VsPath = Get-VisualStudioBuildToolsPath
+    if ($VsPath) {
+        $Candidates += (Join-Path $VsPath "VC\Tools\Llvm\x64\bin\$Executable")
+        $Candidates += (Join-Path $VsPath "VC\Tools\Llvm\bin\$Executable")
+    }
+
+    if (${env:ProgramFiles(x86)}) {
+        $BuildTools = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\2022\BuildTools"
+        $Candidates += (Join-Path $BuildTools "VC\Tools\Llvm\x64\bin\$Executable")
+        $Candidates += (Join-Path $BuildTools "VC\Tools\Llvm\bin\$Executable")
+    }
+
+    foreach ($Candidate in ($Candidates | Select-Object -Unique)) {
+        if (Test-Path $Candidate) {
+            return $Candidate
+        }
+    }
+
+    return $null
+}
+
+function Add-ToolDirectoryToPath {
+    param([string]$ToolPath)
+
+    if (-not $ToolPath) {
+        return
+    }
+
+    $ToolDir = Split-Path $ToolPath -Parent
+    $PathParts = $env:PATH -split ';'
+    if ($PathParts -notcontains $ToolDir) {
+        $env:PATH = "$ToolDir;$env:PATH"
+    }
+}
+
 function Show-Usage {
     @"
 Usage: .\fetch_bitnet_cpp.ps1 [OPTIONS]
@@ -88,17 +155,21 @@ function Test-Dependencies {
 
     if (Test-IsWindows) {
         # Upstream BitNet.cpp uses the Windows ClangCL toolset.
-        if (-not (Get-Command clang -ErrorAction SilentlyContinue)) {
+        $script:BitNetReferenceClang = Find-WindowsClangTool "clang"
+        $script:BitNetReferenceClangxx = Find-WindowsClangTool "clang++"
+        Add-ToolDirectoryToPath $script:BitNetReferenceClang
+        Add-ToolDirectoryToPath $script:BitNetReferenceClangxx
+
+        if (-not $script:BitNetReferenceClang) {
             $MissingDeps += "clang"
         }
 
-        if (-not (Get-Command clang++ -ErrorAction SilentlyContinue)) {
+        if (-not $script:BitNetReferenceClangxx) {
             $MissingDeps += "clang++"
         }
 
         # Check for Visual Studio or Build Tools.
-        $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        if (-not (Test-Path $VsWhere)) {
+        if (-not (Get-VisualStudioBuildToolsPath)) {
             $MissingDeps += "Visual Studio Build Tools"
         }
     }
@@ -190,12 +261,15 @@ function Invoke-Build {
 
         try {
             # Find Visual Studio
-            $VsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-            $VsPath = & $VsWhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+            $VsPath = Get-VisualStudioBuildToolsPath
 
             if (-not $VsPath) {
                 throw "Visual Studio with C++ tools not found"
             }
+            $ClangPath = if ($script:BitNetReferenceClang) { $script:BitNetReferenceClang } else { Find-WindowsClangTool "clang" }
+            $ClangxxPath = if ($script:BitNetReferenceClangxx) { $script:BitNetReferenceClangxx } else { Find-WindowsClangTool "clang++" }
+            Add-ToolDirectoryToPath $ClangPath
+            Add-ToolDirectoryToPath $ClangxxPath
 
             $CMakeArgs = @(
                 "..",
@@ -209,8 +283,8 @@ function Invoke-Build {
                 $CMakeArgs += @(
                     "-T",
                     "ClangCL",
-                    "-DCMAKE_C_COMPILER=clang",
-                    "-DCMAKE_CXX_COMPILER=clang++"
+                    "-DCMAKE_C_COMPILER=$ClangPath",
+                    "-DCMAKE_CXX_COMPILER=$ClangxxPath"
                 )
             }
 

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -89,6 +89,104 @@ fn critical_not_claims() -> Vec<&'static str> {
     ]
 }
 
+struct PromptStopReceiptFields {
+    prompt_identity: serde_json::Value,
+    stop_contract: serde_json::Value,
+    tokenizer_info: serde_json::Value,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_prompt_stop_receipt_fields(
+    template_type: bitnet_inference::TemplateType,
+    formatted_prompt: &str,
+    prompt_token_ids: &[u32],
+    prompt_token_ids_sha256: &str,
+    bos_policy: bool,
+    parse_special: bool,
+    manual_stop_sequences: &[String],
+    manual_stop_token_ids: &[u32],
+    effective_stop_sequences: &[String],
+    effective_stop_token_ids: &[u32],
+    tokenizer: &dyn bitnet_tokenizers::Tokenizer,
+    tokenizer_origin: &str,
+    tokenizer_source: &str,
+    tokenizer_strict: bool,
+) -> PromptStopReceiptFields {
+    let tokenizer_bos = tokenizer.bos_token_id();
+    let tokenizer_eos = tokenizer.eos_token_id();
+    let tokenizer_pad = tokenizer.pad_token_id();
+    let begin_of_text_id = tokenizer.token_to_id("<|begin_of_text|>");
+    let end_of_text_id = tokenizer.token_to_id("<|end_of_text|>");
+    let eot_id = tokenizer.token_to_id("<|eot_id|>");
+    let prompt_token_ids_head: Vec<u32> = prompt_token_ids.iter().take(16).copied().collect();
+    let prompt_token_ids_tail: Vec<u32> = prompt_token_ids
+        .iter()
+        .rev()
+        .take(16)
+        .copied()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    let prompt_starts_with_begin_of_text =
+        begin_of_text_id.is_some_and(|id| prompt_token_ids.first().copied() == Some(id));
+    let prompt_starts_with_trait_bos =
+        tokenizer_bos.is_some_and(|id| prompt_token_ids.first().copied() == Some(id));
+    let rendered_prompt_embeds_begin_of_text = formatted_prompt.starts_with("<|begin_of_text|>");
+
+    PromptStopReceiptFields {
+        prompt_identity: serde_json::json!({
+            "template": template_type.to_string(),
+            "rendered_prompt_sha256": sha256_text(formatted_prompt),
+            "prompt_token_ids_sha256": prompt_token_ids_sha256,
+            "prompt_token_count": prompt_token_ids.len(),
+            "prompt_token_ids_head": prompt_token_ids_head,
+            "prompt_token_ids_tail": prompt_token_ids_tail,
+            "bos_policy": bos_policy,
+            "parse_special": parse_special,
+            "rendered_prompt_embeds_begin_of_text": rendered_prompt_embeds_begin_of_text,
+            "prompt_starts_with_begin_of_text": prompt_starts_with_begin_of_text,
+            "prompt_starts_with_trait_bos": prompt_starts_with_trait_bos,
+        }),
+        stop_contract: serde_json::json!({
+            "manual_stop_sequences": manual_stop_sequences,
+            "template_stop_sequences": template_type.default_stop_sequences(),
+            "effective_stop_sequences": effective_stop_sequences,
+            "manual_stop_token_ids": manual_stop_token_ids,
+            "template_stop_token_ids": template_type.resolve_stop_token_ids(tokenizer),
+            "effective_stop_token_ids": effective_stop_token_ids,
+            "tokenizer_specials": {
+                "bos_token_id": tokenizer_bos,
+                "eos_token_id": tokenizer_eos,
+                "pad_token_id": tokenizer_pad,
+                "begin_of_text_id": begin_of_text_id,
+                "end_of_text_id": end_of_text_id,
+                "eot_id": eot_id,
+                "start_header_id": tokenizer.token_to_id("<|start_header_id|>"),
+                "end_header_id": tokenizer.token_to_id("<|end_header_id|>"),
+            },
+            "diagnostic_only": true,
+            "not_claims": [
+                "tokenizer_template_authority",
+                "semantic_quality",
+                "reference_parity"
+            ],
+        }),
+        tokenizer_info: serde_json::json!({
+            "type": "sentencepiece",
+            "origin": tokenizer_origin,
+            "source": tokenizer_source,
+            "strict": tokenizer_strict,
+            "bos": tokenizer_bos,
+            "eos": tokenizer_eos,
+            "pad": tokenizer_pad,
+            "begin_of_text": begin_of_text_id,
+            "end_of_text": end_of_text_id,
+            "eot": eot_id,
+        }),
+    }
+}
+
 fn greedy_effective_argmax(
     logits: &[f32],
     generated_tokens: &[u32],
@@ -253,6 +351,108 @@ mod proof_summary_tests {
             Some(Commands::Run { strict_backend, .. }) => assert!(strict_backend),
             _ => panic!("expected run command"),
         }
+    }
+
+    #[test]
+    fn prompt_stop_receipts_pin_llama3_special_contract() -> Result<()> {
+        let tokenizer = bitnet_tokenizers::MockTokenizer::with_special_tokens(&[
+            ("<|begin_of_text|>", 128000),
+            ("<|end_of_text|>", 128001),
+            ("<|start_header_id|>", 128006),
+            ("<|end_header_id|>", 128007),
+            ("<|eot_id|>", 128009),
+        ]);
+        let template_type = bitnet_inference::TemplateType::Llama3Chat;
+        let formatted_prompt = template_type.apply("What is 2+2?", None);
+        let prompt_token_ids = vec![
+            128000, 128006, 882, 128007, 271, 3923, 374, 220, 17, 10, 17, 30, 128009, 128006,
+            78191, 128007, 271,
+        ];
+        let prompt_hash = sha256_token_ids(&prompt_token_ids)?;
+        let manual_stop_sequences = Vec::<String>::new();
+        let manual_stop_token_ids = Vec::<u32>::new();
+        let effective_stop_sequences =
+            vec!["<|eot_id|>".to_string(), "<|end_of_text|>".to_string()];
+        let effective_stop_token_ids = vec![128009, 128001];
+        let before_prompt_ids = prompt_token_ids.clone();
+        let before_stop_ids = effective_stop_token_ids.clone();
+
+        let receipts = build_prompt_stop_receipt_fields(
+            template_type,
+            &formatted_prompt,
+            &prompt_token_ids,
+            &prompt_hash,
+            false,
+            true,
+            &manual_stop_sequences,
+            &manual_stop_token_ids,
+            &effective_stop_sequences,
+            &effective_stop_token_ids,
+            &tokenizer,
+            "external",
+            "explicit",
+            true,
+        );
+
+        assert_eq!(
+            prompt_token_ids, before_prompt_ids,
+            "receipt helper must not mutate prompt ids"
+        );
+        assert_eq!(
+            effective_stop_token_ids, before_stop_ids,
+            "receipt helper must not mutate stop ids"
+        );
+        assert_eq!(receipts.tokenizer_info["bos"], serde_json::Value::Null);
+        assert_eq!(receipts.tokenizer_info["eos"], serde_json::Value::Null);
+        assert_ne!(receipts.tokenizer_info["bos"], serde_json::json!(1));
+        assert_ne!(receipts.tokenizer_info["eos"], serde_json::json!(2));
+        assert_eq!(receipts.tokenizer_info["begin_of_text"], serde_json::json!(128000));
+        assert_eq!(receipts.tokenizer_info["end_of_text"], serde_json::json!(128001));
+        assert_eq!(receipts.tokenizer_info["eot"], serde_json::json!(128009));
+
+        assert_eq!(receipts.prompt_identity["template"], serde_json::json!("llama3-chat"));
+        assert_eq!(receipts.prompt_identity["bos_policy"], serde_json::json!(false));
+        assert_eq!(receipts.prompt_identity["parse_special"], serde_json::json!(true));
+        assert_eq!(
+            receipts.prompt_identity["rendered_prompt_embeds_begin_of_text"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            receipts.prompt_identity["prompt_starts_with_begin_of_text"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            receipts.prompt_identity["prompt_starts_with_trait_bos"],
+            serde_json::json!(false)
+        );
+        assert_eq!(receipts.prompt_identity["prompt_token_ids_head"][0], serde_json::json!(128000));
+        assert_eq!(
+            receipts.prompt_identity["prompt_token_ids_tail"]
+                .as_array()
+                .expect("tail should be an array")
+                .last()
+                .cloned(),
+            Some(serde_json::json!(271))
+        );
+
+        assert_eq!(
+            receipts.stop_contract["template_stop_token_ids"],
+            serde_json::json!([128009, 128001])
+        );
+        assert_eq!(
+            receipts.stop_contract["effective_stop_token_ids"],
+            serde_json::json!([128009, 128001])
+        );
+        assert_eq!(
+            receipts.stop_contract["tokenizer_specials"]["eot_id"],
+            serde_json::json!(128009)
+        );
+        let not_claims =
+            receipts.stop_contract["not_claims"].as_array().expect("not_claims should be an array");
+        assert!(not_claims.contains(&serde_json::json!("tokenizer_template_authority")));
+        assert!(not_claims.contains(&serde_json::json!("semantic_quality")));
+        assert!(not_claims.contains(&serde_json::json!("reference_parity")));
+        Ok(())
     }
 }
 
@@ -2132,18 +2332,12 @@ async fn run_simple_generation(
 
         // Get tokenizer info
         let tokenizer_source_str = tokenizer_source.as_str();
-        let tokenizer_info = serde_json::json!({
-            "type": "sentencepiece",
-            "origin": if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
+        let tokenizer_origin =
+            if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
                 "embedded"
             } else {
                 "external"
-            },
-            "source": tokenizer_source_str,
-            "strict": tokenizer_strict,
-            "bos": tokenizer.bos_token_id().unwrap_or(1),
-            "eos": tokenizer.eos_token_id().unwrap_or(2),
-        });
+            };
 
         // Count info from GGUF metadata
         let (n_kv, n_tensors) = gguf_metadata.unwrap_or((0, 0));
@@ -2177,17 +2371,27 @@ async fn run_simple_generation(
         let proof_model_contract_path =
             proof_model_contract.as_ref().map(|path| path.display().to_string());
         let proof_kernel_route_id = proof_kernel_route.as_deref();
+        let prompt_stop_receipts = build_prompt_stop_receipt_fields(
+            template_type,
+            &formatted_prompt,
+            &prompt_token_ids,
+            &prompt_token_ids_sha256,
+            bos_policy,
+            parse_special,
+            &stop,
+            &stop_id,
+            &all_stop_sequences,
+            &all_stop_ids,
+            tokenizer.as_ref(),
+            tokenizer_origin,
+            tokenizer_source_str,
+            tokenizer_strict,
+        );
         let output = serde_json::json!({
             "prompt": prompt,
             "text": generated_text,
-            "prompt_identity": {
-                "template": template_type.to_string(),
-                "rendered_prompt_sha256": sha256_text(&formatted_prompt),
-                "prompt_token_ids_sha256": prompt_token_ids_sha256,
-                "prompt_token_count": prompt_token_ids.len(),
-                "bos_policy": bos_policy,
-                "parse_special": parse_special,
-            },
+            "prompt_identity": prompt_stop_receipts.prompt_identity,
+            "stop_contract": prompt_stop_receipts.stop_contract,
             "tokens": {
                 "prompt": prompt_tokens_len,
                 "generated": generated_tokens.len(),
@@ -2204,7 +2408,7 @@ async fn run_simple_generation(
                 "decoded_tokens": generated_tokens.len(),
             },
             "counts": counts,
-            "tokenizer": tokenizer_info,
+            "tokenizer": prompt_stop_receipts.tokenizer_info,
             "loader": loader_info,
             "gen_policy": gen_policy,
             "proof_summary": {

--- a/xtask/src/bitnet_reference_plan.rs
+++ b/xtask/src/bitnet_reference_plan.rs
@@ -337,9 +337,9 @@ fn executable_names() -> &'static [&'static str] {
 fn reference_setup_prerequisites() -> Value {
     let git = command_probe("git");
     let cmake = command_probe("cmake");
-    let clang = command_probe("clang");
-    let clangxx = command_probe("clang++");
     let vs_build_tools = visual_studio_build_tools_probe();
+    let clang = reference_compiler_probe("clang", &vs_build_tools);
+    let clangxx = reference_compiler_probe("clang++", &vs_build_tools);
     let windows = cfg!(windows);
 
     let mut missing = Vec::new();
@@ -379,16 +379,92 @@ fn reference_setup_prerequisites() -> Value {
 }
 
 fn command_probe(name: &str) -> Value {
+    command_probe_with_candidates(name, &[])
+}
+
+fn reference_compiler_probe(name: &str, vs_build_tools: &Value) -> Value {
+    let candidates = if cfg!(windows) {
+        windows_clang_candidate_paths(name, vs_build_tools)
+    } else {
+        Vec::new()
+    };
+    command_probe_with_candidates(name, &candidates)
+}
+
+fn command_probe_with_candidates(name: &str, candidates: &[PathBuf]) -> Value {
     match which::which(name) {
         Ok(path) => json!({
             "present": true,
             "path": path_to_string(&path),
+            "source": "path",
         }),
-        Err(_) => json!({
-            "present": false,
-            "path": Value::Null,
-        }),
+        Err(_) => {
+            for path in candidates {
+                if path.is_file() {
+                    return json!({
+                        "present": true,
+                        "path": path_to_string(path),
+                        "source": "known_windows_toolchain_path",
+                    });
+                }
+            }
+            json!({
+                "present": false,
+                "path": Value::Null,
+                "source": Value::Null,
+            })
+        }
     }
+}
+
+fn windows_clang_candidate_paths(name: &str, vs_build_tools: &Value) -> Vec<PathBuf> {
+    let executable = windows_tool_executable_name(name);
+    let mut candidates = Vec::new();
+
+    if let Some(program_files) = std::env::var_os("ProgramFiles") {
+        candidates.push(PathBuf::from(program_files).join("LLVM").join("bin").join(&executable));
+    }
+
+    if let Some(vs_path) = str_at(vs_build_tools, "/path") {
+        push_vs_llvm_candidates(&mut candidates, Path::new(vs_path), &executable);
+    }
+
+    if let Some(program_files_x86) = std::env::var_os("ProgramFiles(x86)") {
+        let build_tools = PathBuf::from(program_files_x86)
+            .join("Microsoft Visual Studio")
+            .join("2022")
+            .join("BuildTools");
+        push_vs_llvm_candidates(&mut candidates, &build_tools, &executable);
+    }
+
+    dedupe_paths(candidates)
+}
+
+fn windows_tool_executable_name(name: &str) -> String {
+    if name.to_ascii_lowercase().ends_with(".exe") {
+        name.to_string()
+    } else {
+        format!("{name}.exe")
+    }
+}
+
+fn push_vs_llvm_candidates(candidates: &mut Vec<PathBuf>, vs_path: &Path, executable: &str) {
+    candidates.push(
+        vs_path.join("VC").join("Tools").join("Llvm").join("x64").join("bin").join(executable),
+    );
+    candidates.push(vs_path.join("VC").join("Tools").join("Llvm").join("bin").join(executable));
+}
+
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for path in paths {
+        let key = path_to_string(&path).to_ascii_lowercase();
+        if seen.insert(key) {
+            deduped.push(path);
+        }
+    }
+    deduped
 }
 
 fn visual_studio_build_tools_probe() -> Value {
@@ -639,5 +715,42 @@ mod tests {
         let report = reference_setup_prerequisites();
         assert!(report.pointer("/ready").and_then(Value::as_bool).is_some());
         assert!(report.pointer("/missing").and_then(Value::as_array).is_some());
+    }
+
+    #[test]
+    fn command_probe_reports_known_candidate_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = dir.path().join(windows_tool_executable_name("definitely-not-on-path"));
+        fs::write(&tool, b"").unwrap();
+
+        let report = command_probe_with_candidates("definitely-not-on-path", &[tool.clone()]);
+
+        assert_eq!(report.pointer("/present").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            report.pointer("/path").and_then(Value::as_str),
+            Some(path_to_string(&tool).as_str())
+        );
+        assert_eq!(
+            report.pointer("/source").and_then(Value::as_str),
+            Some("known_windows_toolchain_path")
+        );
+    }
+
+    #[test]
+    fn windows_clang_candidates_include_vs_llvm_bins() {
+        let vs_build_tools = json!({
+            "present": true,
+            "path": "C:/BuildTools",
+        });
+        let candidates = windows_clang_candidate_paths("clang++", &vs_build_tools);
+        let candidate_strings =
+            candidates.iter().map(|path| path_to_string(path)).collect::<Vec<_>>();
+
+        assert!(
+            candidate_strings.iter().any(|path| path
+                .ends_with("C:/BuildTools\\VC\\Tools\\Llvm\\x64\\bin\\clang++.exe")
+                || path.ends_with("C:/BuildTools/VC/Tools/Llvm/x64/bin/clang++.exe"))
+        );
+        assert_eq!(candidate_strings.iter().collect::<HashSet<_>>().len(), candidate_strings.len());
     }
 }


### PR DESCRIPTION
## Summary
- teach `bitnet-reference-plan` to find Windows Clang/clang++ from known LLVM and Visual Studio Build Tools locations when they are not on PATH
- update `ci/fetch_bitnet_cpp.ps1` to use the same tool discovery and pass concrete compiler paths to CMake
- keep the reference plan diagnostic-only; this does not prove reference execution, Rust/reference parity, A770 semantic quality, selected attention, or residency

## Validation
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_plan.rs`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_plan -- --nocapture`
- `powershell -NoProfile -ExecutionPolicy Bypass -File ci\fetch_bitnet_cpp.ps1 -Help`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-plan --format json --output target\a770-diagnostic\bitnet-reference-plan-after-clang-detection.json`
- `cargo check --locked -p xtask --no-default-features`
- `git diff --check`

## Result
The regenerated local plan now reports Clang and clang++ present from `C:\Program Files\LLVM\bin`; the remaining blocker is `reference_executable_missing`.