### PR TITLE
ci(macos): let started apple silicon jobs finish

### DIFF
--- a/.github/workflows/macos-arm64.yml
+++ b/.github/workflows/macos-arm64.yml
@@ -30,7 +30,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Apple Silicon minutes are scarce, but cancelling a started macOS build near
+  # completion discards the platform evidence after most of the cost is paid.
+  # Keep timeout-minutes as the cap and let active jobs emit their result.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -151,6 +151,12 @@ uploads the receipt directory with `if: always()`. Future M3 Air model, artifact
 or timing lanes should either reuse that pattern or explain why the selected
 lane can safely discard partial work.
 
+The shared macOS Apple Silicon PR workflow follows the same cancellation rule
+for started jobs. It is still bounded by per-job `timeout-minutes` and path
+filters, but it uses `cancel-in-progress: false` so platform-specific compile
+and test evidence is not thrown away by a later push after runner time has
+already been spent.
+
 ## Why the budget target is aggressive
 
 Our CI budget target is intentionally aggressive — but **not because we want


### PR DESCRIPTION
## Summary
- keep started `macOS (Apple Silicon)` CI jobs running instead of cancelling in-progress work on later pushes
- document the same long-job rule in the CI cost policy for shared Apple Silicon PR validation

## Why
For M3/Mac work, cancelling an already-running platform job near completion wastes scarce macOS runner time and loses the platform evidence. Timeouts remain the cap; cancellation should not be the cost mechanism for active Apple Silicon validation.

## Validation
- `git diff --check`
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/macos-arm64.yml"); puts "yaml ok"'`
