### PR TITLE
diag(bitnet): plan reference first-token logit instrumentation

### DIFF
--- a/ci/reference-instrumentation/README.md
+++ b/ci/reference-instrumentation/README.md
@@ -1,0 +1,10 @@
+# Reference Instrumentation
+
+This directory holds target-local diagnostic instrumentation for external
+BitNet/llama.cpp reference builds. These patches are not part of the default
+`patches/` directory and are not applied by `ci/fetch_bitnet_cpp.ps1`.
+
+Use these only to localize shared Rust/reference numerical divergence. They do
+not promote reference parity, A770 semantic quality, selected attention, KV
+residency, or full device residency.
+

--- a/ci/reference-instrumentation/bitnet-rs-first-token-logits-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-first-token-logits-main.patch
@@ -1,0 +1,193 @@
+# Upstream-Issue: not-applicable; BitNet-rs target-local diagnostic instrumentation only
+# Reason: Emit first-token raw logits from llama-cli when stock llama-perplexity cannot provide matched first-token logits
+# Status: under-review
+# Created: 2026-05-15
+# Review-By: 2026-06-15
+# Author: BitNet-rs maintainers
+
+diff --git a/examples/main/main.cpp b/examples/main/main.cpp
+index fb10c20c..5608262d 100644
+--- a/examples/main/main.cpp
++++ b/examples/main/main.cpp
+@@ -5,12 +5,17 @@
+ #include "sampling.h"
+ #include "llama.h"
+ 
++#include <algorithm>
+ #include <cassert>
++#include <cmath>
+ #include <cstdio>
++#include <cstdlib>
+ #include <cstring>
+ #include <ctime>
+ #include <fstream>
++#include <iomanip>
+ #include <iostream>
++#include <limits>
+ #include <sstream>
+ #include <string>
+ #include <vector>
+@@ -62,6 +67,141 @@ static bool file_is_empty(const std::string & path) {
+     return f.tellg() == 0;
+ }
+ 
++static std::string bitnet_rs_json_escape(const std::string & value) {
++    std::ostringstream out;
++    for (unsigned char ch : value) {
++        switch (ch) {
++            case '"':  out << "\\\""; break;
++            case '\\': out << "\\\\"; break;
++            case '\b': out << "\\b"; break;
++            case '\f': out << "\\f"; break;
++            case '\n': out << "\\n"; break;
++            case '\r': out << "\\r"; break;
++            case '\t': out << "\\t"; break;
++            default:
++                if (ch < 0x20) {
++                    out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (int) ch
++                        << std::dec << std::setfill(' ');
++                } else {
++                    out << ch;
++                }
++                break;
++        }
++    }
++    return out.str();
++}
++
++static void bitnet_rs_write_json_number(std::ostream & out, double value) {
++    if (std::isfinite(value)) {
++        out << std::setprecision(9) << value;
++    } else {
++        out << "null";
++    }
++}
++
++static void bitnet_rs_write_logit_row(
++    std::ostream & out,
++    llama_context * ctx,
++    const float * logits,
++    int n_vocab,
++    llama_token token,
++    double softmax_max,
++    double softmax_sum,
++    bool first
++) {
++    if (!first) {
++        out << ",";
++    }
++    const double logit = token >= 0 && token < n_vocab ? logits[token] : std::numeric_limits<double>::quiet_NaN();
++    const double probability = token >= 0 && token < n_vocab && softmax_sum > 0.0
++        ? std::exp(logit - softmax_max) / softmax_sum
++        : std::numeric_limits<double>::quiet_NaN();
++    size_t rank = 1;
++    if (token >= 0 && token < n_vocab) {
++        for (int i = 0; i < n_vocab; ++i) {
++            if (logits[i] > logits[token]) {
++                rank++;
++            }
++        }
++    }
++    out << "{\"token_id\":" << token
++        << ",\"token_piece\":\"" << bitnet_rs_json_escape(common_token_to_piece(ctx, token)) << "\""
++        << ",\"logit\":";
++    bitnet_rs_write_json_number(out, logit);
++    out << ",\"softmax_probability\":";
++    bitnet_rs_write_json_number(out, probability);
++    out << ",\"softmax_rank\":" << rank << "}";
++}
++
++static void bitnet_rs_dump_first_token_logits(
++    llama_context * ctx,
++    const llama_model * model,
++    const std::vector<llama_token> & prompt_tokens,
++    const char * path
++) {
++    if (path == nullptr || path[0] == '\0') {
++        return;
++    }
++    const float * logits = llama_get_logits_ith(ctx, -1);
++    if (logits == nullptr) {
++        return;
++    }
++    const int n_vocab = llama_n_vocab(model);
++    if (n_vocab <= 0) {
++        return;
++    }
++
++    double max_logit = logits[0];
++    for (int i = 1; i < n_vocab; ++i) {
++        max_logit = std::max(max_logit, (double) logits[i]);
++    }
++    double softmax_sum = 0.0;
++    for (int i = 0; i < n_vocab; ++i) {
++        softmax_sum += std::exp((double) logits[i] - max_logit);
++    }
++
++    std::vector<int> top_tokens;
++    top_tokens.reserve(n_vocab);
++    for (int i = 0; i < n_vocab; ++i) {
++        top_tokens.push_back(i);
++    }
++    const int top_k = std::min(16, n_vocab);
++    std::partial_sort(
++        top_tokens.begin(),
++        top_tokens.begin() + top_k,
++        top_tokens.end(),
++        [logits](int left, int right) {
++            return logits[left] > logits[right];
++        });
++
++    std::ofstream out(path, std::ios::out | std::ios::trunc);
++    if (!out.is_open()) {
++        return;
++    }
++    out << "{"
++        << "\"receipt_type\":\"bitnet_reference_first_token_logits\","
++        << "\"diagnostic_only\":true,"
++        << "\"claim_allowed\":false,"
++        << "\"source\":\"BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS\","
++        << "\"prompt_token_count\":" << prompt_tokens.size() << ","
++        << "\"n_vocab\":" << n_vocab << ",";
++    out << "\"probe_logits\":[";
++    const llama_token probe_tokens[] = {17, 58428};
++    for (size_t i = 0; i < 2; ++i) {
++        bitnet_rs_write_logit_row(out, ctx, logits, n_vocab, probe_tokens[i], max_logit, softmax_sum, i == 0);
++    }
++    out << "],\"top_logits\":[";
++    for (int i = 0; i < top_k; ++i) {
++        bitnet_rs_write_logit_row(out, ctx, logits, n_vocab, top_tokens[i], max_logit, softmax_sum, i == 0);
++    }
++    out << "],\"not_claims\":["
++        << "\"reference_parity_promotion\","
++        << "\"a770_semantic_quality_proven\","
++        << "\"selected_attention_residency\","
++        << "\"full_device_residency\""
++        << "]}";
++}
++
+ static void write_logfile(
+     const llama_context * ctx, const common_params & params, const llama_model * model,
+     const std::vector<llama_token> & input_tokens, const std::string & output,
+@@ -515,6 +655,8 @@ int main(int argc, char ** argv) {
+     display = params.display_prompt;
+ 
+     std::vector<llama_token> embd;
++    const char * bitnet_rs_first_token_logits_path = std::getenv("BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS");
++    bool bitnet_rs_first_token_logits_dumped = false;
+ 
+     // tokenized antiprompts
+     std::vector<std::vector<llama_token>> antiprompt_ids;
+@@ -679,6 +821,11 @@ int main(int argc, char ** argv) {
+                 LOG_DBG("saved session to %s\n", path_session.c_str());
+             }
+ 
++            if (!bitnet_rs_first_token_logits_dumped) {
++                bitnet_rs_dump_first_token_logits(ctx, model, embd_inp, bitnet_rs_first_token_logits_path);
++                bitnet_rs_first_token_logits_dumped = true;
++            }
++
+             const llama_token id = common_sampler_sample(smpl, ctx, -1);
+ 
+             common_sampler_accept(smpl, id, /* accept_grammar= */ true);
+

--- a/xtask/src/bitnet_reference_instrumentation.rs
+++ b/xtask/src/bitnet_reference_instrumentation.rs
@@ -1,0 +1,346 @@
+use anyhow::{Context, Result, bail};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const DEFAULT_CPP_ROOT: &str = "target/external/BitNet-reference/3rdparty/llama.cpp";
+const DEFAULT_PATCH: &str = "ci/reference-instrumentation/bitnet-rs-first-token-logits-main.patch";
+const DEFAULT_OUTPUT: &str = "target/a770-diagnostic/bitnet-reference-instrumentation-plan.json";
+
+const REQUIRED_METADATA: &[&str] =
+    &["Upstream-Issue", "Reason", "Status", "Created", "Review-By", "Author"];
+
+const REQUIRED_ANCHORS: &[&str] = &[
+    "BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS",
+    "llama_get_logits_ith(ctx, -1)",
+    "common_sampler_sample(smpl, ctx, -1)",
+    "const llama_token probe_tokens[] = {17, 58428};",
+    "probe_logits",
+];
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+    "reference_generated_token_ids",
+    "reference_top_logits",
+    "reference_raw_logits",
+    "rust_reference_parity_proven",
+    "a770_semantic_quality_proven",
+];
+
+#[derive(Debug)]
+struct ReferenceInstrumentationArgs {
+    cpp_root: PathBuf,
+    patch: PathBuf,
+    output: Option<PathBuf>,
+    format: String,
+}
+
+#[derive(Debug)]
+struct CommandCapture {
+    status_code: Option<i32>,
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+pub fn maybe_dispatch_from_env() -> Result<bool> {
+    let args = std::env::args().collect::<Vec<_>>();
+    maybe_dispatch(&args)
+}
+
+fn maybe_dispatch(args: &[String]) -> Result<bool> {
+    if args.get(1).map(String::as_str) != Some("bitnet-reference-instrumentation-plan") {
+        return Ok(false);
+    }
+    if args[2..].iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_help();
+        return Ok(true);
+    }
+    let opts = parse_args(args)?;
+    let report = build_plan(&opts)?;
+    if let Some(output) = &opts.output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(output, serde_json::to_vec_pretty(&report)?)
+            .with_context(|| format!("writing {}", output.display()))?;
+    }
+    emit_report(&report, &opts.format)?;
+    Ok(true)
+}
+
+fn print_help() {
+    println!(
+        "Verify the target-local BitNet reference first-token logit instrumentation patch\n\nUsage: xtask.exe bitnet-reference-instrumentation-plan [OPTIONS]\n\nOptions:\n      --cpp-root <PATH>  llama.cpp checkout root [default: target/external/BitNet-reference/3rdparty/llama.cpp]\n      --patch <PATH>     Instrumentation patch [default: ci/reference-instrumentation/bitnet-rs-first-token-logits-main.patch]\n      --output <PATH>    Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-instrumentation-plan.json]\n      --format <FORMAT>  Output format: human or json [default: human]\n  -h, --help             Print help"
+    );
+}
+
+fn parse_args(args: &[String]) -> Result<ReferenceInstrumentationArgs> {
+    let mut cpp_root = PathBuf::from(DEFAULT_CPP_ROOT);
+    let mut patch = PathBuf::from(DEFAULT_PATCH);
+    let mut output = Some(PathBuf::from(DEFAULT_OUTPUT));
+    let mut format = "human".to_string();
+    let mut i = 2usize;
+    while i < args.len() {
+        let key = args[i].as_str();
+        i += 1;
+        let mut value = || -> Result<String> {
+            let value = args.get(i).with_context(|| format!("{key} requires a value"))?.clone();
+            i += 1;
+            Ok(value)
+        };
+        match key {
+            "--cpp-root" => cpp_root = PathBuf::from(value()?),
+            "--patch" => patch = PathBuf::from(value()?),
+            "--output" => output = Some(PathBuf::from(value()?)),
+            "--format" => format = value()?,
+            other => bail!("unknown bitnet-reference-instrumentation-plan option {other}"),
+        }
+    }
+    Ok(ReferenceInstrumentationArgs { cpp_root, patch, output, format })
+}
+
+fn build_plan(args: &ReferenceInstrumentationArgs) -> Result<Value> {
+    let cpp_root = normalize_path(&args.cpp_root)?;
+    let patch = normalize_path(&args.patch)?;
+    let patch_text = fs::read_to_string(&patch).unwrap_or_default();
+    let metadata = patch_metadata(&patch_text);
+    let missing_metadata = missing_metadata(&metadata);
+    let missing_anchors = missing_patch_anchors(&patch_text);
+    let source_target = cpp_root.join("examples/main/main.cpp");
+    let git_status = if cpp_root.is_dir() {
+        Some(run_git(&cpp_root, &["status", "--porcelain"])?)
+    } else {
+        None
+    };
+    let apply_check = if cpp_root.is_dir() && patch.is_file() {
+        Some(run_git(&cpp_root, &["apply", "--check", &path_to_string(&patch)])?)
+    } else {
+        None
+    };
+    let git_clean = git_status.as_ref().is_some_and(|capture| {
+        capture.success && capture.stdout.trim().is_empty() && capture.stderr.trim().is_empty()
+    });
+    let patch_applies = apply_check.as_ref().is_some_and(|capture| capture.success);
+    let ready = cpp_root.is_dir()
+        && patch.is_file()
+        && source_target.is_file()
+        && git_clean
+        && patch_applies
+        && missing_metadata.is_empty()
+        && missing_anchors.is_empty();
+    let mut blocked_reasons = Vec::new();
+    if !cpp_root.is_dir() {
+        blocked_reasons.push("reference_llama_cpp_root_missing".to_string());
+    }
+    if !source_target.is_file() {
+        blocked_reasons.push("reference_llama_main_source_missing".to_string());
+    }
+    if !patch.is_file() {
+        blocked_reasons.push("reference_instrumentation_patch_missing".to_string());
+    }
+    if !git_clean {
+        blocked_reasons.push("reference_llama_cpp_worktree_not_clean".to_string());
+    }
+    if !patch_applies {
+        blocked_reasons.push("reference_instrumentation_patch_apply_check_failed".to_string());
+    }
+    if !missing_metadata.is_empty() {
+        blocked_reasons.push("reference_instrumentation_patch_metadata_incomplete".to_string());
+    }
+    if !missing_anchors.is_empty() {
+        blocked_reasons.push("reference_instrumentation_patch_anchor_missing".to_string());
+    }
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+
+    Ok(json!({
+        "schema_version": 1,
+        "receipt_type": "bitnet_reference_instrumentation_plan",
+        "diagnostic": "bitnet_reference_instrumentation_plan",
+        "producer": "cargo xtask bitnet-reference-instrumentation-plan",
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "diagnostic_only": true,
+        "promotion_allowed": false,
+        "claim_allowed": false,
+        "classification": "diagnostic_only",
+        "cpp_root": {
+            "path": path_to_string(&cpp_root),
+            "exists": cpp_root.is_dir(),
+            "main_source": path_to_string(&source_target),
+            "main_source_exists": source_target.is_file(),
+            "git_status_clean": git_clean,
+            "git_status_stdout": git_status.as_ref().map(|capture| capture.stdout.trim().to_string()),
+            "git_status_stderr": git_status.as_ref().map(|capture| capture.stderr.trim().to_string()),
+        },
+        "patch": {
+            "path": path_to_string(&patch),
+            "exists": patch.is_file(),
+            "sha256": patch.is_file().then(|| sha256_bytes(&fs::read(&patch).unwrap_or_default())),
+            "metadata": metadata,
+            "missing_metadata": missing_metadata,
+            "required_anchors": REQUIRED_ANCHORS,
+            "missing_anchors": missing_anchors,
+            "apply_check_success": patch_applies,
+            "apply_check_exit_code": apply_check.as_ref().and_then(|capture| capture.status_code),
+            "apply_check_stdout": apply_check.as_ref().map(|capture| capture.stdout.trim().to_string()),
+            "apply_check_stderr": apply_check.as_ref().map(|capture| capture.stderr.trim().to_string()),
+            "default_applied": false,
+            "policy": "target-local diagnostic instrumentation patch; not stored under patches/ and not applied by default fetch scripts",
+        },
+        "instrumentation": {
+            "environment_variable": "BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS",
+            "receipt_type_when_applied": "bitnet_reference_first_token_logits",
+            "probe_token_ids": [17, 58428],
+            "top_k": 16,
+            "captures": [
+                "prompt_token_count",
+                "n_vocab",
+                "probe token logits and probabilities",
+                "top logits for first generated token"
+            ],
+            "not_claim": "instrumentation output is reference-side diagnostic evidence only until compared against Rust CPU and strict A770 receipts",
+        },
+        "operator_commands": {
+            "apply_patch": format!("git -C {} apply {}", path_to_string(&cpp_root), path_to_string(&patch)),
+            "rebuild_reference": "cmake --build target/external/BitNet-reference/build --config Release --target llama-cli",
+            "run_with_receipt_env": "set BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS=target/a770-diagnostic/reference-first-token-logits.json before running bitnet-reference-run",
+        },
+        "decision": {
+            "instrumentation_ready_to_apply": ready,
+            "reference_raw_logits_available": false,
+            "current_blocked_reasons": blocked_reasons,
+            "next_action": "apply instrumentation patch in the external reference worktree, rebuild llama-cli, run matched reference prompt with BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS, then compare token 17 and 58428 against Rust CPU and strict A770 logits",
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    }))
+}
+
+fn normalize_path(path: &Path) -> Result<PathBuf> {
+    let path =
+        if path.is_absolute() { path.to_path_buf() } else { std::env::current_dir()?.join(path) };
+    Ok(path)
+}
+
+fn patch_metadata(text: &str) -> Value {
+    let mut map = Map::new();
+    for line in text.lines().take_while(|line| line.trim_start().starts_with('#')) {
+        let line = line.trim_start().trim_start_matches('#').trim();
+        if let Some((key, value)) = line.split_once(':') {
+            map.insert(key.trim().to_string(), Value::String(value.trim().to_string()));
+        }
+    }
+    Value::Object(map)
+}
+
+fn missing_metadata(metadata: &Value) -> Vec<String> {
+    REQUIRED_METADATA
+        .iter()
+        .filter(|key| metadata.pointer(&format!("/{key}")).and_then(Value::as_str).is_none())
+        .map(|key| (*key).to_string())
+        .collect()
+}
+
+fn missing_patch_anchors(text: &str) -> Vec<String> {
+    REQUIRED_ANCHORS
+        .iter()
+        .filter(|anchor| !text.contains(**anchor))
+        .map(|anchor| (*anchor).to_string())
+        .collect()
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Result<CommandCapture> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("running git {} in {}", args.join(" "), cwd.display()))?;
+    Ok(CommandCapture {
+        status_code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.display().to_string()
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
+fn emit_report(value: &Value, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(value)?),
+        "human" => {
+            println!("diagnostic: bitnet_reference_instrumentation_plan");
+            println!(
+                "instrumentation_ready_to_apply: {}",
+                value
+                    .pointer("/decision/instrumentation_ready_to_apply")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            );
+            if let Some(reasons) = value.pointer("/decision/current_blocked_reasons") {
+                println!("blocked_reasons: {}", serde_json::to_string(reasons)?);
+            }
+            println!("not_claims: {}", serde_json::to_string(&value["not_claims"])?);
+        }
+        other => bail!("unsupported bitnet-reference-instrumentation-plan output format: {other}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn patch_metadata_reads_header_fields() {
+        let metadata = patch_metadata(
+            "# Upstream-Issue: not-applicable\n# Reason: test\n\n--- a/file\n+++ b/file\n",
+        );
+
+        assert_eq!(metadata["Upstream-Issue"], json!("not-applicable"));
+        assert_eq!(metadata["Reason"], json!("test"));
+    }
+
+    #[test]
+    fn missing_metadata_reports_required_fields() {
+        let metadata = json!({
+            "Upstream-Issue": "not-applicable",
+            "Reason": "test"
+        });
+
+        let missing = missing_metadata(&metadata);
+
+        assert!(missing.contains(&"Status".to_string()));
+        assert!(missing.contains(&"Created".to_string()));
+        assert!(!missing.contains(&"Reason".to_string()));
+    }
+
+    #[test]
+    fn anchor_check_requires_probe_tokens_and_env_name() {
+        let missing = missing_patch_anchors(
+            "BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS const llama_token probe_tokens[] = {17, 58428};",
+        );
+
+        assert!(!missing.contains(&"BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS".to_string()));
+        assert!(!missing.contains(&"const llama_token probe_tokens[] = {17, 58428};".to_string()));
+        assert!(missing.contains(&"llama_get_logits_ith(ctx, -1)".to_string()));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,6 +39,7 @@ use walkdir::WalkDir;
 mod bench_receipt;
 mod bitnet_reference_all_logits;
 mod bitnet_reference_compare;
+mod bitnet_reference_instrumentation;
 mod bitnet_reference_plan;
 mod bitnet_reference_run;
 mod bitnet_reference_server_run;
@@ -1328,6 +1329,9 @@ fn classify_exit(e: &anyhow::Error) -> i32 {
 }
 
 fn real_main() -> Result<()> {
+    if bitnet_reference_instrumentation::maybe_dispatch_from_env()? {
+        return Ok(());
+    }
     if bitnet_reference_all_logits::maybe_dispatch_from_env()? {
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- add an explicit target-local reference instrumentation patch outside the default `patches/` auto-apply path
- add `bitnet-reference-instrumentation-plan` to verify metadata, anchors, clean external worktree state, and `git apply --check`
- keep the lane diagnostic-only: this prepares first-token reference-logit capture, but does not claim reference parity or A770 semantic quality

## What the patch does when applied manually
- gates output behind `BITNET_RS_REFERENCE_FIRST_TOKEN_LOGITS`
- writes `bitnet_reference_first_token_logits` JSON sidecar from `llama-cli`
- captures first-token probe logits/probabilities/ranks for token `17` (`2`) and `58428` (`.ps`)
- captures top-16 first-token logits from the reference side

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_instrumentation -- --nocapture`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_all_logits -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-instrumentation-plan --format json --output target/a770-diagnostic/bitnet-reference-instrumentation-plan.json`
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-first-token-logits-main.patch`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_instrumentation.rs xtask\src\main.rs`
- `git diff --check`

## Notes
A manual apply/build attempt reached the known Windows reference const-compatibility failure in `src/ggml-bitnet-mad.cpp`, before validating the patched `llama-cli` target. I restored the external worktree and did not fold that unrelated external fix into this PR.