### PR TITLE
diag(bitnet): run reference hidden-state instrumentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Enforce LF line endings for shell scripts
 *.sh text eol=lf
+
+# Stored reference-instrumentation patches need unified-diff blank context lines.
+ci/reference-instrumentation/*.patch whitespace=-blank-at-eol

--- a/ci/reference-instrumentation/bitnet-rs-first-token-hidden-state-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-first-token-hidden-state-main.patch
@@ -1,0 +1,179 @@
+# Upstream-Issue: not-applicable; BitNet-rs target-local diagnostic instrumentation only
+# Reason: Emit first-token final hidden state from llama-cli generation when stock reference generation exposes logits but not hidden-state embeddings
+# Status: under-review
+# Created: 2026-05-15
+# Review-By: 2026-06-15
+# Author: BitNet-rs maintainers
+
+diff --git a/examples/main/main.cpp b/examples/main/main.cpp
+index fb10c20c..3c381c18 100644
+--- a/examples/main/main.cpp
++++ b/examples/main/main.cpp
+@@ -6,11 +6,15 @@
+ #include "llama.h"
+ 
+ #include <cassert>
++#include <cmath>
+ #include <cstdio>
++#include <cstdlib>
+ #include <cstring>
+ #include <ctime>
+ #include <fstream>
++#include <iomanip>
+ #include <iostream>
++#include <limits>
+ #include <sstream>
+ #include <string>
+ #include <vector>
+@@ -62,6 +66,99 @@ static bool file_is_empty(const std::string & path) {
+     return f.tellg() == 0;
+ }
+ 
++static void bitnet_rs_write_json_number(std::ostream & out, double value) {
++    if (std::isfinite(value)) {
++        out << std::setprecision(9) << value;
++    } else {
++        out << "null";
++    }
++}
++
++static void bitnet_rs_dump_first_token_hidden_state(
++    llama_context * ctx,
++    const llama_model * model,
++    const std::vector<llama_token> & prompt_tokens,
++    const char * path
++) {
++    if (path == nullptr || path[0] == '\0') {
++        return;
++    }
++
++    const int n_embd = llama_n_embd(model);
++    if (n_embd <= 0) {
++        return;
++    }
++    const float * hidden = llama_get_embeddings_ith(ctx, -1);
++    if (hidden == nullptr) {
++        return;
++    }
++
++    double sum = 0.0;
++    double sq_sum = 0.0;
++    double min_value = std::numeric_limits<double>::infinity();
++    double max_value = -std::numeric_limits<double>::infinity();
++    for (int i = 0; i < n_embd; ++i) {
++        const double value = hidden[i];
++        sum += value;
++        sq_sum += value * value;
++        min_value = value < min_value ? value : min_value;
++        max_value = value > max_value ? value : max_value;
++    }
++    const double mean = n_embd > 0 ? sum / n_embd : std::numeric_limits<double>::quiet_NaN();
++    const double rms = n_embd > 0 ? std::sqrt(sq_sum / n_embd) : std::numeric_limits<double>::quiet_NaN();
++
++    std::ofstream out(path, std::ios::out | std::ios::trunc);
++    if (!out.is_open()) {
++        return;
++    }
++
++    out << "{"
++        << "\"receipt_type\":\"bitnet_reference_first_token_hidden_state\","
++        << "\"diagnostic_only\":true,"
++        << "\"claim_allowed\":false,"
++        << "\"source\":\"BITNET_RS_REFERENCE_FIRST_TOKEN_HIDDEN_STATE\","
++        << "\"prompt_token_count\":" << prompt_tokens.size() << ","
++        << "\"n_embd\":" << n_embd << ","
++        << "\"hidden_state\":{"
++        << "\"present\":true,"
++        << "\"value_count\":" << n_embd << ","
++        << "\"mean\":";
++    bitnet_rs_write_json_number(out, mean);
++    out << ",\"rms\":";
++    bitnet_rs_write_json_number(out, rms);
++    out << ",\"min\":";
++    bitnet_rs_write_json_number(out, min_value);
++    out << ",\"max\":";
++    bitnet_rs_write_json_number(out, max_value);
++    out << ",\"first_values\":[";
++    const int sample_count = n_embd < 16 ? n_embd : 16;
++    for (int i = 0; i < sample_count; ++i) {
++        if (i > 0) {
++            out << ",";
++        }
++        bitnet_rs_write_json_number(out, hidden[i]);
++    }
++    out << "],\"values\":[";
++    for (int i = 0; i < n_embd; ++i) {
++        if (i > 0) {
++            out << ",";
++        }
++        bitnet_rs_write_json_number(out, hidden[i]);
++    }
++    out << "]},\"not_claims\":["
++        << "\"reference_parity_promotion\","
++        << "\"a770_semantic_quality_proven\","
++        << "\"selected_attention_residency\","
++        << "\"resident_kv_decode\","
++        << "\"attention_scores_residency\","
++        << "\"softmax_residency\","
++        << "\"attention_value_mix_residency\","
++        << "\"full_support_op_residency\","
++        << "\"full_device_residency\","
++        << "\"completion\""
++        << "]}";
++}
++
+ static void write_logfile(
+     const llama_context * ctx, const common_params & params, const llama_model * model,
+     const std::vector<llama_token> & input_tokens, const std::string & output,
+@@ -515,6 +624,8 @@ int main(int argc, char ** argv) {
+     display = params.display_prompt;
+ 
+     std::vector<llama_token> embd;
++    const char * bitnet_rs_first_token_hidden_state_path = std::getenv("BITNET_RS_REFERENCE_FIRST_TOKEN_HIDDEN_STATE");
++    bool bitnet_rs_first_token_hidden_state_dumped = false;
+ 
+     // tokenized antiprompts
+     std::vector<std::vector<llama_token>> antiprompt_ids;
+@@ -679,6 +790,11 @@ int main(int argc, char ** argv) {
+                 LOG_DBG("saved session to %s\n", path_session.c_str());
+             }
+ 
++            if (!bitnet_rs_first_token_hidden_state_dumped) {
++                bitnet_rs_dump_first_token_hidden_state(ctx, model, embd_inp, bitnet_rs_first_token_hidden_state_path);
++                bitnet_rs_first_token_hidden_state_dumped = true;
++            }
++
+             const llama_token id = common_sampler_sample(smpl, ctx, -1);
+ 
+             common_sampler_accept(smpl, id, /* accept_grammar= */ true);
+diff --git a/src/llama.cpp b/src/llama.cpp
+index 66f4791e..aa339f08 100644
+--- a/src/llama.cpp
++++ b/src/llama.cpp
+@@ -17364,7 +17364,8 @@ static size_t llama_output_reserve(llama_context & lctx, size_t n_outputs) {
+ 
+     // TODO: use a per-batch flag for logits presence instead
+     const bool has_logits = !cparams.embeddings;
+-    const bool has_embd   =  cparams.embeddings && (cparams.pooling_type == LLAMA_POOLING_TYPE_NONE);
++    const bool bitnet_rs_capture_hidden = getenv("BITNET_RS_REFERENCE_FIRST_TOKEN_HIDDEN_STATE") != nullptr;
++    const bool has_embd   = (cparams.embeddings || bitnet_rs_capture_hidden) && (cparams.pooling_type == LLAMA_POOLING_TYPE_NONE);
+ 
+     const size_t logits_size = has_logits ? n_vocab*n_outputs_max : 0;
+     const size_t embd_size   = has_embd   ?  n_embd*n_outputs_max : 0;
+@@ -17504,6 +17505,7 @@ static int llama_decode_internal(
+     const int64_t n_vocab = hparams.n_vocab;
+ 
+     uint32_t n_outputs = 0;
++    const bool bitnet_rs_capture_hidden = getenv("BITNET_RS_REFERENCE_FIRST_TOKEN_HIDDEN_STATE") != nullptr;
+     uint32_t n_outputs_prev = 0;
+ 
+     const auto n_ubatch = cparams.n_ubatch;
+@@ -17633,7 +17635,7 @@ static int llama_decode_internal(
+                 }
+             }
+             GGML_ASSERT(embd != nullptr && "missing embeddings tensor");
+-        } else {
++        } else if (!bitnet_rs_capture_hidden) {
+             embd = nullptr; // do not extract embeddings when not needed
+             GGML_ASSERT(strcmp(res->name, "result_output") == 0 && "missing result_output tensor");
+         }

--- a/xtask/src/bitnet_reference_compare.rs
+++ b/xtask/src/bitnet_reference_compare.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -468,7 +469,8 @@ fn top_logits(value: &Value) -> Option<Vec<TopLogit>> {
 }
 
 fn hidden_state(value: &Value) -> Option<HiddenStateStats> {
-    for pointer in ["/logits_dump/0/hidden_state", "/hidden_state"] {
+    for pointer in ["/logits_dump/0/hidden_state", "/hidden_state", "/sidecar/receipt/hidden_state"]
+    {
         if let Some(stats) = hidden_state_stats(value.pointer(pointer)) {
             return Some(stats);
         }
@@ -490,8 +492,19 @@ fn hidden_state_stats(value: Option<&Value>) -> Option<HiddenStateStats> {
         vector_sha256_f32_le: value
             .pointer("/vector_sha256_f32_le")
             .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
+            .map(ToOwned::to_owned)
+            .or_else(|| vector_sha256_f32_le_from_values(value.pointer("/values"))),
     })
+}
+
+fn vector_sha256_f32_le_from_values(value: Option<&Value>) -> Option<String> {
+    let values = value?.as_array()?;
+    let mut hasher = Sha256::new();
+    for value in values {
+        let value = value.as_f64()? as f32;
+        hasher.update(value.to_le_bytes());
+    }
+    Some(format!("{:x}", hasher.finalize()))
 }
 
 fn top_logits_array(value: Option<&Value>) -> Option<Vec<TopLogit>> {
@@ -1551,6 +1564,27 @@ mod tests {
         assert_eq!(stats.mean, Some(-0.002));
         assert_eq!(stats.rms, Some(0.055));
         assert_eq!(stats.vector_sha256_f32_le.as_deref(), Some("abc123"));
+
+        let sidecar_value = json!({
+            "sidecar": {
+                "receipt": {
+                    "hidden_state": {
+                        "present": true,
+                        "value_count": 2560,
+                        "mean": -0.004,
+                        "rms": 0.061,
+                        "min": -0.6,
+                        "max": 0.8,
+                        "values": [1.0, -2.0]
+                    }
+                }
+            }
+        });
+        let sidecar_stats = hidden_state(&sidecar_value).expect("sidecar hidden state stats");
+        assert_eq!(sidecar_stats.value_count, Some(2560));
+        assert_eq!(sidecar_stats.mean, Some(-0.004));
+        assert_eq!(sidecar_stats.rms, Some(0.061));
+        assert!(sidecar_stats.vector_sha256_f32_le.is_some());
 
         let left = HiddenStateStats {
             value_count: Some(2560),

--- a/xtask/src/bitnet_reference_hidden_state.rs
+++ b/xtask/src/bitnet_reference_hidden_state.rs
@@ -3,9 +3,16 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
+const DEFAULT_REFERENCE_ROOT: &str = "target/external/BitNet-reference";
 const DEFAULT_CPP_ROOT: &str = "target/external/BitNet-reference/3rdparty/llama.cpp";
+const DEFAULT_PATCH: &str =
+    "ci/reference-instrumentation/bitnet-rs-first-token-hidden-state-main.patch";
 const DEFAULT_OUTPUT: &str = "target/a770-diagnostic/bitnet-reference-hidden-state-plan.json";
+const DEFAULT_RUN_OUTPUT: &str = "target/a770-diagnostic/bitnet-reference-hidden-state-run.json";
+const DEFAULT_REFERENCE_PLAN: &str = "target/a770-diagnostic/bitnet-reference-plan.json";
+const DEFAULT_SIDECAR: &str = "target/a770-diagnostic/reference-first-token-hidden-state.json";
 
 const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "selected_attention_residency",
@@ -30,6 +37,17 @@ struct HiddenStatePlanArgs {
 }
 
 #[derive(Debug)]
+struct HiddenStateRunArgs {
+    reference_root: PathBuf,
+    cpp_root: PathBuf,
+    patch: PathBuf,
+    plan: PathBuf,
+    sidecar: PathBuf,
+    output: Option<PathBuf>,
+    format: String,
+}
+
+#[derive(Debug)]
 struct SourceText {
     path: PathBuf,
     exists: bool,
@@ -49,6 +67,14 @@ struct HiddenStateSourceSignals {
     decode_nulls_embeddings_when_not_needed: bool,
     decode_mentions_last_graph_embedding_node: bool,
     common_sampler_sample_anchor: bool,
+}
+
+#[derive(Debug)]
+struct CommandCapture {
+    status_code: Option<i32>,
+    success: bool,
+    stdout: String,
+    stderr: String,
 }
 
 pub fn maybe_dispatch_from_env() -> Result<bool> {
@@ -76,6 +102,24 @@ fn maybe_dispatch(args: &[String]) -> Result<bool> {
             emit_report(&report, &opts.format)?;
             Ok(true)
         }
+        Some("bitnet-reference-hidden-state-run") => {
+            if args[2..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_run_help();
+                return Ok(true);
+            }
+            let opts = parse_run_args(args)?;
+            let report = run_instrumented_reference(&opts)?;
+            if let Some(output) = &opts.output {
+                if let Some(parent) = output.parent() {
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("creating {}", parent.display()))?;
+                }
+                fs::write(output, serde_json::to_vec_pretty(&report)?)
+                    .with_context(|| format!("writing {}", output.display()))?;
+            }
+            emit_report(&report, &opts.format)?;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }
@@ -83,6 +127,12 @@ fn maybe_dispatch(args: &[String]) -> Result<bool> {
 fn print_help() {
     println!(
         "Plan target-local BitNet reference hidden-state instrumentation for first-token divergence localization\n\nUsage: xtask.exe bitnet-reference-hidden-state-plan [OPTIONS]\n\nOptions:\n      --cpp-root <PATH>  llama.cpp checkout root [default: target/external/BitNet-reference/3rdparty/llama.cpp]\n      --output <PATH>    Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-hidden-state-plan.json]\n      --format <FORMAT>  Output format: human or json [default: human]\n  -h, --help             Print help"
+    );
+}
+
+fn print_run_help() {
+    println!(
+        "Temporarily apply BitNet reference first-token hidden-state instrumentation, run the matched reference plan, and restore source worktrees\n\nUsage: xtask.exe bitnet-reference-hidden-state-run [OPTIONS]\n\nOptions:\n      --reference-root <PATH>  BitNet.cpp checkout root [default: target/external/BitNet-reference]\n      --cpp-root <PATH>        llama.cpp checkout root [default: target/external/BitNet-reference/3rdparty/llama.cpp]\n      --patch <PATH>           Hidden-state instrumentation patch [default: ci/reference-instrumentation/bitnet-rs-first-token-hidden-state-main.patch]\n      --plan <PATH>            Reference plan JSON [default: target/a770-diagnostic/bitnet-reference-plan.json]\n      --sidecar <PATH>         First-token hidden-state sidecar JSON [default: target/a770-diagnostic/reference-first-token-hidden-state.json]\n      --output <PATH>          Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-hidden-state-run.json]\n      --format <FORMAT>        Output format: human or json [default: human]\n  -h, --help                   Print help"
     );
 }
 
@@ -110,6 +160,242 @@ fn parse_args(args: &[String]) -> Result<HiddenStatePlanArgs> {
         }
     }
     Ok(HiddenStatePlanArgs { cpp_root, output, format })
+}
+
+fn parse_run_args(args: &[String]) -> Result<HiddenStateRunArgs> {
+    if args.get(1).map(String::as_str) != Some("bitnet-reference-hidden-state-run") {
+        bail!("parse_run_args called for unexpected command");
+    }
+    let mut reference_root = PathBuf::from(DEFAULT_REFERENCE_ROOT);
+    let mut cpp_root = PathBuf::from(DEFAULT_CPP_ROOT);
+    let mut patch = PathBuf::from(DEFAULT_PATCH);
+    let mut plan = PathBuf::from(DEFAULT_REFERENCE_PLAN);
+    let mut sidecar = PathBuf::from(DEFAULT_SIDECAR);
+    let mut output = Some(PathBuf::from(DEFAULT_RUN_OUTPUT));
+    let mut format = "human".to_string();
+    let mut i = 2usize;
+    while i < args.len() {
+        let key = args[i].as_str();
+        i += 1;
+        let mut value = || -> Result<String> {
+            let value = args.get(i).with_context(|| format!("{key} requires a value"))?.clone();
+            i += 1;
+            Ok(value)
+        };
+        match key {
+            "--reference-root" => reference_root = PathBuf::from(value()?),
+            "--cpp-root" => cpp_root = PathBuf::from(value()?),
+            "--patch" => patch = PathBuf::from(value()?),
+            "--plan" => plan = PathBuf::from(value()?),
+            "--sidecar" => sidecar = PathBuf::from(value()?),
+            "--output" => output = Some(PathBuf::from(value()?)),
+            "--format" => format = value()?,
+            other => bail!("unknown bitnet-reference-hidden-state-run option {other}"),
+        }
+    }
+    Ok(HiddenStateRunArgs { reference_root, cpp_root, patch, plan, sidecar, output, format })
+}
+
+fn run_instrumented_reference(args: &HiddenStateRunArgs) -> Result<Value> {
+    let reference_root = normalize_path(&args.reference_root)?;
+    let cpp_root = normalize_path(&args.cpp_root)?;
+    let patch = normalize_path(&args.patch)?;
+    let plan_path = normalize_path(&args.plan)?;
+    let sidecar = normalize_path(&args.sidecar)?;
+    let build_dir = reference_root.join("build");
+    let selected_exe = build_dir.join("bin").join(exe_name("llama-cli"));
+    let generated_lut_header = reference_root.join("include/bitnet-lut-kernels.h");
+    let generated_kernel_config = reference_root.join("include/kernel_config.ini");
+    let plan_result = read_json(&plan_path);
+    let plan_read_success = plan_result.is_ok();
+    let plan = plan_result.unwrap_or(Value::Null);
+    let reference_argv = reference_argv(&plan).unwrap_or_default();
+
+    if let Some(parent) = sidecar.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    if sidecar.exists() {
+        fs::remove_file(&sidecar)
+            .with_context(|| format!("removing stale {}", sidecar.display()))?;
+    }
+
+    let reference_status_before = git_status(&reference_root);
+    let cpp_status_before = git_status(&cpp_root);
+    let clean_before = capture_success_empty(&reference_status_before)
+        && capture_success_empty(&cpp_status_before);
+
+    let mut blocked_reasons = Vec::<String>::new();
+    if !reference_root.is_dir() {
+        blocked_reasons.push("reference_root_missing".to_string());
+    }
+    if !cpp_root.is_dir() {
+        blocked_reasons.push("reference_llama_cpp_root_missing".to_string());
+    }
+    if !patch.is_file() {
+        blocked_reasons.push("reference_hidden_state_patch_missing".to_string());
+    }
+    if !plan_path.is_file() {
+        blocked_reasons.push("reference_plan_missing".to_string());
+    }
+    if plan_path.is_file() && !plan_read_success {
+        blocked_reasons.push("reference_plan_json_invalid".to_string());
+    }
+    if plan_path.is_file() && reference_argv.is_empty() {
+        blocked_reasons.push("reference_plan_command_argv_missing".to_string());
+    }
+    if !build_dir.is_dir() {
+        blocked_reasons.push("reference_build_dir_missing".to_string());
+    }
+    if !clean_before {
+        blocked_reasons.push("reference_external_worktree_not_clean_before_run".to_string());
+    }
+
+    let generated_lut_header_exists_before = generated_lut_header.is_file();
+    let generated_kernel_config_exists_before = generated_kernel_config.is_file();
+    let mut generated_lut_header_exists_after_codegen = generated_lut_header_exists_before;
+    let mut generated_kernel_config_exists_after_codegen = generated_kernel_config_exists_before;
+    let mut compatibility = Vec::<Value>::new();
+    let mut codegen_capture = None;
+    let mut patch_apply = None;
+    let mut build_capture = None;
+    let mut run_capture = None;
+
+    if blocked_reasons.is_empty() && !generated_lut_header_exists_before {
+        codegen_capture = Some(run_reference_kernel_codegen(&reference_root)?);
+        generated_lut_header_exists_after_codegen = generated_lut_header.is_file();
+        generated_kernel_config_exists_after_codegen = generated_kernel_config.is_file();
+        if !codegen_capture.as_ref().is_some_and(|capture| capture.success) {
+            blocked_reasons.push("reference_kernel_codegen_failed".to_string());
+        }
+        if !generated_lut_header.is_file() {
+            blocked_reasons.push("reference_generated_lut_header_missing".to_string());
+        }
+    }
+
+    if blocked_reasons.is_empty() {
+        compatibility = apply_windows_reference_compatibility_fixes(&reference_root)?;
+        patch_apply = Some(run_git(&cpp_root, &["apply", &path_to_string(&patch)])?);
+        if !patch_apply.as_ref().is_some_and(|capture| capture.success) {
+            blocked_reasons.push("reference_hidden_state_patch_apply_failed".to_string());
+        }
+    }
+
+    if blocked_reasons.is_empty() {
+        build_capture = Some(build_reference_cli(&reference_root, &build_dir)?);
+        if !build_capture.as_ref().is_some_and(|capture| capture.success) {
+            blocked_reasons.push("reference_hidden_state_build_failed".to_string());
+        }
+    }
+
+    if blocked_reasons.is_empty() {
+        if !selected_exe.is_file() {
+            blocked_reasons.push("reference_hidden_state_executable_missing".to_string());
+        } else if reference_argv.is_empty() {
+            blocked_reasons.push("reference_plan_command_argv_missing".to_string());
+        } else {
+            let mut argv = reference_argv.clone();
+            argv[0] = path_to_string(&selected_exe);
+            run_capture = Some(run_reference_with_sidecar(&argv, &sidecar)?);
+            if !run_capture.as_ref().is_some_and(|capture| capture.success) {
+                blocked_reasons.push("reference_hidden_state_run_failed".to_string());
+            }
+        }
+    }
+
+    let sidecar_value = if sidecar.is_file() { Some(read_json(&sidecar)?) } else { None };
+    if run_capture.as_ref().is_some_and(|capture| capture.success) && sidecar_value.is_none() {
+        blocked_reasons.push("reference_first_token_hidden_state_sidecar_missing".to_string());
+    }
+
+    let cleanup_capture = if reference_root.is_dir() && cpp_root.is_dir() {
+        Some(cleanup_reference_sources(
+            &reference_root,
+            &cpp_root,
+            &generated_lut_header,
+            generated_lut_header_exists_before,
+            &generated_kernel_config,
+            generated_kernel_config_exists_before,
+        )?)
+    } else {
+        None
+    };
+    let reference_status_after = git_status(&reference_root);
+    let cpp_status_after = git_status(&cpp_root);
+    let clean_after =
+        capture_success_empty(&reference_status_after) && capture_success_empty(&cpp_status_after);
+    if !clean_after {
+        blocked_reasons.push("reference_external_worktree_not_clean_after_run".to_string());
+    }
+
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+    let reference_hidden_state_available = sidecar_value.is_some() && blocked_reasons.is_empty();
+
+    Ok(json!({
+        "schema_version": 1,
+        "receipt_type": "bitnet_reference_hidden_state_run",
+        "diagnostic": "bitnet_reference_hidden_state_run",
+        "producer": "cargo xtask bitnet-reference-hidden-state-run",
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "diagnostic_only": true,
+        "promotion_allowed": false,
+        "claim_allowed": false,
+        "classification": "diagnostic_only",
+        "paths": {
+            "reference_root": path_to_string(&reference_root),
+            "cpp_root": path_to_string(&cpp_root),
+            "patch": path_to_string(&patch),
+            "plan": path_to_string(&plan_path),
+            "build_dir": path_to_string(&build_dir),
+            "selected_executable": path_to_string(&selected_exe),
+            "sidecar": path_to_string(&sidecar),
+        },
+        "model": plan.pointer("/model").cloned().unwrap_or(Value::Null),
+        "prompt_identity": plan.pointer("/prompt_identity").cloned().unwrap_or(Value::Null),
+        "preflight": {
+            "reference_root_exists": reference_root.is_dir(),
+            "cpp_root_exists": cpp_root.is_dir(),
+            "patch_exists": patch.is_file(),
+            "plan_exists": plan_path.is_file(),
+            "build_dir_exists": build_dir.is_dir(),
+            "external_worktrees_clean_before_run": clean_before,
+            "generated_lut_header": {
+                "path": path_to_string(&generated_lut_header),
+                "exists_before": generated_lut_header_exists_before,
+                "exists_after_codegen": generated_lut_header_exists_after_codegen,
+            },
+            "generated_kernel_config": {
+                "path": path_to_string(&generated_kernel_config),
+                "exists_before": generated_kernel_config_exists_before,
+                "exists_after_codegen": generated_kernel_config_exists_after_codegen,
+            },
+            "reference_status_before": capture_json(reference_status_before.as_ref()),
+            "cpp_status_before": capture_json(cpp_status_before.as_ref()),
+        },
+        "kernel_codegen": capture_json(codegen_capture.as_ref()),
+        "compatibility_fixes": compatibility,
+        "patch_apply": capture_json(patch_apply.as_ref()),
+        "build": capture_json(build_capture.as_ref()),
+        "reference_run": capture_json(run_capture.as_ref()),
+        "sidecar": {
+            "exists": sidecar.is_file(),
+            "sha256": sidecar.is_file().then(|| sha256_bytes(&fs::read(&sidecar).unwrap_or_default())),
+            "receipt": sidecar_value,
+            "policy": "reference-side first-token hidden state is diagnostic evidence only until compared with Rust CPU and strict A770 hidden-state receipts",
+        },
+        "cleanup": {
+            "source_restore": capture_json(cleanup_capture.as_ref()),
+            "external_worktrees_clean_after_run": clean_after,
+            "reference_status_after": capture_json(reference_status_after.as_ref()),
+            "cpp_status_after": capture_json(cpp_status_after.as_ref()),
+        },
+        "decision": {
+            "reference_hidden_state_available": reference_hidden_state_available,
+            "current_blocked_reasons": blocked_reasons,
+            "next_when_available": "compare reference first-token hidden state against Rust CPU and strict A770 hidden-state receipts before changing Rust model math",
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    }))
 }
 
 fn build_plan(args: &HiddenStatePlanArgs) -> Result<Value> {
@@ -281,6 +567,282 @@ fn source_receipt(source: &SourceText) -> Value {
     })
 }
 
+fn read_json(path: &Path) -> Result<Value> {
+    let text = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn reference_argv(plan: &Value) -> Result<Vec<String>> {
+    plan.pointer("/reference/command_argv")
+        .and_then(Value::as_array)
+        .context("plan missing /reference/command_argv")?
+        .iter()
+        .map(|item| {
+            item.as_str().map(ToOwned::to_owned).context("command_argv item is not a string")
+        })
+        .collect()
+}
+
+fn apply_windows_reference_compatibility_fixes(reference_root: &Path) -> Result<Vec<Value>> {
+    let mut applied = Vec::new();
+    applied.push(replace_file_text(
+        &reference_root.join("src/ggml-bitnet-mad.cpp"),
+        "        int8_t * y_col = y + col * by;",
+        "        const int8_t * y_col = y + col * by;",
+        "windows_const_compatibility",
+    )?);
+    applied.push(insert_after_if_missing(
+        &reference_root.join("3rdparty/llama.cpp/common/common.cpp"),
+        "#include <ctime>",
+        "#include <chrono>",
+        "windows_common_chrono_include",
+    )?);
+    applied.push(insert_after_if_missing(
+        &reference_root.join("3rdparty/llama.cpp/common/log.cpp"),
+        "#include <condition_variable>",
+        "#include <chrono>",
+        "windows_log_chrono_include",
+    )?);
+    Ok(applied)
+}
+
+fn replace_file_text(path: &Path, before: &str, after: &str, fix_id: &str) -> Result<Value> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if content.contains(before) {
+        fs::write(path, content.replace(before, after))
+            .with_context(|| format!("writing {}", path.display()))?;
+        return Ok(json!({
+            "fix_id": fix_id,
+            "path": path_to_string(path),
+            "applied": true,
+            "already_present": false,
+        }));
+    }
+    if content.contains(after) {
+        return Ok(json!({
+            "fix_id": fix_id,
+            "path": path_to_string(path),
+            "applied": false,
+            "already_present": true,
+        }));
+    }
+    bail!("expected compatibility fix target not found in {}", path.display())
+}
+
+fn insert_after_if_missing(path: &Path, anchor: &str, insert: &str, fix_id: &str) -> Result<Value> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if content.contains(insert) {
+        return Ok(json!({
+            "fix_id": fix_id,
+            "path": path_to_string(path),
+            "applied": false,
+            "already_present": true,
+        }));
+    }
+    if !content.contains(anchor) {
+        bail!("expected compatibility include anchor not found in {}", path.display());
+    }
+    fs::write(path, content.replace(anchor, &format!("{anchor}\n{insert}")))
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(json!({
+        "fix_id": fix_id,
+        "path": path_to_string(path),
+        "applied": true,
+        "already_present": false,
+    }))
+}
+
+fn run_reference_kernel_codegen(reference_root: &Path) -> Result<CommandCapture> {
+    run_command(Command::new("python").current_dir(reference_root).args([
+        "utils/codegen_tl2.py",
+        "--model",
+        "bitnet_b1_58-3B",
+        "--BM",
+        "160,320,320",
+        "--BK",
+        "96,96,96",
+        "--bm",
+        "32,32,32",
+    ]))
+}
+
+fn build_reference_cli(reference_root: &Path, build_dir: &Path) -> Result<CommandCapture> {
+    if cfg!(windows) {
+        let vsdevcmd = find_vsdevcmd();
+        let Some(vsdevcmd) = vsdevcmd else {
+            return Ok(CommandCapture {
+                status_code: None,
+                success: false,
+                stdout: String::new(),
+                stderr: "Visual Studio developer command prompt not found".to_string(),
+            });
+        };
+        let script = reference_root.join("build_bitnet_rs_hidden_state_reference.cmd");
+        let lines = [
+            "@echo off".to_string(),
+            format!("call {} -arch=x64 -host_arch=x64 || exit /b 1", cmd_quote(&vsdevcmd)),
+            format!(
+                "cmake --build {} --config Release --target llama-cli || exit /b 1",
+                cmd_quote(build_dir)
+            ),
+        ];
+        fs::write(&script, lines.join("\r\n"))
+            .with_context(|| format!("writing {}", script.display()))?;
+        let capture =
+            run_command(Command::new("cmd.exe").args(["/d", "/c"]).arg(path_to_string(&script)))?;
+        let _ = fs::remove_file(&script);
+        Ok(capture)
+    } else {
+        run_command(Command::new("cmake").args([
+            "--build",
+            &path_to_string(build_dir),
+            "--config",
+            "Release",
+            "--target",
+            "llama-cli",
+        ]))
+    }
+}
+
+fn find_vsdevcmd() -> Option<PathBuf> {
+    let program_files_x86 = std::env::var_os("ProgramFiles(x86)")?;
+    let vswhere =
+        PathBuf::from(program_files_x86).join("Microsoft Visual Studio/Installer/vswhere.exe");
+    if !vswhere.is_file() {
+        return None;
+    }
+    let output = Command::new(vswhere)
+        .args([
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        return None;
+    }
+    let vsdevcmd = PathBuf::from(path).join("Common7/Tools/VsDevCmd.bat");
+    vsdevcmd.is_file().then_some(vsdevcmd)
+}
+
+fn run_reference_with_sidecar(argv: &[String], sidecar: &Path) -> Result<CommandCapture> {
+    let executable = argv.first().context("empty reference command")?;
+    let mut command = Command::new(executable);
+    command
+        .args(&argv[1..])
+        .env("BITNET_RS_REFERENCE_FIRST_TOKEN_HIDDEN_STATE", sidecar)
+        .stdin(Stdio::null());
+    run_command(&mut command)
+}
+
+fn cleanup_reference_sources(
+    reference_root: &Path,
+    cpp_root: &Path,
+    generated_lut_header: &Path,
+    generated_lut_header_existed_before: bool,
+    generated_kernel_config: &Path,
+    generated_kernel_config_existed_before: bool,
+) -> Result<CommandCapture> {
+    let mut capture = run_git(reference_root, &["restore", "--", "src/ggml-bitnet-mad.cpp"])?;
+    let cpp_capture = run_git(
+        cpp_root,
+        &[
+            "restore",
+            "--",
+            "common/common.cpp",
+            "common/log.cpp",
+            "examples/main/main.cpp",
+            "src/llama.cpp",
+        ],
+    )?;
+    if !generated_lut_header_existed_before && generated_lut_header.exists() {
+        fs::remove_file(generated_lut_header)
+            .with_context(|| format!("removing {}", generated_lut_header.display()))?;
+    }
+    if !generated_kernel_config_existed_before && generated_kernel_config.exists() {
+        fs::remove_file(generated_kernel_config)
+            .with_context(|| format!("removing {}", generated_kernel_config.display()))?;
+    }
+    capture.success = capture.success && cpp_capture.success;
+    capture.status_code = if capture.status_code == Some(0) && cpp_capture.status_code == Some(0) {
+        Some(0)
+    } else {
+        cpp_capture.status_code.or(capture.status_code)
+    };
+    if !cpp_capture.stdout.is_empty() {
+        capture.stdout.push_str(&cpp_capture.stdout);
+    }
+    if !cpp_capture.stderr.is_empty() {
+        capture.stderr.push_str(&cpp_capture.stderr);
+    }
+    Ok(capture)
+}
+
+fn run_command(command: &mut Command) -> Result<CommandCapture> {
+    let output = command.output().with_context(|| format!("running command {:?}", command))?;
+    Ok(CommandCapture {
+        status_code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn git_status(path: &Path) -> Option<CommandCapture> {
+    path.is_dir().then(|| run_git(path, &["status", "--porcelain"]).ok()).flatten()
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Result<CommandCapture> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("running git {} in {}", args.join(" "), cwd.display()))?;
+    Ok(CommandCapture {
+        status_code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn capture_success_empty(capture: &Option<CommandCapture>) -> bool {
+    capture.as_ref().is_some_and(|capture| capture.success && capture.stdout.trim().is_empty())
+}
+
+fn capture_json(capture: Option<&CommandCapture>) -> Value {
+    match capture {
+        Some(capture) => json!({
+            "success": capture.success,
+            "exit_code": capture.status_code,
+            "stdout": capture.stdout.trim(),
+            "stderr": capture.stderr.trim(),
+        }),
+        None => Value::Null,
+    }
+}
+
+fn exe_name(stem: &str) -> String {
+    if cfg!(windows) { format!("{stem}.exe") } else { stem.to_string() }
+}
+
+fn cmd_quote(path: &Path) -> String {
+    format!("\"{}\"", path_to_string(path).replace('"', "\"\""))
+}
+
 fn normalize_path(path: &Path) -> Result<PathBuf> {
     if path.exists() {
         path.canonicalize().with_context(|| format!("canonicalizing {}", path.display()))
@@ -298,7 +860,8 @@ fn sha256_bytes(bytes: &[u8]) -> String {
 }
 
 fn path_to_string(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let path = path.to_string_lossy().replace('\\', "/");
+    path.strip_prefix("//?/").unwrap_or(&path).to_string()
 }
 
 fn emit_report(report: &Value, format: &str) -> Result<()> {


### PR DESCRIPTION
## Summary
- add a target-local reference hidden-state instrumentation patch for llama-cli generation
- add `cargo xtask bitnet-reference-hidden-state-run` to apply/build/run/restore the reference checkout and emit a diagnostic sidecar receipt
- teach `bitnet-reference-compare` to consume hidden-state sidecars and hash dumped f32 values for comparison

## Evidence
- Reference hidden state captured: `reference_hidden_state_available=true`, `n_embd=2560`, `prompt_token_count=18`
- Reference vs Rust CPU hidden-state differs: RMS delta `0.0024943107224144`, vector hash mismatch
- Rust CPU vs strict A770 remain close: RMS delta `0.0002584420144557953`, generated text/token IDs exact

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_hidden_state -- --nocapture`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_compare -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_hidden_state.rs xtask\src\bitnet_reference_compare.rs`
- `git diff --check`
- `git -C target\external\BitNet-reference\3rdparty\llama.cpp apply --check E:\Code\Rust\BitNet-rs\ci\reference-instrumentation\bitnet-rs-first-token-hidden-state-main.patch`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-hidden-state-run --output target/a770-diagnostic/bitnet-reference-hidden-state-run.json --format json`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-compare --reference target/a770-diagnostic/bitnet-reference-hidden-state-run.json --cpu target/a770-diagnostic/hidden-stats-cpu-first-token.json --a770 target/a770-diagnostic/hidden-stats-a770-first-token.json --output target/a770-diagnostic/bitnet-reference-compare-hidden-state-reference-sidecar.json --format json`

## Not claims
- selected attention residency
- resident KV decode
- attention scores / softmax / value mix residency
- full support-op residency
- full device residency
- completion
- A770 semantic quality
- reference parity promotion