### PR TITLE
diag(bitnet): run reference layer trace instrumentation

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -1,0 +1,324 @@
+# Upstream-Issue: not-applicable; BitNet-rs target-local diagnostic instrumentation only
+# Reason: Emit first-output BitNet graph stage trace stats from llama-cli generation for Rust/reference divergence localization
+# Status: under-review
+# Created: 2026-05-15
+# Review-By: 2026-06-15
+# Author: BitNet-rs maintainers
+
+diff --git a/src/llama.cpp b/src/llama.cpp
+index 66f4791e..2f0c21d4 100644
+--- a/src/llama.cpp
++++ b/src/llama.cpp
+@@ -64,6 +64,8 @@
++#include <cstdlib>
+ #include <cstring>
+ #include <ctime>
+ #include <fstream>
++#include <iomanip>
+ #include <functional>
+ #include <future>
+ #include <initializer_list>
+@@ -75,6 +76,7 @@
+ #include <map>
+ #include <memory>
+ #include <mutex>
++#include <limits>
+ #include <numeric>
+ #include <set>
+ #include <sstream>
+@@ -3434,6 +3436,281 @@ struct llama_context {
+     struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
+ };
+ 
++static bool bitnet_rs_reference_layer_trace_target(const char * name) {
++    if (name == nullptr || name[0] == '\0') {
++        return false;
++    }
++
++    static const char * names[] = {
++        "inp_embd",
++        "attn_norm-0",
++        "Qcur-0",
++        "Kcur-0",
++        "Vcur-0",
++        "attn_sub_norm-0",
++        "attn_o_out-0",
++        "ffn_inp-0",
++        "ffn_norm-0",
++        "ffn_out-0",
++        "ffn_sub_norm-0",
++        "ffn_down-0",
++        "l_out-0",
++        "result_norm",
++        "result_output",
++    };
++
++    for (const char * target : names) {
++        if (strcmp(name, target) == 0) {
++            return true;
++        }
++    }
++    return false;
++}
++
++static const char * bitnet_rs_reference_layer_trace_stage(const char * name) {
++    if (strcmp(name, "inp_embd") == 0) {
++        return "inp_embd";
++    }
++    if (strcmp(name, "attn_norm-0") == 0) {
++        return "attn_norm";
++    }
++    if (strcmp(name, "Qcur-0") == 0) {
++        return "Qcur";
++    }
++    if (strcmp(name, "Kcur-0") == 0) {
++        return "Kcur";
++    }
++    if (strcmp(name, "Vcur-0") == 0) {
++        return "Vcur";
++    }
++    if (strcmp(name, "attn_sub_norm-0") == 0) {
++        return "attn_sub_norm";
++    }
++    if (strcmp(name, "attn_o_out-0") == 0) {
++        return "attn_o_out";
++    }
++    if (strcmp(name, "ffn_inp-0") == 0) {
++        return "ffn_inp";
++    }
++    if (strcmp(name, "ffn_norm-0") == 0) {
++        return "ffn_norm";
++    }
++    if (strcmp(name, "ffn_out-0") == 0) {
++        return "ffn_out";
++    }
++    if (strcmp(name, "ffn_sub_norm-0") == 0) {
++        return "ffn_sub_norm";
++    }
++    if (strcmp(name, "ffn_down-0") == 0) {
++        return "ffn_down";
++    }
++    if (strcmp(name, "l_out-0") == 0) {
++        return "l_out";
++    }
++    if (strcmp(name, "result_norm") == 0) {
++        return "result_norm";
++    }
++    if (strcmp(name, "result_output") == 0) {
++        return "result_output";
++    }
++    return name;
++}
++
++static int bitnet_rs_reference_layer_trace_layer(const char * name) {
++    const size_t len = strlen(name);
++    if (len >= 2 && name[len - 2] == '-' && name[len - 1] == '0') {
++        return 0;
++    }
++    return -1;
++}
++
++static void bitnet_rs_reference_layer_trace_json_string(std::ostream & out, const char * value) {
++    out << '"';
++    if (value != nullptr) {
++        for (const char * p = value; *p != '\0'; ++p) {
++            switch (*p) {
++                case '\\': out << "\\\\"; break;
++                case '"': out << "\\\""; break;
++                case '\n': out << "\\n"; break;
++                case '\r': out << "\\r"; break;
++                case '\t': out << "\\t"; break;
++                default: out << *p; break;
++            }
++        }
++    }
++    out << '"';
++}
++
++static void bitnet_rs_reference_layer_trace_json_number(std::ostream & out, double value) {
++    if (std::isfinite(value)) {
++        out << std::setprecision(9) << value;
++    } else {
++        out << "null";
++    }
++}
++
++static uint64_t bitnet_rs_reference_layer_trace_hash(const std::vector<float> & values) {
++    uint64_t hash = 1469598103934665603ULL;
++    const unsigned char * bytes = reinterpret_cast<const unsigned char *>(values.data());
++    const size_t n_bytes = values.size() * sizeof(float);
++    for (size_t i = 0; i < n_bytes; ++i) {
++        hash ^= (uint64_t) bytes[i];
++        hash *= 1099511628211ULL;
++    }
++    return hash;
++}
++
++static void bitnet_rs_reference_layer_trace_write_record(
++    std::ostream & out,
++    llama_context & lctx,
++    struct ggml_tensor * tensor,
++    int graph_index,
++    bool first
++) {
++    const char * name = ggml_get_name(tensor);
++    const int64_t nelements = ggml_nelements(tensor);
++    const size_t nbytes = ggml_nbytes(tensor);
++    const bool f32_contiguous = tensor->type == GGML_TYPE_F32 && ggml_is_contiguous(tensor);
++    const bool copy_size_ok = nbytes <= 64ULL * 1024ULL * 1024ULL;
++    bool values_available = false;
++    std::vector<float> values;
++    double sum = 0.0;
++    double sq_sum = 0.0;
++    double min_value = std::numeric_limits<double>::infinity();
++    double max_value = -std::numeric_limits<double>::infinity();
++    uint64_t value_hash = 0;
++
++    if (f32_contiguous && copy_size_ok && nelements > 0) {
++        ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(lctx.sched, tensor);
++        if (backend != nullptr) {
++            values.resize((size_t) nelements);
++            ggml_backend_tensor_get(tensor, values.data(), 0, nbytes);
++            values_available = true;
++            for (float value_f32 : values) {
++                const double value = value_f32;
++                sum += value;
++                sq_sum += value * value;
++                min_value = value < min_value ? value : min_value;
++                max_value = value > max_value ? value : max_value;
++            }
++            value_hash = bitnet_rs_reference_layer_trace_hash(values);
++        }
++    }
++
++    if (!first) {
++        out << ",";
++    }
++    out << "{";
++    out << "\"graph_index\":" << graph_index;
++    out << ",\"name\":";
++    bitnet_rs_reference_layer_trace_json_string(out, name);
++    out << ",\"stage\":";
++    bitnet_rs_reference_layer_trace_json_string(
++        out,
++        bitnet_rs_reference_layer_trace_stage(name)
++    );
++    out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);
++    out << ",\"dtype\":";
++    bitnet_rs_reference_layer_trace_json_string(out, ggml_type_name(tensor->type));
++    out << ",\"shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++    out << ",\"nelements\":" << nelements;
++    out << ",\"nbytes\":" << nbytes;
++    out << ",\"contiguous\":" << (ggml_is_contiguous(tensor) ? "true" : "false");
++    out << ",\"values_available\":" << (values_available ? "true" : "false");
++    out << ",\"values_unavailable_reason\":";
++    if (values_available) {
++        out << "null";
++    } else if (tensor->type != GGML_TYPE_F32) {
++        bitnet_rs_reference_layer_trace_json_string(out, "non_f32_tensor");
++    } else if (!ggml_is_contiguous(tensor)) {
++        bitnet_rs_reference_layer_trace_json_string(out, "non_contiguous_tensor");
++    } else if (!copy_size_ok) {
++        bitnet_rs_reference_layer_trace_json_string(out, "tensor_too_large_for_diagnostic_copy");
++    } else {
++        bitnet_rs_reference_layer_trace_json_string(out, "backend_unavailable");
++    }
++
++    out << ",\"stats\":";
++    if (values_available) {
++        const double mean = values.empty() ? std::numeric_limits<double>::quiet_NaN() : sum / (double) values.size();
++        const double rms = values.empty() ? std::numeric_limits<double>::quiet_NaN() : std::sqrt(sq_sum / (double) values.size());
++        out << "{\"mean\":";
++        bitnet_rs_reference_layer_trace_json_number(out, mean);
++        out << ",\"rms\":";
++        bitnet_rs_reference_layer_trace_json_number(out, rms);
++        out << ",\"min\":";
++        bitnet_rs_reference_layer_trace_json_number(out, min_value);
++        out << ",\"max\":";
++        bitnet_rs_reference_layer_trace_json_number(out, max_value);
++        out << ",\"fnv1a64\":\"" << std::hex << value_hash << std::dec << "\"}";
++    } else {
++        out << "null";
++    }
++
++    out << ",\"first_values\":[";
++    const size_t sample_count = values.size() < 16 ? values.size() : 16;
++    for (size_t i = 0; i < sample_count; ++i) {
++        if (i > 0) {
++            out << ",";
++        }
++        bitnet_rs_reference_layer_trace_json_number(out, values[i]);
++    }
++    out << "]}";
++}
++
++static void bitnet_rs_reference_layer_trace_dump(
++    llama_context & lctx,
++    struct ggml_cgraph * gf,
++    uint32_t n_tokens,
++    int32_t n_outputs,
++    const char * path
++) {
++    if (path == nullptr || path[0] == '\0' || n_outputs <= 0) {
++        return;
++    }
++
++    std::ofstream out(path, std::ios::out | std::ios::trunc);
++    if (!out.is_open()) {
++        return;
++    }
++
++    out << "{"
++        << "\"receipt_type\":\"bitnet_reference_layer_trace\","
++        << "\"diagnostic_only\":true,"
++        << "\"claim_allowed\":false,"
++        << "\"source\":\"BITNET_RS_REFERENCE_LAYER_TRACE\","
++        << "\"capture_scope\":\"first_decode_with_outputs\","
++        << "\"n_tokens\":" << n_tokens << ","
++        << "\"n_outputs\":" << n_outputs << ","
++        << "\"records\":[";
++
++    bool first = true;
++    for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
++        struct ggml_tensor * tensor = ggml_graph_node(gf, i);
++        const char * name = ggml_get_name(tensor);
++        if (!bitnet_rs_reference_layer_trace_target(name)) {
++            continue;
++        }
++        bitnet_rs_reference_layer_trace_write_record(out, lctx, tensor, i, first);
++        first = false;
++    }
++
++    out << "],\"not_claims\":["
++        << "\"reference_trace_match_rust_cpu\","
++        << "\"reference_trace_match_strict_a770\","
++        << "\"reference_parity_promotion\","
++        << "\"a770_semantic_quality_proven\","
++        << "\"selected_attention_residency\","
++        << "\"resident_kv_decode\","
++        << "\"attention_scores_residency\","
++        << "\"softmax_residency\","
++        << "\"attention_value_mix_residency\","
++        << "\"full_support_op_residency\","
++        << "\"full_device_residency\","
++        << "\"completion\""
++        << "]}";
++}
++
+ struct llama_lora_weight {
+     struct ggml_tensor * a = nullptr;
+     struct ggml_tensor * b = nullptr;
+@@ -17658,6 +17934,13 @@ static int llama_decode_internal(
+ 
+         llama_graph_compute(lctx, gf, n_threads, threadpool);
+ 
++        static bool bitnet_rs_reference_layer_trace_dumped = false;
++        const char * bitnet_rs_reference_layer_trace_path = std::getenv("BITNET_RS_REFERENCE_LAYER_TRACE");
++        if (!bitnet_rs_reference_layer_trace_dumped && bitnet_rs_reference_layer_trace_path != nullptr && bitnet_rs_reference_layer_trace_path[0] != '\0' && lctx.n_outputs > 0) {
++            bitnet_rs_reference_layer_trace_dump(lctx, gf, n_tokens, lctx.n_outputs, bitnet_rs_reference_layer_trace_path);
++            bitnet_rs_reference_layer_trace_dumped = true;
++        }
++
+         // update the kv ring buffer
+         {
+             kv_self.head += n_tokens;

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -3,10 +3,16 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
+const DEFAULT_REFERENCE_ROOT: &str = "target/external/BitNet-reference";
 const DEFAULT_CPP_ROOT: &str = "target/external/BitNet-reference/3rdparty/llama.cpp";
 const DEFAULT_RUST_TRANSFORMER: &str = "crates/bitnet-transformer/src/lib.rs";
+const DEFAULT_PATCH: &str = "ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch";
 const DEFAULT_OUTPUT: &str = "target/a770-diagnostic/bitnet-reference-layer-trace-plan.json";
+const DEFAULT_RUN_OUTPUT: &str = "target/a770-diagnostic/bitnet-reference-layer-trace-run.json";
+const DEFAULT_REFERENCE_PLAN: &str = "target/a770-diagnostic/bitnet-reference-plan.json";
+const DEFAULT_SIDECAR: &str = "target/a770-diagnostic/reference-first-token-layer-trace.json";
 
 const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "selected_attention_residency",
@@ -78,12 +84,31 @@ struct LayerTracePlanArgs {
 }
 
 #[derive(Debug)]
+struct LayerTraceRunArgs {
+    reference_root: PathBuf,
+    cpp_root: PathBuf,
+    patch: PathBuf,
+    plan: PathBuf,
+    sidecar: PathBuf,
+    output: Option<PathBuf>,
+    format: String,
+}
+
+#[derive(Debug)]
 struct SourceText {
     path: PathBuf,
     exists: bool,
     read_ok: bool,
     sha256: Option<String>,
     text: String,
+}
+
+#[derive(Debug)]
+struct CommandCapture {
+    status_code: Option<i32>,
+    success: bool,
+    stdout: String,
+    stderr: String,
 }
 
 pub fn maybe_dispatch_from_env() -> Result<bool> {
@@ -111,6 +136,24 @@ fn maybe_dispatch(args: &[String]) -> Result<bool> {
             emit_report(&report, &opts.format)?;
             Ok(true)
         }
+        Some("bitnet-reference-layer-trace-run") => {
+            if args[2..].iter().any(|arg| arg == "-h" || arg == "--help") {
+                print_run_help();
+                return Ok(true);
+            }
+            let opts = parse_run_args(args)?;
+            let report = run_instrumented_reference(&opts)?;
+            if let Some(output) = &opts.output {
+                if let Some(parent) = output.parent() {
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("creating {}", parent.display()))?;
+                }
+                fs::write(output, serde_json::to_vec_pretty(&report)?)
+                    .with_context(|| format!("writing {}", output.display()))?;
+            }
+            emit_report(&report, &opts.format)?;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }
@@ -118,6 +161,12 @@ fn maybe_dispatch(args: &[String]) -> Result<bool> {
 fn print_help() {
     println!(
         "Plan target-local BitNet reference layer/stage trace instrumentation\n\nUsage: xtask.exe bitnet-reference-layer-trace-plan [OPTIONS]\n\nOptions:\n      --cpp-root <PATH>          llama.cpp checkout root [default: target/external/BitNet-reference/3rdparty/llama.cpp]\n      --rust-transformer <PATH>  Rust transformer source [default: crates/bitnet-transformer/src/lib.rs]\n      --output <PATH>            Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-layer-trace-plan.json]\n      --format <FORMAT>          Output format: human or json [default: human]\n  -h, --help                     Print help"
+    );
+}
+
+fn print_run_help() {
+    println!(
+        "Temporarily apply BitNet reference layer trace instrumentation, run the matched reference plan, and restore source worktrees\n\nUsage: xtask.exe bitnet-reference-layer-trace-run [OPTIONS]\n\nOptions:\n      --reference-root <PATH>  BitNet.cpp checkout root [default: target/external/BitNet-reference]\n      --cpp-root <PATH>        llama.cpp checkout root [default: target/external/BitNet-reference/3rdparty/llama.cpp]\n      --patch <PATH>           Layer-trace instrumentation patch [default: ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch]\n      --plan <PATH>            Reference plan JSON [default: target/a770-diagnostic/bitnet-reference-plan.json]\n      --sidecar <PATH>         Layer-trace sidecar JSON [default: target/a770-diagnostic/reference-first-token-layer-trace.json]\n      --output <PATH>          Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-layer-trace-run.json]\n      --format <FORMAT>        Output format: human or json [default: human]\n  -h, --help                   Print help"
     );
 }
 
@@ -149,6 +198,249 @@ fn parse_args(args: &[String]) -> Result<LayerTracePlanArgs> {
     }
 
     Ok(LayerTracePlanArgs { cpp_root, rust_transformer, output, format })
+}
+
+fn parse_run_args(args: &[String]) -> Result<LayerTraceRunArgs> {
+    if args.get(1).map(String::as_str) != Some("bitnet-reference-layer-trace-run") {
+        bail!("parse_run_args called for unexpected command");
+    }
+    let mut reference_root = PathBuf::from(DEFAULT_REFERENCE_ROOT);
+    let mut cpp_root = PathBuf::from(DEFAULT_CPP_ROOT);
+    let mut patch = PathBuf::from(DEFAULT_PATCH);
+    let mut plan = PathBuf::from(DEFAULT_REFERENCE_PLAN);
+    let mut sidecar = PathBuf::from(DEFAULT_SIDECAR);
+    let mut output = Some(PathBuf::from(DEFAULT_RUN_OUTPUT));
+    let mut format = "human".to_string();
+    let mut i = 2usize;
+    while i < args.len() {
+        let key = args[i].as_str();
+        i += 1;
+        let mut value = || -> Result<String> {
+            let value = args.get(i).with_context(|| format!("{key} requires a value"))?.clone();
+            i += 1;
+            Ok(value)
+        };
+        match key {
+            "--reference-root" => reference_root = PathBuf::from(value()?),
+            "--cpp-root" => cpp_root = PathBuf::from(value()?),
+            "--patch" => patch = PathBuf::from(value()?),
+            "--plan" => plan = PathBuf::from(value()?),
+            "--sidecar" => sidecar = PathBuf::from(value()?),
+            "--output" => output = Some(PathBuf::from(value()?)),
+            "--format" => format = value()?,
+            other => bail!("unknown bitnet-reference-layer-trace-run option {other}"),
+        }
+    }
+    Ok(LayerTraceRunArgs { reference_root, cpp_root, patch, plan, sidecar, output, format })
+}
+
+fn run_instrumented_reference(args: &LayerTraceRunArgs) -> Result<Value> {
+    let reference_root = normalize_path(&args.reference_root)?;
+    let cpp_root = normalize_path(&args.cpp_root)?;
+    let patch = normalize_path(&args.patch)?;
+    let plan_path = normalize_path(&args.plan)?;
+    let sidecar = normalize_path(&args.sidecar)?;
+    let build_dir = reference_root.join("build");
+    let selected_exe = build_dir.join("bin").join(exe_name("llama-cli"));
+    let generated_lut_header = reference_root.join("include/bitnet-lut-kernels.h");
+    let generated_kernel_config = reference_root.join("include/kernel_config.ini");
+    let plan_result = read_json(&plan_path);
+    let plan_read_success = plan_result.is_ok();
+    let plan = plan_result.unwrap_or(Value::Null);
+    let reference_argv = reference_argv(&plan).unwrap_or_default();
+
+    if let Some(parent) = sidecar.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    if sidecar.exists() {
+        fs::remove_file(&sidecar)
+            .with_context(|| format!("removing stale {}", sidecar.display()))?;
+    }
+
+    let reference_status_before = git_status(&reference_root);
+    let cpp_status_before = git_status(&cpp_root);
+    let clean_before = capture_success_empty(&reference_status_before)
+        && capture_success_empty(&cpp_status_before);
+
+    let mut blocked_reasons = Vec::<String>::new();
+    if !reference_root.is_dir() {
+        blocked_reasons.push("reference_root_missing".to_string());
+    }
+    if !cpp_root.is_dir() {
+        blocked_reasons.push("reference_llama_cpp_root_missing".to_string());
+    }
+    if !patch.is_file() {
+        blocked_reasons.push("reference_layer_trace_patch_missing".to_string());
+    }
+    if !plan_path.is_file() {
+        blocked_reasons.push("reference_plan_missing".to_string());
+    }
+    if plan_path.is_file() && !plan_read_success {
+        blocked_reasons.push("reference_plan_json_invalid".to_string());
+    }
+    if plan_path.is_file() && reference_argv.is_empty() {
+        blocked_reasons.push("reference_plan_command_argv_missing".to_string());
+    }
+    if !build_dir.is_dir() {
+        blocked_reasons.push("reference_build_dir_missing".to_string());
+    }
+    if !clean_before {
+        blocked_reasons.push("reference_external_worktree_not_clean_before_run".to_string());
+    }
+
+    let generated_lut_header_exists_before = generated_lut_header.is_file();
+    let generated_kernel_config_exists_before = generated_kernel_config.is_file();
+    let mut generated_lut_header_exists_after_codegen = generated_lut_header_exists_before;
+    let mut generated_kernel_config_exists_after_codegen = generated_kernel_config_exists_before;
+    let mut compatibility = Vec::<Value>::new();
+    let mut codegen_capture = None;
+    let mut patch_apply = None;
+    let mut build_capture = None;
+    let mut run_capture = None;
+
+    if blocked_reasons.is_empty() && !generated_lut_header_exists_before {
+        codegen_capture = Some(run_reference_kernel_codegen(&reference_root)?);
+        generated_lut_header_exists_after_codegen = generated_lut_header.is_file();
+        generated_kernel_config_exists_after_codegen = generated_kernel_config.is_file();
+        if !codegen_capture.as_ref().is_some_and(|capture| capture.success) {
+            blocked_reasons.push("reference_kernel_codegen_failed".to_string());
+        }
+        if !generated_lut_header.is_file() {
+            blocked_reasons.push("reference_generated_lut_header_missing".to_string());
+        }
+    }
+
+    if blocked_reasons.is_empty() {
+        compatibility = apply_windows_reference_compatibility_fixes(&reference_root)?;
+        patch_apply = Some(run_git(&cpp_root, &["apply", &path_to_string(&patch)])?);
+        if !patch_apply.as_ref().is_some_and(|capture| capture.success) {
+            blocked_reasons.push("reference_layer_trace_patch_apply_failed".to_string());
+        }
+    }
+
+    if blocked_reasons.is_empty() {
+        build_capture = Some(build_reference_cli(&reference_root, &build_dir)?);
+        if !build_capture.as_ref().is_some_and(|capture| capture.success) {
+            blocked_reasons.push("reference_layer_trace_build_failed".to_string());
+        }
+    }
+
+    if blocked_reasons.is_empty() {
+        if !selected_exe.is_file() {
+            blocked_reasons.push("reference_layer_trace_executable_missing".to_string());
+        } else if reference_argv.is_empty() {
+            blocked_reasons.push("reference_plan_command_argv_missing".to_string());
+        } else {
+            let mut argv = reference_argv.clone();
+            argv[0] = path_to_string(&selected_exe);
+            run_capture = Some(run_reference_with_sidecar(&argv, &sidecar)?);
+            if !run_capture.as_ref().is_some_and(|capture| capture.success) {
+                blocked_reasons.push("reference_layer_trace_run_failed".to_string());
+            }
+        }
+    }
+
+    let sidecar_value = if sidecar.is_file() { Some(read_json(&sidecar)?) } else { None };
+    if run_capture.as_ref().is_some_and(|capture| capture.success) && sidecar_value.is_none() {
+        blocked_reasons.push("reference_first_token_layer_trace_sidecar_missing".to_string());
+    }
+
+    let cleanup_capture = if reference_root.is_dir() && cpp_root.is_dir() {
+        Some(cleanup_reference_sources(
+            &reference_root,
+            &cpp_root,
+            &generated_lut_header,
+            generated_lut_header_exists_before,
+            &generated_kernel_config,
+            generated_kernel_config_exists_before,
+        )?)
+    } else {
+        None
+    };
+    let reference_status_after = git_status(&reference_root);
+    let cpp_status_after = git_status(&cpp_root);
+    let clean_after =
+        capture_success_empty(&reference_status_after) && capture_success_empty(&cpp_status_after);
+    if !clean_after {
+        blocked_reasons.push("reference_external_worktree_not_clean_after_run".to_string());
+    }
+
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+    let record_count = sidecar_value
+        .as_ref()
+        .and_then(|sidecar| sidecar.pointer("/records"))
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let reference_layer_trace_available =
+        sidecar_value.is_some() && record_count > 0 && blocked_reasons.is_empty();
+
+    Ok(json!({
+        "schema_version": 1,
+        "receipt_type": "bitnet_reference_layer_trace_run",
+        "diagnostic": "bitnet_reference_layer_trace_run",
+        "producer": "cargo xtask bitnet-reference-layer-trace-run",
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "diagnostic_only": true,
+        "promotion_allowed": false,
+        "claim_allowed": false,
+        "classification": "diagnostic_only",
+        "paths": {
+            "reference_root": path_to_string(&reference_root),
+            "cpp_root": path_to_string(&cpp_root),
+            "patch": path_to_string(&patch),
+            "plan": path_to_string(&plan_path),
+            "build_dir": path_to_string(&build_dir),
+            "selected_executable": path_to_string(&selected_exe),
+            "sidecar": path_to_string(&sidecar),
+        },
+        "model": plan.pointer("/model").cloned().unwrap_or(Value::Null),
+        "prompt_identity": plan.pointer("/prompt_identity").cloned().unwrap_or(Value::Null),
+        "preflight": {
+            "reference_root_exists": reference_root.is_dir(),
+            "cpp_root_exists": cpp_root.is_dir(),
+            "patch_exists": patch.is_file(),
+            "plan_exists": plan_path.is_file(),
+            "build_dir_exists": build_dir.is_dir(),
+            "external_worktrees_clean_before_run": clean_before,
+            "generated_lut_header": {
+                "path": path_to_string(&generated_lut_header),
+                "exists_before": generated_lut_header_exists_before,
+                "exists_after_codegen": generated_lut_header_exists_after_codegen,
+            },
+            "generated_kernel_config": {
+                "path": path_to_string(&generated_kernel_config),
+                "exists_before": generated_kernel_config_exists_before,
+                "exists_after_codegen": generated_kernel_config_exists_after_codegen,
+            },
+            "reference_status_before": capture_json(reference_status_before.as_ref()),
+            "cpp_status_before": capture_json(cpp_status_before.as_ref()),
+        },
+        "kernel_codegen": capture_json(codegen_capture.as_ref()),
+        "compatibility_fixes": compatibility,
+        "patch_apply": capture_json(patch_apply.as_ref()),
+        "build": capture_json(build_capture.as_ref()),
+        "reference_run": capture_json(run_capture.as_ref()),
+        "sidecar": {
+            "exists": sidecar.is_file(),
+            "sha256": sidecar.is_file().then(|| sha256_bytes(&fs::read(&sidecar).unwrap_or_default())),
+            "record_count": record_count,
+            "receipt": sidecar_value,
+            "policy": "reference-side layer trace is diagnostic evidence only until compared with Rust CPU and strict A770 layer traces",
+        },
+        "cleanup": {
+            "source_restore": capture_json(cleanup_capture.as_ref()),
+            "external_worktrees_clean_after_run": clean_after,
+            "reference_status_after": capture_json(reference_status_after.as_ref()),
+            "cpp_status_after": capture_json(cpp_status_after.as_ref()),
+        },
+        "decision": {
+            "reference_layer_trace_available": reference_layer_trace_available,
+            "current_blocked_reasons": blocked_reasons,
+            "next_when_available": "compare reference stage trace against Rust CPU and strict A770 trace receipts before changing Rust model math",
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS,
+    }))
 }
 
 fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
@@ -290,6 +582,272 @@ fn source_receipt(source: &SourceText) -> Value {
     })
 }
 
+fn read_json(path: &Path) -> Result<Value> {
+    let text = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&text).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn reference_argv(plan: &Value) -> Result<Vec<String>> {
+    plan.pointer("/reference/command_argv")
+        .and_then(Value::as_array)
+        .context("plan missing /reference/command_argv")?
+        .iter()
+        .map(|item| {
+            item.as_str().map(ToOwned::to_owned).context("command_argv item is not a string")
+        })
+        .collect()
+}
+
+fn apply_windows_reference_compatibility_fixes(reference_root: &Path) -> Result<Vec<Value>> {
+    let mut applied = Vec::new();
+    applied.push(replace_file_text(
+        &reference_root.join("src/ggml-bitnet-mad.cpp"),
+        "        int8_t * y_col = y + col * by;",
+        "        const int8_t * y_col = y + col * by;",
+        "windows_const_compatibility",
+    )?);
+    applied.push(insert_after_if_missing(
+        &reference_root.join("3rdparty/llama.cpp/common/common.cpp"),
+        "#include <ctime>",
+        "#include <chrono>",
+        "windows_common_chrono_include",
+    )?);
+    applied.push(insert_after_if_missing(
+        &reference_root.join("3rdparty/llama.cpp/common/log.cpp"),
+        "#include <condition_variable>",
+        "#include <chrono>",
+        "windows_log_chrono_include",
+    )?);
+    Ok(applied)
+}
+
+fn replace_file_text(path: &Path, before: &str, after: &str, fix_id: &str) -> Result<Value> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if content.contains(before) {
+        fs::write(path, content.replace(before, after))
+            .with_context(|| format!("writing {}", path.display()))?;
+        return Ok(json!({
+            "fix_id": fix_id,
+            "path": path_to_string(path),
+            "applied": true,
+            "already_present": false,
+        }));
+    }
+    if content.contains(after) {
+        return Ok(json!({
+            "fix_id": fix_id,
+            "path": path_to_string(path),
+            "applied": false,
+            "already_present": true,
+        }));
+    }
+    bail!("expected compatibility fix target not found in {}", path.display())
+}
+
+fn insert_after_if_missing(path: &Path, anchor: &str, insert: &str, fix_id: &str) -> Result<Value> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if content.contains(insert) {
+        return Ok(json!({
+            "fix_id": fix_id,
+            "path": path_to_string(path),
+            "applied": false,
+            "already_present": true,
+        }));
+    }
+    if !content.contains(anchor) {
+        bail!("expected compatibility include anchor not found in {}", path.display());
+    }
+    fs::write(path, content.replace(anchor, &format!("{anchor}\n{insert}")))
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(json!({
+        "fix_id": fix_id,
+        "path": path_to_string(path),
+        "applied": true,
+        "already_present": false,
+    }))
+}
+
+fn run_reference_kernel_codegen(reference_root: &Path) -> Result<CommandCapture> {
+    run_command(Command::new("python").current_dir(reference_root).args([
+        "utils/codegen_tl2.py",
+        "--model",
+        "bitnet_b1_58-3B",
+        "--BM",
+        "160,320,320",
+        "--BK",
+        "96,96,96",
+        "--bm",
+        "32,32,32",
+    ]))
+}
+
+fn build_reference_cli(reference_root: &Path, build_dir: &Path) -> Result<CommandCapture> {
+    if cfg!(windows) {
+        let vsdevcmd = find_vsdevcmd();
+        let Some(vsdevcmd) = vsdevcmd else {
+            return Ok(CommandCapture {
+                status_code: None,
+                success: false,
+                stdout: String::new(),
+                stderr: "Visual Studio developer command prompt not found".to_string(),
+            });
+        };
+        let script = reference_root.join("build_bitnet_rs_layer_trace_reference.cmd");
+        let lines = [
+            "@echo off".to_string(),
+            format!("call {} -arch=x64 -host_arch=x64 || exit /b 1", cmd_quote(&vsdevcmd)),
+            format!(
+                "cmake --build {} --config Release --target llama-cli || exit /b 1",
+                cmd_quote(build_dir)
+            ),
+        ];
+        fs::write(&script, lines.join("\r\n"))
+            .with_context(|| format!("writing {}", script.display()))?;
+        let capture =
+            run_command(Command::new("cmd.exe").args(["/d", "/c"]).arg(path_to_string(&script)))?;
+        let _ = fs::remove_file(&script);
+        Ok(capture)
+    } else {
+        run_command(Command::new("cmake").args([
+            "--build",
+            &path_to_string(build_dir),
+            "--config",
+            "Release",
+            "--target",
+            "llama-cli",
+        ]))
+    }
+}
+
+fn find_vsdevcmd() -> Option<PathBuf> {
+    let program_files_x86 = std::env::var_os("ProgramFiles(x86)")?;
+    let vswhere =
+        PathBuf::from(program_files_x86).join("Microsoft Visual Studio/Installer/vswhere.exe");
+    if !vswhere.is_file() {
+        return None;
+    }
+    let output = Command::new(vswhere)
+        .args([
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        return None;
+    }
+    let vsdevcmd = PathBuf::from(path).join("Common7/Tools/VsDevCmd.bat");
+    vsdevcmd.is_file().then_some(vsdevcmd)
+}
+
+fn run_reference_with_sidecar(argv: &[String], sidecar: &Path) -> Result<CommandCapture> {
+    let executable = argv.first().context("empty reference command")?;
+    let mut command = Command::new(executable);
+    command.args(&argv[1..]).env("BITNET_RS_REFERENCE_LAYER_TRACE", sidecar).stdin(Stdio::null());
+    run_command(&mut command)
+}
+
+fn cleanup_reference_sources(
+    reference_root: &Path,
+    cpp_root: &Path,
+    generated_lut_header: &Path,
+    generated_lut_header_existed_before: bool,
+    generated_kernel_config: &Path,
+    generated_kernel_config_existed_before: bool,
+) -> Result<CommandCapture> {
+    let mut capture = run_git(reference_root, &["restore", "--", "src/ggml-bitnet-mad.cpp"])?;
+    let cpp_capture = run_git(
+        cpp_root,
+        &["restore", "--", "common/common.cpp", "common/log.cpp", "src/llama.cpp"],
+    )?;
+    if !generated_lut_header_existed_before && generated_lut_header.exists() {
+        fs::remove_file(generated_lut_header)
+            .with_context(|| format!("removing {}", generated_lut_header.display()))?;
+    }
+    if !generated_kernel_config_existed_before && generated_kernel_config.exists() {
+        fs::remove_file(generated_kernel_config)
+            .with_context(|| format!("removing {}", generated_kernel_config.display()))?;
+    }
+    capture.success = capture.success && cpp_capture.success;
+    capture.status_code = if capture.status_code == Some(0) && cpp_capture.status_code == Some(0) {
+        Some(0)
+    } else {
+        cpp_capture.status_code.or(capture.status_code)
+    };
+    if !cpp_capture.stdout.is_empty() {
+        capture.stdout.push_str(&cpp_capture.stdout);
+    }
+    if !cpp_capture.stderr.is_empty() {
+        capture.stderr.push_str(&cpp_capture.stderr);
+    }
+    Ok(capture)
+}
+
+fn run_command(command: &mut Command) -> Result<CommandCapture> {
+    let output = command.output().with_context(|| format!("running command {:?}", command))?;
+    Ok(CommandCapture {
+        status_code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn git_status(path: &Path) -> Option<CommandCapture> {
+    path.is_dir().then(|| run_git(path, &["status", "--porcelain"]).ok()).flatten()
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Result<CommandCapture> {
+    let output = Command::new("git")
+        .current_dir(cwd)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("running git {} in {}", args.join(" "), cwd.display()))?;
+    Ok(CommandCapture {
+        status_code: output.status.code(),
+        success: output.status.success(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn capture_success_empty(capture: &Option<CommandCapture>) -> bool {
+    capture.as_ref().is_some_and(|capture| capture.success && capture.stdout.trim().is_empty())
+}
+
+fn capture_json(capture: Option<&CommandCapture>) -> Value {
+    match capture {
+        Some(capture) => json!({
+            "success": capture.success,
+            "exit_code": capture.status_code,
+            "stdout": capture.stdout.trim(),
+            "stderr": capture.stderr.trim(),
+        }),
+        None => Value::Null,
+    }
+}
+
+fn exe_name(stem: &str) -> String {
+    if cfg!(windows) { format!("{stem}.exe") } else { stem.to_string() }
+}
+
+fn cmd_quote(path: &Path) -> String {
+    format!("\"{}\"", path_to_string(path).replace('"', "\"\""))
+}
+
 fn normalize_path(path: &Path) -> Result<PathBuf> {
     if path.exists() {
         path.canonicalize().with_context(|| format!("canonicalizing {}", path.display()))
@@ -315,6 +873,33 @@ fn emit_report(report: &Value, format: &str) -> Result<()> {
     match format {
         "json" => println!("{}", serde_json::to_string_pretty(report)?),
         "human" => {
+            let receipt_type = report
+                .pointer("/receipt_type")
+                .and_then(Value::as_str)
+                .unwrap_or("bitnet_reference_layer_trace_plan");
+            if receipt_type == "bitnet_reference_layer_trace_run" {
+                let available = report
+                    .pointer("/decision/reference_layer_trace_available")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let record_count =
+                    report.pointer("/sidecar/record_count").and_then(Value::as_u64).unwrap_or(0);
+                let reasons = report
+                    .pointer("/decision/current_blocked_reasons")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                println!(
+                    "bitnet reference layer trace run: diagnostic_only=true claim_allowed=false available={available} records={record_count}"
+                );
+                if !reasons.is_empty() {
+                    println!("blocked_reasons:");
+                    for reason in reasons {
+                        println!("  - {}", reason.as_str().unwrap_or("<non-string>"));
+                    }
+                }
+                return Ok(());
+            }
             let ready = report
                 .pointer("/decision/source_anchors_ready_for_target_local_patch")
                 .and_then(Value::as_bool)
@@ -407,5 +992,28 @@ mod tests {
             report.pointer("/decision/source_anchors_ready_for_target_local_patch"),
             Some(&json!(false))
         );
+    }
+
+    #[test]
+    fn run_report_stays_diagnostic_when_inputs_are_missing() {
+        let dir = tempdir().unwrap();
+        let report = run_instrumented_reference(&LayerTraceRunArgs {
+            reference_root: dir.path().join("missing-reference"),
+            cpp_root: dir.path().join("missing-cpp"),
+            patch: dir.path().join("missing.patch"),
+            plan: dir.path().join("missing-plan.json"),
+            sidecar: dir.path().join("sidecar.json"),
+            output: None,
+            format: "json".to_string(),
+        })
+        .unwrap();
+        let reasons =
+            report.pointer("/decision/current_blocked_reasons").and_then(Value::as_array).unwrap();
+
+        assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert!(reasons.contains(&json!("reference_root_missing")));
+        assert!(reasons.contains(&json!("reference_layer_trace_patch_missing")));
+        assert!(reasons.contains(&json!("reference_plan_missing")));
     }
 }


### PR DESCRIPTION
## Summary
- add target-local `bitnet-reference-layer-trace-run` xtask command
- add reference llama.cpp instrumentation patch that emits diagnostic layer/stage trace records
- preserve non-claim posture and restore external reference worktrees after the run

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --check --edition 2024 --config skip_children=true xtask\src\bitnet_reference_layer_trace.rs`
- `git apply --check ..\..\..\..\..\ci\reference-instrumentation\bitnet-rs-layer-trace-main.patch` from the reference llama.cpp checkout
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-run --output target\a770-diagnostic\bitnet-reference-layer-trace-run.json --format json`
- `git diff --check`

## Claim boundary
- diagnostic only
- does not promote semantic quality, A770 support, selected attention, resident KV, support residency, full device residency, or completion