### PR TITLE
diag(bitnet): compare full hidden-state vectors

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -467,7 +467,7 @@ mod proof_summary_tests {
     #[test]
     fn f32_vector_stats_receipt_reports_hidden_state_shape_and_hash() {
         let values = [1.0f32, -2.0, 3.0, 4.0];
-        let receipt = f32_vector_stats_receipt(&values);
+        let receipt = f32_vector_stats_receipt(&values, false);
 
         assert_eq!(receipt["present"], serde_json::json!(true));
         assert_eq!(receipt["value_count"], serde_json::json!(4));
@@ -477,6 +477,20 @@ mod proof_summary_tests {
         assert_eq!(receipt["max"], serde_json::json!(4.0f32));
         assert_eq!(receipt["vector_sha256_f32_le"], serde_json::json!(sha256_f32_le(&values)));
         assert_eq!(receipt["first_values"], serde_json::json!([1.0f32, -2.0, 3.0, 4.0]));
+        assert_eq!(receipt["values_included"], serde_json::json!(false));
+        assert!(receipt.get("values").is_none());
+    }
+
+    #[test]
+    fn f32_vector_stats_receipt_can_include_full_hidden_values() {
+        let values = [1.0f32, -2.0, 3.0, 4.0];
+        let receipt = f32_vector_stats_receipt(&values, true);
+
+        assert_eq!(receipt["present"], serde_json::json!(true));
+        assert_eq!(receipt["value_count"], serde_json::json!(4));
+        assert_eq!(receipt["vector_sha256_f32_le"], serde_json::json!(sha256_f32_le(&values)));
+        assert_eq!(receipt["values_included"], serde_json::json!(true));
+        assert_eq!(receipt["values"], serde_json::json!([1.0f32, -2.0, 3.0, 4.0]));
     }
 
     #[test]
@@ -879,6 +893,10 @@ enum Commands {
         #[arg(long)]
         dump_logit_steps: Option<usize>,
 
+        /// Include full hidden-state vectors in dumped logit steps (diagnostic only)
+        #[arg(long, default_value_t = false)]
+        dump_hidden_values: bool,
+
         /// Top-k tokens to include in logit dump
         #[arg(long, default_value = "10", value_name = "K")]
         logits_topk: usize,
@@ -1158,6 +1176,7 @@ async fn main() -> Result<()> {
             stop,
             stop_id,
             dump_logit_steps,
+            dump_hidden_values,
             logits_topk,
             logit_id,
             assert_greedy,
@@ -1194,6 +1213,7 @@ async fn main() -> Result<()> {
                 stop,
                 stop_id,
                 dump_logit_steps,
+                dump_hidden_values,
                 logits_topk,
                 logit_id,
                 assert_greedy,
@@ -1944,6 +1964,7 @@ async fn run_simple_generation(
     stop: Vec<String>,
     stop_id: Vec<u32>,
     dump_logit_steps: Option<usize>,
+    dump_hidden_values: bool,
     logits_topk: usize,
     logit_id: Vec<u32>,
     assert_greedy: bool,
@@ -2364,7 +2385,7 @@ async fn run_simple_generation(
             // Will capture chosen_id after sampling
             let step = LogitStep {
                 step: step_idx,
-                hidden_state: f32_vector_stats_receipt(&hidden_vec),
+                hidden_state: f32_vector_stats_receipt(&hidden_vec, dump_hidden_values),
                 top_logits: top_logits
                     .iter()
                     .map(|&(token_id, logit)| {
@@ -2774,9 +2795,9 @@ fn compute_rms(xs: &[f32]) -> f32 {
     (sum_sq / (xs.len() as f32)).sqrt()
 }
 
-fn f32_vector_stats_receipt(values: &[f32]) -> serde_json::Value {
+fn f32_vector_stats_receipt(values: &[f32], include_values: bool) -> serde_json::Value {
     if values.is_empty() {
-        return serde_json::json!({
+        let mut receipt = serde_json::json!({
             "present": false,
             "value_count": 0,
             "mean": serde_json::Value::Null,
@@ -2785,7 +2806,12 @@ fn f32_vector_stats_receipt(values: &[f32]) -> serde_json::Value {
             "max": serde_json::Value::Null,
             "vector_sha256_f32_le": serde_json::Value::Null,
             "first_values": Vec::<f32>::new(),
+            "values_included": include_values,
         });
+        if include_values {
+            receipt["values"] = serde_json::json!(Vec::<f32>::new());
+        }
+        return receipt;
     }
 
     let mut min = f32::INFINITY;
@@ -2797,7 +2823,7 @@ fn f32_vector_stats_receipt(values: &[f32]) -> serde_json::Value {
         sum += *value as f64;
     }
 
-    serde_json::json!({
+    let mut receipt = serde_json::json!({
         "present": true,
         "value_count": values.len(),
         "mean": (sum / values.len() as f64) as f32,
@@ -2806,7 +2832,12 @@ fn f32_vector_stats_receipt(values: &[f32]) -> serde_json::Value {
         "max": max,
         "vector_sha256_f32_le": sha256_f32_le(values),
         "first_values": values.iter().copied().take(8).collect::<Vec<_>>(),
-    })
+        "values_included": include_values,
+    });
+    if include_values {
+        receipt["values"] = serde_json::json!(values);
+    }
+    receipt
 }
 
 /// Show system information

--- a/xtask/src/bitnet_reference_compare.rs
+++ b/xtask/src/bitnet_reference_compare.rs
@@ -98,6 +98,7 @@ struct HiddenStateStats {
     min: Option<f64>,
     max: Option<f64>,
     vector_sha256_f32_le: Option<String>,
+    values: Option<Vec<f64>>,
 }
 
 #[derive(Clone, Debug)]
@@ -494,7 +495,12 @@ fn hidden_state_stats(value: Option<&Value>) -> Option<HiddenStateStats> {
             .and_then(Value::as_str)
             .map(ToOwned::to_owned)
             .or_else(|| vector_sha256_f32_le_from_values(value.pointer("/values"))),
+        values: f64_array(value.pointer("/values")),
     })
+}
+
+fn f64_array(value: Option<&Value>) -> Option<Vec<f64>> {
+    value?.as_array()?.iter().map(Value::as_f64).collect()
 }
 
 fn vector_sha256_f32_le_from_values(value: Option<&Value>) -> Option<String> {
@@ -891,6 +897,7 @@ fn compare_hidden_state(
     right: Option<&HiddenStateStats>,
 ) -> Value {
     let hidden_state_available = left.is_some() && right.is_some();
+    let elementwise = compare_hidden_state_values(left, right);
     let value_count_exact = left
         .zip(right)
         .and_then(|(left, right)| left.value_count.zip(right.value_count))
@@ -938,6 +945,81 @@ fn compare_hidden_state(
         "vector_sha256_f32_le_exact": hash_exact,
         "left_vector_sha256_f32_le": left.and_then(|stats| stats.vector_sha256_f32_le.clone()),
         "right_vector_sha256_f32_le": right.and_then(|stats| stats.vector_sha256_f32_le.clone()),
+        "elementwise": elementwise,
+    })
+}
+
+fn compare_hidden_state_values(
+    left: Option<&HiddenStateStats>,
+    right: Option<&HiddenStateStats>,
+) -> Value {
+    let Some((left, right)) = left.zip(right) else {
+        return json!({
+            "available": false,
+            "reason": "hidden_state_missing",
+        });
+    };
+    let Some((left_values, right_values)) = left.values.as_ref().zip(right.values.as_ref()) else {
+        return json!({
+            "available": false,
+            "reason": "hidden_state_values_missing",
+            "left_values_present": left.values.is_some(),
+            "right_values_present": right.values.is_some(),
+        });
+    };
+    if left_values.len() != right_values.len() {
+        return json!({
+            "available": false,
+            "reason": "hidden_state_value_count_mismatch",
+            "left_len": left_values.len(),
+            "right_len": right_values.len(),
+        });
+    }
+
+    let mut max_abs_delta = 0.0f64;
+    let mut max_abs_index = None;
+    let mut sum_abs_delta = 0.0f64;
+    let mut sum_sq_delta = 0.0f64;
+    let mut rows = left_values
+        .iter()
+        .zip(right_values.iter())
+        .enumerate()
+        .map(|(index, (left, right))| {
+            let delta = right - left;
+            let abs_delta = delta.abs();
+            if abs_delta > max_abs_delta {
+                max_abs_delta = abs_delta;
+                max_abs_index = Some(index);
+            }
+            sum_abs_delta += abs_delta;
+            sum_sq_delta += delta * delta;
+            (index, *left, *right, delta, abs_delta)
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|a, b| b.4.partial_cmp(&a.4).unwrap_or(std::cmp::Ordering::Equal));
+    let top_abs_deltas = rows
+        .into_iter()
+        .take(8)
+        .map(|(index, left, right, delta, abs_delta)| {
+            json!({
+                "index": index,
+                "left": left,
+                "right": right,
+                "delta_right_minus_left": delta,
+                "abs_delta": abs_delta,
+            })
+        })
+        .collect::<Vec<_>>();
+    let len = left_values.len() as f64;
+
+    json!({
+        "available": true,
+        "value_count": left_values.len(),
+        "mean_abs_delta": sum_abs_delta / len,
+        "rms_delta": (sum_sq_delta / len).sqrt(),
+        "max_abs_delta": max_abs_delta,
+        "max_abs_index": max_abs_index,
+        "top_abs_deltas": top_abs_deltas,
     })
 }
 
@@ -1585,6 +1667,7 @@ mod tests {
         assert_eq!(sidecar_stats.mean, Some(-0.004));
         assert_eq!(sidecar_stats.rms, Some(0.061));
         assert!(sidecar_stats.vector_sha256_f32_le.is_some());
+        assert_eq!(sidecar_stats.values.as_deref(), Some(&[1.0, -2.0][..]));
 
         let left = HiddenStateStats {
             value_count: Some(2560),
@@ -1593,6 +1676,7 @@ mod tests {
             min: Some(-0.5),
             max: Some(0.75),
             vector_sha256_f32_le: Some("abc123".to_string()),
+            values: Some(vec![1.0, 2.0, 3.0]),
         };
         let right = HiddenStateStats {
             value_count: Some(2560),
@@ -1601,6 +1685,7 @@ mod tests {
             min: Some(-0.55),
             max: Some(0.7),
             vector_sha256_f32_le: Some("def456".to_string()),
+            values: Some(vec![1.5, -1.0, 3.25]),
         };
         let report = compare_hidden_state(Some(&left), Some(&right));
         assert_eq!(report["available"], true);
@@ -1616,6 +1701,11 @@ mod tests {
             report["rms_abs_delta"]
         );
         assert_eq!(report["vector_sha256_f32_le_exact"], false);
+        assert_eq!(report["elementwise"]["available"], true);
+        assert_eq!(report["elementwise"]["value_count"], 3);
+        assert_eq!(report["elementwise"]["max_abs_delta"], 3.0);
+        assert_eq!(report["elementwise"]["max_abs_index"], 1);
+        assert_eq!(report["elementwise"]["top_abs_deltas"][0]["index"], 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an explicit `bitnet run --dump-hidden-values` diagnostic flag for logit-step hidden-state dumps
- keep default receipts compact with stats, first values, and f32-le vector hash only
- teach `bitnet-reference-compare` to compute elementwise hidden-state deltas when both sides carry full vectors

## Why
#4915 captures a full reference hidden-state vector, but Rust CPU/A770 diagnostic receipts only expose aggregate stats and hashes by default. This PR adds an opt-in path for full-vector Rust receipts and a compare report that can name elementwise max/mean/RMS deltas without changing runtime math.

## Validation
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu --bin bitnet proof_summary_tests -- --nocapture`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_compare -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu`
- `cargo check --locked -p bitnet-cli --no-default-features --features opencl`
- `rustfmt --check --edition 2024 --config skip_children=true crates\bitnet-cli\src\main.rs xtask\src\bitnet_reference_compare.rs`
- `git diff --check`

## Notes
A debug-build real-model CPU run with `--dump-hidden-values` exceeded the local timeout and was killed; no artifact was produced or used for promotion. This remains diagnostic plumbing only.

## Not claims
- selected attention residency
- resident KV decode
- attention scores / softmax / value mix residency
- full support-op residency
- full device residency
- completion
- A770 semantic quality
- reference parity promotion