### PR TITLE
fix(server): satisfy OneAPI clippy selected backend lint

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -1231,7 +1231,7 @@ fn build_server_readiness_response(
         parameters: metadata.parameters,
         context_length: metadata.context_length,
     });
-    let selected_backend = active_model.as_ref().and_then(|_| selected_backend_label);
+    let selected_backend = active_model.as_ref().and(selected_backend_label);
 
     let batch_inference_ready = false;
     let simulated_inference_enabled = false;


### PR DESCRIPTION
## Summary
- replace a lazy Option combinator in server readiness response construction with the eager `and` form required by Rust 1.95 clippy
- unblocks the shared OneAPI clippy gate without changing readiness behavior

## Validation
- cargo fmt --all -- --check
- cargo clippy --locked --lib --no-default-features --features oneapi -- -D warnings
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to improve maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/4935)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->