### PR TITLE
diag(bitnet): add reference run receipt

### DIFF
--- a/xtask/src/bitnet_reference_plan.rs
+++ b/xtask/src/bitnet_reference_plan.rs
@@ -176,21 +176,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
     }
 
     let reference_argv = selected.map(|candidate| {
-        vec![
-            candidate.path.clone(),
-            "-m".to_string(),
-            model_path.clone(),
-            "--override-kv".to_string(),
-            "tokenizer.ggml.add_bos_token=bool:false".to_string(),
-            "-p".to_string(),
-            rendered_prompt.clone(),
-            "-n".to_string(),
-            args.max_new_tokens.to_string(),
-            "--temp".to_string(),
-            "0".to_string(),
-            "--seed".to_string(),
-            "0".to_string(),
-        ]
+        reference_argv(&candidate.path, &model_path, &rendered_prompt, args.max_new_tokens)
     });
 
     Ok(json!({
@@ -235,7 +221,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
                 })
             }).collect::<Vec<_>>(),
             "command_argv": reference_argv,
-            "command_policy": "uses_rendered_prompt_text_for_template_parity; disables reference auto-BOS because the rendered Llama3 prompt already contains BOS; token parity still must be verified against reference output",
+            "command_policy": "uses_rendered_prompt_text_for_template_parity; disables reference auto-BOS because the rendered Llama3 prompt already contains BOS; suppresses prompt echo so stdout is generated text; token parity still must be verified against reference output",
             "setup_command_pwsh": format!(
                 "powershell -ExecutionPolicy Bypass -File ci\\fetch_bitnet_cpp.ps1 -Tag main -CachePath target\\external\\BitNet-reference -ModelDir \"{}\" -QuantType i2_s -Force -SkipPatches",
                 model_dir.replace('"', "\\\"")
@@ -281,6 +267,30 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
         },
         "not_claims": CRITICAL_NOT_CLAIMS,
     }))
+}
+
+fn reference_argv(
+    executable: &str,
+    model_path: &str,
+    rendered_prompt: &str,
+    max_new_tokens: usize,
+) -> Vec<String> {
+    vec![
+        executable.to_string(),
+        "-m".to_string(),
+        model_path.to_string(),
+        "--override-kv".to_string(),
+        "tokenizer.ggml.add_bos_token=bool:false".to_string(),
+        "-p".to_string(),
+        rendered_prompt.to_string(),
+        "-n".to_string(),
+        max_new_tokens.to_string(),
+        "--temp".to_string(),
+        "0".to_string(),
+        "--seed".to_string(),
+        "0".to_string(),
+        "--no-display-prompt".to_string(),
+    ]
 }
 
 #[derive(Debug)]
@@ -768,5 +778,17 @@ mod tests {
                 || path.ends_with("C:/BuildTools/VC/Tools/Llvm/x64/bin/clang++.exe"))
         );
         assert_eq!(candidate_strings.iter().collect::<HashSet<_>>().len(), candidate_strings.len());
+    }
+
+    #[test]
+    fn reference_argv_disables_auto_bos_and_prompt_echo() {
+        let argv = reference_argv("llama-cli", "model.gguf", "<|begin_of_text|>prompt", 16);
+
+        assert!(
+            argv.windows(2).any(|args| {
+                args == ["--override-kv", "tokenizer.ggml.add_bos_token=bool:false"]
+            })
+        );
+        assert!(argv.iter().any(|arg| arg == "--no-display-prompt"));
     }
 }

--- a/xtask/src/bitnet_reference_run.rs
+++ b/xtask/src/bitnet_reference_run.rs
@@ -1,0 +1,335 @@
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+    "reference_generated_token_ids",
+    "reference_top_logits",
+    "rust_reference_parity_proven",
+    "a770_semantic_quality_proven",
+];
+
+#[derive(Debug)]
+struct ReferenceRunArgs {
+    plan: PathBuf,
+    output: Option<PathBuf>,
+    format: String,
+}
+
+#[derive(Debug)]
+struct CommandCapture {
+    status_code: Option<i32>,
+    success: bool,
+    stdout: String,
+    stderr: String,
+    elapsed_ms: f64,
+}
+
+pub fn maybe_dispatch_from_env() -> Result<bool> {
+    let args = std::env::args().collect::<Vec<_>>();
+    maybe_dispatch(&args)
+}
+
+fn maybe_dispatch(args: &[String]) -> Result<bool> {
+    if args.get(1).map(String::as_str) != Some("bitnet-reference-run") {
+        return Ok(false);
+    }
+    if args[2..].iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_help();
+        return Ok(true);
+    }
+    let opts = parse_args(args)?;
+    let report = run_reference(&opts)?;
+    if let Some(output) = &opts.output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(output, serde_json::to_vec_pretty(&report)?)
+            .with_context(|| format!("writing {}", output.display()))?;
+    }
+    emit_report(&report, &opts.format)?;
+    Ok(true)
+}
+
+fn print_help() {
+    println!(
+        "Run the BitNet C++ reference command from a plan and emit a diagnostic receipt\n\nUsage: xtask.exe bitnet-reference-run [OPTIONS]\n\nOptions:\n      --plan <PATH>       Reference plan JSON [default: target/a770-diagnostic/bitnet-reference-plan.json]\n      --output <PATH>     Output reference run JSON [default: target/a770-diagnostic/bitnet-reference-run.json]\n      --format <FORMAT>   Output format: human or json [default: human]\n  -h, --help              Print help"
+    );
+}
+
+fn parse_args(args: &[String]) -> Result<ReferenceRunArgs> {
+    let mut plan = PathBuf::from("target/a770-diagnostic/bitnet-reference-plan.json");
+    let mut output = Some(PathBuf::from("target/a770-diagnostic/bitnet-reference-run.json"));
+    let mut format = "human".to_string();
+    let mut i = 2usize;
+    while i < args.len() {
+        let key = args[i].as_str();
+        i += 1;
+        let mut value = || -> Result<String> {
+            let value = args.get(i).with_context(|| format!("{key} requires a value"))?.clone();
+            i += 1;
+            Ok(value)
+        };
+        match key {
+            "--plan" => plan = PathBuf::from(value()?),
+            "--output" => output = Some(PathBuf::from(value()?)),
+            "--format" => format = value()?,
+            other => bail!("unknown bitnet-reference-run option {other}"),
+        }
+    }
+    Ok(ReferenceRunArgs { plan, output, format })
+}
+
+fn run_reference(args: &ReferenceRunArgs) -> Result<Value> {
+    let plan = read_json(&args.plan)?;
+    let argv = reference_argv(&plan)?;
+    let capture = run_command(&argv)?;
+    Ok(build_receipt(&args.plan, &plan, &argv, &capture))
+}
+
+fn reference_argv(plan: &Value) -> Result<Vec<String>> {
+    let argv = plan
+        .pointer("/reference/command_argv")
+        .and_then(Value::as_array)
+        .context("plan missing /reference/command_argv")?
+        .iter()
+        .map(|item| {
+            item.as_str().map(ToOwned::to_owned).context("command_argv item is not a string")
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if argv.is_empty() {
+        bail!("plan reference command_argv is empty");
+    }
+    if !argv.iter().any(|arg| arg == "--no-display-prompt") {
+        bail!(
+            "reference command must include --no-display-prompt before it can produce a clean text receipt"
+        );
+    }
+    Ok(argv)
+}
+
+fn run_command(argv: &[String]) -> Result<CommandCapture> {
+    let executable = argv.first().context("empty reference command")?;
+    let start = Instant::now();
+    let output = Command::new(executable)
+        .args(&argv[1..])
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("running reference executable {executable}"))?;
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    Ok(CommandCapture {
+        status_code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        elapsed_ms,
+    })
+}
+
+fn build_receipt(
+    plan_path: &Path,
+    plan: &Value,
+    argv: &[String],
+    capture: &CommandCapture,
+) -> Value {
+    let generated_text = generated_text_from_stdout(&capture.stdout);
+    let stderr_contains_double_bos_warning =
+        capture.stderr.contains("final prompt starts with 2 BOS tokens");
+    let stderr_contains_auto_bos_override =
+        capture.stderr.contains("tokenizer.ggml.add_bos_token") && capture.stderr.contains("false");
+    let mut blocked_reasons = Vec::new();
+    if !capture.success {
+        blocked_reasons.push("reference_command_failed".to_string());
+    }
+    if generated_text.is_empty() {
+        blocked_reasons.push("reference_generated_text_missing".to_string());
+    }
+    if stderr_contains_double_bos_warning {
+        blocked_reasons.push("reference_double_bos_warning_present".to_string());
+    }
+    let generated_text_present = !generated_text.is_empty();
+
+    json!({
+        "schema_version": 1,
+        "receipt_type": "bitnet_reference_run",
+        "diagnostic": "bitnet_reference_run",
+        "producer": "cargo xtask bitnet-reference-run",
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "diagnostic_only": true,
+        "promotion_allowed": false,
+        "claim_allowed": false,
+        "classification": "diagnostic_only",
+        "plan": {
+            "path": plan_path.display().to_string(),
+            "diagnostic": str_at(plan, "/diagnostic").unwrap_or(""),
+            "prompt_identity": plan.pointer("/prompt_identity").cloned().unwrap_or(Value::Null),
+            "model": plan.pointer("/model").cloned().unwrap_or(Value::Null),
+            "command_policy": str_at(plan, "/reference/command_policy").unwrap_or(""),
+        },
+        "reference": {
+            "backend": str_at(plan, "/reference/backend").unwrap_or("bitnet.cpp_or_llama.cpp_cli"),
+            "selected_executable": str_at(plan, "/reference/selected_executable").unwrap_or(""),
+            "command_argv": argv,
+            "command_argv_sha256": sha256_json(argv),
+            "stderr_contains_auto_bos_override": stderr_contains_auto_bos_override,
+            "stderr_contains_double_bos_warning": stderr_contains_double_bos_warning,
+        },
+        "execution": {
+            "success": capture.success,
+            "exit_code": capture.status_code,
+            "elapsed_ms": capture.elapsed_ms,
+            "stdout_bytes": capture.stdout.len(),
+            "stderr_bytes": capture.stderr.len(),
+            "stdout_sha256": sha256_text(&capture.stdout),
+            "stderr_sha256": sha256_text(&capture.stderr),
+            "stderr_tail": stderr_tail(&capture.stderr, 24),
+        },
+        "text": generated_text.clone(),
+        "generated_text": generated_text,
+        "signals": {
+            "generated_text_present": generated_text_present,
+            "actual_generated_token_ids_present": false,
+            "top_logits_present": false,
+            "policy": "reference CLI stdout is captured as generated text only; generated token ids and top logits are not inferred from text",
+        },
+        "decision": {
+            "reference_execution_ready": blocked_reasons.is_empty(),
+            "current_blocked_reasons": blocked_reasons,
+            "next_when_ready": "compare reference text against Rust CPU and strict A770 receipts; use a deeper reference hook before token/logit parity claims",
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    })
+}
+
+fn generated_text_from_stdout(stdout: &str) -> String {
+    stdout.trim().to_string()
+}
+
+fn stderr_tail(stderr: &str, max_lines: usize) -> Vec<String> {
+    let lines = stderr.lines().map(ToOwned::to_owned).collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].to_vec()
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn sha256_json<T: serde::Serialize + ?Sized>(value: &T) -> String {
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    sha256_bytes(&bytes)
+}
+
+fn sha256_text(value: &str) -> String {
+    sha256_bytes(value.as_bytes())
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
+fn emit_report(value: &Value, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(value)?),
+        "human" => {
+            println!("diagnostic: bitnet_reference_run");
+            println!(
+                "classification: {}",
+                value
+                    .pointer("/classification")
+                    .and_then(Value::as_str)
+                    .unwrap_or("diagnostic_only")
+            );
+            println!(
+                "reference_execution_ready: {}",
+                value
+                    .pointer("/decision/reference_execution_ready")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            );
+            if let Some(text) = value.pointer("/generated_text").and_then(Value::as_str) {
+                println!("generated_text: {text}");
+            }
+            if let Some(reasons) = value.pointer("/decision/current_blocked_reasons") {
+                println!("blocked_reasons: {}", serde_json::to_string(reasons)?);
+            }
+            println!("not_claims: {}", serde_json::to_string(&value["not_claims"])?);
+        }
+        other => bail!("unsupported bitnet-reference-run output format: {other}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_text_trims_reference_stdout() {
+        assert_eq!(
+            generated_text_from_stdout("\n2+2 equals 4. [end of text]\r\n\n"),
+            "2+2 equals 4. [end of text]"
+        );
+    }
+
+    #[test]
+    fn reference_receipt_is_text_only_and_non_promoting() {
+        let plan = json!({
+            "diagnostic": "bitnet_reference_plan",
+            "prompt_identity": {"prompt_token_count": 17},
+            "model": {"model_id": "test"},
+            "reference": {
+                "backend": "bitnet.cpp_or_llama.cpp_cli",
+                "selected_executable": "llama-cli",
+                "command_policy": "test"
+            }
+        });
+        let capture = CommandCapture {
+            status_code: Some(0),
+            success: true,
+            stdout: "2+2 equals 4. [end of text]\n".to_string(),
+            stderr: "validate_override: Using metadata override ( bool) 'tokenizer.ggml.add_bos_token' = false\n".to_string(),
+            elapsed_ms: 10.0,
+        };
+        let receipt =
+            build_receipt(Path::new("plan.json"), &plan, &["llama-cli".to_string()], &capture);
+        assert_eq!(receipt["claim_allowed"], false);
+        assert_eq!(receipt["decision"]["reference_execution_ready"], true);
+        assert_eq!(receipt["signals"]["actual_generated_token_ids_present"], false);
+        assert_eq!(receipt["signals"]["top_logits_present"], false);
+        let not_claims = receipt["not_claims"].as_array().unwrap();
+        assert!(not_claims.contains(&json!("reference_generated_token_ids")));
+        assert!(not_claims.contains(&json!("reference_top_logits")));
+        assert!(not_claims.contains(&json!("rust_reference_parity_proven")));
+    }
+
+    #[test]
+    fn reference_argv_requires_prompt_echo_suppression() {
+        let plan = json!({
+            "reference": {
+                "command_argv": ["llama-cli", "-m", "model.gguf"]
+            }
+        });
+        let error = reference_argv(&plan).unwrap_err().to_string();
+        assert!(error.contains("--no-display-prompt"));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,6 +39,7 @@ use walkdir::WalkDir;
 mod bench_receipt;
 mod bitnet_reference_compare;
 mod bitnet_reference_plan;
+mod bitnet_reference_run;
 mod campaign;
 mod claims;
 mod cpp_setup_auto;
@@ -1329,6 +1330,9 @@ fn real_main() -> Result<()> {
         return Ok(());
     }
     if bitnet_reference_plan::maybe_dispatch_from_env()? {
+        return Ok(());
+    }
+    if bitnet_reference_run::maybe_dispatch_from_env()? {
         return Ok(());
     }
     if llm_experience::maybe_dispatch_from_env()? {


### PR DESCRIPTION
## Summary
- add `cargo xtask bitnet-reference-run` to execute the reference command emitted by `bitnet-reference-plan`
- update the plan command to disable reference auto-BOS and suppress prompt echo so stdout is generated text
- emit a diagnostic-only reference run receipt with stdout/stderr hashes, generated text, execution status, and critical not-claims

## Claim Boundary
- diagnostic only
- no selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, completion, reference parity, or A770 semantic quality promotion
- generated token IDs and top logits are explicitly not claimed because the reference CLI does not emit them

## Validation
- `cargo check --locked -p xtask --no-default-features`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-plan --format json --output target\a770-diagnostic\bitnet-reference-plan-for-run.json`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-run --plan target\a770-diagnostic\bitnet-reference-plan-for-run.json --output target\a770-diagnostic\bitnet-reference-run.json --format json`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-compare --reference target\a770-diagnostic\bitnet-reference-run.json --cpu target\a770-diagnostic\reference-plan-cpu.json --a770 target\a770-diagnostic\reference-plan-a770.json --output target\a770-diagnostic\bitnet-reference-compare-text-only.json --format json`
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_plan.rs xtask\src\bitnet_reference_run.rs xtask\src\main.rs`
- `git diff --check`