### PR TITLE
feat(slm): carry Qwen no-think into answer corpus

### DIFF
--- a/ci/quality/slm-answer-corpus.yaml
+++ b/ci/quality/slm-answer-corpus.yaml
@@ -11,6 +11,7 @@ model:
   quant_format: Q8_0
 defaults:
   prompt_template: qwen
+  qwen_no_think: true
   max_new_tokens: 8
   greedy: true
   deterministic: true
@@ -46,7 +47,7 @@ cases:
 
   - id: say_ok
     question: "Say exactly: OK"
-    max_new_tokens: 4
+    max_new_tokens: 1
     gate:
       kind: exact_trimmed
       expected: "OK"

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-answer-corpus-say-ok.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-answer-corpus-say-ok.json
@@ -1,0 +1,402 @@
+{
+  "artifact_kind": "slm_cpu_answer_corpus",
+  "backend": {
+    "fallback_used": false,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust"
+  },
+  "backend_lane": "dense_slm_cpu",
+  "cases": [
+    {
+      "answer": "OK",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "say_ok",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 10280,
+        "decode_first_ms": 10280,
+        "total_ms": 10281
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 3925,
+          "logits_vector_length": 151936,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 24.454410552978516,
+              "token_id": 3925
+            },
+            {
+              "logit": 22.050979614257812,
+              "token_id": 9454
+            },
+            {
+              "logit": 22.04498291015625,
+              "token_id": 32313
+            },
+            {
+              "logit": 20.461334228515625,
+              "token_id": 1
+            },
+            {
+              "logit": 19.988340377807617,
+              "token_id": 2124
+            },
+            {
+              "logit": 19.301259994506836,
+              "token_id": 39814
+            },
+            {
+              "logit": 19.291507720947266,
+              "token_id": 71486
+            },
+            {
+              "logit": 19.132837295532227,
+              "token_id": 334
+            },
+            {
+              "logit": 18.406352996826172,
+              "token_id": 2610
+            },
+            {
+              "logit": 18.214012145996097,
+              "token_id": 40
+            }
+          ]
+        }
+      ],
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": 151936,
+        "observed_logits_vector_length": 151936,
+        "observed_logits_vector_length_source": "run_receipt_logits_dump"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 27
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "3fca40d20860c2d088882adb69a4487b324eb24b6231eca8d527e3ae4335935c",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nSay exactly: OK<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 27,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 27,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 1,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "exact_trimmed",
+        "generated_tokens": 1,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "Say exactly: OK",
+      "run_receipt_path": "target/slm-cpu\\qwen3-answer-corpus-say-ok-runs\\say_ok.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 1,
+        "tokens_per_second": 0.09726680284019064
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": null,
+        "decode_total_ms": 619.93,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 619.93,
+        "first_token_ms": 10280,
+        "host_to_device_bytes": null,
+        "model_load_ms": 34494.096,
+        "prefill_ms": 9658.373,
+        "sampling_ms_per_token": 4.697,
+        "tokenize_ms": 1529.074,
+        "tokenizer_load_ms": 614.22
+      },
+      "token_ids": {
+        "generated": [
+          3925
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          45764,
+          6896,
+          25,
+          10402,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 1,
+        "generated_ids": [
+          3925
+        ],
+        "ids": [
+          3925
+        ],
+        "prompt": 27,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          45764,
+          6896,
+          25,
+          10402,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 28
+      }
+    }
+  ],
+  "claim_boundary": {
+    "answer_ready_artifact_available": false,
+    "backend_quality_gate_passed": true,
+    "bounded_slm_answer_smoke_passed": true,
+    "broad_performance_claimed": false,
+    "coherent_answer_claimed": false,
+    "coherent_output_observed": false,
+    "cuda_answer_corpus": false,
+    "dense_slm_clean_provenance": true,
+    "diagnostic_only_until_answer_ready_artifact": false,
+    "full_metal_inference_claimed": false,
+    "local_answer_path": false,
+    "neural_engine_claimed": false,
+    "qk256_apple_claimed": false,
+    "slm_answer_path": true,
+    "strict_cuda_answer_claimed": false
+  },
+  "corpus": {
+    "case_count": 5,
+    "description": "Tiny deterministic Qwen3 dense SLM answer-readiness corpus for strict CPU receipts.",
+    "name": "qwen3-0-6b-strict-slm-answer-corpus-v1",
+    "path": "ci/quality/slm-answer-corpus.yaml",
+    "selected_case_count": 1,
+    "selected_case_ids": [
+      "say_ok"
+    ]
+  },
+  "execution_plan": null,
+  "fallback_used": false,
+  "generation": {
+    "default_max_new_tokens": 8,
+    "deterministic": true,
+    "logits_dump_steps": 1,
+    "logits_topk": 10,
+    "mode": "greedy",
+    "per_prompt_timeout_seconds": 420,
+    "requested_cpu_kernel": null,
+    "strict_loader": true,
+    "temperature": 0.0
+  },
+  "model": {
+    "answer_ready": null,
+    "answer_ready_artifact_available": false,
+    "architecture": "qwen3",
+    "bytes": null,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "id": null,
+    "loader_mode": "real_gguf",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "revision": null,
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tokenizer": "gguf_metadata",
+    "tokenizer_authority": null,
+    "tokenizer_path": null
+  },
+  "model_architecture": "qwen3",
+  "model_family": "qwen",
+  "prompt_template": "qwen",
+  "prompt_template_policy": {
+    "family": "qwen"
+  },
+  "quality_summary": {
+    "failed": 0,
+    "not_run": 0,
+    "passed": 1,
+    "timeout": 0,
+    "total": 1
+  },
+  "quantization": "Q8_0",
+  "receipt_quality": {
+    "case_receipt_checker": "answer_receipt_failed_rules",
+    "checked": true,
+    "checked_rules": [
+      "generated_text_recorded",
+      "prompt_token_count_recorded",
+      "generated_token_count_recorded",
+      "total_token_count_recorded",
+      "prompt_token_ids_recorded",
+      "generated_token_ids_recorded",
+      "prompt_token_count_matches_ids",
+      "generated_token_count_matches_ids",
+      "total_token_count_matches",
+      "model_repo_recorded",
+      "model_file_recorded",
+      "model_sha256_recorded",
+      "model_family_recorded",
+      "model_architecture_recorded",
+      "tokenizer_source_recorded",
+      "tokenizer_strict",
+      "tokenizer_pretokenizer_authority_recorded",
+      "requested_backend",
+      "selected_backend",
+      "runtime_api",
+      "fallback_false",
+      "speedup_claim_false",
+      "loader_real_gguf",
+      "selected_kernel_recorded",
+      "selected_kernel_production",
+      "timing_model_load_ms_recorded",
+      "timing_tokenizer_load_ms_recorded",
+      "timing_tokenize_ms_recorded",
+      "timing_prefill_ms_recorded",
+      "timing_first_token_ms_recorded",
+      "timing_decode_total_ms_recorded",
+      "latency_total_ms_recorded"
+    ],
+    "required_case_fields": [
+      "text",
+      "tokens.prompt",
+      "tokens.generated",
+      "tokens.total",
+      "tokens.prompt_ids",
+      "tokens.generated_ids",
+      "model.repo",
+      "model.file",
+      "model.sha256",
+      "model.family",
+      "model.architecture",
+      "tokenizer.source",
+      "tokenizer.strict",
+      "tokenizer.pretokenizer_authority",
+      "requested_backend",
+      "selected_backend",
+      "runtime_api",
+      "fallback_used",
+      "loader.mode",
+      "kernel.kernel_id",
+      "timing.model_load_ms",
+      "timing.tokenizer_load_ms",
+      "timing.tokenize_ms",
+      "timing.prefill_ms",
+      "timing.first_token_ms",
+      "timing.decode_total_ms",
+      "latency.total_ms"
+    ]
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "scoring_summary": {
+    "enabled": false,
+    "failed": 0,
+    "failure_taxonomy": {},
+    "kinds": [],
+    "not_run": 0,
+    "passed": 0,
+    "total": 0
+  },
+  "selected_backend": "cpu-rust",
+  "selected_kernel_or_runtime": "dense-qwen-cpu-reference",
+  "speedup_claim": false,
+  "timestamp": "2026-05-15T03:16:59.574610900+00:00",
+  "tokenizer": {
+    "authority": null,
+    "path": null,
+    "source": "gguf_metadata",
+    "strict": true
+  },
+  "tokenizer_source": "gguf_metadata"
+}

--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -494,6 +494,9 @@ impl AnswerCorpusCommand {
         if corpus.defaults.deterministic {
             args.push("--deterministic".into());
         }
+        if corpus.defaults.qwen_no_think {
+            args.push("--no-think".into());
+        }
         if corpus.defaults.strict_loader {
             args.push("--strict-loader".into());
             args.push("--strict-tokenizer".into());
@@ -589,6 +592,7 @@ impl AnswerCorpusCommand {
                     .unwrap_or_else(|| run_receipt["prompt"].clone()),
                 "rendered_sha256": run_receipt["prompt_render"]["rendered_sha256"].clone(),
                 "template_family": corpus.defaults.prompt_template,
+                "qwen_no_think": corpus.defaults.qwen_no_think,
                 "add_bos": run_receipt["prompt_render"]["add_bos"]
                     .as_bool()
                     .map(Value::from)
@@ -819,6 +823,8 @@ struct CorpusTokenizerAuthority {
 #[derive(Debug, Deserialize)]
 struct CorpusDefaults {
     prompt_template: String,
+    #[serde(default)]
+    qwen_no_think: bool,
     max_new_tokens: usize,
     greedy: bool,
     deterministic: bool,
@@ -2397,6 +2403,70 @@ mod tests {
         assert_eq!(effective_default_timeout_seconds(None, Some(120)), 120);
         assert_eq!(effective_default_timeout_seconds(None, None), 300);
         assert_eq!(effective_default_timeout_seconds(Some(0), Some(300)), 1);
+    }
+
+    #[test]
+    fn qwen_no_think_defaults_to_false_and_can_be_set() {
+        let corpus = serde_yaml::from_str::<AnswerCorpus>(
+            r#"
+schema: 1
+artifact_kind: slm_answer_corpus
+name: qwen-no-think-fixture
+description: qwen no-thinking fixture
+model:
+  repo: Qwen/Qwen3-0.6B-GGUF
+  file: Qwen3-0.6B-Q8_0.gguf
+  sha256: 9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031
+  family: qwen
+defaults:
+  prompt_template: qwen
+  qwen_no_think: true
+  max_new_tokens: 1
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+cases:
+  - id: say_ok
+    question: "Say exactly: OK"
+    gate:
+      kind: exact_trimmed
+      expected: "OK"
+"#,
+        );
+        assert!(corpus.is_ok());
+        let Some(corpus) = corpus.ok() else { return };
+        assert!(corpus.defaults.qwen_no_think);
+
+        let corpus = serde_yaml::from_str::<AnswerCorpus>(
+            r#"
+schema: 1
+artifact_kind: slm_answer_corpus
+name: qwen-default-fixture
+description: qwen default fixture
+model:
+  repo: Qwen/Qwen3-0.6B-GGUF
+  file: Qwen3-0.6B-Q8_0.gguf
+  sha256: 9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031
+  family: qwen
+defaults:
+  prompt_template: qwen
+  max_new_tokens: 1
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+cases:
+  - id: say_ok
+    question: "Say exactly: OK"
+    gate:
+      kind: exact_trimmed
+      expected: "OK"
+"#,
+        );
+        assert!(corpus.is_ok());
+        let Some(corpus) = corpus.ok() else { return };
+        assert!(!corpus.defaults.qwen_no_think);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a `qwen_no_think` corpus default and pass it through to child `bitnet run` invocations as `--no-think`
- record the no-thinking prompt policy in per-case corpus receipts
- constrain the `say_ok` SLM corpus case to one generated token and add the passing 8250U strict CPU receipt artifact

## Claim boundary
This is an SLM-CPU-009 support slice only. It proves the corpus runner can reproduce the bounded Qwen3 no-thinking `say_ok` pass with strict GGUF tokenizer provenance and `fallback_used=false`; it does not close the full tiny corpus, claim broad answer quality, throughput, warm-session behavior, Q4/Q5 support, server/GPU/NPU/OpenVINO/UHD 620 execution, Qwen3.5 support, or BitNet QK256 changes.

## Validation
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli qwen_no_think_defaults_to_false_and_can_be_set`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-corpus --corpus ci/quality/slm-answer-corpus.yaml --model models/slm/Qwen3-0.6B-Q8_0.gguf --device cpu --case-id say_ok --dump-logit-steps 1 --json-out target/slm-cpu/qwen3-answer-corpus-say-ok.json`
- `git diff --check`