### PR TITLE
fix(bitnet): use activation-quantized I2S QK256 dispatch

### DIFF
--- a/crates/bitnet-cli/src/commands/inspect.rs
+++ b/crates/bitnet-cli/src/commands/inspect.rs
@@ -251,7 +251,7 @@ impl InspectCommand {
         let file_type = reader.get_u32_metadata("general.file_type");
 
         let qk256_inventory = qk256_contract_inventory(&reader)?;
-        let rust_uses_reference_activation_quantization = false;
+        let rust_uses_reference_activation_quantization = true;
         let summary = i2s_matmul_contract_summary(
             &qk256_inventory,
             rust_uses_reference_activation_quantization,
@@ -269,8 +269,8 @@ impl InspectCommand {
             gguf_metadata: I2sMatmulGgufMetadata { architecture, file_type },
             qk256_inventory,
             rust_policy: I2sRustMatmulPolicy {
-                activation_quantization: "none_dense_f32_input".to_string(),
-                dot_formula: "sum(code_to_f32(code) * activation_f32) * trailer_scale".to_string(),
+                activation_quantization: "quantize_row_i8_s".to_string(),
+                dot_formula: "(integer_dot - act_sum) / act_scale * trailer_scale".to_string(),
                 code3_value: 2.0,
                 uses_reference_activation_quantization: rust_uses_reference_activation_quantization,
             },
@@ -285,12 +285,7 @@ impl InspectCommand {
             summary,
             not_claims: critical_qk256_report_not_claims()
                 .into_iter()
-                .chain([
-                    "runtime_reference_parity",
-                    "semantic_quality",
-                    "i2s_activation_quantization_implemented",
-                    "a770_semantic_quality",
-                ])
+                .chain(["runtime_reference_parity", "semantic_quality", "a770_semantic_quality"])
                 .map(str::to_string)
                 .collect(),
         })

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -51,9 +51,9 @@ pub fn reset_qk256_dispatch_counters() {
 
 /// Describes which QK256 runtime is currently used by this dispatch crate.
 ///
-/// OpenCL/oneAPI features currently compile the route dependencies only. The actual
-/// GGML QK256 no-scale GEMV remains the CPU implementation until a format-correct
-/// OpenCL QK256 runtime is wired here.
+/// OpenCL/oneAPI features expose an explicit diagnostic route when selected by
+/// the transformer. The route remains non-claiming until semantic quality and
+/// route receipts prove the full model path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Qk256DispatchStatus {
     pub compiled_opencl: bool,
@@ -70,18 +70,25 @@ pub fn qk256_dispatch_status() -> Qk256DispatchStatus {
     let compiled_opencl = cfg!(feature = "opencl");
     let compiled_oneapi = cfg!(feature = "oneapi");
     let blocker = if compiled_oneapi {
-        Some("oneapi_qk256_transformer_dispatch_not_wired")
+        Some("oneapi_qk256_semantic_quality_unproven")
     } else if compiled_opencl {
-        Some("opencl_qk256_transformer_dispatch_not_wired")
+        Some("opencl_qk256_semantic_quality_unproven")
     } else {
-        Some("cpu_qk256_dispatch_only")
+        Some("cpu_qk256_semantic_quality_unproven")
+    };
+    let runtime_backend = if compiled_oneapi {
+        "oneapi_qk256_activation_quantized_diagnostic"
+    } else if compiled_opencl {
+        "opencl_qk256_activation_quantized_diagnostic"
+    } else {
+        "cpu_qk256_activation_quantized_reference"
     };
 
     Qk256DispatchStatus {
         compiled_opencl,
         compiled_oneapi,
         opencl_launcher_available: cfg!(feature = "opencl"),
-        runtime_backend: "cpu_qk256_reference",
+        runtime_backend,
         accelerator_claimable: false,
         blocker,
         not_claims: NOT_CLAIMED_OPENCL_QK256,
@@ -117,7 +124,7 @@ pub fn forward_qk256_scaled_with_backend(
     backend: Qk256DispatchBackend,
     scale: f32,
 ) -> Result<Tensor> {
-    use bitnet_quantization::i2s_qk256::gemv_qk256_scaled;
+    use bitnet_quantization::i2s_qk256::gemv_qk256_activation_quantized_scaled;
 
     let qk256_dims = qk256_tensor.dims();
     let layout = parse_qk256_layout(weight_name, qk256_dims)
@@ -172,7 +179,7 @@ pub fn forward_qk256_scaled_with_backend(
             for (i, input_row) in input_vec.iter().enumerate() {
                 let start = i * layout.rows;
                 let end = start + layout.rows;
-                gemv_qk256_scaled(
+                gemv_qk256_activation_quantized_scaled(
                     &flat_bytes,
                     input_row,
                     &mut output_flat[start..end],

--- a/crates/bitnet-qk256-dispatch/src/opencl.rs
+++ b/crates/bitnet-qk256-dispatch/src/opencl.rs
@@ -13,6 +13,12 @@ use std::sync::{Arc, OnceLock};
 pub const QK256_OPENCL_KERNEL_NAME: &str = "qk256_gemm_no_scale";
 
 pub const QK256_OPENCL_KERNEL_SRC: &str = r#"
+inline int qk256_nearest_int_reference(const float fval) {
+    const float val = fval + 12582912.0f;
+    const int bits = as_int(val);
+    return (bits & 0x007fffff) - 0x00400000;
+}
+
 __kernel void qk256_gemm_no_scale(
     __global const uchar* qs,
     __global const float* input,
@@ -32,7 +38,14 @@ __kernel void qk256_gemm_no_scale(
     __global const uchar* row_bytes = qs + ((ulong)row * (ulong)row_stride_bytes);
     __global const float* x = input + ((ulong)input_row * (ulong)cols);
 
-    float acc = 0.0f;
+    float max_abs = 0.00001f;
+    for (uint col = 0; col < cols; ++col) {
+        max_abs = fmax(max_abs, fabs(x[col]));
+    }
+
+    const float act_scale = 127.0f / max_abs;
+    int integer_dot = 0;
+    int act_sum = 0;
     for (uint col = 0; col < cols; ++col) {
         const uint group128 = col / 128u;
         const uint within = col - (group128 * 128u);
@@ -40,11 +53,13 @@ __kernel void qk256_gemm_no_scale(
         const uint pos = within - (lane * 32u);
         const uchar packed = row_bytes[(group128 * 32u) + pos];
         const uchar code = (packed >> (6u - (lane * 2u))) & 3u;
-        const float w = ((float)code) - 1.0f;
-        acc += w * x[col];
+        const int q = max(-128, min(127, qk256_nearest_int_reference(x[col] * act_scale)));
+        integer_dot += ((int)code) * q;
+        act_sum += q;
     }
 
-    output[((ulong)input_row * (ulong)rows) + (ulong)row] = acc * scale;
+    output[((ulong)input_row * (ulong)rows) + (ulong)row] =
+        (((float)(integer_dot - act_sum)) / act_scale) * scale;
 }
 "#;
 

--- a/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
+++ b/crates/bitnet-qk256-dispatch/tests/forward_qk256.rs
@@ -1,5 +1,9 @@
 use bitnet_qk256_dispatch::{
-    Qk256DispatchBackend, forward_qk256, forward_qk256_with_backend, qk256_dispatch_status,
+    Qk256DispatchBackend, forward_qk256, forward_qk256_scaled_with_backend,
+    forward_qk256_with_backend, qk256_dispatch_status,
+};
+use bitnet_quantization::i2s_qk256::{
+    QK256_BLOCK, gemv_qk256_row_activation_quantized_reference, pack_qk256_codes_for_cols,
 };
 use candle_core::{Device, Tensor};
 
@@ -80,6 +84,32 @@ fn forward_qk256_rank3_preserves_varied_token_rows() {
 }
 
 #[test]
+fn forward_qk256_cpu_uses_reference_activation_quantization() {
+    let device = Device::Cpu;
+    let cols = QK256_BLOCK;
+    let scale = 0.375f32;
+    let codes: Vec<u8> = (0..cols).map(|i| (i % 4) as u8).collect();
+    let qk_bytes = pack_qk256_codes_for_cols(&codes, cols);
+    let input_values: Vec<f32> = (0..cols).map(|i| ((i % 13) as f32 - 6.0) / 7.0).collect();
+
+    let input = Tensor::from_vec(input_values.clone(), (1, cols), &device).unwrap();
+    let qk = Tensor::from_vec(qk_bytes.clone(), (1, qk_bytes.len()), &device).unwrap();
+    let out = forward_qk256_scaled_with_backend(
+        &input,
+        &qk,
+        "layers.0.attention.q_proj.weight.qk256_qs",
+        Qk256DispatchBackend::Cpu,
+        scale,
+    )
+    .unwrap();
+
+    let expected =
+        gemv_qk256_row_activation_quantized_reference(&qk_bytes, &input_values, cols, scale);
+    let out_vals = out.to_vec2::<f32>().unwrap();
+    assert!((out_vals[0][0] - expected).abs() < 1e-5);
+}
+
+#[test]
 fn forward_qk256_rejects_dimension_mismatch() {
     let device = Device::Cpu;
     let input = Tensor::from_vec(vec![1.0f32; 128], (1, 128), &device).unwrap();
@@ -114,16 +144,18 @@ fn qk256_dispatch_status_keeps_opencl_non_claiming() {
     assert_eq!(status.compiled_opencl, cfg!(feature = "opencl"));
     assert_eq!(status.compiled_oneapi, cfg!(feature = "oneapi"));
     assert_eq!(status.opencl_launcher_available, cfg!(feature = "opencl"));
-    assert_eq!(status.runtime_backend, "cpu_qk256_reference");
     assert!(!status.accelerator_claimable);
     assert!(status.not_claims.contains(&"a770_qk256_opencl_execution"));
 
     if cfg!(feature = "oneapi") {
-        assert_eq!(status.blocker, Some("oneapi_qk256_transformer_dispatch_not_wired"));
+        assert_eq!(status.runtime_backend, "oneapi_qk256_activation_quantized_diagnostic");
+        assert_eq!(status.blocker, Some("oneapi_qk256_semantic_quality_unproven"));
     } else if cfg!(feature = "opencl") {
-        assert_eq!(status.blocker, Some("opencl_qk256_transformer_dispatch_not_wired"));
+        assert_eq!(status.runtime_backend, "opencl_qk256_activation_quantized_diagnostic");
+        assert_eq!(status.blocker, Some("opencl_qk256_semantic_quality_unproven"));
     } else {
-        assert_eq!(status.blocker, Some("cpu_qk256_dispatch_only"));
+        assert_eq!(status.runtime_backend, "cpu_qk256_activation_quantized_reference");
+        assert_eq!(status.blocker, Some("cpu_qk256_semantic_quality_unproven"));
     }
 }
 
@@ -141,7 +173,9 @@ fn qk256_opencl_source_matches_microsoft_bitnet_mapping() {
     assert!(
         QK256_OPENCL_KERNEL_SRC.contains("const uchar code = (packed >> (6u - (lane * 2u))) & 3u")
     );
-    assert!(QK256_OPENCL_KERNEL_SRC.contains("const float w = ((float)code) - 1.0f"));
-    assert!(QK256_OPENCL_KERNEL_SRC.contains("acc * scale"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("qk256_nearest_int_reference"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("const float act_scale = 127.0f / max_abs"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("integer_dot += ((int)code) * q"));
+    assert!(QK256_OPENCL_KERNEL_SRC.contains("(integer_dot - act_sum"));
     assert!(QK256_OPENCL_KERNEL_SRC.contains("const float scale"));
 }

--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -231,6 +231,22 @@ pub fn gemv_qk256_row_activation_quantized_reference(
     debug_assert!(x.len() >= cols, "I2S_QK256: x too short: {} < {}", x.len(), cols);
 
     let activation = quantize_row_i8_s_reference(&x[..cols]);
+    gemv_qk256_row_with_activation_quantized_reference(qs_row, &activation, cols, trailer_scale)
+}
+
+#[inline]
+fn gemv_qk256_row_with_activation_quantized_reference(
+    qs_row: &[u8],
+    activation: &I2SActivationQuant,
+    cols: usize,
+    trailer_scale: f32,
+) -> f32 {
+    debug_assert!(
+        activation.values.len() >= cols,
+        "I2S_QK256: activation values too short: {} < {}",
+        activation.values.len(),
+        cols
+    );
     let mut integer_dot = 0i32;
     for (col, &q) in activation.values.iter().enumerate().take(cols) {
         let raw_code = i32::from(packed_code_at(qs_row, col));
@@ -582,6 +598,55 @@ pub fn gemv_qk256_scaled(
             *output *= scale;
         }
     }
+    Ok(())
+}
+
+/// Multi-row GEMV using the reference `I2_S` activation quantization contract.
+///
+/// This matches GGML's BitNet matmul rule:
+/// `(integer_dot - act_sum) / act_scale * trailer_scale`.
+pub fn gemv_qk256_activation_quantized_scaled(
+    qs_data: &[u8],
+    x: &[f32],
+    y_out: &mut [f32],
+    rows: usize,
+    cols: usize,
+    row_stride_bytes: usize,
+    scale: f32,
+) -> Result<()> {
+    if y_out.len() != rows {
+        bail!("I2S_QK256: y_out length {} != rows {}", y_out.len(), rows);
+    }
+    if x.len() < cols {
+        bail!("I2S_QK256: x length {} < cols {}", x.len(), cols);
+    }
+    let expected_stride = qk256_row_stride_bytes(cols)?;
+    if row_stride_bytes != expected_stride {
+        bail!(
+            "I2S_QK256: row_stride_bytes {} != expected {} for cols={}",
+            row_stride_bytes,
+            expected_stride,
+            cols
+        );
+    }
+
+    let expected_total = rows * row_stride_bytes;
+    if qs_data.len() < expected_total {
+        bail!("I2S_QK256: data too short: {} < {}", qs_data.len(), expected_total);
+    }
+
+    let activation = quantize_row_i8_s_reference(&x[..cols]);
+    for (row, output) in y_out.iter_mut().enumerate().take(rows) {
+        let start = row * row_stride_bytes;
+        let end = start + row_stride_bytes;
+        *output = gemv_qk256_row_with_activation_quantized_reference(
+            &qs_data[start..end],
+            &activation,
+            cols,
+            scale,
+        );
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary- switch transformer-facing QK256 CPU dispatch to the reference activation-quantized `I2_S` rule- update the OpenCL QK256 diagnostic kernel to mirror `(integer_dot - act_sum) / act_scale * trailer_scale`- keep QK256 dispatch non-claiming while reporting activation-quantized diagnostic backends until semantic quality/route receipts prove the full model path## Claim boundary- no clean A770 claim sequence in this PR- no semantic quality promotion- no reference parity promotion- no A770 performance claim- no selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion promotion## Validation```textcargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu -- --nocapturecargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl -- --nocapturecargo test --locked -p bitnet-qk256-dispatch --no-default-features --features opencl --test opencl_qk256_hardware -- --ignored --nocapturecargo test --locked -p bitnet-quantization i2s_qk256 -- --nocapturecargo check --locked -p bitnet-cli --no-default-features --features cpucargo check --locked -p bitnet-cli --no-default-features --features openclrustfmt --check --edition 2024 --config skip_children=true crates\bitnet-quantization\src\i2s_qk256.rs crates\bitnet-qk256-dispatch\src\lib.rs crates\bitnet-qk256-dispatch\src\opencl.rs crates\bitnet-qk256-dispatch\tests\forward_qk256.rsgit diff --check```## NotesA direct Rust CPU real-model smoke was attempted as a diagnostic check, but it exceeded the local 15-minute timeout and was killed. It is not used as evidence for this PR.