### PR TITLE
diag(bitnet): surface reference trace graph provenance

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -26,7 +26,7 @@ index 66f4791e..2f0c21d4 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3434,6 +3436,319 @@ struct llama_context {
+@@ -3434,6 +3436,359 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -154,6 +154,27 @@ index 66f4791e..2f0c21d4 100644
 +    return hash;
 +}
 +
++static void bitnet_rs_reference_layer_trace_write_tensor_provenance(
++    std::ostream & out,
++    struct ggml_tensor * tensor
++) {
++    if (tensor == nullptr) {
++        out << "null";
++        return;
++    }
++    const char * name = ggml_get_name(tensor);
++    out << "{";
++    out << "\"name\":";
++    bitnet_rs_reference_layer_trace_json_string(out, name);
++    out << ",\"op\":";
++    bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++    out << ",\"dtype\":";
++    bitnet_rs_reference_layer_trace_json_string(out, ggml_type_name(tensor->type));
++    out << ",\"shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++    out << ",\"nelements\":" << ggml_nelements(tensor);
++    out << "}";
++}
++
 +static void bitnet_rs_reference_layer_trace_write_record(
 +    std::ostream & out,
 +    llama_context & lctx,
@@ -238,6 +259,25 @@ index 66f4791e..2f0c21d4 100644
 +        bitnet_rs_reference_layer_trace_stage(name)
 +    );
 +    out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);
++    out << ",\"graph_op\":";
++    bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++    out << ",\"graph_sources\":[";
++    bool first_source = true;
++    for (int src_i = 0; src_i < GGML_MAX_SRC; ++src_i) {
++        struct ggml_tensor * source = tensor->src[src_i];
++        if (source == nullptr) {
++            continue;
++        }
++        if (!first_source) {
++            out << ",";
++        }
++        bitnet_rs_reference_layer_trace_write_tensor_provenance(out, source);
++        first_source = false;
++    }
++    out << "]";
++    out << ",\"view_source\":";
++    bitnet_rs_reference_layer_trace_write_tensor_provenance(out, tensor->view_src);
++    out << ",\"view_offset\":" << tensor->view_offs;
 +    out << ",\"dtype\":";
 +    bitnet_rs_reference_layer_trace_json_string(out, ggml_type_name(tensor->type));
 +    out << ",\"shape\":[" << sample_shape[0] << "," << sample_shape[1] << "," << sample_shape[2] << "," << sample_shape[3] << "]";
@@ -346,7 +386,7 @@ index 66f4791e..2f0c21d4 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -17658,6 +17972,13 @@ static int llama_decode_internal(
+@@ -17658,6 +18012,13 @@ static int llama_decode_internal(
  
          llama_graph_compute(lctx, gf, n_threads, threadpool);
  

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -144,6 +144,10 @@ struct ReferenceTraceRecord {
     stage: String,
     graph_index: Option<i64>,
     layer: Option<i64>,
+    graph_op: Option<String>,
+    graph_sources: Value,
+    view_source: Value,
+    view_offset: Option<u64>,
     dtype: String,
     shape: Vec<i64>,
     nelements: u64,
@@ -678,6 +682,10 @@ fn compare_reference_layer_trace(args: &LayerTraceCompareArgs) -> Result<Value> 
                     "name": record.name,
                     "stage": record.stage,
                     "graph_index": record.graph_index,
+                    "graph_op": record.graph_op,
+                    "graph_sources": record.graph_sources,
+                    "view_source": record.view_source,
+                    "view_offset": record.view_offset,
                     "shape": record.shape,
                     "dtype": record.dtype,
                     "nelements": record.nelements,
@@ -855,6 +863,16 @@ fn read_reference_records(root: &Value) -> Result<Vec<ReferenceTraceRecord>> {
                     .to_string(),
                 graph_index: record.pointer("/graph_index").and_then(Value::as_i64),
                 layer: record.pointer("/layer").and_then(Value::as_i64),
+                graph_op: record
+                    .pointer("/graph_op")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                graph_sources: record
+                    .pointer("/graph_sources")
+                    .cloned()
+                    .unwrap_or_else(|| json!([])),
+                view_source: record.pointer("/view_source").cloned().unwrap_or(Value::Null),
+                view_offset: record.pointer("/view_offset").and_then(Value::as_u64),
                 dtype: record
                     .pointer("/dtype")
                     .and_then(Value::as_str)
@@ -1020,6 +1038,10 @@ fn reference_record_summary(record: &ReferenceTraceRecord) -> Value {
         "stage": record.stage,
         "graph_index": record.graph_index,
         "layer": record.layer,
+        "graph_op": record.graph_op,
+        "graph_sources": record.graph_sources,
+        "view_source": record.view_source,
+        "view_offset": record.view_offset,
         "shape": record.shape,
         "dtype": record.dtype,
         "nelements": record.nelements,
@@ -1983,6 +2005,16 @@ mod tests {
                         "stage": "attn_norm",
                         "graph_index": 2,
                         "layer": 0,
+                        "graph_op": "RMS_NORM",
+                        "graph_sources": [
+                            {
+                                "name": "inp_embd",
+                                "op": "GET_ROWS",
+                                "dtype": "f32",
+                                "shape": [2, 2, 1, 1],
+                                "nelements": 4
+                            }
+                        ],
                         "dtype": "f32",
                         "shape": [2, 2, 1, 1],
                         "nelements": 4,
@@ -2014,6 +2046,14 @@ mod tests {
         assert_eq!(
             report.pointer("/cpu/first_material_mismatch/status"),
             Some(&json!("material_mismatch"))
+        );
+        assert_eq!(
+            report.pointer("/cpu/first_material_mismatch/reference/graph_op"),
+            Some(&json!("RMS_NORM"))
+        );
+        assert_eq!(
+            report.pointer("/cpu/first_material_mismatch/reference/graph_sources/0/name"),
+            Some(&json!("inp_embd"))
         );
         assert!(report.pointer("/decision/current_blocked_reasons").unwrap().is_array());
     }


### PR DESCRIPTION
## Summary
- add graph operation/source provenance to reference layer-trace records
- pass reference graph provenance through `bitnet-reference-layer-trace-compare` summaries
- keep the trace and compare receipts diagnostic-only with all A770/selected-attention not-claims intact

## Diagnostic result
- target-local reference trace now shows `inp_embd` is `GET_ROWS` from `token_embd.weight` and `inp_tokens`
- matched compare still reports `rust_cpu_reference_layer_trace_divergence_unresolved`
- the first material mismatch is now confirmed at the embedding lookup boundary: reference `inp_embd` RMS is ~6994 while Rust CPU/A770 `embeddings` RMS is ~1.3
- no Rust model math was changed

## Verification
- `git apply --check ..\..\..\..\..\ci\reference-instrumentation\bitnet-rs-layer-trace-main.patch` from `target/external/BitNet-reference/3rdparty/llama.cpp`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --edition 2024 --config skip_children=true xtask\src\bitnet_reference_layer_trace.rs --check`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-run --output target\a770-diagnostic\bitnet-reference-layer-trace-run.json --format json`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-compare --reference target\a770-diagnostic\bitnet-reference-layer-trace-run.json --cpu-trace-dir target\a770-diagnostic\reference-layer-trace-rust-cpu --a770-trace-dir target\a770-diagnostic\reference-layer-trace-rust-a770 --output target\a770-diagnostic\bitnet-reference-layer-trace-compare-matched.json --format json`
- `git diff --check`

## Claim boundary
- no semantic-quality claim promoted
- no A770 performance/support claim promoted
- selected attention, resident KV, attention scores, softmax, value mix, full support/device residency, and completion remain unclaimed