### PR TITLE
diag(bitnet): emit release Rust reference commands

### DIFF
--- a/xtask/src/bitnet_reference_plan.rs
+++ b/xtask/src/bitnet_reference_plan.rs
@@ -297,6 +297,12 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
                 "purpose": "bounded prompt-matched Rust CPU/A770 receipts for first-token, top-logit, and diagnostic selected-logit comparison"
             },
             "reference_text_tokenization": reference_text_probe.report,
+            "rust_receipt_command_policy": {
+                "cargo_profile": "release",
+                "reason": "real-model CPU diagnostics are too slow in debug and can leave stale non-matching receipts",
+                "diagnostic_only": true,
+                "claimable": false
+            },
             "cpu_first_token_logit_argv": rust_cli_first_token_logit_argv(
                 "cpu",
                 &model_path,
@@ -681,6 +687,7 @@ fn rust_cli_argv(
         "cargo".to_string(),
         "run".to_string(),
         "--locked".to_string(),
+        "--release".to_string(),
         "-p".to_string(),
         "bitnet-cli".to_string(),
         "--no-default-features".to_string(),
@@ -981,6 +988,8 @@ mod tests {
         );
         assert!(cpu.windows(2).any(|args| args == ["--features", "cpu"]));
         assert!(a770.windows(2).any(|args| args == ["--features", "opencl"]));
+        assert!(cpu.iter().any(|arg| arg == "--release"));
+        assert!(a770.iter().any(|arg| arg == "--release"));
         assert!(a770.windows(2).any(|args| args == ["--device", "intel-arc-a770-opencl"]));
         assert!(
             cpu.windows(2)
@@ -1100,6 +1109,7 @@ mod tests {
             &[17, 10, 17239],
         );
 
+        assert!(argv.iter().any(|arg| arg == "--release"));
         assert!(argv.windows(2).any(|args| args == ["--max-new-tokens", "1"]));
         assert!(argv.windows(2).any(|args| args == ["--dump-logit-steps", "1"]));
         assert!(argv.windows(2).any(|args| args == ["--logits-topk", "10"]));


### PR DESCRIPTION
## Summary
- make `bitnet-reference-plan` emit release-profile Rust CLI commands for CPU and strict A770 receipts
- record the release command policy in the diagnostic plan so operators do not accidentally use slow debug receipts for real-model localization
- keep CPU and A770 proof identity/route separation unchanged

## Evidence
Generated `target/a770-diagnostic/bitnet-reference-plan-release-rust-commands.json` locally. The emitted Rust receipt commands now include `--release` for:
- `rust_commands.cpu_argv`
- `rust_commands.a770_argv`
- `rust_commands.cpu_first_token_logit_argv`
- `rust_commands.a770_first_token_logit_argv`

The plan also records:
- `rust_receipt_command_policy.cargo_profile=release`
- `rust_receipt_command_policy.diagnostic_only=true`
- `rust_receipt_command_policy.claimable=false`

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_plan -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-plan --reference-run-receipt target/a770-diagnostic/bitnet-reference-run-gguf-tokenizer-fix.json --output target/a770-diagnostic/bitnet-reference-plan-release-rust-commands.json --format json`
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_plan.rs`
- `git diff --check`

## Claim Boundary
No claim promotion. This does not claim selected attention, resident KV, attention scores, softmax, value mix, full support-op residency, full device residency, completion, runtime reference parity, semantic quality, or A770 semantic quality.