### PR TITLE
diag(bitnet): report top-logit argmax agreement

### DIFF
--- a/xtask/src/bitnet_reference_compare.rs
+++ b/xtask/src/bitnet_reference_compare.rs
@@ -396,6 +396,14 @@ fn compare_pair(left: &OutputSignal, right: &OutputSignal) -> Value {
             left.iter().map(|item| item.token_id).collect::<Vec<_>>()
                 == right.iter().map(|item| item.token_id).collect::<Vec<_>>()
         });
+    let top_logit_argmax_token_exact =
+        left.top_logits.as_ref().zip(right.top_logits.as_ref()).and_then(|(left, right)| {
+            left.first().zip(right.first()).map(|(left, right)| left.token_id == right.token_id)
+        });
+    let top_logit_argmax_delta =
+        left.top_logits.as_ref().zip(right.top_logits.as_ref()).and_then(|(left, right)| {
+            left.first().zip(right.first()).map(|(left, right)| (left.logit - right.logit).abs())
+        });
     let top_logit_max_abs_delta =
         left.top_logits.as_ref().zip(right.top_logits.as_ref()).map(|(left, right)| {
             left.iter()
@@ -417,6 +425,8 @@ fn compare_pair(left: &OutputSignal, right: &OutputSignal) -> Value {
         "top_logits_available": left.top_logits.is_some() && right.top_logits.is_some(),
         "top_logit_count": left.top_logits.as_ref().zip(right.top_logits.as_ref()).map(|(left, right)| left.len().min(right.len())),
         "top_logit_token_ids_exact": top_logit_token_ids_exact,
+        "top_logit_argmax_token_exact": top_logit_argmax_token_exact,
+        "top_logit_argmax_delta": top_logit_argmax_delta,
         "top_logit_max_abs_delta": top_logit_max_abs_delta,
         "reference_text_candidate_logits": reference_text_candidate_logits(left, right),
     })
@@ -671,6 +681,8 @@ mod tests {
         assert_eq!(report["text_exact"], false);
         assert_eq!(report["top_logits_available"], true);
         assert_eq!(report["top_logit_token_ids_exact"], false);
+        assert_eq!(report["top_logit_argmax_token_exact"], true);
+        assert_eq!(report["top_logit_argmax_delta"], 0.25);
         assert_eq!(report["top_logit_max_abs_delta"], 0.25);
     }
 


### PR DESCRIPTION
## Summary
- add `top_logit_argmax_token_exact` to `bitnet-reference-compare`
- add `top_logit_argmax_delta` for the top-1 logit value gap
- keep full top-k token-id exactness as a separate diagnostic blocker

## Evidence
A same-prompt release diagnostic compare using the current reference, Rust CPU, and strict A770 receipts now reports:
- `cpu_vs_a770.token_ids_exact=true`
- `cpu_vs_a770.text_exact=true`
- `cpu_vs_a770.top_logit_argmax_token_exact=true`
- `cpu_vs_a770.top_logit_token_ids_exact=false`

This makes the CPU/A770 top-1 agreement visible without weakening the full top-k parity blocker.

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_compare -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-compare --reference target/a770-diagnostic/bitnet-reference-run-gguf-tokenizer-fix.json --cpu target/a770-diagnostic/reference-plan-cpu-first-token.json --a770 target/a770-diagnostic/reference-plan-a770-first-token.json --output target/a770-diagnostic/bitnet-reference-compare-release-rust-first-token-argmax.json --format json`
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_compare.rs`
- `git diff --check`

## Claim Boundary
No claim promotion. This does not claim selected attention, resident KV, attention scores, softmax, value mix, full support-op residency, full device residency, completion, runtime reference parity, semantic quality, or A770 semantic quality.