### PR TITLE
perf(slm): use no-bias dense linear path

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -253,7 +253,7 @@ fn dbg_finite(tag: &str, t: &Tensor) -> candle_core::Result<()> {
     Ok(())
 }
 
-/// Helper to create linear layers with optional bias tensors (zero-injection)
+/// Helper to create linear layers with optional bias tensors.
 fn linear_with_optional_bias(
     in_dim: usize,
     out_dim: usize,
@@ -261,12 +261,13 @@ fn linear_with_optional_bias(
 ) -> candle_core::Result<Linear> {
     let weight = vb.get((out_dim, in_dim), "weight")?;
 
-    // Try to get bias, create zeros if missing
+    // Missing bias is semantically a no-bias linear layer. Avoid materializing
+    // zero tensors and a runtime add for dense GGUF weights that omit bias.
     let bias = match vb.get(out_dim, "bias") {
         Ok(b) => Some(b),
         Err(_) => {
-            tracing::debug!("Bias tensor missing for linear layer; injecting zeros [{}]", out_dim);
-            Some(Tensor::zeros(out_dim, DType::F32, vb.device())?)
+            tracing::debug!("Bias tensor missing for linear layer; using no-bias path [{out_dim}]");
+            None
         }
     };
 
@@ -1926,6 +1927,28 @@ mod tests {
         let has_inf = vec_data.iter().any(|x| x.is_infinite());
         assert!(!has_nan, "Output should not contain NaN");
         assert!(!has_inf, "Output should not contain Inf");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_linear_with_optional_bias_uses_no_bias_path() -> candle_core::Result<()> {
+        let device = Device::Cpu;
+        let weight = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], (2, 2), &device)?;
+        let input = Tensor::from_slice(&[5.0f32, 6.0], (1, 2), &device)?;
+
+        let mut tensors = HashMap::new();
+        tensors.insert("weight".to_string(), weight.clone());
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+
+        let no_bias = linear_with_optional_bias(2, 2, vb)?;
+        let no_bias_output = no_bias.forward(&input)?;
+
+        let explicit_zero_bias = Linear::new(weight, Some(Tensor::zeros(2, DType::F32, &device)?));
+        let zero_bias_output = explicit_zero_bias.forward(&input)?;
+
+        assert_eq!(no_bias_output.to_vec2::<f32>()?, zero_bias_output.to_vec2::<f32>()?);
+        assert_eq!(no_bias_output.to_vec2::<f32>()?, vec![vec![17.0, 39.0]]);
 
         Ok(())
     }

--- a/docs/slm/SLM_CPU_QWEN3_WARM_SESSION.md
+++ b/docs/slm/SLM_CPU_QWEN3_WARM_SESSION.md
@@ -88,3 +88,13 @@ buffers and records that prompt-invariant stop sequences and stop token IDs are
 computed once per session. This is allocation/layout evidence only; resident
 memory, thermal, and power fields remain explicitly unavailable unless a later
 hardware-specific sampler fills them in.
+
+## SLM-CPU-013 Q8_0 Hot-Path Boundary
+
+The first Q8_0 hot-path cleanup keeps the SLM-CPU-011/012 generated IDs and
+strict receipt provenance as the behavior oracle. Dense GGUF linear layers that
+omit a bias now use the no-bias `Linear` path instead of materializing a zero
+bias tensor, preserving numerical output while avoiding unnecessary allocation
+and per-forward bias addition. This is implementation cleanup only; it does not
+claim sustained throughput, Q4/Q5 support, GPU/NPU/OpenVINO/UHD 620 execution,
+server inference, Qwen3.5 support, or BitNet QK256 kernel changes.


### PR DESCRIPTION
## Summary
- use Candle's no-bias `Linear` path when dense GGUF linear weights omit bias instead of materializing a zero bias tensor
- add a regression test proving the no-bias path matches explicit zero-bias output
- document the SLM-CPU-013 Q8_0 hot-path cleanup boundary without throughput or broader backend claims

## Validation
- `cargo test --locked -p bitnet-transformer --no-default-features --features cpu test_linear_with_optional_bias_uses_no_bias_path`
- `cargo test --locked -p bitnet-transformer --no-default-features --features cpu`
- `cargo clippy --locked -p bitnet-transformer --no-default-features --features cpu -- -D warnings`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli slm_warm_session`
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

## Notes
- `cargo fmt --package bitnet-transformer --all -- --check` hit the known Windows path-length `os error 206` limitation. Direct `rustfmt --edition 2024 --check crates/bitnet-transformer/src/lib.rs` only reported newline-style issues in module files after the local formatting adjustment.
- No Q4/Q5, server, GPU/NPU/OpenVINO/UHD 620, Qwen3.5, sustained throughput, or BitNet QK256 changes.