### PR TITLE
test(slm): record Qwen3 multi-token stability

### DIFF
--- a/ci/quality/slm-multitoken-stability.yaml
+++ b/ci/quality/slm-multitoken-stability.yaml
@@ -1,0 +1,50 @@
+schema: 1
+artifact_kind: slm_answer_corpus
+name: qwen3-0-6b-strict-slm-multitoken-stability-v1
+description: Bounded deterministic Qwen3 dense SLM multi-token stability corpus for strict CPU receipts.
+model:
+  repo: Qwen/Qwen3-0.6B-GGUF
+  file: Qwen3-0.6B-Q8_0.gguf
+  sha256: 9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031
+  family: qwen
+  architecture: qwen3
+  quant_format: Q8_0
+defaults:
+  prompt_template: qwen
+  qwen_no_think: true
+  max_new_tokens: 8
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+  per_prompt_timeout_seconds: 420
+  min_generated_tokens: 1
+cases:
+  - id: bounded_4_yes_no_water
+    question: "Answer yes or no: is water wet?"
+    max_new_tokens: 4
+    gate:
+      kind: starts_with_any
+      starts_with_any:
+        - "yes"
+        - "no"
+
+  - id: bounded_8_repeat_colors
+    question: "Repeat exactly: red blue green"
+    max_new_tokens: 8
+    gate:
+      kind: contains_any
+      contains_any:
+        - "red blue green"
+        - "Red blue green"
+        - "Red, blue, green"
+        - "Red, blue, green."
+
+  - id: bounded_16_capital_france
+    question: "What is the capital of France? Answer with one word."
+    max_new_tokens: 16
+    gate:
+      kind: contains_any
+      contains_any:
+        - "Paris"
+        - "paris"

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1-runs/bounded_16_capital_france.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1-runs/bounded_16_capital_france.json
@@ -1,0 +1,478 @@
+{
+  "artifact_kind": "inference_result",
+  "artifact_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run1-runs\\bounded_16_capital_france.json",
+  "counts": {
+    "n_kv": 28,
+    "n_tensors": 310,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 1
+  },
+  "dense_slm": {
+    "architecture": "qwen3",
+    "claim_scope": "strict dense SLM CPU answer smoke only",
+    "execution_phase": "decode",
+    "kernel_family": "dense_qwen",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0",
+    "layout_source": "gguf_dense_q8_0_reference",
+    "model_family": "qwen",
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0"
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 2,
+    "phase": "decode",
+    "prompt_tokens": 35,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "dense_slm_layers_on_cpu": null,
+    "dense_slm_layers_total": null,
+    "execution_claim": "dense_slm_cpu_reference_answer_smoke",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "explicit_bos_requested": false,
+    "greedy": true,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": true,
+    "family": "dense_qwen",
+    "implementation": "cpu-reference",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0"
+  },
+  "latency": {
+    "cmd_to_first_ms": 13318,
+    "decode_first_ms": 13318,
+    "total_ms": 13872
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "logits_index_boundary": {
+    "expected_logits_vector_length": 151936,
+    "expected_logits_vector_length_source": "tokenizer_vocab_size",
+    "first_step_logits_vector_length": null,
+    "observed_logits_vector_length": null,
+    "observed_logits_vector_length_source": "not_available"
+  },
+  "model": {
+    "architecture": "qwen3",
+    "context_length": 40960,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "output_head_tensor": "tied_token_embeddings",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tie_word_embeddings": true,
+    "tokenizer": "gguf_metadata",
+    "vocab_size": 151936
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 2,
+        "max_ms": 0.032,
+        "mean_ms": 0.025,
+        "min_ms": 0.018,
+        "p50_ms": 0.018,
+        "p95_ms": 0.032,
+        "total_ms": 0.05
+      },
+      "first_token_decode_ms": 391.135,
+      "forward_ms": {
+        "count": 2,
+        "max_ms": 342.875,
+        "mean_ms": 314.468,
+        "min_ms": 286.062,
+        "p50_ms": 286.062,
+        "p95_ms": 342.875,
+        "total_ms": 628.936
+      },
+      "generated_tokens": 2,
+      "logits_ms": {
+        "count": 2,
+        "max_ms": 184.23,
+        "mean_ms": 137.986,
+        "min_ms": 91.742,
+        "p50_ms": 91.742,
+        "p95_ms": 184.23,
+        "total_ms": 275.971
+      },
+      "per_token_ms": {
+        "count": 2,
+        "max_ms": 553.108,
+        "mean_ms": 472.121,
+        "min_ms": 391.135,
+        "p50_ms": 391.135,
+        "p95_ms": 553.108,
+        "total_ms": 944.242
+      },
+      "sample_ms": {
+        "count": 2,
+        "max_ms": 9.168,
+        "mean_ms": 6.797,
+        "min_ms": 4.426,
+        "p50_ms": 4.426,
+        "p95_ms": 9.168,
+        "total_ms": 13.594
+      },
+      "steady_per_token_ms": {
+        "count": 1,
+        "max_ms": 553.108,
+        "mean_ms": 553.108,
+        "min_ms": 553.108,
+        "p50_ms": 553.108,
+        "p95_ms": 553.108,
+        "total_ms": 553.108
+      },
+      "steady_state_tok_s": 1.808,
+      "steady_state_tokens": 1,
+      "token_decode_ms": {
+        "count": 2,
+        "max_ms": 0.057,
+        "mean_ms": 0.041,
+        "min_ms": 0.025,
+        "p50_ms": 0.025,
+        "p95_ms": 0.057,
+        "total_ms": 0.082
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 35899.008,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 12923.972,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 34
+    },
+    "prompt_tokenize_ms": 691.657,
+    "requested": false,
+    "tokenizer_load_ms": 1185.799
+  },
+  "prompt": "What is the capital of France? Answer with one word.",
+  "prompt_render": {
+    "add_bos": false,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "rendered_sha256": "16bc76ecf8712a419e443ffa93da426f79bc4f73ba2deb5e6c59a60444ac6d47",
+    "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is the capital of France? Answer with one word.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    "stop_sequences": [
+      "<|im_end|>",
+      "<|endoftext|>"
+    ],
+    "stop_token_ids": [
+      151645,
+      151643
+    ],
+    "template_family": "qwen-chat"
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 2,
+    "decode_tps": 0.14417531718569782,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "qwen",
+    "phase": "decode",
+    "prompt_tokens": 35,
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0",
+    "requested_backend": "cpu",
+    "requested_kernel": "dense-qwen-cpu-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "dense-qwen-cpu-reference",
+    "thread_count": 1,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "Paris<|im_end|>",
+  "throughput": {
+    "decoded_tokens": 2,
+    "tokens_per_second": 0.14417531718569782
+  },
+  "timestamp": "2026-05-15T05:33:34.751678200+00:00",
+  "timing": {
+    "cuda_kernel_time_ms": null,
+    "decode_steady_state_tok_s": 1.808,
+    "decode_total_ms": 944.242,
+    "device_to_host_bytes": null,
+    "first_token_decode_ms": 391.135,
+    "first_token_ms": 13318,
+    "host_to_device_bytes": null,
+    "model_load_ms": 35899.008,
+    "prefill_ms": 12923.972,
+    "sampling_ms_per_token": 6.797,
+    "tokenize_ms": 691.657,
+    "tokenizer_load_ms": 1185.799
+  },
+  "tokenizer": {
+    "bos": 151643,
+    "eos": 151645,
+    "model_family": "gguf_metadata",
+    "origin": "embedded",
+    "pretokenizer_authority": "present",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "gguf_metadata"
+  },
+  "tokens": {
+    "generated": 2,
+    "generated_ids": [
+      59604,
+      151645
+    ],
+    "ids": [
+      59604,
+      151645
+    ],
+    "prompt": 35,
+    "prompt_ids": [
+      151644,
+      8948,
+      198,
+      2610,
+      525,
+      264,
+      10950,
+      17847,
+      13,
+      151645,
+      198,
+      151644,
+      872,
+      198,
+      3838,
+      374,
+      279,
+      6722,
+      315,
+      9625,
+      30,
+      21806,
+      448,
+      825,
+      3409,
+      13,
+      151645,
+      198,
+      151644,
+      77091,
+      198,
+      151667,
+      271,
+      151668,
+      271
+    ],
+    "total": 37
+  }
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1-runs/bounded_4_yes_no_water.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1-runs/bounded_4_yes_no_water.json
@@ -1,0 +1,479 @@
+{
+  "artifact_kind": "inference_result",
+  "artifact_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run1-runs\\bounded_4_yes_no_water.json",
+  "counts": {
+    "n_kv": 28,
+    "n_tensors": 310,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 1
+  },
+  "dense_slm": {
+    "architecture": "qwen3",
+    "claim_scope": "strict dense SLM CPU answer smoke only",
+    "execution_phase": "decode",
+    "kernel_family": "dense_qwen",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0",
+    "layout_source": "gguf_dense_q8_0_reference",
+    "model_family": "qwen",
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0"
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 32,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "dense_slm_layers_on_cpu": null,
+    "dense_slm_layers_total": null,
+    "execution_claim": "dense_slm_cpu_reference_answer_smoke",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "explicit_bos_requested": false,
+    "greedy": true,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": true,
+    "family": "dense_qwen",
+    "implementation": "cpu-reference",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0"
+  },
+  "latency": {
+    "cmd_to_first_ms": 12258,
+    "decode_first_ms": 12258,
+    "total_ms": 13919
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "logits_index_boundary": {
+    "expected_logits_vector_length": 151936,
+    "expected_logits_vector_length_source": "tokenizer_vocab_size",
+    "first_step_logits_vector_length": null,
+    "observed_logits_vector_length": null,
+    "observed_logits_vector_length_source": "not_available"
+  },
+  "model": {
+    "architecture": "qwen3",
+    "context_length": 40960,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "output_head_tensor": "tied_token_embeddings",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tie_word_embeddings": true,
+    "tokenizer": "gguf_metadata",
+    "vocab_size": 151936
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.06,
+        "mean_ms": 0.031,
+        "min_ms": 0.017,
+        "p50_ms": 0.019,
+        "p95_ms": 0.06,
+        "total_ms": 0.125
+      },
+      "first_token_decode_ms": 675.429,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 543.437,
+        "mean_ms": 424.596,
+        "min_ms": 279.466,
+        "p50_ms": 414.016,
+        "p95_ms": 543.437,
+        "total_ms": 1698.385
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 185.663,
+        "mean_ms": 138.563,
+        "min_ms": 91.993,
+        "p50_ms": 95.401,
+        "p95_ms": 185.663,
+        "total_ms": 554.252
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 750.892,
+        "mean_ms": 583.443,
+        "min_ms": 388.464,
+        "p50_ms": 518.987,
+        "p95_ms": 750.892,
+        "total_ms": 2333.771
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 9.736,
+        "mean_ms": 7.042,
+        "min_ms": 4.334,
+        "p50_ms": 4.539,
+        "p95_ms": 9.736,
+        "total_ms": 28.168
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 750.892,
+        "mean_ms": 552.781,
+        "min_ms": 388.464,
+        "p50_ms": 518.987,
+        "p95_ms": 750.892,
+        "total_ms": 1658.343
+      },
+      "steady_state_tok_s": 1.809,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.159,
+        "mean_ms": 0.054,
+        "min_ms": 0.015,
+        "p50_ms": 0.017,
+        "p95_ms": 0.159,
+        "total_ms": 0.215
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 34921.881,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 11582.243,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 31
+    },
+    "prompt_tokenize_ms": 988.5,
+    "requested": false,
+    "tokenizer_load_ms": 561.191
+  },
+  "prompt": "Answer yes or no: is water wet?",
+  "prompt_render": {
+    "add_bos": false,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "rendered_sha256": "542f6f4d235dfb6ebcc5b535cf71fa8a356cc94511c4449509f8845845c0f840",
+    "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nAnswer yes or no: is water wet?<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    "stop_sequences": [
+      "<|im_end|>",
+      "<|endoftext|>"
+    ],
+    "stop_token_ids": [
+      151645,
+      151643
+    ],
+    "template_family": "qwen-chat"
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.28737696673611607,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "qwen",
+    "phase": "decode",
+    "prompt_tokens": 32,
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0",
+    "requested_backend": "cpu",
+    "requested_kernel": "dense-qwen-cpu-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "dense-qwen-cpu-reference",
+    "thread_count": 1,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "Yes, water is",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.28737696673611607
+  },
+  "timestamp": "2026-05-15T05:31:39.127401+00:00",
+  "timing": {
+    "cuda_kernel_time_ms": null,
+    "decode_steady_state_tok_s": 1.809,
+    "decode_total_ms": 2333.771,
+    "device_to_host_bytes": null,
+    "first_token_decode_ms": 675.429,
+    "first_token_ms": 12258,
+    "host_to_device_bytes": null,
+    "model_load_ms": 34921.881,
+    "prefill_ms": 11582.243,
+    "sampling_ms_per_token": 7.042,
+    "tokenize_ms": 988.5,
+    "tokenizer_load_ms": 561.191
+  },
+  "tokenizer": {
+    "bos": 151643,
+    "eos": 151645,
+    "model_family": "gguf_metadata",
+    "origin": "embedded",
+    "pretokenizer_authority": "present",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "gguf_metadata"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      9454,
+      11,
+      3015,
+      374
+    ],
+    "ids": [
+      9454,
+      11,
+      3015,
+      374
+    ],
+    "prompt": 32,
+    "prompt_ids": [
+      151644,
+      8948,
+      198,
+      2610,
+      525,
+      264,
+      10950,
+      17847,
+      13,
+      151645,
+      198,
+      151644,
+      872,
+      198,
+      16141,
+      9834,
+      476,
+      902,
+      25,
+      374,
+      3015,
+      14401,
+      30,
+      151645,
+      198,
+      151644,
+      77091,
+      198,
+      151667,
+      271,
+      151668,
+      271
+    ],
+    "total": 36
+  }
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1-runs/bounded_8_repeat_colors.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1-runs/bounded_8_repeat_colors.json
@@ -1,0 +1,482 @@
+{
+  "artifact_kind": "inference_result",
+  "artifact_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run1-runs\\bounded_8_repeat_colors.json",
+  "counts": {
+    "n_kv": 28,
+    "n_tensors": 310,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 1
+  },
+  "dense_slm": {
+    "architecture": "qwen3",
+    "claim_scope": "strict dense SLM CPU answer smoke only",
+    "execution_phase": "decode",
+    "kernel_family": "dense_qwen",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0",
+    "layout_source": "gguf_dense_q8_0_reference",
+    "model_family": "qwen",
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0"
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 7,
+    "phase": "decode",
+    "prompt_tokens": 29,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "dense_slm_layers_on_cpu": null,
+    "dense_slm_layers_total": null,
+    "execution_claim": "dense_slm_cpu_reference_answer_smoke",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "explicit_bos_requested": false,
+    "greedy": true,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": true,
+    "family": "dense_qwen",
+    "implementation": "cpu-reference",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0"
+  },
+  "latency": {
+    "cmd_to_first_ms": 10684,
+    "decode_first_ms": 10684,
+    "total_ms": 13868
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "logits_index_boundary": {
+    "expected_logits_vector_length": 151936,
+    "expected_logits_vector_length_source": "tokenizer_vocab_size",
+    "first_step_logits_vector_length": null,
+    "observed_logits_vector_length": null,
+    "observed_logits_vector_length_source": "not_available"
+  },
+  "model": {
+    "architecture": "qwen3",
+    "context_length": 40960,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "output_head_tensor": "tied_token_embeddings",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tie_word_embeddings": true,
+    "tokenizer": "gguf_metadata",
+    "vocab_size": 151936
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 7,
+        "max_ms": 0.031,
+        "mean_ms": 0.022,
+        "min_ms": 0.016,
+        "p50_ms": 0.025,
+        "p95_ms": 0.031,
+        "total_ms": 0.155
+      },
+      "first_token_decode_ms": 384.508,
+      "forward_ms": {
+        "count": 7,
+        "max_ms": 552.18,
+        "mean_ms": 369.861,
+        "min_ms": 276.521,
+        "p50_ms": 324.434,
+        "p95_ms": 552.18,
+        "total_ms": 2589.027
+      },
+      "generated_tokens": 7,
+      "logits_ms": {
+        "count": 7,
+        "max_ms": 185.018,
+        "mean_ms": 122.747,
+        "min_ms": 92.055,
+        "p50_ms": 98.935,
+        "p95_ms": 185.018,
+        "total_ms": 859.231
+      },
+      "per_token_ms": {
+        "count": 7,
+        "max_ms": 763.544,
+        "mean_ms": 509.527,
+        "min_ms": 384.392,
+        "p50_ms": 447.886,
+        "p95_ms": 763.544,
+        "total_ms": 3566.688
+      },
+      "sample_ms": {
+        "count": 7,
+        "max_ms": 9.349,
+        "mean_ms": 6.102,
+        "min_ms": 4.597,
+        "p50_ms": 4.962,
+        "p95_ms": 9.349,
+        "total_ms": 42.717
+      },
+      "steady_per_token_ms": {
+        "count": 6,
+        "max_ms": 763.544,
+        "mean_ms": 530.363,
+        "min_ms": 384.392,
+        "p50_ms": 447.886,
+        "p95_ms": 763.544,
+        "total_ms": 3182.179
+      },
+      "steady_state_tok_s": 1.886,
+      "steady_state_tokens": 6,
+      "token_decode_ms": {
+        "count": 7,
+        "max_ms": 0.082,
+        "mean_ms": 0.027,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.082,
+        "total_ms": 0.19
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 34995.267,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 10298.15,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 28
+    },
+    "prompt_tokenize_ms": 997.343,
+    "requested": false,
+    "tokenizer_load_ms": 928.426
+  },
+  "prompt": "Repeat exactly: red blue green",
+  "prompt_render": {
+    "add_bos": false,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "rendered_sha256": "25f070614e9cbae4889ac2c92711b9f132b3e20c5b680a743ec0fa0526bbb9c1",
+    "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nRepeat exactly: red blue green<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    "stop_sequences": [
+      "<|im_end|>",
+      "<|endoftext|>"
+    ],
+    "stop_token_ids": [
+      151645,
+      151643
+    ],
+    "template_family": "qwen-chat"
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 7,
+    "decode_tps": 0.5047591577732911,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "qwen",
+    "phase": "decode",
+    "prompt_tokens": 29,
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0",
+    "requested_backend": "cpu",
+    "requested_kernel": "dense-qwen-cpu-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "dense-qwen-cpu-reference",
+    "thread_count": 1,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "Red, blue, green.<|im_end|>",
+  "throughput": {
+    "decoded_tokens": 7,
+    "tokens_per_second": 0.5047591577732911
+  },
+  "timestamp": "2026-05-15T05:32:36.870991500+00:00",
+  "timing": {
+    "cuda_kernel_time_ms": null,
+    "decode_steady_state_tok_s": 1.886,
+    "decode_total_ms": 3566.688,
+    "device_to_host_bytes": null,
+    "first_token_decode_ms": 384.508,
+    "first_token_ms": 10684,
+    "host_to_device_bytes": null,
+    "model_load_ms": 34995.267,
+    "prefill_ms": 10298.15,
+    "sampling_ms_per_token": 6.102,
+    "tokenize_ms": 997.343,
+    "tokenizer_load_ms": 928.426
+  },
+  "tokenizer": {
+    "bos": 151643,
+    "eos": 151645,
+    "model_family": "gguf_metadata",
+    "origin": "embedded",
+    "pretokenizer_authority": "present",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "gguf_metadata"
+  },
+  "tokens": {
+    "generated": 7,
+    "generated_ids": [
+      6033,
+      11,
+      6303,
+      11,
+      6176,
+      13,
+      151645
+    ],
+    "ids": [
+      6033,
+      11,
+      6303,
+      11,
+      6176,
+      13,
+      151645
+    ],
+    "prompt": 29,
+    "prompt_ids": [
+      151644,
+      8948,
+      198,
+      2610,
+      525,
+      264,
+      10950,
+      17847,
+      13,
+      151645,
+      198,
+      151644,
+      872,
+      198,
+      38718,
+      6896,
+      25,
+      2518,
+      6303,
+      6176,
+      151645,
+      198,
+      151644,
+      77091,
+      198,
+      151667,
+      271,
+      151668,
+      271
+    ],
+    "total": 36
+  }
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1.json
@@ -1,0 +1,774 @@
+{
+  "artifact_kind": "slm_cpu_answer_corpus",
+  "backend": {
+    "fallback_used": false,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust"
+  },
+  "backend_lane": "dense_slm_cpu",
+  "cases": [
+    {
+      "answer": "Yes, water is",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "bounded_4_yes_no_water",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 12258,
+        "decode_first_ms": 12258,
+        "total_ms": 13919
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": null,
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": null,
+        "observed_logits_vector_length": null,
+        "observed_logits_vector_length_source": "not_available"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 32
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "542f6f4d235dfb6ebcc5b535cf71fa8a356cc94511c4449509f8845845c0f840",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nAnswer yes or no: is water wet?<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 32,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 32,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "starts_with_any",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "Answer yes or no: is water wet?",
+      "run_receipt_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run1-runs\\bounded_4_yes_no_water.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 4,
+        "tokens_per_second": 0.28737696673611607
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": 1.809,
+        "decode_total_ms": 2333.771,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 675.429,
+        "first_token_ms": 12258,
+        "host_to_device_bytes": null,
+        "model_load_ms": 34921.881,
+        "prefill_ms": 11582.243,
+        "sampling_ms_per_token": 7.042,
+        "tokenize_ms": 988.5,
+        "tokenizer_load_ms": 561.191
+      },
+      "token_ids": {
+        "generated": [
+          9454,
+          11,
+          3015,
+          374
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          16141,
+          9834,
+          476,
+          902,
+          25,
+          374,
+          3015,
+          14401,
+          30,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          9454,
+          11,
+          3015,
+          374
+        ],
+        "ids": [
+          9454,
+          11,
+          3015,
+          374
+        ],
+        "prompt": 32,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          16141,
+          9834,
+          476,
+          902,
+          25,
+          374,
+          3015,
+          14401,
+          30,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 36
+      }
+    },
+    {
+      "answer": "Red, blue, green.<|im_end|>",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "bounded_8_repeat_colors",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 10684,
+        "decode_first_ms": 10684,
+        "total_ms": 13868
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": null,
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": null,
+        "observed_logits_vector_length": null,
+        "observed_logits_vector_length_source": "not_available"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 29
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "25f070614e9cbae4889ac2c92711b9f132b3e20c5b680a743ec0fa0526bbb9c1",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nRepeat exactly: red blue green<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 29,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 29,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 6,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "contains_any",
+        "generated_tokens": 7,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "Repeat exactly: red blue green",
+      "run_receipt_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run1-runs\\bounded_8_repeat_colors.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 7,
+        "tokens_per_second": 0.5047591577732911
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": 1.886,
+        "decode_total_ms": 3566.688,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 384.508,
+        "first_token_ms": 10684,
+        "host_to_device_bytes": null,
+        "model_load_ms": 34995.267,
+        "prefill_ms": 10298.15,
+        "sampling_ms_per_token": 6.102,
+        "tokenize_ms": 997.343,
+        "tokenizer_load_ms": 928.426
+      },
+      "token_ids": {
+        "generated": [
+          6033,
+          11,
+          6303,
+          11,
+          6176,
+          13,
+          151645
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          38718,
+          6896,
+          25,
+          2518,
+          6303,
+          6176,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 7,
+        "generated_ids": [
+          6033,
+          11,
+          6303,
+          11,
+          6176,
+          13,
+          151645
+        ],
+        "ids": [
+          6033,
+          11,
+          6303,
+          11,
+          6176,
+          13,
+          151645
+        ],
+        "prompt": 29,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          38718,
+          6896,
+          25,
+          2518,
+          6303,
+          6176,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 36
+      }
+    },
+    {
+      "answer": "Paris<|im_end|>",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "bounded_16_capital_france",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 13318,
+        "decode_first_ms": 13318,
+        "total_ms": 13872
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": null,
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": null,
+        "observed_logits_vector_length": null,
+        "observed_logits_vector_length_source": "not_available"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 35
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "16bc76ecf8712a419e443ffa93da426f79bc4f73ba2deb5e6c59a60444ac6d47",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is the capital of France? Answer with one word.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 35,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 35,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 2,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "contains_any",
+        "generated_tokens": 2,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "What is the capital of France? Answer with one word.",
+      "run_receipt_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run1-runs\\bounded_16_capital_france.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 2,
+        "tokens_per_second": 0.14417531718569782
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": 1.808,
+        "decode_total_ms": 944.242,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 391.135,
+        "first_token_ms": 13318,
+        "host_to_device_bytes": null,
+        "model_load_ms": 35899.008,
+        "prefill_ms": 12923.972,
+        "sampling_ms_per_token": 6.797,
+        "tokenize_ms": 691.657,
+        "tokenizer_load_ms": 1185.799
+      },
+      "token_ids": {
+        "generated": [
+          59604,
+          151645
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          3838,
+          374,
+          279,
+          6722,
+          315,
+          9625,
+          30,
+          21806,
+          448,
+          825,
+          3409,
+          13,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 2,
+        "generated_ids": [
+          59604,
+          151645
+        ],
+        "ids": [
+          59604,
+          151645
+        ],
+        "prompt": 35,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          3838,
+          374,
+          279,
+          6722,
+          315,
+          9625,
+          30,
+          21806,
+          448,
+          825,
+          3409,
+          13,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 37
+      }
+    }
+  ],
+  "claim_boundary": {
+    "answer_ready_artifact_available": false,
+    "backend_quality_gate_passed": true,
+    "bounded_slm_answer_smoke_passed": true,
+    "broad_performance_claimed": false,
+    "coherent_answer_claimed": false,
+    "coherent_output_observed": false,
+    "cuda_answer_corpus": false,
+    "dense_slm_clean_provenance": true,
+    "diagnostic_only_until_answer_ready_artifact": false,
+    "full_metal_inference_claimed": false,
+    "local_answer_path": false,
+    "neural_engine_claimed": false,
+    "qk256_apple_claimed": false,
+    "slm_answer_path": true,
+    "strict_cuda_answer_claimed": false
+  },
+  "corpus": {
+    "case_count": 3,
+    "description": "Bounded deterministic Qwen3 dense SLM multi-token stability corpus for strict CPU receipts.",
+    "name": "qwen3-0-6b-strict-slm-multitoken-stability-v1",
+    "path": "ci/quality/slm-multitoken-stability.yaml",
+    "selected_case_count": 3,
+    "selected_case_ids": [
+      "bounded_4_yes_no_water",
+      "bounded_8_repeat_colors",
+      "bounded_16_capital_france"
+    ]
+  },
+  "execution_plan": null,
+  "fallback_used": false,
+  "generation": {
+    "default_max_new_tokens": 8,
+    "deterministic": true,
+    "logits_dump_steps": null,
+    "logits_topk": null,
+    "mode": "greedy",
+    "per_prompt_timeout_seconds": 420,
+    "requested_cpu_kernel": null,
+    "strict_loader": true,
+    "temperature": 0.0
+  },
+  "model": {
+    "answer_ready": null,
+    "answer_ready_artifact_available": false,
+    "architecture": "qwen3",
+    "bytes": null,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "id": null,
+    "loader_mode": "real_gguf",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "revision": null,
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tokenizer": "gguf_metadata",
+    "tokenizer_authority": null,
+    "tokenizer_path": null
+  },
+  "model_architecture": "qwen3",
+  "model_family": "qwen",
+  "prompt_template": "qwen",
+  "prompt_template_policy": {
+    "family": "qwen"
+  },
+  "quality_summary": {
+    "failed": 0,
+    "not_run": 0,
+    "passed": 3,
+    "timeout": 0,
+    "total": 3
+  },
+  "quantization": "Q8_0",
+  "receipt_quality": {
+    "case_receipt_checker": "answer_receipt_failed_rules",
+    "checked": true,
+    "checked_rules": [
+      "generated_text_recorded",
+      "prompt_token_count_recorded",
+      "generated_token_count_recorded",
+      "total_token_count_recorded",
+      "prompt_token_ids_recorded",
+      "generated_token_ids_recorded",
+      "prompt_token_count_matches_ids",
+      "generated_token_count_matches_ids",
+      "total_token_count_matches",
+      "model_repo_recorded",
+      "model_file_recorded",
+      "model_sha256_recorded",
+      "model_family_recorded",
+      "model_architecture_recorded",
+      "tokenizer_source_recorded",
+      "tokenizer_strict",
+      "tokenizer_pretokenizer_authority_recorded",
+      "requested_backend",
+      "selected_backend",
+      "runtime_api",
+      "fallback_false",
+      "speedup_claim_false",
+      "loader_real_gguf",
+      "selected_kernel_recorded",
+      "selected_kernel_production",
+      "timing_model_load_ms_recorded",
+      "timing_tokenizer_load_ms_recorded",
+      "timing_tokenize_ms_recorded",
+      "timing_prefill_ms_recorded",
+      "timing_first_token_ms_recorded",
+      "timing_decode_total_ms_recorded",
+      "latency_total_ms_recorded"
+    ],
+    "required_case_fields": [
+      "text",
+      "tokens.prompt",
+      "tokens.generated",
+      "tokens.total",
+      "tokens.prompt_ids",
+      "tokens.generated_ids",
+      "model.repo",
+      "model.file",
+      "model.sha256",
+      "model.family",
+      "model.architecture",
+      "tokenizer.source",
+      "tokenizer.strict",
+      "tokenizer.pretokenizer_authority",
+      "requested_backend",
+      "selected_backend",
+      "runtime_api",
+      "fallback_used",
+      "loader.mode",
+      "kernel.kernel_id",
+      "timing.model_load_ms",
+      "timing.tokenizer_load_ms",
+      "timing.tokenize_ms",
+      "timing.prefill_ms",
+      "timing.first_token_ms",
+      "timing.decode_total_ms",
+      "latency.total_ms"
+    ]
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "scoring_summary": {
+    "enabled": false,
+    "failed": 0,
+    "failure_taxonomy": {},
+    "kinds": [],
+    "not_run": 0,
+    "passed": 0,
+    "total": 0
+  },
+  "selected_backend": "cpu-rust",
+  "selected_kernel_or_runtime": "dense-qwen-cpu-reference",
+  "speedup_claim": false,
+  "timestamp": "2026-05-15T05:33:35.263112100+00:00",
+  "tokenizer": {
+    "authority": null,
+    "path": null,
+    "source": "gguf_metadata",
+    "strict": true
+  },
+  "tokenizer_source": "gguf_metadata"
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2-runs/bounded_16_capital_france.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2-runs/bounded_16_capital_france.json
@@ -1,0 +1,478 @@
+{
+  "artifact_kind": "inference_result",
+  "artifact_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run2-runs\\bounded_16_capital_france.json",
+  "counts": {
+    "n_kv": 28,
+    "n_tensors": 310,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 1
+  },
+  "dense_slm": {
+    "architecture": "qwen3",
+    "claim_scope": "strict dense SLM CPU answer smoke only",
+    "execution_phase": "decode",
+    "kernel_family": "dense_qwen",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0",
+    "layout_source": "gguf_dense_q8_0_reference",
+    "model_family": "qwen",
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0"
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 2,
+    "phase": "decode",
+    "prompt_tokens": 35,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "dense_slm_layers_on_cpu": null,
+    "dense_slm_layers_total": null,
+    "execution_claim": "dense_slm_cpu_reference_answer_smoke",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "explicit_bos_requested": false,
+    "greedy": true,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": true,
+    "family": "dense_qwen",
+    "implementation": "cpu-reference",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0"
+  },
+  "latency": {
+    "cmd_to_first_ms": 13643,
+    "decode_first_ms": 13643,
+    "total_ms": 14032
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "logits_index_boundary": {
+    "expected_logits_vector_length": 151936,
+    "expected_logits_vector_length_source": "tokenizer_vocab_size",
+    "first_step_logits_vector_length": null,
+    "observed_logits_vector_length": null,
+    "observed_logits_vector_length_source": "not_available"
+  },
+  "model": {
+    "architecture": "qwen3",
+    "context_length": 40960,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "output_head_tensor": "tied_token_embeddings",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tie_word_embeddings": true,
+    "tokenizer": "gguf_metadata",
+    "vocab_size": 151936
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 2,
+        "max_ms": 0.043,
+        "mean_ms": 0.037,
+        "min_ms": 0.032,
+        "p50_ms": 0.032,
+        "p95_ms": 0.043,
+        "total_ms": 0.074
+      },
+      "first_token_decode_ms": 384.522,
+      "forward_ms": {
+        "count": 2,
+        "max_ms": 279.08,
+        "mean_ms": 278.739,
+        "min_ms": 278.397,
+        "p50_ms": 278.397,
+        "p95_ms": 279.08,
+        "total_ms": 557.477
+      },
+      "generated_tokens": 2,
+      "logits_ms": {
+        "count": 2,
+        "max_ms": 95.103,
+        "mean_ms": 93.794,
+        "min_ms": 92.485,
+        "p50_ms": 92.485,
+        "p95_ms": 95.103,
+        "total_ms": 187.588
+      },
+      "per_token_ms": {
+        "count": 2,
+        "max_ms": 387.006,
+        "mean_ms": 385.764,
+        "min_ms": 384.522,
+        "p50_ms": 384.522,
+        "p95_ms": 387.006,
+        "total_ms": 771.527
+      },
+      "sample_ms": {
+        "count": 2,
+        "max_ms": 4.842,
+        "mean_ms": 4.612,
+        "min_ms": 4.383,
+        "p50_ms": 4.383,
+        "p95_ms": 4.842,
+        "total_ms": 9.224
+      },
+      "steady_per_token_ms": {
+        "count": 1,
+        "max_ms": 387.006,
+        "mean_ms": 387.006,
+        "min_ms": 387.006,
+        "p50_ms": 387.006,
+        "p95_ms": 387.006,
+        "total_ms": 387.006
+      },
+      "steady_state_tok_s": 2.584,
+      "steady_state_tokens": 1,
+      "token_decode_ms": {
+        "count": 2,
+        "max_ms": 0.065,
+        "mean_ms": 0.04,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.065,
+        "total_ms": 0.079
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 35808.685,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 13256.863,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 34
+    },
+    "prompt_tokenize_ms": 1208.538,
+    "requested": false,
+    "tokenizer_load_ms": 717.512
+  },
+  "prompt": "What is the capital of France? Answer with one word.",
+  "prompt_render": {
+    "add_bos": false,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "rendered_sha256": "16bc76ecf8712a419e443ffa93da426f79bc4f73ba2deb5e6c59a60444ac6d47",
+    "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is the capital of France? Answer with one word.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    "stop_sequences": [
+      "<|im_end|>",
+      "<|endoftext|>"
+    ],
+    "stop_token_ids": [
+      151645,
+      151643
+    ],
+    "template_family": "qwen-chat"
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 2,
+    "decode_tps": 0.14253135689851767,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "qwen",
+    "phase": "decode",
+    "prompt_tokens": 35,
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0",
+    "requested_backend": "cpu",
+    "requested_kernel": "dense-qwen-cpu-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "dense-qwen-cpu-reference",
+    "thread_count": 1,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "Paris<|im_end|>",
+  "throughput": {
+    "decoded_tokens": 2,
+    "tokens_per_second": 0.14253135689851767
+  },
+  "timestamp": "2026-05-15T05:36:33.832804200+00:00",
+  "timing": {
+    "cuda_kernel_time_ms": null,
+    "decode_steady_state_tok_s": 2.584,
+    "decode_total_ms": 771.527,
+    "device_to_host_bytes": null,
+    "first_token_decode_ms": 384.522,
+    "first_token_ms": 13643,
+    "host_to_device_bytes": null,
+    "model_load_ms": 35808.685,
+    "prefill_ms": 13256.863,
+    "sampling_ms_per_token": 4.612,
+    "tokenize_ms": 1208.538,
+    "tokenizer_load_ms": 717.512
+  },
+  "tokenizer": {
+    "bos": 151643,
+    "eos": 151645,
+    "model_family": "gguf_metadata",
+    "origin": "embedded",
+    "pretokenizer_authority": "present",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "gguf_metadata"
+  },
+  "tokens": {
+    "generated": 2,
+    "generated_ids": [
+      59604,
+      151645
+    ],
+    "ids": [
+      59604,
+      151645
+    ],
+    "prompt": 35,
+    "prompt_ids": [
+      151644,
+      8948,
+      198,
+      2610,
+      525,
+      264,
+      10950,
+      17847,
+      13,
+      151645,
+      198,
+      151644,
+      872,
+      198,
+      3838,
+      374,
+      279,
+      6722,
+      315,
+      9625,
+      30,
+      21806,
+      448,
+      825,
+      3409,
+      13,
+      151645,
+      198,
+      151644,
+      77091,
+      198,
+      151667,
+      271,
+      151668,
+      271
+    ],
+    "total": 37
+  }
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2-runs/bounded_4_yes_no_water.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2-runs/bounded_4_yes_no_water.json
@@ -1,0 +1,479 @@
+{
+  "artifact_kind": "inference_result",
+  "artifact_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run2-runs\\bounded_4_yes_no_water.json",
+  "counts": {
+    "n_kv": 28,
+    "n_tensors": 310,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 1
+  },
+  "dense_slm": {
+    "architecture": "qwen3",
+    "claim_scope": "strict dense SLM CPU answer smoke only",
+    "execution_phase": "decode",
+    "kernel_family": "dense_qwen",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0",
+    "layout_source": "gguf_dense_q8_0_reference",
+    "model_family": "qwen",
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0"
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 32,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "dense_slm_layers_on_cpu": null,
+    "dense_slm_layers_total": null,
+    "execution_claim": "dense_slm_cpu_reference_answer_smoke",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "explicit_bos_requested": false,
+    "greedy": true,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": true,
+    "family": "dense_qwen",
+    "implementation": "cpu-reference",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0"
+  },
+  "latency": {
+    "cmd_to_first_ms": 12488,
+    "decode_first_ms": 12488,
+    "total_ms": 13784
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "logits_index_boundary": {
+    "expected_logits_vector_length": 151936,
+    "expected_logits_vector_length_source": "tokenizer_vocab_size",
+    "first_step_logits_vector_length": null,
+    "observed_logits_vector_length": null,
+    "observed_logits_vector_length_source": "not_available"
+  },
+  "model": {
+    "architecture": "qwen3",
+    "context_length": 40960,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "output_head_tensor": "tied_token_embeddings",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tie_word_embeddings": true,
+    "tokenizer": "gguf_metadata",
+    "vocab_size": 151936
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.03,
+        "mean_ms": 0.021,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.03,
+        "total_ms": 0.084
+      },
+      "first_token_decode_ms": 397.408,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 303.76,
+        "mean_ms": 295.925,
+        "min_ms": 286.96,
+        "p50_ms": 291.451,
+        "p95_ms": 303.76,
+        "total_ms": 1183.701
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 146.672,
+        "mean_ms": 110.518,
+        "min_ms": 92.739,
+        "p50_ms": 97.198,
+        "p95_ms": 146.672,
+        "total_ms": 442.071
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 475.279,
+        "mean_ms": 423.068,
+        "min_ms": 396.769,
+        "p50_ms": 397.408,
+        "p95_ms": 475.279,
+        "total_ms": 1692.272
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 9.217,
+        "mean_ms": 5.572,
+        "min_ms": 4.329,
+        "p50_ms": 4.349,
+        "p95_ms": 9.217,
+        "total_ms": 22.289
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 475.279,
+        "mean_ms": 431.621,
+        "min_ms": 396.769,
+        "p50_ms": 422.815,
+        "p95_ms": 475.279,
+        "total_ms": 1294.864
+      },
+      "steady_state_tok_s": 2.317,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.072,
+        "mean_ms": 0.031,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.072,
+        "total_ms": 0.125
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 34963.71,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 12086.972,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 31
+    },
+    "prompt_tokenize_ms": 579.375,
+    "requested": false,
+    "tokenizer_load_ms": 553.199
+  },
+  "prompt": "Answer yes or no: is water wet?",
+  "prompt_render": {
+    "add_bos": false,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "rendered_sha256": "542f6f4d235dfb6ebcc5b535cf71fa8a356cc94511c4449509f8845845c0f840",
+    "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nAnswer yes or no: is water wet?<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    "stop_sequences": [
+      "<|im_end|>",
+      "<|endoftext|>"
+    ],
+    "stop_token_ids": [
+      151645,
+      151643
+    ],
+    "template_family": "qwen-chat"
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.2901915264074289,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "qwen",
+    "phase": "decode",
+    "prompt_tokens": 32,
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0",
+    "requested_backend": "cpu",
+    "requested_kernel": "dense-qwen-cpu-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "dense-qwen-cpu-reference",
+    "thread_count": 1,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "Yes, water is",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.2901915264074289
+  },
+  "timestamp": "2026-05-15T05:34:38.533573100+00:00",
+  "timing": {
+    "cuda_kernel_time_ms": null,
+    "decode_steady_state_tok_s": 2.317,
+    "decode_total_ms": 1692.272,
+    "device_to_host_bytes": null,
+    "first_token_decode_ms": 397.408,
+    "first_token_ms": 12488,
+    "host_to_device_bytes": null,
+    "model_load_ms": 34963.71,
+    "prefill_ms": 12086.972,
+    "sampling_ms_per_token": 5.572,
+    "tokenize_ms": 579.375,
+    "tokenizer_load_ms": 553.199
+  },
+  "tokenizer": {
+    "bos": 151643,
+    "eos": 151645,
+    "model_family": "gguf_metadata",
+    "origin": "embedded",
+    "pretokenizer_authority": "present",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "gguf_metadata"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      9454,
+      11,
+      3015,
+      374
+    ],
+    "ids": [
+      9454,
+      11,
+      3015,
+      374
+    ],
+    "prompt": 32,
+    "prompt_ids": [
+      151644,
+      8948,
+      198,
+      2610,
+      525,
+      264,
+      10950,
+      17847,
+      13,
+      151645,
+      198,
+      151644,
+      872,
+      198,
+      16141,
+      9834,
+      476,
+      902,
+      25,
+      374,
+      3015,
+      14401,
+      30,
+      151645,
+      198,
+      151644,
+      77091,
+      198,
+      151667,
+      271,
+      151668,
+      271
+    ],
+    "total": 36
+  }
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2-runs/bounded_8_repeat_colors.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2-runs/bounded_8_repeat_colors.json
@@ -1,0 +1,482 @@
+{
+  "artifact_kind": "inference_result",
+  "artifact_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run2-runs\\bounded_8_repeat_colors.json",
+  "counts": {
+    "n_kv": 28,
+    "n_tensors": 310,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 1
+  },
+  "dense_slm": {
+    "architecture": "qwen3",
+    "claim_scope": "strict dense SLM CPU answer smoke only",
+    "execution_phase": "decode",
+    "kernel_family": "dense_qwen",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0",
+    "layout_source": "gguf_dense_q8_0_reference",
+    "model_family": "qwen",
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0"
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 7,
+    "phase": "decode",
+    "prompt_tokens": 29,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "dense_slm_layers_on_cpu": null,
+    "dense_slm_layers_total": null,
+    "execution_claim": "dense_slm_cpu_reference_answer_smoke",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "explicit_bos_requested": false,
+    "greedy": true,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": true,
+    "family": "dense_qwen",
+    "implementation": "cpu-reference",
+    "kernel_id": "dense-qwen-cpu-reference",
+    "layout": "gguf_dense_q8_0"
+  },
+  "latency": {
+    "cmd_to_first_ms": 11486,
+    "decode_first_ms": 11486,
+    "total_ms": 14632
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "logits_index_boundary": {
+    "expected_logits_vector_length": 151936,
+    "expected_logits_vector_length_source": "tokenizer_vocab_size",
+    "first_step_logits_vector_length": null,
+    "observed_logits_vector_length": null,
+    "observed_logits_vector_length_source": "not_available"
+  },
+  "model": {
+    "architecture": "qwen3",
+    "context_length": 40960,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "output_head_tensor": "tied_token_embeddings",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tie_word_embeddings": true,
+    "tokenizer": "gguf_metadata",
+    "vocab_size": 151936
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 7,
+        "max_ms": 0.027,
+        "mean_ms": 0.021,
+        "min_ms": 0.014,
+        "p50_ms": 0.021,
+        "p95_ms": 0.027,
+        "total_ms": 0.145
+      },
+      "first_token_decode_ms": 406.571,
+      "forward_ms": {
+        "count": 7,
+        "max_ms": 553.095,
+        "mean_ms": 368.087,
+        "min_ms": 278.194,
+        "p50_ms": 300.85,
+        "p95_ms": 553.095,
+        "total_ms": 2576.608
+      },
+      "generated_tokens": 7,
+      "logits_ms": {
+        "count": 7,
+        "max_ms": 194.035,
+        "mean_ms": 122.43,
+        "min_ms": 91.281,
+        "p50_ms": 99.738,
+        "p95_ms": 194.035,
+        "total_ms": 857.007
+      },
+      "per_token_ms": {
+        "count": 7,
+        "max_ms": 764.695,
+        "mean_ms": 507.417,
+        "min_ms": 383.174,
+        "p50_ms": 415.436,
+        "p95_ms": 764.695,
+        "total_ms": 3551.92
+      },
+      "sample_ms": {
+        "count": 7,
+        "max_ms": 9.787,
+        "mean_ms": 5.986,
+        "min_ms": 4.256,
+        "p50_ms": 4.434,
+        "p95_ms": 9.787,
+        "total_ms": 41.902
+      },
+      "steady_per_token_ms": {
+        "count": 6,
+        "max_ms": 764.695,
+        "mean_ms": 524.225,
+        "min_ms": 383.174,
+        "p50_ms": 415.436,
+        "p95_ms": 764.695,
+        "total_ms": 3145.349
+      },
+      "steady_state_tok_s": 1.908,
+      "steady_state_tokens": 6,
+      "token_decode_ms": {
+        "count": 7,
+        "max_ms": 0.077,
+        "mean_ms": 0.029,
+        "min_ms": 0.015,
+        "p50_ms": 0.023,
+        "p95_ms": 0.077,
+        "total_ms": 0.206
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 34825.482,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 11076.262,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 28
+    },
+    "prompt_tokenize_ms": 861.489,
+    "requested": false,
+    "tokenizer_load_ms": 556.945
+  },
+  "prompt": "Repeat exactly: red blue green",
+  "prompt_render": {
+    "add_bos": false,
+    "parse_special": true,
+    "qwen_no_think": true,
+    "rendered_sha256": "25f070614e9cbae4889ac2c92711b9f132b3e20c5b680a743ec0fa0526bbb9c1",
+    "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nRepeat exactly: red blue green<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+    "stop_sequences": [
+      "<|im_end|>",
+      "<|endoftext|>"
+    ],
+    "stop_token_ids": [
+      151645,
+      151643
+    ],
+    "template_family": "qwen-chat"
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 7,
+    "decode_tps": 0.47840349917987973,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "qwen",
+    "phase": "decode",
+    "prompt_tokens": 29,
+    "provenance": "dense_slm_gguf_cpu_reference",
+    "quant_format": "Q8_0",
+    "requested_backend": "cpu",
+    "requested_kernel": "dense-qwen-cpu-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "dense-qwen-cpu-reference",
+    "thread_count": 1,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "Red, blue, green.<|im_end|>",
+  "throughput": {
+    "decoded_tokens": 7,
+    "tokens_per_second": 0.47840349917987973
+  },
+  "timestamp": "2026-05-15T05:35:35.464237800+00:00",
+  "timing": {
+    "cuda_kernel_time_ms": null,
+    "decode_steady_state_tok_s": 1.908,
+    "decode_total_ms": 3551.92,
+    "device_to_host_bytes": null,
+    "first_token_decode_ms": 406.571,
+    "first_token_ms": 11486,
+    "host_to_device_bytes": null,
+    "model_load_ms": 34825.482,
+    "prefill_ms": 11076.262,
+    "sampling_ms_per_token": 5.986,
+    "tokenize_ms": 861.489,
+    "tokenizer_load_ms": 556.945
+  },
+  "tokenizer": {
+    "bos": 151643,
+    "eos": 151645,
+    "model_family": "gguf_metadata",
+    "origin": "embedded",
+    "pretokenizer_authority": "present",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "gguf_metadata"
+  },
+  "tokens": {
+    "generated": 7,
+    "generated_ids": [
+      6033,
+      11,
+      6303,
+      11,
+      6176,
+      13,
+      151645
+    ],
+    "ids": [
+      6033,
+      11,
+      6303,
+      11,
+      6176,
+      13,
+      151645
+    ],
+    "prompt": 29,
+    "prompt_ids": [
+      151644,
+      8948,
+      198,
+      2610,
+      525,
+      264,
+      10950,
+      17847,
+      13,
+      151645,
+      198,
+      151644,
+      872,
+      198,
+      38718,
+      6896,
+      25,
+      2518,
+      6303,
+      6176,
+      151645,
+      198,
+      151644,
+      77091,
+      198,
+      151667,
+      271,
+      151668,
+      271
+    ],
+    "total": 36
+  }
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2.json
@@ -1,0 +1,774 @@
+{
+  "artifact_kind": "slm_cpu_answer_corpus",
+  "backend": {
+    "fallback_used": false,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust"
+  },
+  "backend_lane": "dense_slm_cpu",
+  "cases": [
+    {
+      "answer": "Yes, water is",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "bounded_4_yes_no_water",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 12488,
+        "decode_first_ms": 12488,
+        "total_ms": 13784
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": null,
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": null,
+        "observed_logits_vector_length": null,
+        "observed_logits_vector_length_source": "not_available"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 32
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "542f6f4d235dfb6ebcc5b535cf71fa8a356cc94511c4449509f8845845c0f840",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nAnswer yes or no: is water wet?<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 32,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 32,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "starts_with_any",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "Answer yes or no: is water wet?",
+      "run_receipt_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run2-runs\\bounded_4_yes_no_water.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 4,
+        "tokens_per_second": 0.2901915264074289
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": 2.317,
+        "decode_total_ms": 1692.272,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 397.408,
+        "first_token_ms": 12488,
+        "host_to_device_bytes": null,
+        "model_load_ms": 34963.71,
+        "prefill_ms": 12086.972,
+        "sampling_ms_per_token": 5.572,
+        "tokenize_ms": 579.375,
+        "tokenizer_load_ms": 553.199
+      },
+      "token_ids": {
+        "generated": [
+          9454,
+          11,
+          3015,
+          374
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          16141,
+          9834,
+          476,
+          902,
+          25,
+          374,
+          3015,
+          14401,
+          30,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          9454,
+          11,
+          3015,
+          374
+        ],
+        "ids": [
+          9454,
+          11,
+          3015,
+          374
+        ],
+        "prompt": 32,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          16141,
+          9834,
+          476,
+          902,
+          25,
+          374,
+          3015,
+          14401,
+          30,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 36
+      }
+    },
+    {
+      "answer": "Red, blue, green.<|im_end|>",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "bounded_8_repeat_colors",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 11486,
+        "decode_first_ms": 11486,
+        "total_ms": 14632
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": null,
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": null,
+        "observed_logits_vector_length": null,
+        "observed_logits_vector_length_source": "not_available"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 29
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "25f070614e9cbae4889ac2c92711b9f132b3e20c5b680a743ec0fa0526bbb9c1",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nRepeat exactly: red blue green<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 29,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 29,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 6,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "contains_any",
+        "generated_tokens": 7,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "Repeat exactly: red blue green",
+      "run_receipt_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run2-runs\\bounded_8_repeat_colors.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 7,
+        "tokens_per_second": 0.4784034991798798
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": 1.908,
+        "decode_total_ms": 3551.92,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 406.571,
+        "first_token_ms": 11486,
+        "host_to_device_bytes": null,
+        "model_load_ms": 34825.482,
+        "prefill_ms": 11076.262,
+        "sampling_ms_per_token": 5.986,
+        "tokenize_ms": 861.489,
+        "tokenizer_load_ms": 556.945
+      },
+      "token_ids": {
+        "generated": [
+          6033,
+          11,
+          6303,
+          11,
+          6176,
+          13,
+          151645
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          38718,
+          6896,
+          25,
+          2518,
+          6303,
+          6176,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 7,
+        "generated_ids": [
+          6033,
+          11,
+          6303,
+          11,
+          6176,
+          13,
+          151645
+        ],
+        "ids": [
+          6033,
+          11,
+          6303,
+          11,
+          6176,
+          13,
+          151645
+        ],
+        "prompt": 29,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          38718,
+          6896,
+          25,
+          2518,
+          6303,
+          6176,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 36
+      }
+    },
+    {
+      "answer": "Paris<|im_end|>",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "execution_plan": null,
+      "id": "bounded_16_capital_france",
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "latency": {
+        "cmd_to_first_ms": 13643,
+        "decode_first_ms": 13643,
+        "total_ms": 14032
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": null,
+      "logits_index_boundary": {
+        "expected_logits_vector_length": 151936,
+        "expected_logits_vector_length_source": "tokenizer_vocab_size",
+        "first_step_logits_vector_length": null,
+        "observed_logits_vector_length": null,
+        "observed_logits_vector_length_source": "not_available"
+      },
+      "model": {
+        "architecture": "qwen3",
+        "family": "qwen",
+        "file": "Qwen3-0.6B-Q8_0.gguf",
+        "output_head_tensor": "tied_token_embeddings",
+        "quant_format": "Q8_0",
+        "repo": "Qwen/Qwen3-0.6B-GGUF",
+        "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+        "tie_word_embeddings": true,
+        "vocab_size": 151936
+      },
+      "position": {
+        "next_decode_position": 35
+      },
+      "prompt": {
+        "add_bos": false,
+        "add_special": true,
+        "qwen_no_think": true,
+        "rendered_sha256": "16bc76ecf8712a419e443ffa93da426f79bc4f73ba2deb5e6c59a60444ac6d47",
+        "rendered_text": "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is the capital of France? Answer with one word.<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "template_family": "qwen"
+      },
+      "prompt_prefill": {
+        "decode_start_position": 35,
+        "executed": true,
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "prompt_token_count": 35,
+        "source": "run_receipt_profile"
+      },
+      "prompt_template": "qwen",
+      "quality": {
+        "distinct_generated_tokens": 2,
+        "failed_rules": [],
+        "failure_taxonomy": [],
+        "gate_kind": "contains_any",
+        "generated_tokens": 2,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": 1,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": true,
+        "printable_utf8": true,
+        "scoring": null
+      },
+      "question": "What is the capital of France? Answer with one word.",
+      "run_receipt_path": "ci/slm-cpu/intel-i5-8250u/2026-05-07\\qwen3-multitoken-stability-run2-runs\\bounded_16_capital_france.json",
+      "status": "passed",
+      "throughput": {
+        "decoded_tokens": 2,
+        "tokens_per_second": 0.14253135689851767
+      },
+      "timing": {
+        "cuda_kernel_time_ms": null,
+        "decode_steady_state_tok_s": 2.584,
+        "decode_total_ms": 771.527,
+        "device_to_host_bytes": null,
+        "first_token_decode_ms": 384.522,
+        "first_token_ms": 13643,
+        "host_to_device_bytes": null,
+        "model_load_ms": 35808.685,
+        "prefill_ms": 13256.863,
+        "sampling_ms_per_token": 4.612,
+        "tokenize_ms": 1208.538,
+        "tokenizer_load_ms": 717.512
+      },
+      "token_ids": {
+        "generated": [
+          59604,
+          151645
+        ],
+        "prompt": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          3838,
+          374,
+          279,
+          6722,
+          315,
+          9625,
+          30,
+          21806,
+          448,
+          825,
+          3409,
+          13,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ]
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 2,
+        "generated_ids": [
+          59604,
+          151645
+        ],
+        "ids": [
+          59604,
+          151645
+        ],
+        "prompt": 35,
+        "prompt_ids": [
+          151644,
+          8948,
+          198,
+          2610,
+          525,
+          264,
+          10950,
+          17847,
+          13,
+          151645,
+          198,
+          151644,
+          872,
+          198,
+          3838,
+          374,
+          279,
+          6722,
+          315,
+          9625,
+          30,
+          21806,
+          448,
+          825,
+          3409,
+          13,
+          151645,
+          198,
+          151644,
+          77091,
+          198,
+          151667,
+          271,
+          151668,
+          271
+        ],
+        "total": 37
+      }
+    }
+  ],
+  "claim_boundary": {
+    "answer_ready_artifact_available": false,
+    "backend_quality_gate_passed": true,
+    "bounded_slm_answer_smoke_passed": true,
+    "broad_performance_claimed": false,
+    "coherent_answer_claimed": false,
+    "coherent_output_observed": false,
+    "cuda_answer_corpus": false,
+    "dense_slm_clean_provenance": true,
+    "diagnostic_only_until_answer_ready_artifact": false,
+    "full_metal_inference_claimed": false,
+    "local_answer_path": false,
+    "neural_engine_claimed": false,
+    "qk256_apple_claimed": false,
+    "slm_answer_path": true,
+    "strict_cuda_answer_claimed": false
+  },
+  "corpus": {
+    "case_count": 3,
+    "description": "Bounded deterministic Qwen3 dense SLM multi-token stability corpus for strict CPU receipts.",
+    "name": "qwen3-0-6b-strict-slm-multitoken-stability-v1",
+    "path": "ci/quality/slm-multitoken-stability.yaml",
+    "selected_case_count": 3,
+    "selected_case_ids": [
+      "bounded_4_yes_no_water",
+      "bounded_8_repeat_colors",
+      "bounded_16_capital_france"
+    ]
+  },
+  "execution_plan": null,
+  "fallback_used": false,
+  "generation": {
+    "default_max_new_tokens": 8,
+    "deterministic": true,
+    "logits_dump_steps": null,
+    "logits_topk": null,
+    "mode": "greedy",
+    "per_prompt_timeout_seconds": 420,
+    "requested_cpu_kernel": null,
+    "strict_loader": true,
+    "temperature": 0.0
+  },
+  "model": {
+    "answer_ready": null,
+    "answer_ready_artifact_available": false,
+    "architecture": "qwen3",
+    "bytes": null,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "id": null,
+    "loader_mode": "real_gguf",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "revision": null,
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tokenizer": "gguf_metadata",
+    "tokenizer_authority": null,
+    "tokenizer_path": null
+  },
+  "model_architecture": "qwen3",
+  "model_family": "qwen",
+  "prompt_template": "qwen",
+  "prompt_template_policy": {
+    "family": "qwen"
+  },
+  "quality_summary": {
+    "failed": 0,
+    "not_run": 0,
+    "passed": 3,
+    "timeout": 0,
+    "total": 3
+  },
+  "quantization": "Q8_0",
+  "receipt_quality": {
+    "case_receipt_checker": "answer_receipt_failed_rules",
+    "checked": true,
+    "checked_rules": [
+      "generated_text_recorded",
+      "prompt_token_count_recorded",
+      "generated_token_count_recorded",
+      "total_token_count_recorded",
+      "prompt_token_ids_recorded",
+      "generated_token_ids_recorded",
+      "prompt_token_count_matches_ids",
+      "generated_token_count_matches_ids",
+      "total_token_count_matches",
+      "model_repo_recorded",
+      "model_file_recorded",
+      "model_sha256_recorded",
+      "model_family_recorded",
+      "model_architecture_recorded",
+      "tokenizer_source_recorded",
+      "tokenizer_strict",
+      "tokenizer_pretokenizer_authority_recorded",
+      "requested_backend",
+      "selected_backend",
+      "runtime_api",
+      "fallback_false",
+      "speedup_claim_false",
+      "loader_real_gguf",
+      "selected_kernel_recorded",
+      "selected_kernel_production",
+      "timing_model_load_ms_recorded",
+      "timing_tokenizer_load_ms_recorded",
+      "timing_tokenize_ms_recorded",
+      "timing_prefill_ms_recorded",
+      "timing_first_token_ms_recorded",
+      "timing_decode_total_ms_recorded",
+      "latency_total_ms_recorded"
+    ],
+    "required_case_fields": [
+      "text",
+      "tokens.prompt",
+      "tokens.generated",
+      "tokens.total",
+      "tokens.prompt_ids",
+      "tokens.generated_ids",
+      "model.repo",
+      "model.file",
+      "model.sha256",
+      "model.family",
+      "model.architecture",
+      "tokenizer.source",
+      "tokenizer.strict",
+      "tokenizer.pretokenizer_authority",
+      "requested_backend",
+      "selected_backend",
+      "runtime_api",
+      "fallback_used",
+      "loader.mode",
+      "kernel.kernel_id",
+      "timing.model_load_ms",
+      "timing.tokenizer_load_ms",
+      "timing.tokenize_ms",
+      "timing.prefill_ms",
+      "timing.first_token_ms",
+      "timing.decode_total_ms",
+      "latency.total_ms"
+    ]
+  },
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "scoring_summary": {
+    "enabled": false,
+    "failed": 0,
+    "failure_taxonomy": {},
+    "kinds": [],
+    "not_run": 0,
+    "passed": 0,
+    "total": 0
+  },
+  "selected_backend": "cpu-rust",
+  "selected_kernel_or_runtime": "dense-qwen-cpu-reference",
+  "speedup_claim": false,
+  "timestamp": "2026-05-15T05:36:34.337725400+00:00",
+  "tokenizer": {
+    "authority": null,
+    "path": null,
+    "source": "gguf_metadata",
+    "strict": true
+  },
+  "tokenizer_source": "gguf_metadata"
+}

--- a/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-validation.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-validation.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "slm_multitoken_stability_validation",
+  "claim": "bounded_qwen3_multitoken_determinism",
+  "speedup_claim": false,
+  "model": {
+    "answer_ready": null,
+    "answer_ready_artifact_available": false,
+    "architecture": "qwen3",
+    "bytes": null,
+    "fallback_loader_used": false,
+    "family": "qwen",
+    "file": "Qwen3-0.6B-Q8_0.gguf",
+    "id": null,
+    "loader_mode": "real_gguf",
+    "path": "models/slm/Qwen3-0.6B-Q8_0.gguf",
+    "quant_format": "Q8_0",
+    "repo": "Qwen/Qwen3-0.6B-GGUF",
+    "revision": null,
+    "sha256": "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
+    "tokenizer": "gguf_metadata",
+    "tokenizer_authority": null,
+    "tokenizer_path": null
+  },
+  "prompt_template": "qwen",
+  "prompt_template_policy": {
+    "family": "qwen"
+  },
+  "requested_backend": "cpu",
+  "selected_backend": "cpu-rust",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "selected_kernel_or_runtime": "dense-qwen-cpu-reference",
+  "run_artifacts": [
+    "ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1.json",
+    "ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2.json"
+  ],
+  "validation": {
+    "passed": true,
+    "repeated_run_count": 2,
+    "case_count": 3,
+    "prompt_ids_match": true,
+    "generated_ids_match": true,
+    "strict_receipts": true,
+    "fallback_false": true,
+    "kv_cache_append_read_proven": false,
+    "kv_cache_position_metadata_scope": "prompt_prefill_and_decode_start_only"
+  },
+  "cases": [
+    {
+      "id": "bounded_4_yes_no_water",
+      "max_new_tokens": 4,
+      "prompt_ids_match": true,
+      "generated_ids_match": true,
+      "run1_passed": true,
+      "run2_passed": true,
+      "run1_generated_ids": [
+        9454,
+        11,
+        3015,
+        374
+      ],
+      "run2_generated_ids": [
+        9454,
+        11,
+        3015,
+        374
+      ],
+      "run1_decoded_text": "Yes, water is",
+      "run2_decoded_text": "Yes, water is",
+      "stop_reason": "max_new_tokens_reached",
+      "eos_token_id": 151645,
+      "prompt_tokens": 32,
+      "generated_tokens": 4,
+      "prompt_prefill": {
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "decode_start_position": 32,
+        "prompt_token_count": 32,
+        "source": "run_receipt_profile"
+      },
+      "kv_position_metadata": {
+        "next_decode_position": 32,
+        "limitation": "receipt records prompt prefill/decode-start position metadata; per-token KV append/read positions are not yet exposed"
+      },
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "loader": {
+        "mode": "real_gguf"
+      }
+    },
+    {
+      "id": "bounded_8_repeat_colors",
+      "max_new_tokens": 8,
+      "prompt_ids_match": true,
+      "generated_ids_match": true,
+      "run1_passed": true,
+      "run2_passed": true,
+      "run1_generated_ids": [
+        6033,
+        11,
+        6303,
+        11,
+        6176,
+        13,
+        151645
+      ],
+      "run2_generated_ids": [
+        6033,
+        11,
+        6303,
+        11,
+        6176,
+        13,
+        151645
+      ],
+      "run1_decoded_text": "Red, blue, green.<|im_end|>",
+      "run2_decoded_text": "Red, blue, green.<|im_end|>",
+      "stop_reason": "eos_token",
+      "eos_token_id": 151645,
+      "prompt_tokens": 29,
+      "generated_tokens": 7,
+      "prompt_prefill": {
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "decode_start_position": 29,
+        "prompt_token_count": 29,
+        "source": "run_receipt_profile"
+      },
+      "kv_position_metadata": {
+        "next_decode_position": 29,
+        "limitation": "receipt records prompt prefill/decode-start position metadata; per-token KV append/read positions are not yet exposed"
+      },
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "loader": {
+        "mode": "real_gguf"
+      }
+    },
+    {
+      "id": "bounded_16_capital_france",
+      "max_new_tokens": 16,
+      "prompt_ids_match": true,
+      "generated_ids_match": true,
+      "run1_passed": true,
+      "run2_passed": true,
+      "run1_generated_ids": [
+        59604,
+        151645
+      ],
+      "run2_generated_ids": [
+        59604,
+        151645
+      ],
+      "run1_decoded_text": "Paris<|im_end|>",
+      "run2_decoded_text": "Paris<|im_end|>",
+      "stop_reason": "eos_token",
+      "eos_token_id": 151645,
+      "prompt_tokens": 35,
+      "generated_tokens": 2,
+      "prompt_prefill": {
+        "exercised": true,
+        "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+        "decode_start_position": 35,
+        "prompt_token_count": 35,
+        "source": "run_receipt_profile"
+      },
+      "kv_position_metadata": {
+        "next_decode_position": 35,
+        "limitation": "receipt records prompt prefill/decode-start position metadata; per-token KV append/read positions are not yet exposed"
+      },
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "kernel": {
+        "family": "dense_qwen",
+        "selected_kernel": "dense-qwen-cpu-reference"
+      },
+      "tokenizer": {
+        "model_family": "gguf_metadata",
+        "pretokenizer_authority": "present",
+        "source": "gguf_metadata",
+        "strict": true
+      },
+      "loader": {
+        "mode": "real_gguf"
+      }
+    }
+  ],
+  "claim_boundary": {
+    "broad_chat_quality_claim": false,
+    "warm_session_claim": false,
+    "sustained_throughput_claim": false,
+    "q4_q5_quant_claim": false,
+    "server_gpu_npu_openvino_uhd620_claim": false,
+    "qwen35_claim": false,
+    "bitnet_qk256_claim": false
+  }
+}
+

--- a/docs/slm/SLM_CPU_QWEN3_MULTITOKEN_STABILITY.md
+++ b/docs/slm/SLM_CPU_QWEN3_MULTITOKEN_STABILITY.md
@@ -1,0 +1,70 @@
+# Qwen3 Multi-Token Stability on i5-8250U
+
+This note records the `SLM-CPU-010` evidence shape for bounded Qwen3-0.6B
+Q8_0 multi-token stability on the i5-8250U strict CPU path.
+
+## Scope
+
+This is a correctness and determinism artifact, not a performance claim.
+
+It uses:
+
+- model: `Qwen/Qwen3-0.6B-GGUF`
+- file: `Qwen3-0.6B-Q8_0.gguf`
+- sha256: `9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031`
+- prompt template: `qwen`
+- Qwen thinking policy: `--no-think`
+- backend: `cpu`
+- selected backend: `cpu-rust`
+- selected kernel/runtime: `dense-qwen-cpu-reference`
+- fallback: `false`
+
+## Corpus
+
+The bounded stability corpus is:
+
+```text
+ci/quality/slm-multitoken-stability.yaml
+```
+
+It covers three fixed prompts with `max_new_tokens` caps of 4, 8, and 16.
+Each prompt is run twice under deterministic greedy settings. Stability is
+scored by exact repeated prompt ID and generated ID equality.
+
+## Evidence
+
+The i5-8250U evidence bundle is:
+
+```text
+ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1.json
+ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2.json
+ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-validation.json
+```
+
+The validation artifact records `passed=true` when:
+
+- both runs pass the bounded quality gates
+- prompt IDs match between repeated runs
+- generated IDs match between repeated runs
+- strict GGUF tokenizer metadata is recorded
+- `fallback_used=false`
+
+## KV Metadata
+
+The current receipt surface records prompt-prefill and decode-start position
+metadata, including `kv_cache_behavior=prompt_prefix_prefilled_before_decode`.
+It does not yet expose per-token KV append/read positions. The validation
+artifact records this limitation explicitly as
+`kv_cache_position_metadata_scope=prompt_prefill_and_decode_start_only`.
+
+## Claim Boundary
+
+This evidence does not claim:
+
+- broad Qwen answer quality
+- warm-session usability
+- sustained i5-8250U throughput
+- Q4/Q5 quant support
+- server, GPU, NPU, OpenVINO, or UHD 620 execution
+- Qwen3.5 or hybrid Qwen support
+- BitNet QK256/I2_S kernel changes


### PR DESCRIPTION
## Summary
- add a bounded Qwen3 multi-token stability corpus for max_new_tokens 4, 8, and 16
- record two strict i5-8250U CPU runs and a validation artifact comparing prompt IDs and generated IDs
- document the claim boundary and the current KV metadata limitation: prompt-prefill/decode-start positions are visible, per-token KV append/read positions are not yet exposed

## Evidence
- `ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1.json`
- `ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2.json`
- `ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-validation.json`

## Claim boundary
- claims bounded repeated-run determinism only for the recorded Qwen3 Q8_0 strict CPU cases
- does not claim broad answer quality, warm-session usability, sustained 8250U throughput, Q4/Q5 support, server/GPU/NPU/OpenVINO/UHD 620 execution, Qwen3.5 support, or BitNet QK256 changes

## Validation
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-corpus --corpus ci/quality/slm-multitoken-stability.yaml --model models/slm/Qwen3-0.6B-Q8_0.gguf --device cpu --json-out ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run1.json`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-corpus --corpus ci/quality/slm-multitoken-stability.yaml --model models/slm/Qwen3-0.6B-Q8_0.gguf --device cpu --json-out ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-multitoken-stability-run2.json`
- validation artifact self-check over repeated prompt/generated IDs
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus`
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`