### PR TITLE
ci: avoid cancelling selected proof lanes

### DIFF
--- a/.github/workflows/campaign-tracker.yml
+++ b/.github/workflows/campaign-tracker.yml
@@ -24,7 +24,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Tracker runs compile xtask and produce campaign freshness evidence. Let
+  # started runs finish so failed metadata has a durable log.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -60,7 +60,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Core PR jobs compile and may feed cache state. Do not cancel an already
+  # started run near completion; reject irrelevant work before it starts.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/docs-automation.yml
+++ b/.github/workflows/docs-automation.yml
@@ -24,34 +24,97 @@ on:
       - '.github/workflows/docs-automation.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # This workflow may build Rustdoc. Do not cancel selected work after setup;
+  # route tracker-only PRs to the fast path below instead.
+  cancel-in-progress: false
 
 jobs:
+  classify-docs:
+    name: Classify Docs Change
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      tracker_only: ${{ steps.classify.outputs.tracker_only }}
+    steps:
+      - name: Detect tracker-only docs PR
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          tracker_only=false
+
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
+            changed_files=$(gh api --paginate \
+              "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/files" \
+              --jq '.[].filename')
+            echo "Changed files considered by docs automation:"
+            printf '%s\n' "$changed_files"
+
+            tracker_only=true
+            while IFS= read -r path; do
+              [ -n "$path" ] || continue
+              case "$path" in
+                docs/tracking/*|.codex/campaigns/*)
+                  ;;
+                *)
+                  tracker_only=false
+                  ;;
+              esac
+            done <<< "$changed_files"
+
+            if [ -z "$changed_files" ]; then
+              tracker_only=false
+            fi
+          fi
+
+          echo "tracker_only=${tracker_only}" >> "$GITHUB_OUTPUT"
+          echo "tracker_only=${tracker_only}"
+
   docs-automation:
     name: Lint + Link Check + Rustdoc
     runs-on: ubuntu-22.04
     timeout-minutes: 25
+    needs: [classify-docs]
     steps:
+      - name: Tracker-only fast path
+        if: needs.classify-docs.outputs.tracker_only == 'true'
+        run: |
+          echo "Tracker-only PR: markdownlint, link-check, and campaign tracker workflows cover this diff."
+
       - name: Checkout code
+        if: needs.classify-docs.outputs.tracker_only != 'true'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
 
       - name: Install Rust toolchain
+        if: needs.classify-docs.outputs.tracker_only != 'true'
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
           toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
+        if: needs.classify-docs.outputs.tracker_only != 'true'
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
           shared-key: docs-automation
 
       - name: Install docs tooling
+        if: needs.classify-docs.outputs.tracker_only != 'true'
         run: |
           cargo install --locked lychee --version 0.15.1
           npm --global install markdownlint-cli2@0.18.1
 
       - name: Run docs automation checks
+        if: needs.classify-docs.outputs.tracker_only != 'true'
         run: scripts/docs_automation.sh
-

--- a/.github/workflows/performance-tracking.yml
+++ b/.github/workflows/performance-tracking.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore:
+      - 'docs/tracking/**'
+      - '.codex/campaigns/**'
   schedule:
     # Run performance tracking daily at 4 AM UTC
     - cron: '0 4 * * *'
@@ -26,7 +29,9 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Performance smoke builds are selected proof. Avoid cancelling started
+  # builds; control cost with event/path routing instead.
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -46,7 +46,9 @@ on:
 
 concurrency:
   group: pr-gate-${{ github.ref }}
-  cancel-in-progress: true
+  # The gate polls upstream jobs and should outlive selected long lanes.
+  # Let started gates finish rather than discarding near-complete CI evidence.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/ripr-pr-evidence.yml
+++ b/.github/workflows/ripr-pr-evidence.yml
@@ -2,6 +2,9 @@ name: RIPR PR Evidence
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/tracking/**'
+      - '.codex/campaigns/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- stop cancelling already-started CI Core, campaign tracker, docs automation, performance smoke, and PR gate runs
- add a tracker-only fast path to Docs Automation so pure tracker/campaign PRs skip Rustdoc/tooling install
- skip RIPR PR Evidence and Performance Baseline Tracking entirely for pure tracker/campaign metadata diffs

## Default LEM before/after
- Before: pure tracker PRs still started Docs Automation Rustdoc/tooling, RIPR evidence, and performance smoke; selected lanes could also be cancelled mid-run by workflow concurrency.
- After: pure tracker/campaign PRs rely on markdownlint, link-check, campaign tracker, and CI Core tracker fast path; selected nontrivial lanes are allowed to finish once started.

## Lanes removed from default
- RIPR PR Evidence for pure `docs/tracking/**` / `.codex/campaigns/**` diffs
- Performance Baseline Tracking for pure `docs/tracking/**` / `.codex/campaigns/**` diffs
- Docs Automation Rustdoc/tooling work for tracker-only PRs

## Preserved verification
- Markdownlint and Link Checker still cover markdown/docs hygiene.
- Campaign Tracker and CI Core Tracker Fast Path still run `campaign doctor` and generated dashboard freshness checks.
- Non-tracker docs and Rust source docs changes still run Docs Automation normally.

## Boundaries
- This does not weaken Rust code PR validation.
- This does not remove explicit long-lane timeouts.
- This changes cancellation/routing only for workflow-level CI behavior.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci-core.yml .github/workflows/campaign-tracker.yml .github/workflows/docs-automation.yml .github/workflows/performance-tracking.yml .github/workflows/pr-gate.yml .github/workflows/ripr-pr-evidence.yml`\n- `git diff --check`