### PR TITLE
diag(bitnet): report reference logit hook capability

### DIFF
--- a/xtask/src/bitnet_reference_compare.rs
+++ b/xtask/src/bitnet_reference_compare.rs
@@ -1000,6 +1000,12 @@ fn input_value(input: &ReceiptInput, signal: &OutputSignal) -> Value {
         "selected_logit_count": signal.selected_logits.as_ref().map(Vec::len),
         "reference_text_candidate_ids_present": signal.reference_text_candidate_ids.is_some(),
         "reference_text_candidate_id_count": signal.reference_text_candidate_ids.as_ref().map(Vec::len),
+        "reference_top_logit_capability": input
+            .value
+            .as_ref()
+            .and_then(reference_top_logit_capability_value)
+            .cloned()
+            .unwrap_or(Value::Null),
         "prompt_identity_present": signal.prompt.available(),
         "prompt_identity": prompt_identity_value(&signal.prompt),
     })
@@ -1060,9 +1066,42 @@ fn push_input_blockers(
     if signal.top_logits.is_none() {
         blocked_reasons.push(format!("{label}_top_logits_missing"));
     }
+    if label == "reference"
+        && signal.top_logits.is_none()
+        && let Some(capability) =
+            input.value.as_ref().and_then(reference_top_logit_capability_value)
+    {
+        for reason in string_array_at(capability, "/decision/current_blocked_reasons") {
+            if reason.starts_with("reference_top_logits_")
+                || reason.starts_with("reference_generated_token_ids_")
+            {
+                blocked_reasons.push(reason);
+            }
+        }
+    }
     if !signal.prompt.available() {
         blocked_reasons.push(format!("{label}_prompt_identity_missing"));
     }
+}
+
+fn reference_top_logit_capability_value(value: &Value) -> Option<&Value> {
+    [
+        "/plan/reference_top_logit_capability",
+        "/reference/top_logit_capability",
+        "/reference_top_logit_capability",
+    ]
+    .into_iter()
+    .find_map(|pointer| value.pointer(pointer))
+}
+
+fn string_array_at(value: &Value, pointer: &str) -> Vec<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
 }
 
 fn push_reference_server_blockers(
@@ -1511,6 +1550,74 @@ mod tests {
         assert!(
             !reasons.iter().any(|reason| reason == "reference_cpu_top_logit_ids_not_proven_exact")
         );
+    }
+
+    #[test]
+    fn reference_capability_blockers_are_carried_when_top_logits_are_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let reference_path = dir.path().join("reference.json");
+        let cpu_path = dir.path().join("cpu.json");
+        let a770_path = dir.path().join("a770.json");
+        let prompt = json!({
+            "prompt_template": "llama3-chat",
+            "rendered_prompt_sha256": "rendered",
+            "prompt_token_ids_sha256": "ids",
+            "prompt_token_count": 17,
+            "add_bos": false,
+            "parse_special": true
+        });
+        let top_logits = json!([{"token_id": 123, "logit": 4.0}]);
+        std::fs::write(
+            &reference_path,
+            serde_json::to_vec(&json!({
+                "generated_text": "2+2 equals 4.",
+                "plan": {
+                    "prompt_identity": prompt.clone(),
+                    "reference_top_logit_capability": {
+                        "diagnostic_only": true,
+                        "claimable": false,
+                        "decision": {
+                            "current_blocked_reasons": [
+                                "reference_top_logits_executable_hook_missing",
+                                "reference_generated_token_ids_executable_hook_missing"
+                            ]
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            &cpu_path,
+            serde_json::to_vec(&json!({
+                "generated_tokens": [123],
+                "generated_text": "2+2 equals 4.",
+                "top_logits": top_logits,
+                "prompt_identity": prompt,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(&a770_path, std::fs::read(&cpu_path).unwrap()).unwrap();
+
+        let report = build_report(&CompareArgs {
+            reference: reference_path,
+            reference_server: None,
+            cpu: cpu_path,
+            a770: a770_path,
+            output: None,
+            format: "json".to_string(),
+        });
+
+        assert_eq!(
+            report["inputs"]["reference"]["reference_top_logit_capability"]["claimable"],
+            false
+        );
+        let reasons = report["decision"]["current_blocked_reasons"].as_array().unwrap();
+        assert!(reasons.contains(&json!("reference_top_logits_executable_hook_missing")));
+        assert!(reasons.contains(&json!("reference_generated_token_ids_executable_hook_missing")));
+        assert!(reasons.contains(&json!("reference_top_logits_missing")));
     }
 
     #[test]

--- a/xtask/src/bitnet_reference_plan.rs
+++ b/xtask/src/bitnet_reference_plan.rs
@@ -209,6 +209,10 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
     let reference_argv = selected.map(|candidate| {
         reference_argv(&candidate.path, &model_path, &rendered_prompt, args.max_new_tokens)
     });
+    let reference_top_logit_capability = reference_top_logit_capability(
+        args.cpp_root,
+        selected.map(|candidate| candidate.path.as_str()),
+    );
 
     Ok(json!({
         "schema_version": 1,
@@ -263,6 +267,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             }).collect::<Vec<_>>(),
             "command_argv": reference_argv,
             "command_policy": "uses_rendered_prompt_text_for_template_parity; disables reference auto-BOS because the rendered Llama3 prompt already contains BOS; suppresses prompt echo so stdout is generated text; enables verbose prompt output so the reference run receipt can compare actual reference prompt tokenization",
+            "top_logit_capability": reference_top_logit_capability,
             "setup_command_pwsh": format!(
                 "powershell -ExecutionPolicy Bypass -File ci\\fetch_bitnet_cpp.ps1 -Tag main -CachePath target\\external\\BitNet-reference -ModelDir \"{}\" -QuantType i2_s -Force -SkipPatches",
                 model_dir.replace('"', "\\\"")
@@ -490,6 +495,210 @@ fn reference_candidates(reference_exe: Option<&Path>, cpp_root: Option<&Path>) -
 fn push_candidate(candidates: &mut Vec<Candidate>, path: PathBuf, source: &str) {
     let exists = path.is_file();
     candidates.push(Candidate { path: path_to_string(&path), source: source.to_string(), exists });
+}
+
+const REFERENCE_SOURCE_SCAN_MAX_FILES: usize = 4096;
+const REFERENCE_SOURCE_SCAN_MAX_BYTES: u64 = 2 * 1024 * 1024;
+
+const RAW_TOP_LOGIT_HOOK_PATTERNS: &[(&str, &str)] = &[
+    ("--logits-file", "cli_logits_file_flag"),
+    ("--logits-all", "cli_logits_all_flag"),
+    ("llama_get_logits", "llama_raw_logits_api"),
+    ("get_all_logits", "reference_all_logits_api"),
+    ("top_logits", "top_logits_json_surface"),
+];
+
+const GENERATED_TOKEN_ID_HOOK_PATTERNS: &[(&str, &str)] = &[
+    ("generated_token_ids", "generated_token_ids_json_surface"),
+    ("output_tokens", "output_tokens_json_surface"),
+    ("token_ids", "token_ids_json_surface"),
+];
+
+const PROBABILITY_STRING_PATTERNS: &[(&str, &str)] = &[
+    ("completion_probabilities", "server_completion_probabilities"),
+    ("n_probs", "server_probability_string_count"),
+];
+
+fn reference_top_logit_capability(
+    cpp_root: Option<&Path>,
+    selected_executable: Option<&str>,
+) -> Value {
+    let roots = reference_source_roots(cpp_root, selected_executable);
+    let source_files = reference_source_files(&roots);
+    let raw_top_logit_hits = source_pattern_hits(&source_files, RAW_TOP_LOGIT_HOOK_PATTERNS);
+    let generated_token_id_hits =
+        source_pattern_hits(&source_files, GENERATED_TOKEN_ID_HOOK_PATTERNS);
+    let probability_string_hits = source_pattern_hits(&source_files, PROBABILITY_STRING_PATTERNS);
+    let raw_top_logit_hook_candidate = !raw_top_logit_hits.is_empty();
+    let generated_token_id_hook_candidate = !generated_token_id_hits.is_empty();
+
+    let mut blocked_reasons = Vec::new();
+    if source_files.is_empty() {
+        blocked_reasons.push("reference_source_tree_missing".to_string());
+    }
+    if raw_top_logit_hook_candidate {
+        blocked_reasons.push("reference_top_logits_receipt_not_wired".to_string());
+    } else {
+        blocked_reasons.push("reference_top_logits_executable_hook_missing".to_string());
+    }
+    if generated_token_id_hook_candidate {
+        blocked_reasons.push("reference_generated_token_ids_receipt_not_wired".to_string());
+    } else {
+        blocked_reasons.push("reference_generated_token_ids_executable_hook_missing".to_string());
+    }
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+
+    json!({
+        "diagnostic_only": true,
+        "claimable": false,
+        "capability_ready": false,
+        "raw_top_logits_available": false,
+        "generated_token_ids_available": false,
+        "source_scan": {
+            "roots": roots.iter().map(|root| json!({
+                "path": path_to_string(root),
+                "exists": root.is_dir(),
+            })).collect::<Vec<_>>(),
+            "source_file_count": source_files.len(),
+            "file_limit": REFERENCE_SOURCE_SCAN_MAX_FILES,
+            "max_bytes_per_file": REFERENCE_SOURCE_SCAN_MAX_BYTES,
+        },
+        "raw_top_logits": {
+            "hook_candidate": raw_top_logit_hook_candidate,
+            "hits": raw_top_logit_hits,
+        },
+        "generated_token_ids": {
+            "hook_candidate": generated_token_id_hook_candidate,
+            "hits": generated_token_id_hits,
+        },
+        "probability_strings": {
+            "surface_candidate": !probability_string_hits.is_empty(),
+            "hits": probability_string_hits,
+            "policy": "probability strings are useful diagnostic evidence but are not generated token ids or raw logits",
+        },
+        "decision": {
+            "reference_top_logit_capability_ready": false,
+            "current_blocked_reasons": blocked_reasons,
+            "next_when_hook_available": "wire a reference receipt that emits generated token ids and top logits, then compare against Rust CPU and strict A770 receipts",
+        },
+        "not_claims": [
+            "reference_generated_token_ids",
+            "reference_top_logits",
+            "reference_parity_promotion",
+            "a770_semantic_quality_proven"
+        ],
+    })
+}
+
+fn reference_source_roots(
+    cpp_root: Option<&Path>,
+    selected_executable: Option<&str>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(root) = cpp_root {
+        roots.push(root.to_path_buf());
+    }
+    if let Some(executable) = selected_executable {
+        for ancestor in Path::new(executable).ancestors() {
+            if ancestor.as_os_str().is_empty() {
+                continue;
+            }
+            if ancestor.join("3rdparty").join("llama.cpp").is_dir()
+                || ancestor.join("src").is_dir()
+                || ancestor.join("common").is_dir()
+            {
+                roots.push(ancestor.to_path_buf());
+            }
+        }
+    }
+    roots.push(PathBuf::from("target/external/BitNet-reference"));
+    roots.push(PathBuf::from("target/external/BitNet"));
+    dedupe_paths(roots)
+}
+
+fn reference_source_files(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for root in roots {
+        collect_reference_source_files(root, &mut files);
+        if files.len() >= REFERENCE_SOURCE_SCAN_MAX_FILES {
+            files.truncate(REFERENCE_SOURCE_SCAN_MAX_FILES);
+            break;
+        }
+    }
+    dedupe_paths(files)
+}
+
+fn collect_reference_source_files(path: &Path, files: &mut Vec<PathBuf>) {
+    if files.len() >= REFERENCE_SOURCE_SCAN_MAX_FILES || !path.exists() {
+        return;
+    }
+    if path.is_file() {
+        if is_reference_source_file(path) {
+            files.push(path.to_path_buf());
+        }
+        return;
+    }
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if should_skip_reference_source_dir(&path) {
+                continue;
+            }
+            collect_reference_source_files(&path, files);
+        } else if is_reference_source_file(&path) {
+            files.push(path);
+        }
+        if files.len() >= REFERENCE_SOURCE_SCAN_MAX_FILES {
+            break;
+        }
+    }
+}
+
+fn should_skip_reference_source_dir(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | "build" | "CMakeFiles" | "__pycache__")
+    )
+}
+
+fn is_reference_source_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()).map(|ext| ext.to_ascii_lowercase()),
+        Some(ext)
+            if matches!(
+                ext.as_str(),
+                "c" | "cc" | "cpp" | "cxx" | "h" | "hh" | "hpp" | "hxx" | "rs" | "md"
+            )
+    )
+}
+
+fn source_pattern_hits(files: &[PathBuf], patterns: &[(&str, &str)]) -> Vec<Value> {
+    let mut hits = Vec::new();
+    for file in files {
+        let Ok(metadata) = fs::metadata(file) else {
+            continue;
+        };
+        if metadata.len() > REFERENCE_SOURCE_SCAN_MAX_BYTES {
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(file) else {
+            continue;
+        };
+        for (pattern, kind) in patterns {
+            if text.contains(pattern) {
+                hits.push(json!({
+                    "path": path_to_string(file),
+                    "pattern": pattern,
+                    "kind": kind,
+                }));
+            }
+        }
+    }
+    hits
 }
 
 fn executable_names() -> &'static [&'static str] {
@@ -1254,6 +1463,69 @@ mod tests {
         );
         assert!(argv.iter().any(|arg| arg == "--no-display-prompt"));
         assert!(argv.iter().any(|arg| arg == "--verbose-prompt"));
+    }
+
+    #[test]
+    fn reference_top_logit_capability_reports_missing_hook_without_promoting() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src").join("main.cpp"), "int main() { return 0; }\n").unwrap();
+
+        let report = reference_top_logit_capability(Some(dir.path()), None);
+
+        assert_eq!(report["diagnostic_only"], true);
+        assert_eq!(report["claimable"], false);
+        assert_eq!(report["capability_ready"], false);
+        assert_eq!(report["raw_top_logits"]["hook_candidate"], false);
+        assert_eq!(report["generated_token_ids"]["hook_candidate"], false);
+        let blockers = report["decision"]["current_blocked_reasons"].as_array().expect("blockers");
+        assert!(blockers.contains(&json!("reference_top_logits_executable_hook_missing")));
+        assert!(blockers.contains(&json!("reference_generated_token_ids_executable_hook_missing")));
+        let not_claims = report["not_claims"].as_array().unwrap();
+        assert!(not_claims.contains(&json!("reference_generated_token_ids")));
+        assert!(not_claims.contains(&json!("reference_top_logits")));
+    }
+
+    #[test]
+    fn reference_top_logit_capability_surfaces_source_candidates_without_claiming() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("3rdparty").join("llama.cpp").join("tools");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(
+            source.join("main.cpp"),
+            "--logits-file\nllama_get_logits\ncompletion_probabilities\ngenerated_token_ids\n",
+        )
+        .unwrap();
+
+        let report = reference_top_logit_capability(Some(dir.path()), None);
+
+        assert_eq!(report["diagnostic_only"], true);
+        assert_eq!(report["claimable"], false);
+        assert_eq!(report["capability_ready"], false);
+        assert_eq!(report["raw_top_logits"]["hook_candidate"], true);
+        assert_eq!(report["generated_token_ids"]["hook_candidate"], true);
+        assert_eq!(report["probability_strings"]["surface_candidate"], true);
+        assert!(
+            report["raw_top_logits"]["hits"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|hit| hit["pattern"] == "--logits-file")
+        );
+        let blockers = report["decision"]["current_blocked_reasons"].as_array().expect("blockers");
+        assert!(blockers.contains(&json!("reference_top_logits_receipt_not_wired")));
+        assert!(blockers.contains(&json!("reference_generated_token_ids_receipt_not_wired")));
+        assert!(!blockers.contains(&json!("reference_top_logits_executable_hook_missing")));
+    }
+
+    #[test]
+    fn reference_source_roots_skip_empty_relative_ancestor() {
+        let roots = reference_source_roots(
+            None,
+            Some("target/external/BitNet-reference/build/bin/llama-cli.exe"),
+        );
+
+        assert!(roots.iter().all(|root| !root.as_os_str().is_empty()));
     }
 
     #[test]

--- a/xtask/src/bitnet_reference_run.rs
+++ b/xtask/src/bitnet_reference_run.rs
@@ -204,6 +204,10 @@ fn build_receipt(
                 .pointer("/rust_commands/reference_text_tokenization")
                 .cloned()
                 .unwrap_or(Value::Null),
+            "reference_top_logit_capability": plan
+                .pointer("/reference/top_logit_capability")
+                .cloned()
+                .unwrap_or(Value::Null),
             "command_policy": str_at(plan, "/reference/command_policy").unwrap_or(""),
         },
         "reference_text_tokenization": plan
@@ -430,7 +434,17 @@ mod tests {
             "reference": {
                 "backend": "bitnet.cpp_or_llama.cpp_cli",
                 "selected_executable": "llama-cli",
-                "command_policy": "test"
+                "command_policy": "test",
+                "top_logit_capability": {
+                    "diagnostic_only": true,
+                    "claimable": false,
+                    "capability_ready": false,
+                    "decision": {
+                        "current_blocked_reasons": [
+                            "reference_top_logits_executable_hook_missing"
+                        ]
+                    }
+                }
             }
         });
         let capture = CommandCapture {
@@ -464,6 +478,11 @@ sampler seed: 0\n"
         assert_eq!(
             receipt["plan"]["reference_text_tokenization"]["selected_logit_probe_ids"],
             json!([17, 10])
+        );
+        assert_eq!(
+            receipt["plan"]["reference_top_logit_capability"]["decision"]["current_blocked_reasons"]
+                [0],
+            json!("reference_top_logits_executable_hook_missing")
         );
         let not_claims = receipt["not_claims"].as_array().unwrap();
         assert!(not_claims.contains(&json!("reference_generated_token_ids")));


### PR DESCRIPTION
## Summary
- add a diagnostic reference top-logit/token-id capability section to bitnet-reference-plan
- carry that capability into reference-run receipts
- surface missing/wired reference top-logit blockers in bitnet-reference-compare

## Claim boundary
- diagnostic only; claim_allowed remains false
- does not promote A770 semantic quality, selected attention, resident KV, attention scores, softmax, value mix, full support/device residency, or completion
- probability strings remain diagnostic and are not treated as generated token IDs or raw logits

## Validation
- cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_plan -- --nocapture
- cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_compare -- --nocapture
- cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_run -- --nocapture
- cargo check --locked -p xtask --no-default-features
- rustfmt --check --edition 2024 --config skip_children=true xtask\\src\\bitnet_reference_plan.rs xtask\\src\\bitnet_reference_run.rs xtask\\src\\bitnet_reference_compare.rs
- git diff --check