### PR TITLE
Close apple-m4-slm-eval-v2

### DIFF
--- a/docs/tracking/campaigns/apple-m4-slm-eval-v2/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-v2/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-slm-eval-v2`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -55,7 +55,7 @@ MacBook behavior, or broad Apple Silicon performance.
 | M4-SLM-EVAL2-002 | merged | PR #4792 added stop-token/template/scoring failure taxonomy for v2 reports. |
 | M4-SLM-EVAL2-003 | merged | PR #4834 published supported dense M4 v2 task-family pass-rate reports. |
 | M4-SLM-EVAL2-004 | merged | PR #4879 published supported dense M4 benchmark v2 receipts with p50/p90/p99 timing, throughput, and memory fields. |
-| M4-SLM-EVAL2-005 | in progress | Wire v2 eval/benchmark reports into advisory or nightly regression dashboards. |
+| M4-SLM-EVAL2-005 | merged | PR #4886 wired v2 eval and benchmark reports into model-free regression dashboard checks. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-slm-eval-v2/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-v2/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-slm-eval-v2"
 title = "Apple M4 dense SLM eval v2"
-status = "active"
+status = "complete"
 
 objective = "Move the Apple M4 dense SLM lane from bounded 10-case proof into broader, reproducible quality and benchmark reporting with a 100-500 case deterministic corpus, task-family pass rates, full latency/throughput profiles, and regression dashboards without broad model-quality or Apple Silicon benchmark claims."
 
@@ -195,7 +195,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-SLM-EVAL2-005"
-status = "in_progress"
+status = "merged"
+pr = 4886
 branch = "codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-005-regression-dashboard"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-slm-eval-v2/events/2026-05-15T094631Z-M4-SLM-EVAL2-005-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-v2/events/2026-05-15T094631Z-M4-SLM-EVAL2-005-merged.toml
@@ -1,0 +1,24 @@
+timestamp = "2026-05-15T09:46:31Z"
+campaign = "apple-m4-slm-eval-v2"
+item = "M4-SLM-EVAL2-005"
+event = "merged"
+actor = "codex"
+from = "in_progress"
+to = "merged"
+branch = "codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-005-regression-dashboard"
+pr = 4886
+head_sha = "60f321b15c44cb36cc75e8fe7a7aa65131b87710"
+merge_sha = "6aecd5d25f70a086696251d0f07ee7ca1df62915"
+summary = "Marked M4-SLM-EVAL2-005 merged after v2 regression dashboard wiring landed."
+
+artifacts = [
+  "https://github.com/EffortlessMetrics/BitNet-rs/pull/4886",
+  ".github/workflows/apple-m4-slm-eval-tier0.yml",
+  "docs/slm/apple-m4-slm-eval-v2.md",
+]
+
+notes = [
+  "The merged PR adds apple_m4_slm_benchmark_v2 support to mac regression and extends dense SLM eval regression to scoring-summary and task-family fields.",
+  "Tier 0 now validates committed v2 reports and self-baseline regression checks under --fail-on-drift without fetching models or running live M4 inference.",
+  "The change is bounded to recorded dense M4 SLM reports and does not claim broad quality, broad Apple Silicon performance, BitNet evidence, full Metal inference, QK256, Neural Engine, MPSGraph, or MacBook behavior.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-eval-v2/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-v2/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 dense SLM eval v2 Campaign Status
 
 - Campaign: `apple-m4-slm-eval-v2`
-- State: `active`
+- State: `complete`
 - Objective: Move the Apple M4 dense SLM lane from bounded 10-case proof into broader, reproducible quality and benchmark reporting with a 100-500 case deterministic corpus, task-family pass rates, full latency/throughput profiles, and regression dashboards without broad model-quality or Apple Silicon benchmark claims.
 
 ## Work Items
@@ -13,7 +13,7 @@
 | M4-SLM-EVAL2-002 | merged | #4792 | `codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-002-failure-taxonomy` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add stop-token/template/scoring failure taxonomy so v2 reports distinguish raw special-token tails, fenced JSON, punctuation/casing/normalization differences, format-only failures, and answer-content failures without hiding strict scoring results. |
 | M4-SLM-EVAL2-003 | merged | #4834 | `codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-003-v2-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run the v2 corpus for every supported dense M4 model ID and publish per-model reports with task-family pass rates, strict scoring totals, generated text/token IDs, backend/fallback identity, catalog-pinned aggregate model identity, and dense-SLM-only claim boundaries. |
 | M4-SLM-EVAL2-004 | merged | #4879 | `codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-004-benchmark-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Refresh dense M4 benchmark profiles for every supported model with cold load, tokenizer load, prompt tokenization, prefill, TTFT, input tok/s, output tok/s, decode tok/s, total wall time, peak memory, memory drift, and p50/p90/p99 summaries. |
-| M4-SLM-EVAL2-005 | in_progress | TBD | `codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-005-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire v2 eval and benchmark reports into advisory/nightly regression dashboards with thresholds for task-family pass rates, strict scoring totals, TTFT, input/output/decode throughput, total wall time, peak memory, and memory drift while keeping generic PR CI model-free. |
+| M4-SLM-EVAL2-005 | merged | #4886 | `codex/apple-m4-slm-eval-v2/M4-SLM-EVAL2-005-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire v2 eval and benchmark reports into advisory/nightly regression dashboards with thresholds for task-family pass rates, strict scoring totals, TTFT, input/output/decode throughput, total wall time, peak memory, and memory drift while keeping generic PR CI model-free. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -86,7 +86,7 @@
 | apple-m4-slm-eval-v2 | M4-SLM-EVAL2-002 | M4-SLM-EVAL2-001 | merged |
 | apple-m4-slm-eval-v2 | M4-SLM-EVAL2-003 | M4-SLM-EVAL2-002 | merged |
 | apple-m4-slm-eval-v2 | M4-SLM-EVAL2-004 | M4-SLM-EVAL2-003 | merged |
-| apple-m4-slm-eval-v2 | M4-SLM-EVAL2-005 | M4-SLM-EVAL2-003, M4-SLM-EVAL2-004 | in_progress |
+| apple-m4-slm-eval-v2 | M4-SLM-EVAL2-005 | M4-SLM-EVAL2-003, M4-SLM-EVAL2-004 | merged |
 | apple-m4-slm-excellence | M4-SLM-EX-002 | M4-SLM-EX-001 | merged |
 | apple-m4-slm-excellence | M4-SLM-EX-003 | M4-SLM-EX-002 | merged |
 | apple-m4-slm-excellence | M4-SLM-EX-004 | M4-SLM-EX-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -15,7 +15,7 @@
 | apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-eval-and-proof | M4-SLM-EVAL-006 | #4677 | merged | none | This is an M4 Mac mini dense SLM campaign. |
-| apple-m4-slm-eval-v2 | M4-SLM-EVAL2-005 | TBD | in_progress | none | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-eval-v2 | M4-SLM-EVAL2-005 | #4886 | merged | none | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-excellence | M4-SLM-EX-010 | #4307 | merged | none | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
 | apple-m4-slm-metal-phases | M4-METAL-007 | #4397 | merged | none | This is an M4 Mac mini dense SLM campaign. |


### PR DESCRIPTION
## Summary

- tracker-only closeout for `apple-m4-slm-eval-v2`
- marks `M4-SLM-EVAL2-005` merged after PR #4886 landed
- marks the campaign complete and regenerates tracking dashboards

## Claim boundary

No runtime, model, server, Metal, QK256, Neural Engine, MPSGraph, MacBook, BitNet, or broad quality/performance claim change.

## Validation

- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-eval-v2`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign next apple-m4-slm-eval-v2` -> `next_item: none`
- `git diff --check`
