### PR TITLE
fix(ci): satisfy feature cpu clippy lints

### DIFF
--- a/crates/bitnet-bench-receipts/src/bin/cpu_benchmark_receipt.rs
+++ b/crates/bitnet-bench-receipts/src/bin/cpu_benchmark_receipt.rs
@@ -942,7 +942,7 @@ fn run_threaded_gemv_qk256(
         }
         Ok(())
     });
-    scope_result.map_err(|err| std::io::Error::other(err))?;
+    scope_result.map_err(std::io::Error::other)?;
 
     let selection =
         selections.into_iter().next().ok_or("threaded GEMV produced no worker selection")?;
@@ -981,7 +981,7 @@ fn run_threaded_gemm_qk256(
         }
         Ok(())
     });
-    scope_result.map_err(|err| std::io::Error::other(err))?;
+    scope_result.map_err(std::io::Error::other)?;
     Ok(applied_thread_count)
 }
 

--- a/xtask/src/model_contract.rs
+++ b/xtask/src/model_contract.rs
@@ -149,7 +149,7 @@ fn lint_one_contract(path: &Path, allow_missing_assets: bool) -> Result<Contract
 
     let mut missing = Vec::new();
     for pointer in REQUIRED_POINTERS {
-        if value.pointer(pointer).map_or(true, Value::is_null) {
+        if value.pointer(pointer).is_none_or(Value::is_null) {
             missing.push((*pointer).to_string());
         }
     }

--- a/xtask/src/prompt_suite.rs
+++ b/xtask/src/prompt_suite.rs
@@ -246,14 +246,14 @@ fn build_verify_report(suite_path: &Path, suite: &PromptSuite) -> PromptSuiteVer
             failures.push(format!("{} has unknown oracle {}", case.id, case.oracle));
         }
         if (case.requires_pair || case.oracle == "semantic_pair_difference")
-            && case.pair_prompt.as_deref().map_or(true, str::is_empty)
+            && case.pair_prompt.as_deref().is_none_or(str::is_empty)
         {
             failures.push(format!("{} requires pair_prompt", case.id));
         }
         if (case.oracle == "repetition_guard"
             || case.oracle == "stop_condition"
             || case.category == "stop_repetition_stress")
-            && case.stop_expectation.as_deref().map_or(true, str::is_empty)
+            && case.stop_expectation.as_deref().is_none_or(str::is_empty)
         {
             failures.push(format!("{} missing stop_expectation", case.id));
         }


### PR DESCRIPTION
## Summary
- replace redundant closure clippy patterns in the CPU benchmark receipt threaded scope handling
- update two xtask option/null checks to the Rust 1.95 `is_none_or` idiom required by clippy

## Why
PR #4929 is blocked by the `Feature cpu` check after the toolchain started flagging these as `clippy::redundant_closure` / `clippy::unnecessary_map_or` under `-D warnings`. The changes are behavior-preserving lint fixes on main so M3 work can rebase cleanly instead of carrying unrelated CI fixes.

## Validation
- `CARGO_TARGET_DIR=/tmp/bitnet-closeout-target CARGO_INCREMENTAL=0 cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/bitnet-closeout-target CARGO_INCREMENTAL=0 cargo clippy --locked --workspace --no-default-features --features cpu -- -D warnings`
- `git diff --check`
