### PR TITLE
perf(slm): avoid output-head zero bias allocation

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1251,8 +1251,7 @@ impl TransformerModel {
                         vocab_size,
                         hidden_size
                     );
-                    let bias = Tensor::zeros(vocab_size, DType::F32, vb.device())?;
-                    (Some(Linear::new(weight.clone(), Some(bias))), Some(weight), false)
+                    (Some(Linear::new(weight.clone(), None)), Some(weight), false)
                 }
                 Err(_) => match vb.get((hidden_size, vocab_size), "lm_head.weight") {
                     Ok(weight) => {
@@ -1271,8 +1270,7 @@ impl TransformerModel {
                                 hidden_size
                             );
                             let weight = weight.reshape((vocab_size, hidden_size))?;
-                            let bias = Tensor::zeros(vocab_size, DType::F32, vb.device())?;
-                            (Some(Linear::new(weight.clone(), Some(bias))), Some(weight), false)
+                            (Some(Linear::new(weight.clone(), None)), Some(weight), false)
                         }
                         Err(_) => {
                             tracing::info!(

--- a/docs/slm/SLM_CPU_QWEN3_WARM_SESSION.md
+++ b/docs/slm/SLM_CPU_QWEN3_WARM_SESSION.md
@@ -98,3 +98,14 @@ bias tensor, preserving numerical output while avoiding unnecessary allocation
 and per-forward bias addition. This is implementation cleanup only; it does not
 claim sustained throughput, Q4/Q5 support, GPU/NPU/OpenVINO/UHD 620 execution,
 server inference, Qwen3.5 support, or BitNet QK256 kernel changes.
+
+## SLM-CPU-014 Dense Output-Head Cleanup Boundary
+
+The next bounded cleanup extends the no-bias rule to recovered dense
+`lm_head.weight` / `output.weight` heads. When the loader recovers a canonical
+or reshaped dense output head after the primary `lm_head` construction path
+fails, it now constructs a no-bias `Linear` instead of allocating a zero bias.
+Existing output-head regression tests remain the behavior oracle for generated
+logits. This is allocation cleanup only; it does not introduce dense AVX2
+kernels, Q4/Q5 support, server inference, GPU/NPU/OpenVINO/UHD 620 execution,
+Qwen3.5 support, sustained throughput claims, or BitNet QK256 kernel changes.


### PR DESCRIPTION
## Summary
- avoid materializing zero-bias tensors when recovering dense `lm_head.weight` / `output.weight` heads
- preserve existing output-head logits behavior through the transformer regression suite
- document the SLM-CPU-014 cleanup boundary as allocation cleanup only

## Validation
- `cargo test --locked -p bitnet-transformer --no-default-features --features cpu transformer_`
- `cargo test --locked -p bitnet-transformer --no-default-features --features cpu`
- `cargo clippy --locked -p bitnet-transformer --no-default-features --features cpu -- -D warnings`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli slm_warm_session`
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

## Notes
- `cargo fmt --package bitnet-transformer --all -- --check` still hits Windows path-length `os error 206`; direct rustfmt only reports newline-style issues in existing module files.
- No dense AVX2 kernels, Q4/Q5, server, GPU/NPU/OpenVINO/UHD 620, Qwen3.5, sustained throughput, or BitNet QK256 changes.