### PR TITLE
fix(bitnet): use GGUF BPE tokenizer for reference prompts

### DIFF
--- a/crates/bitnet-tokenizers/src/gguf_loader.rs
+++ b/crates/bitnet-tokenizers/src/gguf_loader.rs
@@ -262,7 +262,8 @@ impl RustTokenizer {
     ) -> Result<(tokenizers::Tokenizer, ahash::AHashMap<String, u32>, usize)> {
         use ahash::AHashMap;
         use tokenizers::{
-            decoders::byte_level::ByteLevel, models::bpe::BPE, pre_tokenizers::byte_level,
+            AddedToken, decoders::byte_level::ByteLevel, models::bpe::BPE,
+            pre_tokenizers::byte_level,
         };
 
         // Load vocabulary array from metadata
@@ -278,6 +279,11 @@ impl RustTokenizer {
         // Build GGUF piece-to-ID mapping (authoritative token IDs from model)
         let piece_to_gguf_id: AHashMap<String, u32> =
             vocab_strings.iter().enumerate().map(|(i, tok)| (tok.clone(), i as u32)).collect();
+        let special_tokens = vocab_strings
+            .iter()
+            .filter(|tok| is_gguf_control_token(tok))
+            .map(|tok| AddedToken::from(tok.clone(), true).normalized(false))
+            .collect::<Vec<_>>();
 
         // Convert to AHashMap<String, u32> for HuggingFace BPE builder
         // NOTE: HuggingFace will assign its own IDs, we'll remap them in encode()
@@ -319,19 +325,21 @@ impl RustTokenizer {
             .context("BPE tokenizer construction failed - vocab or merges may be invalid")?;
 
         // Create tokenizer with ByteLevel pre-tokenizer and decoder (GPT-2 style)
-        // NOTE: add_prefix_space=true ensures first token is treated like subsequent tokens
-        // (llama.cpp GPT-2 behavior: pretend there is a space before the first token)
-        //
-        // CRITICAL: Both pre-tokenizer AND decoder need add_prefix_space(true) to match llama.cpp
+        // GGUF BPE vocabularies already carry explicit leading-space pieces (for example
+        // `ĠWhat`). Do not synthesize a prefix space; llama.cpp's default GGUF path maps
+        // initial text like `What` to the non-prefixed `What` token.
         let mut tokenizer = tokenizers::Tokenizer::new(bpe);
         tokenizer.with_pre_tokenizer(Some(
-            byte_level::ByteLevel::default().add_prefix_space(true).trim_offsets(false), // Preserve byte offsets for accurate decoding
+            byte_level::ByteLevel::default().add_prefix_space(false).trim_offsets(false), // Preserve byte offsets for accurate decoding
         ));
         tokenizer.with_decoder(Some(
             ByteLevel::default()
-                .add_prefix_space(true) // Match pre-tokenizer configuration
+                .add_prefix_space(false) // Match pre-tokenizer configuration
                 .trim_offsets(false),
         ));
+        if !special_tokens.is_empty() {
+            tokenizer.add_special_tokens(&special_tokens);
+        }
 
         Ok((tokenizer, piece_to_gguf_id, real_vocab_size))
     }
@@ -510,6 +518,11 @@ impl RustTokenizer {
     pub fn add_bos_hint(&self) -> Option<bool> {
         self.add_bos_hint
     }
+}
+
+fn is_gguf_control_token(token: &str) -> bool {
+    (token.starts_with("<|") && token.ends_with("|>"))
+        || (token.starts_with('<') && token.ends_with('>') && !token.contains(' '))
 }
 
 // Implement the Tokenizer trait for RustTokenizer

--- a/crates/bitnet-tokenizers/src/loader.rs
+++ b/crates/bitnet-tokenizers/src/loader.rs
@@ -129,6 +129,12 @@ pub fn load_tokenizer_from_gguf(
 pub fn load_tokenizer_from_gguf_reader(
     reader: &bitnet_models::GgufReader,
 ) -> Result<Arc<dyn Tokenizer + Send + Sync>> {
+    if reader.get_string_metadata("tokenizer.ggml.model").is_some() {
+        let tokenizer = crate::gguf_loader::RustTokenizer::from_gguf(reader)
+            .context("Failed to load GGUF tokenizer metadata")?;
+        return Ok(Arc::new(tokenizer));
+    }
+
     if let Some(bytes) = reader.get_bin_or_u8_array("tokenizer.ggml.model") {
         let bos = reader.get_u32_metadata("tokenizer.ggml.bos_token_id");
         let eos = reader.get_u32_metadata("tokenizer.ggml.eos_token_id");
@@ -136,4 +142,102 @@ pub fn load_tokenizer_from_gguf_reader(
     }
 
     Err(anyhow::anyhow!("GGUF missing tokenizer.ggml.model"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitnet_models::GgufReader;
+
+    fn write_string(buf: &mut Vec<u8>, value: &str) {
+        buf.extend(&(value.len() as u64).to_le_bytes());
+        buf.extend(value.as_bytes());
+    }
+
+    fn write_string_kv(buf: &mut Vec<u8>, key: &str, value: &str) {
+        write_string(buf, key);
+        buf.extend(&8u32.to_le_bytes());
+        write_string(buf, value);
+    }
+
+    fn write_u32_kv(buf: &mut Vec<u8>, key: &str, value: u32) {
+        write_string(buf, key);
+        buf.extend(&4u32.to_le_bytes());
+        buf.extend(&value.to_le_bytes());
+    }
+
+    fn write_string_array_kv(buf: &mut Vec<u8>, key: &str, values: &[&str]) {
+        write_string(buf, key);
+        buf.extend(&9u32.to_le_bytes());
+        buf.extend(&8u32.to_le_bytes());
+        buf.extend(&(values.len() as u64).to_le_bytes());
+        for value in values {
+            write_string(buf, value);
+        }
+    }
+
+    fn minimal_bpe_gguf() -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend(&3u32.to_le_bytes());
+        buf.extend(&0u64.to_le_bytes());
+        buf.extend(&6u64.to_le_bytes());
+        buf.extend(&32u32.to_le_bytes());
+        buf.extend(&0u64.to_le_bytes());
+
+        write_string_kv(&mut buf, "tokenizer.ggml.model", "gpt2");
+        write_string_array_kv(
+            &mut buf,
+            "tokenizer.ggml.tokens",
+            &["a", "b", "ab", "<|eot_id|>", "\u{0120}", "\u{0120}a"],
+        );
+        write_string_array_kv(&mut buf, "tokenizer.ggml.merges", &["a b", "\u{0120} a"]);
+        write_u32_kv(&mut buf, "tokenizer.ggml.bos_token_id", 0);
+        write_u32_kv(&mut buf, "tokenizer.ggml.eos_token_id", 1);
+        write_u32_kv(&mut buf, "tokenizer.ggml.eot_token_id", 3);
+
+        let data_offset = buf.len().div_ceil(32) * 32;
+        buf.resize(data_offset, 0);
+        buf[28..36].copy_from_slice(&(data_offset as u64).to_le_bytes());
+        buf
+    }
+
+    #[test]
+    fn gguf_reader_loader_accepts_string_model_bpe_metadata() {
+        let bytes = minimal_bpe_gguf();
+        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let tokenizer = load_tokenizer_from_gguf_reader(&reader)
+            .expect("GGUF BPE tokenizer metadata should load");
+
+        assert_eq!(tokenizer.vocab_size(), 6);
+        assert_eq!(tokenizer.bos_token_id(), Some(0));
+        assert_eq!(tokenizer.eos_token_id(), Some(1));
+    }
+
+    #[test]
+    fn gguf_reader_loader_parses_bpe_special_tokens_when_enabled() {
+        let bytes = minimal_bpe_gguf();
+        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let tokenizer = load_tokenizer_from_gguf_reader(&reader)
+            .expect("GGUF BPE tokenizer metadata should load");
+
+        let ids = tokenizer
+            .encode("<|eot_id|>", false, true)
+            .expect("parse_special should encode known GGUF special token");
+
+        assert_eq!(ids, vec![3]);
+        assert_eq!(tokenizer.token_to_id("<|eot_id|>"), Some(3));
+    }
+
+    #[test]
+    fn gguf_reader_loader_does_not_synthesize_prefix_space() {
+        let bytes = minimal_bpe_gguf();
+        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let tokenizer = load_tokenizer_from_gguf_reader(&reader)
+            .expect("GGUF BPE tokenizer metadata should load");
+
+        let ids = tokenizer.encode("a", false, false).expect("a should encode");
+
+        assert_eq!(ids, vec![0]);
+    }
 }

--- a/xtask/src/bitnet_reference_plan.rs
+++ b/xtask/src/bitnet_reference_plan.rs
@@ -25,6 +25,14 @@ const DEFAULT_REFERENCE_RUN_RECEIPT: &str = "target/a770-diagnostic/bitnet-refer
 const REFERENCE_TEXT_END_MARKER: &str = " [end of text]";
 const REFERENCE_TEXT_PROBE_TOKEN_LIMIT: usize = 32;
 
+struct PlanTokenizer {
+    tokenizer: std::sync::Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>,
+    source: String,
+    path: Option<String>,
+    contract_path: Option<String>,
+    rust_cli_tokenizer_arg: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct ReferencePlanArgs<'a> {
     pub model_contract: &'a Path,
@@ -144,13 +152,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
         .map(path_to_string)
         .or_else(|| str_at(&contract, "/local_path").map(ToOwned::to_owned))
         .context("model path missing; pass --model or set /local_path in the model contract")?;
-    let tokenizer_path = args
-        .tokenizer
-        .map(path_to_string)
-        .or_else(|| str_at(&contract, "/tokenizer/path").map(ToOwned::to_owned))
-        .context(
-            "tokenizer path missing; pass --tokenizer or set /tokenizer/path in the model contract",
-        )?;
+    let plan_tokenizer = resolve_plan_tokenizer(&model_path, args.tokenizer, &contract)?;
     let model_dir =
         Path::new(&model_path).parent().map(path_to_string).unwrap_or_else(|| ".".to_string());
     let template = args
@@ -160,13 +162,15 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
     let rendered_prompt = template.apply(args.prompt, args.system_prompt);
     let add_bos = template.should_add_bos();
     let parse_special = template.parse_special();
-    let tokenizer = bitnet_tokenizers::load_tokenizer(Path::new(&tokenizer_path))
-        .with_context(|| format!("loading tokenizer {tokenizer_path}"))?;
-    let token_ids = tokenizer
+    let token_ids = plan_tokenizer
+        .tokenizer
         .encode(&rendered_prompt, add_bos, parse_special)
         .with_context(|| "tokenizing rendered prompt with contract tokenizer")?;
-    let reference_text_probe =
-        reference_text_probe(args.reference_text, args.reference_run_receipt, tokenizer.as_ref())?;
+    let reference_text_probe = reference_text_probe(
+        args.reference_text,
+        args.reference_run_receipt,
+        plan_tokenizer.tokenizer.as_ref(),
+    )?;
 
     let candidates = reference_candidates(args.reference_exe, args.cpp_root);
     let selected = candidates.iter().find(|candidate| candidate.exists);
@@ -184,7 +188,9 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
     if !Path::new(&model_path).exists() {
         blocked_reasons.push("model_file_missing".to_string());
     }
-    if !Path::new(&tokenizer_path).exists() {
+    if let Some(path) = plan_tokenizer.path.as_deref()
+        && !Path::new(path).exists()
+    {
         blocked_reasons.push("tokenizer_file_missing".to_string());
     }
 
@@ -206,13 +212,23 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "model_id": str_at(&contract, "/model_id").unwrap_or("unknown-model"),
             "model_path": model_path,
             "model_exists": Path::new(&model_path).exists(),
-            "tokenizer_path": tokenizer_path,
-            "tokenizer_exists": Path::new(&tokenizer_path).exists(),
+            "tokenizer_path": plan_tokenizer.path,
+            "tokenizer_source": plan_tokenizer.source,
+            "tokenizer_exists": plan_tokenizer
+                .path
+                .as_deref()
+                .is_some_and(|path| Path::new(path).exists()),
+            "contract_tokenizer_path": plan_tokenizer.contract_path,
+            "contract_tokenizer_exists": plan_tokenizer
+                .contract_path
+                .as_deref()
+                .is_some_and(|path| Path::new(path).exists()),
             "weights_sha256": str_at(&contract, "/sha256").unwrap_or(""),
             "tokenizer_sha256": str_at(&contract, "/tokenizer/sha256").unwrap_or(""),
         },
         "prompt_identity": {
             "prompt_template": args.prompt_template,
+            "tokenizer_source": plan_tokenizer.source,
             "system_prompt_present": args.system_prompt.is_some(),
             "rendered_prompt_sha256": sha256_text(&rendered_prompt),
             "prompt_token_ids_sha256": sha256_token_ids(&token_ids)?,
@@ -251,7 +267,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "cpu_argv": rust_cli_argv(
                 "cpu",
                 &model_path,
-                &tokenizer_path,
+                plan_tokenizer.rust_cli_tokenizer_arg.as_deref(),
                 args.prompt_template,
                 args.system_prompt,
                 args.prompt,
@@ -263,7 +279,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "a770_argv": rust_cli_argv(
                 "intel-arc-a770-opencl",
                 &model_path,
-                &tokenizer_path,
+                plan_tokenizer.rust_cli_tokenizer_arg.as_deref(),
                 args.prompt_template,
                 args.system_prompt,
                 args.prompt,
@@ -284,7 +300,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "cpu_first_token_logit_argv": rust_cli_first_token_logit_argv(
                 "cpu",
                 &model_path,
-                &tokenizer_path,
+                plan_tokenizer.rust_cli_tokenizer_arg.as_deref(),
                 args.prompt_template,
                 args.system_prompt,
                 args.prompt,
@@ -296,7 +312,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "a770_first_token_logit_argv": rust_cli_first_token_logit_argv(
                 "intel-arc-a770-opencl",
                 &model_path,
-                &tokenizer_path,
+                plan_tokenizer.rust_cli_tokenizer_arg.as_deref(),
                 args.prompt_template,
                 args.system_prompt,
                 args.prompt,
@@ -313,6 +329,60 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
         },
         "not_claims": CRITICAL_NOT_CLAIMS,
     }))
+}
+
+fn resolve_plan_tokenizer(
+    model_path: &str,
+    tokenizer_override: Option<&Path>,
+    contract: &Value,
+) -> Result<PlanTokenizer> {
+    let contract_path = str_at(contract, "/tokenizer/path").map(ToOwned::to_owned);
+    if let Some(path) = tokenizer_override {
+        let path_string = path_to_string(path);
+        let tokenizer = bitnet_tokenizers::load_tokenizer(path)
+            .with_context(|| format!("loading explicit tokenizer {path_string}"))?;
+        return Ok(PlanTokenizer {
+            tokenizer,
+            source: "explicit".to_string(),
+            path: Some(path_string.clone()),
+            contract_path,
+            rust_cli_tokenizer_arg: Some(path_string),
+        });
+    }
+
+    let model = Path::new(model_path);
+    if model.extension().and_then(|ext| ext.to_str()) == Some("gguf")
+        && let Ok(resolution) = bitnet_tokenizers::auto::resolve_tokenizer(model, None, true)
+    {
+        let source = resolution.source.as_str().to_string();
+        let path = resolution.path.as_deref().map(path_to_string);
+        let rust_cli_tokenizer_arg =
+            if resolution.source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
+                None
+            } else {
+                path.clone()
+            };
+        return Ok(PlanTokenizer {
+            tokenizer: resolution.tokenizer,
+            source,
+            path,
+            contract_path,
+            rust_cli_tokenizer_arg,
+        });
+    }
+
+    let tokenizer_path = contract_path.clone().context(
+        "tokenizer path missing; pass --tokenizer or set /tokenizer/path in the model contract",
+    )?;
+    let tokenizer = bitnet_tokenizers::load_tokenizer(Path::new(&tokenizer_path))
+        .with_context(|| format!("loading contract tokenizer {tokenizer_path}"))?;
+    Ok(PlanTokenizer {
+        tokenizer,
+        source: "contract_tokenizer".to_string(),
+        path: Some(tokenizer_path.clone()),
+        contract_path,
+        rust_cli_tokenizer_arg: Some(tokenizer_path),
+    })
 }
 
 fn reference_argv(
@@ -596,7 +666,7 @@ fn visual_studio_build_tools_probe() -> Value {
 fn rust_cli_argv(
     device: &str,
     model: &str,
-    tokenizer: &str,
+    tokenizer: Option<&str>,
     prompt_template: &str,
     system_prompt: Option<&str>,
     prompt: &str,
@@ -622,13 +692,15 @@ fn rust_cli_argv(
         device.to_string(),
         "--model".to_string(),
         model.to_string(),
-        "--tokenizer".to_string(),
-        tokenizer.to_string(),
         "--model-format".to_string(),
         "gguf".to_string(),
         "--prompt-template".to_string(),
         prompt_template.to_string(),
     ];
+    if let Some(tokenizer) = tokenizer {
+        argv.push("--tokenizer".to_string());
+        argv.push(tokenizer.to_string());
+    }
     if let Some(system_prompt) = system_prompt {
         argv.push("--system-prompt".to_string());
         argv.push(system_prompt.to_string());
@@ -661,7 +733,7 @@ fn rust_cli_argv(
 fn rust_cli_first_token_logit_argv(
     device: &str,
     model: &str,
-    tokenizer: &str,
+    tokenizer: Option<&str>,
     prompt_template: &str,
     system_prompt: Option<&str>,
     prompt: &str,
@@ -886,7 +958,7 @@ mod tests {
         let cpu = rust_cli_argv(
             "cpu",
             "m.gguf",
-            "tok.json",
+            Some("tok.json"),
             "raw",
             None,
             "x",
@@ -898,7 +970,7 @@ mod tests {
         let a770 = rust_cli_argv(
             "intel-arc-a770-opencl",
             "m.gguf",
-            "tok.json",
+            Some("tok.json"),
             "raw",
             None,
             "x",
@@ -923,6 +995,25 @@ mod tests {
             a770.windows(2)
                 .any(|args| args == ["--proof-kernel-route", A770_BITNET_QK256_ROUTE_ID])
         );
+    }
+
+    #[test]
+    fn rust_cli_argv_can_use_embedded_gguf_tokenizer() {
+        let argv = rust_cli_argv(
+            "cpu",
+            "m.gguf",
+            None,
+            "llama3-chat",
+            None,
+            "What is 2+2?",
+            1,
+            "cpu.json",
+            None,
+            None,
+        );
+
+        assert!(!argv.iter().any(|arg| arg == "--tokenizer"));
+        assert!(argv.iter().any(|arg| arg == "--strict-tokenizer"));
     }
 
     #[test]
@@ -999,7 +1090,7 @@ mod tests {
         let argv = rust_cli_first_token_logit_argv(
             "intel-arc-a770-opencl",
             "m.gguf",
-            "tok.json",
+            Some("tok.json"),
             "llama3-chat",
             None,
             "What is 2+2?",


### PR DESCRIPTION
## Summary
- load string-valued GGUF BPE tokenizer metadata through the reader path instead of treating it as a missing tokenizer
- register GGUF control tokens as special tokens and stop synthesizing prefix spaces so embedded GGUF prompt tokenization matches llama.cpp default behavior
- make the reference plan prefer embedded GGUF tokenizer metadata and omit `--tokenizer` from generated Rust GGUF commands when that path is selected

## Evidence
- Rust GGUF Llama3 prompt token IDs now match the reference verbose prompt receipt for `What is 2+2?`: `dee80bd04f1f830dec51113aa06ddbf22e65e0d451eb77116e90e837b58f12cc`
- refreshed reference run reports `reference_execution_ready=true`, `token_count_matches_plan=true`, and `token_ids_sha256_matches_plan=true`

## Validation
- `cargo test --locked -p bitnet-tokenizers --lib loader::tests -- --nocapture`
- `cargo test --locked -p xtask --bin xtask bitnet_reference_plan -- --nocapture`
- `cargo test --locked -p xtask --bin xtask bitnet_reference_run -- --nocapture`
- `cargo check --locked -p bitnet-tokenizers`
- `cargo check --locked -p xtask`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu`
- `cargo check --locked -p bitnet-cli --no-default-features --features opencl`
- `rustfmt --check --edition 2024 --config skip_children=true crates\bitnet-tokenizers\src\loader.rs crates\bitnet-tokenizers\src\gguf_loader.rs xtask\src\bitnet_reference_plan.rs`
- `git diff --check`

## Not claims
- does not prove semantic quality
- does not prove Rust/reference token or logit parity beyond prompt-token identity
- does not promote A770 performance, selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion