### PR TITLE
Start Apple M4 BitNet eval benchmark campaign

### DIFF
--- a/ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml
+++ b/ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml
@@ -1,0 +1,869 @@
+schema: 1
+artifact_kind: bitnet_answer_corpus
+name: apple-m4-bitnet-eval-seeded-corpus
+description: Seeded deterministic BitNet eval corpus for Apple M4 quality and benchmark reports.
+metadata:
+  campaign: apple-m4-bitnet-eval-and-benchmark
+  work_item: M4-BITNET-EVAL-001
+  seed: 912587
+  generator_policy: deterministic-static-fixture-bitnet-v1
+  case_count_target: 100
+  prompt_template: bitnetcpp-answer
+  scoring_status: deterministic_fixture_scoring
+  claim_boundary:
+    runtime_proof: false
+    bitnet_accuracy_claim: false
+    bitnet_performance_claim: false
+    dense_slm_evidence: false
+    chat_enabled: false
+    serve_enabled: false
+model:
+  repo: microsoft/bitnet-b1.58-2B-4T-gguf
+  repo_revision: a1f2f1c765812aa8af3f6eda4a313707064bba15
+  file: ggml-model-i2_s.gguf
+  sha256: 4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162
+  bytes: 1187801280
+  family: bitnet
+  architecture: bitnet_b1_58
+  quant_format: I2_S
+  answer_ready:
+    state: answer_ready
+    gate: MODEL-ARTIFACT-007
+    manifest: ci/model-artifacts/artifact-manifest.toml
+    evidence: docs/reports/MODEL_ARTIFACT_007_MICROSOFT_BITNETCPP_EXTERNAL_PRETOKENIZER.md
+  tokenizer_authority:
+    source: external_tokenizer_json
+    repo: microsoft/bitnet-b1.58-2B-4T
+    revision: 04c3b9ad9361b824064a1f25ea60a8be9599b127
+    sha256: e134af98b985517b4f068e3755ae90d4e9cd2d45d328325dc503f1c6b2d06cc7
+    ggml_pre: llama-bpe
+defaults:
+  prompt_template: bitnetcpp-answer
+  max_new_tokens: 32
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+  per_prompt_timeout_seconds: 300
+  min_generated_tokens: 1
+  min_distinct_generated_tokens: 1
+cases:
+  - id: bitnet_arithmetic_seed912587_add_001
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=add index=1 a=3 b=8"
+    question: "Compute 3 + 8. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "11"}
+    gate: {kind: exact_trimmed, expected: "11"}
+
+  - id: bitnet_arithmetic_seed912587_add_002
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=add index=2 a=6 b=7"
+    question: "Compute 6 + 7. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "13"}
+    gate: {kind: exact_trimmed, expected: "13"}
+
+  - id: bitnet_arithmetic_seed912587_add_003
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=add index=3 a=9 b=5"
+    question: "Compute 9 + 5. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "14"}
+    gate: {kind: exact_trimmed, expected: "14"}
+
+  - id: bitnet_arithmetic_seed912587_add_004
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=add index=4 a=12 b=4"
+    question: "Compute 12 + 4. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "16"}
+    gate: {kind: exact_trimmed, expected: "16"}
+
+  - id: bitnet_arithmetic_seed912587_add_005
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=add index=5 a=15 b=6"
+    question: "Compute 15 + 6. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "21"}
+    gate: {kind: exact_trimmed, expected: "21"}
+
+  - id: bitnet_arithmetic_seed912587_sub_006
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=sub index=6 a=18 b=7"
+    question: "Compute 18 - 7. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "11"}
+    gate: {kind: exact_trimmed, expected: "11"}
+
+  - id: bitnet_arithmetic_seed912587_sub_007
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=sub index=7 a=25 b=9"
+    question: "Compute 25 - 9. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "16"}
+    gate: {kind: exact_trimmed, expected: "16"}
+
+  - id: bitnet_arithmetic_seed912587_mul_008
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=mul index=8 a=4 b=6"
+    question: "Compute 4 x 6. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "24"}
+    gate: {kind: exact_trimmed, expected: "24"}
+
+  - id: bitnet_arithmetic_seed912587_mul_009
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=mul index=9 a=7 b=3"
+    question: "Compute 7 x 3. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "21"}
+    gate: {kind: exact_trimmed, expected: "21"}
+
+  - id: bitnet_arithmetic_seed912587_mix_010
+    category: arithmetic_exact
+    seed_material: "seed=912587 family=arithmetic op=mix index=10 expr=(5+4)*2"
+    question: "Compute (5 + 4) x 2. Answer with only the number."
+    max_new_tokens: 4
+    scoring: {kind: exact_match, expected_normalized: "18"}
+    gate: {kind: exact_trimmed, expected: "18"}
+
+  - id: bitnet_numeric_seed912587_div_001
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=divide index=1 numerator=7 denominator=2"
+    question: "Compute 7 divided by 2. Answer with a decimal number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 3.5, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["3.5"]}
+
+  - id: bitnet_numeric_seed912587_div_002
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=divide index=2 numerator=9 denominator=4"
+    question: "Compute 9 divided by 4. Answer with a decimal number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 2.25, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["2.25"]}
+
+  - id: bitnet_numeric_seed912587_div_003
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=divide index=3 numerator=11 denominator=5"
+    question: "Compute 11 divided by 5. Answer with a decimal number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 2.2, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["2.2"]}
+
+  - id: bitnet_numeric_seed912587_percent_004
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=percent index=4 value=25 percent=20"
+    question: "What is 20 percent of 25? Answer with a number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 5, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["5"]}
+
+  - id: bitnet_numeric_seed912587_percent_005
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=percent index=5 value=80 percent=12.5"
+    question: "What is 12.5 percent of 80? Answer with a number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 10, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["10"]}
+
+  - id: bitnet_numeric_seed912587_average_006
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=average index=6 values=4,8,10"
+    question: "What is the average of 4, 8, and 10? Answer with a decimal number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 7.33, numeric_tolerance: 0.02}
+    gate: {kind: contains_any, contains_any: ["7.33", "7.3"]}
+
+  - id: bitnet_numeric_seed912587_average_007
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=average index=7 values=6,9,12"
+    question: "What is the average of 6, 9, and 12? Answer with a number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 9, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["9"]}
+
+  - id: bitnet_numeric_seed912587_fraction_008
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=fraction index=8 value=3/8"
+    question: "Convert 3/8 to a decimal. Answer with a decimal number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 0.375, numeric_tolerance: 0.001}
+    gate: {kind: contains_any, contains_any: ["0.375"]}
+
+  - id: bitnet_numeric_seed912587_fraction_009
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=fraction index=9 value=5/8"
+    question: "Convert 5/8 to a decimal. Answer with a decimal number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 0.625, numeric_tolerance: 0.001}
+    gate: {kind: contains_any, contains_any: ["0.625"]}
+
+  - id: bitnet_numeric_seed912587_ratio_010
+    category: numeric_tolerance
+    seed_material: "seed=912587 family=numeric op=ratio index=10 values=18:6"
+    question: "Simplify the ratio 18 to 6 into one number for 18/6. Answer with a number only."
+    max_new_tokens: 8
+    scoring: {kind: numeric_tolerance, expected_number: 3, numeric_tolerance: 0.01}
+    gate: {kind: contains_any, contains_any: ["3"]}
+
+  - id: bitnet_table_seed912587_city_001
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=1"
+    question: "Table: Ada=red, Ben=blue, Cyd=green. What color is Ben? Answer with one word."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "blue"}
+    gate: {kind: contains_any, contains_any: ["blue"]}
+
+  - id: bitnet_table_seed912587_city_002
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=2"
+    question: "Table: Ada=red, Ben=blue, Cyd=green. Who has green? Answer with one name."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "cyd"}
+    gate: {kind: contains_any, contains_any: ["Cyd", "cyd"]}
+
+  - id: bitnet_table_seed912587_city_003
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=3"
+    question: "Table: item A costs 4, item B costs 9, item C costs 12. What does item C cost? Answer with only the number."
+    max_new_tokens: 8
+    scoring: {kind: exact_match, expected_normalized: "12"}
+    gate: {kind: exact_trimmed, expected: "12"}
+
+  - id: bitnet_table_seed912587_city_004
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=4"
+    question: "Table: item A costs 4, item B costs 9, item C costs 12. Which item costs 9? Answer with the item letter only."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "b"}
+    gate: {kind: contains_any, contains_any: ["B", "b"]}
+
+  - id: bitnet_table_seed912587_city_005
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=5"
+    question: "Table: north=12, south=7, east=5. Which direction has value 7? Answer with one word."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "south"}
+    gate: {kind: contains_any, contains_any: ["south"]}
+
+  - id: bitnet_table_seed912587_city_006
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=6"
+    question: "Table: north=12, south=7, east=5. What value is north? Answer with only the number."
+    max_new_tokens: 8
+    scoring: {kind: exact_match, expected_normalized: "12"}
+    gate: {kind: exact_trimmed, expected: "12"}
+
+  - id: bitnet_table_seed912587_city_007
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=7"
+    question: "Table: R1=open, R2=closed, R3=open. What is R2? Answer with one word."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "closed"}
+    gate: {kind: contains_any, contains_any: ["closed"]}
+
+  - id: bitnet_table_seed912587_city_008
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=8"
+    question: "Table: R1=open, R2=closed, R3=open. Which row is closed? Answer with the row id."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "r2"}
+    gate: {kind: contains_any, contains_any: ["R2", "r2"]}
+
+  - id: bitnet_table_seed912587_city_009
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=9"
+    question: "Table: cat=mammal, trout=fish, robin=bird. What type is trout? Answer with one word."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "fish"}
+    gate: {kind: contains_any, contains_any: ["fish"]}
+
+  - id: bitnet_table_seed912587_city_010
+    category: fixed_table_qa
+    seed_material: "seed=912587 family=fixed_table index=10"
+    question: "Table: cat=mammal, trout=fish, robin=bird. Which animal is a bird? Answer with one word."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "robin"}
+    gate: {kind: contains_any, contains_any: ["robin"]}
+
+  - id: bitnet_json_seed912587_001
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=1"
+    question: 'Return exactly this JSON object and no other text: {"status":"ready"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["status"],"additionalProperties":false,"properties":{"status":{"const":"ready"}}}'
+    gate: {kind: contains_any, contains_any: ["ready"]}
+
+  - id: bitnet_json_seed912587_002
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=2"
+    question: 'Return exactly this JSON object and no other text: {"route":"ask"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["route"],"additionalProperties":false,"properties":{"route":{"const":"ask"}}}'
+    gate: {kind: contains_any, contains_any: ["ask"]}
+
+  - id: bitnet_json_seed912587_003
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=3"
+    question: 'Return exactly this JSON object and no other text: {"backend":"cpu"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["backend"],"additionalProperties":false,"properties":{"backend":{"const":"cpu"}}}'
+    gate: {kind: contains_any, contains_any: ["cpu"]}
+
+  - id: bitnet_json_seed912587_004
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=4"
+    question: 'Return exactly this JSON object and no other text: {"family":"bitnet"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["family"],"additionalProperties":false,"properties":{"family":{"const":"bitnet"}}}'
+    gate: {kind: contains_any, contains_any: ["bitnet"]}
+
+  - id: bitnet_json_seed912587_005
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=5"
+    question: 'Return exactly this JSON object and no other text: {"mode":"local"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["mode"],"additionalProperties":false,"properties":{"mode":{"const":"local"}}}'
+    gate: {kind: contains_any, contains_any: ["local"]}
+
+  - id: bitnet_json_seed912587_006
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=6"
+    question: 'Return exactly this JSON object and no other text: {"cache":"warm"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["cache"],"additionalProperties":false,"properties":{"cache":{"const":"warm"}}}'
+    gate: {kind: contains_any, contains_any: ["warm"]}
+
+  - id: bitnet_json_seed912587_007
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=7"
+    question: 'Return exactly this JSON object and no other text: {"result":"pass"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["result"],"additionalProperties":false,"properties":{"result":{"const":"pass"}}}'
+    gate: {kind: contains_any, contains_any: ["pass"]}
+
+  - id: bitnet_json_seed912587_008
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=8"
+    question: 'Return exactly this JSON object and no other text: {"device":"m4"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["device"],"additionalProperties":false,"properties":{"device":{"const":"m4"}}}'
+    gate: {kind: contains_any, contains_any: ["m4"]}
+
+  - id: bitnet_json_seed912587_009
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=9"
+    question: 'Return exactly this JSON object and no other text: {"state":"ok"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["state"],"additionalProperties":false,"properties":{"state":{"const":"ok"}}}'
+    gate: {kind: contains_any, contains_any: ["ok"]}
+
+  - id: bitnet_json_seed912587_010
+    category: format_constrained_json
+    seed_material: "seed=912587 family=json index=10"
+    question: 'Return exactly this JSON object and no other text: {"eval":"seeded"}'
+    max_new_tokens: 16
+    scoring:
+      kind: json_schema
+      schema: '{"type":"object","required":["eval"],"additionalProperties":false,"properties":{"eval":{"const":"seeded"}}}'
+    gate: {kind: contains_any, contains_any: ["seeded"]}
+
+  - id: bitnet_label_seed912587_001
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=1"
+    question: "Classify sentiment as positive, negative, or neutral: The install completed successfully. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "positive"}
+    gate: {kind: contains_any, contains_any: ["positive"]}
+
+  - id: bitnet_label_seed912587_002
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=2"
+    question: "Classify sentiment as positive, negative, or neutral: The command failed twice. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "negative"}
+    gate: {kind: contains_any, contains_any: ["negative"]}
+
+  - id: bitnet_label_seed912587_003
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=3"
+    question: "Classify sentiment as positive, negative, or neutral: The report is available. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "neutral"}
+    gate: {kind: contains_any, contains_any: ["neutral"]}
+
+  - id: bitnet_label_seed912587_004
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=4"
+    question: "Classify size as small, medium, or large: 3 millimeters. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "small"}
+    gate: {kind: contains_any, contains_any: ["small"]}
+
+  - id: bitnet_label_seed912587_005
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=5"
+    question: "Classify size as small, medium, or large: 3 meters. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "medium"}
+    gate: {kind: contains_any, contains_any: ["medium"]}
+
+  - id: bitnet_label_seed912587_006
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=6"
+    question: "Classify size as small, medium, or large: 3 kilometers. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "large"}
+    gate: {kind: contains_any, contains_any: ["large"]}
+
+  - id: bitnet_label_seed912587_007
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=7"
+    question: "Classify route as local or remote: The request stays on this Mac. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "local"}
+    gate: {kind: contains_any, contains_any: ["local"]}
+
+  - id: bitnet_label_seed912587_008
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=8"
+    question: "Classify route as local or remote: The request goes to a cloud API. Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "remote"}
+    gate: {kind: contains_any, contains_any: ["remote"]}
+
+  - id: bitnet_label_seed912587_009
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=9"
+    question: "Classify answer as yes or no: Is ice frozen water? Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "yes"}
+    gate: {kind: starts_with_any, starts_with_any: ["yes"]}
+
+  - id: bitnet_label_seed912587_010
+    category: closed_label_classification
+    seed_material: "seed=912587 family=closed_label index=10"
+    question: "Classify answer as yes or no: Is the sun made of ice? Answer with one label."
+    max_new_tokens: 8
+    scoring: {kind: normalized_match, expected_normalized: "no"}
+    gate: {kind: starts_with_any, starts_with_any: ["no"]}
+
+  - id: bitnet_extract_seed912587_001
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=1"
+    question: "Extract the code from this text: 'ticket code is AX-14 and owner is Mia'. Answer with only the code."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "ax-14"}
+    gate: {kind: contains_any, contains_any: ["AX-14", "ax-14"]}
+
+  - id: bitnet_extract_seed912587_002
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=2"
+    question: "Extract the owner from this text: 'ticket code is AX-14 and owner is Mia'. Answer with only the owner."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "mia"}
+    gate: {kind: contains_any, contains_any: ["Mia", "mia"]}
+
+  - id: bitnet_extract_seed912587_003
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=3"
+    question: "Extract the port from this text: 'server host alpha uses port 8080'. Answer with only the number."
+    max_new_tokens: 12
+    scoring: {kind: exact_match, expected_normalized: "8080"}
+    gate: {kind: exact_trimmed, expected: "8080"}
+
+  - id: bitnet_extract_seed912587_004
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=4"
+    question: "Extract the host from this text: 'server host alpha uses port 8080'. Answer with only the host."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "alpha"}
+    gate: {kind: contains_any, contains_any: ["alpha"]}
+
+  - id: bitnet_extract_seed912587_005
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=5"
+    question: "Extract the date from this text: 'backup date is 2026-05-15 and status is ok'. Answer with only the date."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "2026-05-15"}
+    gate: {kind: contains_any, contains_any: ["2026-05-15"]}
+
+  - id: bitnet_extract_seed912587_006
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=6"
+    question: "Extract the status from this text: 'backup date is 2026-05-15 and status is ok'. Answer with only the status."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "ok"}
+    gate: {kind: contains_any, contains_any: ["ok"]}
+
+  - id: bitnet_extract_seed912587_007
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=7"
+    question: "Extract the SKU from this text: 'SKU Z9Q and quantity 17 were shipped'. Answer with only the SKU."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "z9q"}
+    gate: {kind: contains_any, contains_any: ["Z9Q", "z9q"]}
+
+  - id: bitnet_extract_seed912587_008
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=8"
+    question: "Extract the quantity from this text: 'SKU Z9Q and quantity 17 were shipped'. Answer with only the number."
+    max_new_tokens: 12
+    scoring: {kind: exact_match, expected_normalized: "17"}
+    gate: {kind: exact_trimmed, expected: "17"}
+
+  - id: bitnet_extract_seed912587_009
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=9"
+    question: "Extract the region from this text: 'region west, priority high, owner Lee'. Answer with only the region."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "west"}
+    gate: {kind: contains_any, contains_any: ["west"]}
+
+  - id: bitnet_extract_seed912587_010
+    category: synthetic_extraction
+    seed_material: "seed=912587 family=extraction index=10"
+    question: "Extract the priority from this text: 'region west, priority high, owner Lee'. Answer with only the priority."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "high"}
+    gate: {kind: contains_any, contains_any: ["high"]}
+
+  - id: bitnet_sort_seed912587_001
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=1"
+    question: "Sort these numbers ascending: 9, 2, 5. Answer as comma-separated numbers."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "2, 5, 9"}
+    gate: {kind: contains_any, contains_any: ["2, 5, 9", "2,5,9"]}
+
+  - id: bitnet_sort_seed912587_002
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=2"
+    question: "Sort these numbers ascending: 4, 1, 7. Answer as comma-separated numbers."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "1, 4, 7"}
+    gate: {kind: contains_any, contains_any: ["1, 4, 7", "1,4,7"]}
+
+  - id: bitnet_sort_seed912587_003
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=3"
+    question: "Sort these words alphabetically: pear, apple, lime. Answer as comma-separated words."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "apple, lime, pear"}
+    gate: {kind: contains_any, contains_any: ["apple, lime, pear", "apple,lime,pear"]}
+
+  - id: bitnet_sort_seed912587_004
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=4"
+    question: "Sort these words alphabetically: beta, alpha, gamma. Answer as comma-separated words."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "alpha, beta, gamma"}
+    gate: {kind: contains_any, contains_any: ["alpha, beta, gamma", "alpha,beta,gamma"]}
+
+  - id: bitnet_sort_seed912587_005
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=5"
+    question: "Order these steps from first to last: finish, start, middle. Answer as comma-separated words."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "start, middle, finish"}
+    gate: {kind: contains_any, contains_any: ["start, middle, finish", "start,middle,finish"]}
+
+  - id: bitnet_sort_seed912587_006
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=6"
+    question: "Order these sizes from smallest to largest: large, small, medium. Answer as comma-separated words."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "small, medium, large"}
+    gate: {kind: contains_any, contains_any: ["small, medium, large", "small,medium,large"]}
+
+  - id: bitnet_sort_seed912587_007
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=7"
+    question: "Sort these numbers descending: 3, 8, 1. Answer as comma-separated numbers."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "8, 3, 1"}
+    gate: {kind: contains_any, contains_any: ["8, 3, 1", "8,3,1"]}
+
+  - id: bitnet_sort_seed912587_008
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=8"
+    question: "Sort these numbers descending: 10, 4, 6. Answer as comma-separated numbers."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "10, 6, 4"}
+    gate: {kind: contains_any, contains_any: ["10, 6, 4", "10,6,4"]}
+
+  - id: bitnet_sort_seed912587_009
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=9"
+    question: "Order these days from earliest to latest in a week: Friday, Monday, Wednesday. Answer as comma-separated words."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "monday, wednesday, friday"}
+    gate: {kind: contains_any, contains_any: ["Monday, Wednesday, Friday", "monday, wednesday, friday"]}
+
+  - id: bitnet_sort_seed912587_010
+    category: ordering_sorting
+    seed_material: "seed=912587 family=sorting index=10"
+    question: "Order these months from earliest to latest: March, January, February. Answer as comma-separated words."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "january, february, march"}
+    gate: {kind: contains_any, contains_any: ["January, February, March", "january, february, march"]}
+
+  - id: bitnet_rewrite_seed912587_001
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=1"
+    question: "Rewrite in lowercase only: LOCAL MODEL"
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "local model"}
+    gate: {kind: contains_any, contains_any: ["local model"]}
+
+  - id: bitnet_rewrite_seed912587_002
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=2"
+    question: "Rewrite in uppercase only: local model"
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "local model"}
+    gate: {kind: contains_any, contains_any: ["LOCAL MODEL", "local model"]}
+
+  - id: bitnet_rewrite_seed912587_003
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=3"
+    question: "Remove extra spaces and repeat: alpha   beta   gamma"
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "alpha beta gamma"}
+    gate: {kind: contains_any, contains_any: ["alpha beta gamma"]}
+
+  - id: bitnet_rewrite_seed912587_004
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=4"
+    question: "Correct the casing and answer with only the phrase: biTnEt runNeR"
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "bitnet runner"}
+    gate: {kind: contains_any, contains_any: ["bitnet runner", "BitNet runner", "BitNet Runner"]}
+
+  - id: bitnet_rewrite_seed912587_005
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=5"
+    question: "Rewrite as two words without punctuation: fast, local."
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "fast local"}
+    gate: {kind: contains_any, contains_any: ["fast local"]}
+
+  - id: bitnet_rewrite_seed912587_006
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=6"
+    question: "Change this sentence to present tense: The model loaded. Answer with only the sentence."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "the model loads"}
+    gate: {kind: contains_any, contains_any: ["model loads"]}
+
+  - id: bitnet_rewrite_seed912587_007
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=7"
+    question: "Change this sentence to past tense: The cache warms. Answer with only the sentence."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "the cache warmed"}
+    gate: {kind: contains_any, contains_any: ["cache warmed"]}
+
+  - id: bitnet_rewrite_seed912587_008
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=8"
+    question: "Replace the word slow with fast: The run is slow. Answer with only the new sentence."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "the run is fast"}
+    gate: {kind: contains_any, contains_any: ["run is fast"]}
+
+  - id: bitnet_rewrite_seed912587_009
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=9"
+    question: "Replace the word remote with local: The route is remote. Answer with only the new sentence."
+    max_new_tokens: 16
+    scoring: {kind: normalized_match, expected_normalized: "the route is local"}
+    gate: {kind: contains_any, contains_any: ["route is local"]}
+
+  - id: bitnet_rewrite_seed912587_010
+    category: rewrite_normalized
+    seed_material: "seed=912587 family=rewrite index=10"
+    question: "Repeat exactly without quotes: receipt ready"
+    max_new_tokens: 12
+    scoring: {kind: normalized_match, expected_normalized: "receipt ready"}
+    gate: {kind: contains_any, contains_any: ["receipt ready"]}
+
+  - id: bitnet_summary_seed912587_001
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=1"
+    question: "Summarize in one short sentence and include the word local: The model runs on the Mac without sending data elsewhere."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["local"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_002
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=2"
+    question: "Summarize in one short sentence and include the word receipt: The run records timing, model hash, and generated tokens."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["receipt"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_003
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=3"
+    question: "Summarize in one short sentence and include the word cache: Reusing a loaded model can reduce repeated setup work."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["cache"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_004
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=4"
+    question: "Summarize in one short sentence and include the word token: The system records the IDs produced by generation."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["token"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_005
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=5"
+    question: "Summarize in one short sentence and include the word fallback: The run must say whether it used another backend."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["fallback"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_006
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=6"
+    question: "Summarize in one short sentence and include the word timeout: A slow run should explain where it stopped."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["timeout"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_007
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=7"
+    question: "Summarize in one short sentence and include the word backend: The selected runtime path must be written into the receipt."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["backend"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_008
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=8"
+    question: "Summarize in one short sentence and include the word prompt: The input is rendered through a fixed template before generation."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["prompt"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_009
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=9"
+    question: "Summarize in one short sentence and include the word memory: Benchmarks should report peak resident size."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["memory"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_summary_seed912587_010
+    category: constrained_summary
+    seed_material: "seed=912587 family=summary index=10"
+    question: "Summarize in one short sentence and include the word warm: A reused session should avoid reloading the model each turn."
+    max_new_tokens: 24
+    scoring: {kind: required_keywords, required_keywords: ["warm"]}
+    gate: {kind: readable, min_words: 3}
+
+  - id: bitnet_required_forbidden_seed912587_001
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=1"
+    question: "Answer in one sentence. Include local. Do not use cloud."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["local"], forbidden_tokens: ["cloud"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_002
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=2"
+    question: "Answer in one sentence. Include receipt. Do not use hidden."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["receipt"], forbidden_tokens: ["hidden"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_003
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=3"
+    question: "Answer in one sentence. Include hash. Do not use unknown."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["hash"], forbidden_tokens: ["unknown"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_004
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=4"
+    question: "Answer in one sentence. Include tokenizer. Do not use default."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["tokenizer"], forbidden_tokens: ["default"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_005
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=5"
+    question: "Answer in one sentence. Include cpu. Do not use gpu."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["cpu"], forbidden_tokens: ["gpu"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_006
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=6"
+    question: "Answer in one sentence. Include strict. Do not use loose."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["strict"], forbidden_tokens: ["loose"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_007
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=7"
+    question: "Answer in one sentence. Include timing. Do not use instant."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["timing"], forbidden_tokens: ["instant"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_008
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=8"
+    question: "Answer in one sentence. Include warm. Do not use chat."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["warm"], forbidden_tokens: ["chat"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_009
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=9"
+    question: "Answer in one sentence. Include ask. Do not use serve."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["ask"], forbidden_tokens: ["serve"]}
+    gate: {kind: readable, min_words: 2}
+
+  - id: bitnet_required_forbidden_seed912587_010
+    category: required_forbidden_tokens
+    seed_material: "seed=912587 family=required_forbidden index=10"
+    question: "Answer in one sentence. Include measured. Do not use magic."
+    max_new_tokens: 24
+    scoring: {kind: required_forbidden_tokens, required_keywords: ["measured"], forbidden_tokens: ["magic"]}
+    gate: {kind: readable, min_words: 2}

--- a/docs/slm/apple-m4-bitnet-eval-and-benchmark.md
+++ b/docs/slm/apple-m4-bitnet-eval-and-benchmark.md
@@ -1,0 +1,66 @@
+# Apple M4 BitNet Eval And Benchmark
+
+This is the next BitNet proof layer after the Apple M4 one-shot `bitnet mac ask`
+route and fixed-prompt `bitnet mac bitnet-warm` proof. The goal is to make
+BitNet measurable enough for operators before any broader product surface is
+enabled.
+
+## Current Boundary
+
+The accepted BitNet artifact is:
+
+- Model id: `microsoft-bitnet-b1.58-2B-4T-i2s`
+- Repo: `microsoft/bitnet-b1.58-2B-4T-gguf`
+- Revision: `a1f2f1c765812aa8af3f6eda4a313707064bba15`
+- File: `ggml-model-i2_s.gguf`
+- SHA256: `4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162`
+- Tokenizer repo: `microsoft/bitnet-b1.58-2B-4T`
+- Tokenizer revision: `04c3b9ad9361b824064a1f25ea60a8be9599b127`
+- Tokenizer file: `tokenizer.json`
+- Tokenizer SHA256: `e134af98b985517b4f068e3755ae90d4e9cd2d45d328325dc503f1c6b2d06cc7`
+- Pre-tokenizer authority: `llama-bpe`
+- Prompt authority: `bitnetcpp-answer`
+
+The current product surface remains narrow:
+
+- `bitnet mac ask` supports explicit one-shot BitNet asks for the accepted
+  artifact and tokenizer.
+- `bitnet mac bitnet-warm` supports a fixed-prompt warm proof route.
+- BitNet chat and BitNet serve remain disabled.
+
+## Campaign Shape
+
+`M4-BITNET-EVAL-001` adds a deterministic BitNet-specific corpus and dry-runs it
+through the existing answer-corpus parser/scoring path. This is a fixture and
+tracking PR only. It does not run the model and does not claim runtime accuracy
+or performance.
+
+Later work items add:
+
+- BitNet eval/report schema fields for reference-vs-Rust comparison.
+- M4 eval receipts for the accepted I2_S artifact.
+- One-shot and fixed-warm benchmark receipts.
+- Advisory/nightly regression dashboards for BitNet quality and performance.
+
+## Claim Policy
+
+Allowed after the first slice:
+
+```text
+A 100-case deterministic BitNet eval corpus exists and parser/scoring dry-run
+validation passes.
+```
+
+Not allowed after the first slice:
+
+```text
+Runtime BitNet accuracy has been measured for this corpus.
+BitNet performance has been benchmarked.
+BitNet chat works.
+BitNet serve works.
+Full apple-m4-metal inference works.
+QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claims.
+```
+
+Dense SLM eval reports stay separate. They can prove dense Qwen behavior only;
+they are not BitNet quality or performance evidence.

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md
@@ -1,0 +1,74 @@
+# Apple M4 BitNet Eval And Benchmark Campaign
+
+Campaign ID: `apple-m4-bitnet-eval-and-benchmark`
+
+Status: active
+
+## Objective
+
+Move Apple M4 BitNet from bounded one-shot and fixed-warm proof into repeatable
+eval and benchmark reporting: accepted artifact/tokenizer identity, seeded
+mechanical quality checks, one-shot and warm timing envelopes, and regression
+dashboards without broad platform or product-surface claims.
+
+## Why This Exists
+
+`apple-m4-local-answer` proved that the accepted Microsoft I2_S GGUF can produce
+strict Apple M4 CPU/NEON BitNet local answers when paired with the external
+Microsoft tokenizer and `bitnetcpp-answer` prompt authority. It also added an
+explicit one-shot `bitnet mac ask` route and a fixed-prompt `bitnet mac
+bitnet-warm` proof route.
+
+That is enough to show BitNet can answer through narrow, receipt-backed paths.
+It is not enough to make BitNet operator-ready. The next layer needs a larger
+mechanical corpus, task-family scoring, timeout/failure taxonomy, reference-vs-
+Rust comparison fields, and timing envelopes that tell operators where the slow
+parts are.
+
+## Scope Boundary
+
+This is a BitNet lane for the M4 Mac mini. It uses the accepted Microsoft I2_S
+GGUF, the external Microsoft tokenizer authority, and the `bitnetcpp-answer`
+prompt authority. It does not use dense Qwen evidence as BitNet evidence, and it
+does not enable BitNet chat or serve.
+
+The campaign does not prove full Apple Metal inference, QK256, Neural Engine
+execution, MPSGraph inference, MacBook behavior, broad Apple Silicon performance,
+or broad BitNet quality.
+
+## End State
+
+- A BitNet-specific seeded deterministic corpus has at least 100
+  parser-validated mechanical cases.
+- Eval reports record generated text, token IDs, model/tokenizer/backend
+  identity, fallback status, task-family scoring, timeout/failure taxonomy, and
+  reference-vs-Rust comparison fields.
+- Benchmark reports cover one-shot and warm paths with model load, tokenizer
+  load, prompt tokenize, prefill, TTFT, input/output/decode throughput, wall
+  time, peak memory, timeout boundaries, and p50/p90/p99 summaries.
+- Regression dashboards compare matching BitNet eval and benchmark reports
+  without putting live M4 model runs in generic required PR CI.
+- Productization receives a clear handoff for variable warm sessions, then chat,
+  then serve, only after receipts prove those surfaces.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-BITNET-EVAL-001 | in_progress | Define the campaign and add a 100-case deterministic BitNet corpus that dry-runs through parser/scoring only. |
+| M4-BITNET-EVAL-002 | proposed | Add BitNet eval/report schema and reference-vs-Rust comparison fields. |
+| M4-BITNET-EVAL-003 | proposed | Run and publish M4 BitNet seeded eval reports for the accepted artifact. |
+| M4-BITNET-EVAL-004 | proposed | Publish one-shot and fixed-warm M4 BitNet benchmark reports. |
+| M4-BITNET-EVAL-005 | proposed | Wire BitNet eval and benchmark reports into advisory/nightly regression dashboards. |
+
+## Review Policy
+
+Each PR owns one item. Parser, schema, fixture, tracker, and synthetic report
+checks belong in generic CI. Live model downloads, full BitNet evals, long warm
+sessions, and hardware timing summaries belong in local, advisory, scheduled, or
+release lanes.
+
+Runtime eval PRs must preserve `apple-m4-cpu-neon`, `fallback_used=false`, exact
+model SHA, tokenizer SHA/authority, `bitnetcpp-answer` prompt authority,
+generated text, generated token IDs, timing fields, memory fields where
+available, and explicit claim boundaries.

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/active.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/active.toml
@@ -1,0 +1,243 @@
+id = "apple-m4-bitnet-eval-and-benchmark"
+title = "Apple M4 BitNet eval and benchmark"
+status = "active"
+
+objective = "Move Apple M4 BitNet from bounded one-shot and fixed-warm proof into repeatable eval and benchmark reporting with accepted artifact/tokenizer authority, reference-vs-Rust comparison fields, one-shot and warm timing envelopes, and regression dashboards without enabling chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claims."
+
+end_state = [
+  "A BitNet-specific seeded deterministic corpus contains at least 100 parser-validated mechanical cases across arithmetic, numeric tolerance, fixed-table QA, JSON/schema output, closed-label classification, synthetic extraction, ordering/sorting, rewrite, constrained summary, and required/forbidden instruction-following families.",
+  "Reports record accepted Microsoft I2_S GGUF identity, external tokenizer authority, bitnetcpp-answer prompt authority, generated text, generated token IDs, backend/fallback identity, quality scoring, and reference-vs-Rust comparison fields.",
+  "Apple M4 BitNet one-shot and warm benchmark reports record model load, tokenizer load, prompt tokenize, prefill, TTFT, input tok/s, output tok/s, decode tok/s, total wall time, peak memory, timeout boundaries, and p50/p90/p99 summaries.",
+  "Regression dashboards compare matching BitNet eval and benchmark reports while keeping live M4 model runs out of generic required PR CI.",
+  "The campaign hands off to BitNet productization only after variable warm-session receipts and timing/failure envelopes are ready to support chat and serve decisions.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini BitNet campaign.",
+  "Use only the accepted Microsoft I2_S GGUF paired with external Microsoft tokenizer authority for answer claims.",
+  "Use the bitnetcpp-answer prompt authority for BitNet M4 answer/eval reports.",
+  "Do not use dense Qwen or dense SLM evidence as BitNet quality, performance, or UX evidence.",
+  "Do not reopen completed dense SLM eval/proof, dense SLM v2, Apple M4 local-answer, server, operational, Metal, or productization campaigns unless a new regression proves they are wrong.",
+  "Do not enable BitNet chat or BitNet serve in this campaign.",
+  "Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, or broad Apple Silicon performance.",
+  "Do not add live model downloads, long hardware timing runs, variable warm-session soaks, or model binaries to generic required PR CI.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "M4-BITNET-EVAL-001"
+status = "in_progress"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-001-campaign-corpus"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Define the apple-m4-bitnet-eval-and-benchmark campaign and add a 100-case seeded deterministic BitNet eval corpus that dry-runs through answer-corpus parsing/scoring with accepted artifact/tokenizer metadata, no live model run, no runtime BitNet accuracy claim, and no performance claim."
+commands = [
+  "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- answer-corpus --dry-run --device cpu --model missing.gguf --corpus ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml --json-out target/apple-m4-bitnet-eval-and-benchmark/bitnet-eval-corpus-dry-run.json",
+  "jq -e '.artifact_kind == \"bitnet_cpu_answer_corpus\" and .corpus.name == \"apple-m4-bitnet-eval-seeded-corpus\" and .corpus.case_count == 100 and .scoring_summary.enabled == true and .scoring_summary.total == 100 and .scoring_summary.not_run == 100' target/apple-m4-bitnet-eval-and-benchmark/bitnet-eval-corpus-dry-run.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "A 100-case seeded deterministic BitNet eval corpus exists and parses through the answer-corpus dry-run path.",
+  "The corpus records the accepted Microsoft I2_S GGUF and external tokenizer authority metadata used by later BitNet M4 eval gates.",
+]
+must_not_claim = [
+  "Runtime BitNet accuracy has run for this corpus.",
+  "BitNet quality improved.",
+  "BitNet performance has been benchmarked.",
+  "BitNet chat works.",
+  "BitNet serve works.",
+  "Full apple-m4-metal inference works.",
+  "QK256 works on Apple Silicon.",
+  "Neural Engine execution is proven.",
+  "MPSGraph inference is proven.",
+]
+
+[[work_item]]
+id = "M4-BITNET-EVAL-002"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-002-report-schema"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-EVAL-001"]
+acceptance = "Add BitNet eval/report schema support with explicit reference-vs-Rust comparison fields, accepted model/tokenizer/prompt authority, task-family pass rates, timeout/failure taxonomy, generated text/token IDs, backend identity, fallback=false, and no chat/serve enablement."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli slm_eval_scoring",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests answer_corpus",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/commands/answer_corpus.rs",
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "BitNet eval reports can represent reference-vs-Rust comparison fields and task-family scoring without hiding strict failures.",
+]
+must_not_claim = [
+  "The full BitNet eval corpus has run on M4.",
+  "BitNet chat or serve is enabled.",
+]
+
+[[work_item]]
+id = "M4-BITNET-EVAL-003"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-003-m4-eval-reports"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-EVAL-002"]
+acceptance = "Run the BitNet seeded corpus on the M4 Mac mini through the accepted I2_S GGUF, external tokenizer, bitnetcpp-answer prompt authority, and apple-m4-cpu-neon backend, then publish eval reports with generated text/token IDs, valid UTF-8, task-family pass rates, timeout/failure taxonomy, reference-vs-Rust comparison fields, and fallback_used=false."
+commands = [
+  "cargo build --release --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet",
+  "target/release/bitnet --device apple-m4-cpu-neon answer-corpus --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json --corpus ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml --json-out ci/hardware/apple-m4-mac-mini/<date>/bitnet-eval/<report>.json --per-prompt-timeout-seconds 300",
+  "target/release/bitnet mac receipts-check ci/hardware/apple-m4-mac-mini/<date>/bitnet-eval/<summary>.json --json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/commands/answer_corpus.rs",
+  "crates/bitnet-cli/src/mac.rs",
+  "ci/hardware/apple-m4-mac-mini/**/bitnet-eval/**",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The recorded Apple M4 BitNet eval receipts describe the accepted I2_S artifact's bounded corpus behavior for those exact runs.",
+]
+must_not_claim = [
+  "The reports are broad BitNet quality benchmarks.",
+  "Dense SLM evidence supports BitNet quality.",
+  "BitNet chat or serve is enabled.",
+]
+
+[[work_item]]
+id = "M4-BITNET-EVAL-004"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-004-benchmark-reports"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-EVAL-003"]
+acceptance = "Benchmark Apple M4 BitNet one-shot and fixed-warm paths with accepted artifact/tokenizer authority, recording model load, tokenizer load, prompt tokenize, prefill, TTFT, input tok/s, output tok/s, decode tok/s, total wall, peak memory, timeout boundaries, and p50/p90/p99 summaries without enabling chat or serve."
+commands = [
+  "target/release/bitnet mac ask --model-id microsoft-bitnet-b1.58-2B-4T-i2s --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json \"What is 2+2? Answer with only the number.\"",
+  "target/release/bitnet mac bitnet-warm --model-id microsoft-bitnet-b1.58-2B-4T-i2s --model-path models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json --max-new-tokens 8",
+  "target/release/bitnet mac receipts-check ci/hardware/apple-m4-mac-mini/<date>/bitnet-benchmark/<summary>.json --json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "ci/hardware/apple-m4-mac-mini/**/bitnet-benchmark/**",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "Recorded Apple M4 BitNet one-shot and fixed-warm benchmark receipts exist for the accepted I2_S artifact.",
+]
+must_not_claim = [
+  "The benchmark is broad Apple Silicon performance evidence.",
+  "BitNet chat or serve is enabled.",
+  "Full apple-m4-metal inference is proven.",
+]
+
+[[work_item]]
+id = "M4-BITNET-EVAL-005"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-005-regression-dashboard"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-EVAL-003", "M4-BITNET-EVAL-004"]
+acceptance = "Wire BitNet eval and benchmark reports into advisory/nightly regression dashboards with thresholds for task-family pass rates, strict scoring totals, TTFT, input/output/decode throughput, total wall time, peak memory, memory drift, timeout boundaries, and exact model/tokenizer/backend identity while keeping generic PR CI model-free."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_regression",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".github/workflows/**",
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/src/model_cache.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "BitNet eval and benchmark report comparison is wired for advisory/nightly regression checks.",
+]
+must_not_claim = [
+  "Live BitNet M4 eval runs are required in generic PR CI.",
+  "BitNet chat or serve is enabled.",
+]

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/events/2026-05-15T101500Z-M4-BITNET-EVAL-001-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/events/2026-05-15T101500Z-M4-BITNET-EVAL-001-in-progress.toml
@@ -1,0 +1,22 @@
+timestamp = "2026-05-15T10:15:00Z"
+campaign = "apple-m4-bitnet-eval-and-benchmark"
+item = "M4-BITNET-EVAL-001"
+event = "in_progress"
+actor = "codex"
+from = "proposed"
+to = "in_progress"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-001-campaign-corpus"
+summary = "Started the M4 BitNet eval and benchmark campaign with a parser/scoring-only seeded corpus slice."
+
+artifacts = [
+  "ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/active.toml",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md",
+]
+
+notes = [
+  "This slice is dry-run only: it validates corpus shape and deterministic scoring metadata without live model execution.",
+  "It records the accepted Microsoft I2_S GGUF and external tokenizer authority for later M4 BitNet eval gates.",
+  "It does not claim runtime BitNet accuracy, BitNet performance, BitNet chat, BitNet serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon support.",
+]

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/generated/status.md
@@ -1,0 +1,28 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 BitNet eval and benchmark Campaign Status
+
+- Campaign: `apple-m4-bitnet-eval-and-benchmark`
+- State: `active`
+- Objective: Move Apple M4 BitNet from bounded one-shot and fixed-warm proof into repeatable eval and benchmark reporting with accepted artifact/tokenizer authority, reference-vs-Rust comparison fields, one-shot and warm timing envelopes, and regression dashboards without enabling chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claims.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-BITNET-EVAL-001 | in_progress | TBD | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-001-campaign-corpus` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the apple-m4-bitnet-eval-and-benchmark campaign and add a 100-case seeded deterministic BitNet eval corpus that dry-runs through answer-corpus parsing/scoring with accepted artifact/tokenizer metadata, no live model run, no runtime BitNet accuracy claim, and no performance claim. |
+| M4-BITNET-EVAL-002 | proposed | TBD | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-002-report-schema` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add BitNet eval/report schema support with explicit reference-vs-Rust comparison fields, accepted model/tokenizer/prompt authority, task-family pass rates, timeout/failure taxonomy, generated text/token IDs, backend identity, fallback=false, and no chat/serve enablement. |
+| M4-BITNET-EVAL-003 | proposed | TBD | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-003-m4-eval-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run the BitNet seeded corpus on the M4 Mac mini through the accepted I2_S GGUF, external tokenizer, bitnetcpp-answer prompt authority, and apple-m4-cpu-neon backend, then publish eval reports with generated text/token IDs, valid UTF-8, task-family pass rates, timeout/failure taxonomy, reference-vs-Rust comparison fields, and fallback_used=false. |
+| M4-BITNET-EVAL-004 | proposed | TBD | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-004-benchmark-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Benchmark Apple M4 BitNet one-shot and fixed-warm paths with accepted artifact/tokenizer authority, recording model load, tokenizer load, prompt tokenize, prefill, TTFT, input tok/s, output tok/s, decode tok/s, total wall, peak memory, timeout boundaries, and p50/p90/p99 summaries without enabling chat or serve. |
+| M4-BITNET-EVAL-005 | proposed | TBD | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-005-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire BitNet eval and benchmark reports into advisory/nightly regression dashboards with thresholds for task-family pass rates, strict scoring totals, TTFT, input/output/decode throughput, total wall time, peak memory, memory drift, timeout boundaries, and exact model/tokenizer/backend identity while keeping generic PR CI model-free. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini BitNet campaign.
+- Use only the accepted Microsoft I2_S GGUF paired with external Microsoft tokenizer authority for answer claims.
+- Use the bitnetcpp-answer prompt authority for BitNet M4 answer/eval reports.
+- Do not use dense Qwen or dense SLM evidence as BitNet quality, performance, or UX evidence.
+- Do not reopen completed dense SLM eval/proof, dense SLM v2, Apple M4 local-answer, server, operational, Metal, or productization campaigns unless a new regression proves they are wrong.
+- Do not enable BitNet chat or BitNet serve in this campaign.
+- Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, or broad Apple Silicon performance.
+- Do not add live model downloads, long hardware timing runs, variable warm-session soaks, or model binaries to generic required PR CI.
+- Never commit model binaries.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -39,6 +39,10 @@
 | apple-m4 | M4-016 | M4-015 | merged |
 | apple-m4 | M4-017 | M4-016 | merged |
 | apple-m4 | M4-018 | M4-017 | merged |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-002 | M4-BITNET-EVAL-001 | proposed |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-003 | M4-BITNET-EVAL-002 | proposed |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-004 | M4-BITNET-EVAL-003 | proposed |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | M4-BITNET-EVAL-003, M4-BITNET-EVAL-004 | proposed |
 | apple-m4-continuity | M4-CONT-002 | M4-CONT-001 | merged |
 | apple-m4-continuity | M4-CONT-003 | M4-CONT-002 | merged |
 | apple-m4-continuity | M4-CONT-004 | M4-CONT-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -7,6 +7,7 @@
 | apple-bitnet-artifact-sweep | ABAS-001 | TBD | proposed | ABAS-002 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m3-macbook-air | M3MBA-010 | #4839 | in_progress | none | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-001 | TBD | in_progress | M4-BITNET-EVAL-002 | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -7,6 +7,7 @@
 | apple-bitnet-artifact-sweep | Apple BitNet artifact sweep | ABAS-001 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m3-macbook-air | Apple M3 MacBook Air | M3MBA-010 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | Apple M4 Mac mini validation | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4-bitnet-eval-and-benchmark | Apple M4 BitNet eval and benchmark | M4-BITNET-EVAL-001 | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | Apple M4 continuity | M4-CONT-005 | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | Apple M4 local answer usability | M4-BITNET-WARM-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |


### PR DESCRIPTION
## Summary
- define the apple-m4-bitnet-eval-and-benchmark campaign and work-item sequence
- add a 100-case seeded deterministic BitNet eval corpus for the accepted Microsoft I2_S GGUF plus external tokenizer authority
- generate the campaign status and global/lane dashboard rows

## Validation
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- answer-corpus --dry-run --device cpu --model missing.gguf --corpus ci/quality/apple-m4-bitnet-eval-seeded-corpus.yaml --json-out target/apple-m4-bitnet-eval-and-benchmark/bitnet-eval-corpus-dry-run.json
- jq -e '.artifact_kind == "bitnet_cpu_answer_corpus" and .corpus.name == "apple-m4-bitnet-eval-seeded-corpus" and .corpus.case_count == 100 and .scoring_summary.enabled == true and .scoring_summary.total == 100 and .scoring_summary.not_run == 100' target/apple-m4-bitnet-eval-and-benchmark/bitnet-eval-corpus-dry-run.json
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Claim boundary
Dry-run and tracker-only first slice. No live BitNet model run, no runtime accuracy claim, no benchmark/performance claim, no BitNet chat/serve enablement, and no Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claim.