### PR TITLE
Close M4 BitNet eval benchmark campaign

### DIFF
--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md
@@ -59,7 +59,7 @@ or broad BitNet quality.
 | M4-BITNET-EVAL-002 | merged | PR #4899 added BitNet eval/report schema and reference-vs-Rust comparison fields; PR #4904 fixed the no-panic policy follow-up. |
 | M4-BITNET-EVAL-003 | merged | PR #4924 published the 2026-05-15 M4 BitNet seeded eval receipt for the accepted artifact: 75/100 passed, 25/100 failed, 0 timeouts, fallback=false. |
 | M4-BITNET-EVAL-004 | merged | PR #4933 published the 2026-05-15 one-shot plus fixed-warm M4 BitNet benchmark summary for the accepted artifact. |
-| M4-BITNET-EVAL-005 | in_progress | Wire BitNet eval and benchmark reports into advisory/nightly regression dashboards. |
+| M4-BITNET-EVAL-005 | merged | PR #4942 wired BitNet eval and benchmark reports into advisory/nightly regression dashboards. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/active.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-bitnet-eval-and-benchmark"
 title = "Apple M4 BitNet eval and benchmark"
-status = "active"
+status = "complete"
 
 objective = "Move Apple M4 BitNet from bounded one-shot and fixed-warm proof into repeatable eval and benchmark reporting with accepted artifact/tokenizer authority, reference-vs-Rust comparison fields, one-shot and warm timing envelopes, and regression dashboards without enabling chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claims."
 
@@ -214,7 +214,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-BITNET-EVAL-005"
-status = "in_progress"
+status = "merged"
 branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-005-regression-dashboard"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/events/2026-05-15T154513Z-M4-BITNET-EVAL-005-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/events/2026-05-15T154513Z-M4-BITNET-EVAL-005-merged.toml
@@ -1,0 +1,37 @@
+timestamp = "2026-05-15T15:45:13Z"
+campaign = "apple-m4-bitnet-eval-and-benchmark"
+item = "M4-BITNET-EVAL-005"
+event = "merged"
+actor = "codex"
+from = "in_progress"
+to = "merged"
+pr = 4942
+head_sha = "fb27740cccb41d4777cfec52d3435c87a4d30967"
+merge_sha = "c0aef415ea54f2fa7dc380cf6f61797db7597d98"
+branch = "codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-005-regression-dashboard"
+summary = "Closed M4-BITNET-EVAL-005 after PR #4942 wired BitNet eval and benchmark report comparison into Apple M4 advisory regression dashboards."
+
+artifacts = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-eval-and-benchmark.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/active.toml",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md",
+]
+
+notes = [
+  "The merged regression path compares BitNet eval quality summaries, task-family pass/fail counts, strict scoring totals, and reference-vs-Rust summary counts.",
+  "The merged benchmark path compares p50/p90/p99 load, tokenization, prefill, TTFT, input/output/decode throughput, decode time, total wall time, peak memory, memory drift, process peak drift, and timeout boundaries.",
+  "Context matching requires exact accepted model/tokenizer/backend/prompt/corpus identity and preserves no-chat, no-serve, no-Metal, no-QK256, no-Neural-Engine, no-MPSGraph, no-MacBook, no-speedup, and no-broad-Apple-Silicon boundaries.",
+  "Generic PR CI remains model-free; the dashboard wiring is for receipt comparison in advisory, nightly, scheduled, or release-refresh lanes.",
+]
+
+[evidence]
+eval_receipt = "ci/hardware/apple-m4-mac-mini/2026-05-15/bitnet-eval/answer-corpus.json"
+benchmark_receipt = "ci/hardware/apple-m4-mac-mini/2026-05-15/bitnet-benchmark/summary.json"
+backend = "apple-m4-cpu-neon"
+runtime_api = "cpu"
+fallback_used = false
+generic_pr_ci_model_free = true
+next_item = "none"
+claim_boundary = "receipt comparison only; no new runtime, model support, chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claim"

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 BitNet eval and benchmark Campaign Status
 
 - Campaign: `apple-m4-bitnet-eval-and-benchmark`
-- State: `active`
+- State: `complete`
 - Objective: Move Apple M4 BitNet from bounded one-shot and fixed-warm proof into repeatable eval and benchmark reporting with accepted artifact/tokenizer authority, reference-vs-Rust comparison fields, one-shot and warm timing envelopes, and regression dashboards without enabling chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claims.
 
 ## Work Items
@@ -13,7 +13,7 @@
 | M4-BITNET-EVAL-002 | merged | #4899 | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-002-report-schema` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add BitNet eval/report schema support with explicit reference-vs-Rust comparison fields, accepted model/tokenizer/prompt authority, task-family pass rates, timeout/failure taxonomy, generated text/token IDs, backend identity, fallback=false, and no chat/serve enablement. |
 | M4-BITNET-EVAL-003 | merged | #4924 | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-003-m4-eval-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run the BitNet seeded corpus on the M4 Mac mini through the accepted I2_S GGUF, external tokenizer, bitnetcpp-answer prompt authority, and apple-m4-cpu-neon backend, then publish eval reports with generated text/token IDs, valid UTF-8, task-family pass rates, timeout/failure taxonomy, reference-vs-Rust comparison fields, and fallback_used=false. |
 | M4-BITNET-EVAL-004 | merged | #4933 | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-004-benchmark-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Benchmark Apple M4 BitNet one-shot and fixed-warm paths with accepted artifact/tokenizer authority, recording model load, tokenizer load, prompt tokenize, prefill, TTFT, input tok/s, output tok/s, decode tok/s, total wall, peak memory, timeout boundaries, and p50/p90/p99 summaries without enabling chat or serve. |
-| M4-BITNET-EVAL-005 | in_progress | TBD | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-005-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire BitNet eval and benchmark reports into advisory/nightly regression dashboards with thresholds for task-family pass rates, strict scoring totals, TTFT, input/output/decode throughput, total wall time, peak memory, memory drift, timeout boundaries, and exact model/tokenizer/backend identity while keeping generic PR CI model-free. |
+| M4-BITNET-EVAL-005 | merged | #4942 | `codex/apple-m4-bitnet-eval-and-benchmark/M4-BITNET-EVAL-005-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire BitNet eval and benchmark reports into advisory/nightly regression dashboards with thresholds for task-family pass rates, strict scoring totals, TTFT, input/output/decode throughput, total wall time, peak memory, memory drift, timeout boundaries, and exact model/tokenizer/backend identity while keeping generic PR CI model-free. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -42,7 +42,7 @@
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-002 | M4-BITNET-EVAL-001 | merged |
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-003 | M4-BITNET-EVAL-002 | merged |
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-004 | M4-BITNET-EVAL-003 | merged |
-| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | M4-BITNET-EVAL-003, M4-BITNET-EVAL-004 | in_progress |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | M4-BITNET-EVAL-003, M4-BITNET-EVAL-004 | merged |
 | apple-m4-continuity | M4-CONT-002 | M4-CONT-001 | merged |
 | apple-m4-continuity | M4-CONT-003 | M4-CONT-002 | merged |
 | apple-m4-continuity | M4-CONT-004 | M4-CONT-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -7,7 +7,7 @@
 | apple-bitnet-artifact-sweep | ABAS-001 | TBD | proposed | ABAS-002 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m3-macbook-air | M3MBA-007 | TBD | proposed | M3MBA-008 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
-| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | TBD | in_progress | none | This is an M4 Mac mini BitNet campaign. |
+| apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | #4942 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |


### PR DESCRIPTION
## Summary
- mark `apple-m4-bitnet-eval-and-benchmark` complete after all five work items merged
- mark M4-BITNET-EVAL-005 merged with PR #4942 metadata
- regenerate tracking dashboards

## Claim boundary
Tracker-only closeout. No runtime, model, BitNet chat, BitNet serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon claim changes.

## Validation
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-eval-and-benchmark`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor` (passed with pre-existing warnings for older CPU events missing metadata)
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign next apple-m4-bitnet-eval-and-benchmark` -> `next_item: none`
- `git diff --check`