### PR TITLE
Allow variable BitNet warm prompts on M4

### DIFF
--- a/crates/bitnet-cli/src/mac.rs
+++ b/crates/bitnet-cli/src/mac.rs
@@ -273,7 +273,7 @@ enum MacAction {
         json_out: PathBuf,
     },
 
-    /// Run fixed BitNet prompts in one warm Apple M4 CPU/NEON process without enabling chat.
+    /// Run BitNet prompts in one warm Apple M4 CPU/NEON process without enabling chat.
     BitnetWarm {
         /// Accepted BitNet model id. Only microsoft-bitnet-b1.58-2B-4T-i2s is supported.
         #[arg(long, default_value = BITNET_M4_MODEL_ID)]
@@ -291,7 +291,11 @@ enum MacAction {
         #[arg(long, value_name = "PATH")]
         tokenizer: Option<PathBuf>,
 
-        /// Maximum new tokens per fixed warm prompt.
+        /// Operator prompt to run in the warm session. Repeat the flag and include at least one exact repeated prompt for determinism. Defaults to the fixed proof prompt set when omitted.
+        #[arg(long = "prompt", value_name = "TEXT")]
+        prompts: Vec<String>,
+
+        /// Maximum new tokens per warm prompt.
         #[arg(long, visible_aliases = ["max-tokens", "n-predict"], default_value_t = 8)]
         max_new_tokens: usize,
 
@@ -817,6 +821,7 @@ impl MacCommand {
                 cache_dir,
                 model_path,
                 tokenizer,
+                prompts,
                 max_new_tokens,
                 threads,
                 progress,
@@ -829,6 +834,7 @@ impl MacCommand {
                     cache_dir,
                     model_path,
                     tokenizer,
+                    prompts,
                     max_new_tokens,
                     threads,
                     progress,
@@ -2499,6 +2505,7 @@ struct BitnetWarmRun<'a> {
     cache_dir: Option<PathBuf>,
     model_path: Option<PathBuf>,
     tokenizer: Option<PathBuf>,
+    prompts: Vec<String>,
     max_new_tokens: usize,
     threads: usize,
     progress: bool,
@@ -2512,6 +2519,7 @@ async fn run_bitnet_warm(request: BitnetWarmRun<'_>) -> Result<()> {
         cache_dir,
         model_path,
         tokenizer,
+        prompts,
         max_new_tokens,
         threads,
         progress,
@@ -2526,6 +2534,7 @@ async fn run_bitnet_warm(request: BitnetWarmRun<'_>) -> Result<()> {
             "`bitnet mac bitnet-warm` only supports {BITNET_M4_MODEL_ID}; got `{model_id}`"
         );
     }
+    let (prompts, prompt_source) = resolve_bitnet_warm_prompts(prompts)?;
     let tokenizer = tokenizer.unwrap_or_else(|| PathBuf::from(BITNET_M4_DEFAULT_TOKENIZER_PATH));
     if !tokenizer.exists() {
         anyhow::bail!(
@@ -2536,7 +2545,7 @@ async fn run_bitnet_warm(request: BitnetWarmRun<'_>) -> Result<()> {
     }
     let tokenizer_sha256 = verify_bitnet_m4_tokenizer(&tokenizer)?;
     let model = model_cache::verified_apple_m4_bitnet_model(model_id, cache_dir, model_path)?;
-    let prompts = BITNET_WARM_PROMPTS.iter().map(|prompt| (*prompt).to_string()).collect();
+    let prompt_count = prompts.len();
 
     crate::run_slm_warm_session(
         APPLE_M4_CPU_NEON,
@@ -2577,15 +2586,70 @@ async fn run_bitnet_warm(request: BitnetWarmRun<'_>) -> Result<()> {
         &model,
         &tokenizer,
         &tokenizer_sha256,
+        prompt_source,
     )?;
     if !quiet {
         println!(
-            "Mac BitNet warm session passed: {} (prompts={}, chat=false, serve=false)",
+            "Mac BitNet warm session passed: {} (prompts={}, prompt_source={}, chat=false, serve=false)",
             json_out.display(),
-            BITNET_WARM_PROMPTS.len()
+            prompt_count,
+            prompt_source.as_str()
         );
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BitnetWarmPromptSource {
+    FixedProof,
+    OperatorPrompts,
+}
+
+impl BitnetWarmPromptSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::FixedProof => "fixed_proof_prompts",
+            Self::OperatorPrompts => "operator_prompts",
+        }
+    }
+
+    const fn variable_prompts(self) -> bool {
+        matches!(self, Self::OperatorPrompts)
+    }
+}
+
+fn resolve_bitnet_warm_prompts(
+    prompts: Vec<String>,
+) -> Result<(Vec<String>, BitnetWarmPromptSource)> {
+    if prompts.is_empty() {
+        return Ok((
+            BITNET_WARM_PROMPTS.iter().map(|prompt| (*prompt).to_string()).collect(),
+            BitnetWarmPromptSource::FixedProof,
+        ));
+    }
+    if prompts.len() < 2 {
+        anyhow::bail!(
+            "`bitnet mac bitnet-warm --prompt` requires at least two prompt values for a warm session"
+        );
+    }
+    for (index, prompt) in prompts.iter().enumerate() {
+        if prompt.trim().is_empty() {
+            anyhow::bail!(
+                "`bitnet mac bitnet-warm --prompt` value {} must not be empty",
+                index + 1
+            );
+        }
+    }
+    let mut counts = std::collections::BTreeMap::<&str, usize>::new();
+    for prompt in &prompts {
+        *counts.entry(prompt.as_str()).or_default() += 1;
+    }
+    if !counts.values().any(|count| *count >= 2) {
+        anyhow::bail!(
+            "`bitnet mac bitnet-warm --prompt` requires at least one exact repeated prompt so deterministic warm reuse can be checked before chat is enabled"
+        );
+    }
+    Ok((prompts, BitnetWarmPromptSource::OperatorPrompts))
 }
 
 struct BitnetBenchmarkRun<'a> {
@@ -2740,6 +2804,7 @@ async fn run_bitnet_benchmark(request: BitnetBenchmarkRun<'_>) -> Result<()> {
         cache_dir,
         model_path,
         tokenizer,
+        prompts: Vec::new(),
         max_new_tokens,
         threads,
         progress,
@@ -6354,6 +6419,7 @@ fn annotate_and_validate_bitnet_warm_session_receipt(
     model: &VerifiedCachedModel,
     tokenizer: &Path,
     tokenizer_sha256: &str,
+    prompt_source: BitnetWarmPromptSource,
 ) -> Result<()> {
     let bytes = std::fs::read(path).with_context(|| {
         format!("failed to read BitNet warm-session receipt {}", path.display())
@@ -6387,12 +6453,20 @@ fn annotate_and_validate_bitnet_warm_session_receipt(
     if receipt["generation"]["prompt_template"].as_str() != Some(BITNET_M4_PROMPT_TEMPLATE) {
         anyhow::bail!("{} does not use the BitNet.cpp answer prompt template", path.display());
     }
-    if receipt["session"]["prompt_count"].as_u64() != Some(BITNET_WARM_PROMPTS.len() as u64)
-        || receipt["session"]["model_loaded_once"].as_bool() != Some(true)
+    let prompt_count = receipt["session"]["prompt_count"].as_u64().unwrap_or_default();
+    if prompt_source == BitnetWarmPromptSource::FixedProof
+        && prompt_count != BITNET_WARM_PROMPTS.len() as u64
+    {
+        anyhow::bail!("{} must record the fixed BitNet warm proof prompt count", path.display());
+    }
+    if prompt_source == BitnetWarmPromptSource::OperatorPrompts && prompt_count < 2 {
+        anyhow::bail!("{} must record at least two operator BitNet warm prompts", path.display());
+    }
+    if receipt["session"]["model_loaded_once"].as_bool() != Some(true)
         || receipt["session"]["tokenizer_loaded_once"].as_bool() != Some(true)
     {
         anyhow::bail!(
-            "{} must record the fixed BitNet warm prompt count and one model/tokenizer load",
+            "{} must record one BitNet warm-session model/tokenizer load",
             path.display()
         );
     }
@@ -6407,6 +6481,16 @@ fn annotate_and_validate_bitnet_warm_session_receipt(
     object.insert("artifact_kind".to_string(), serde_json::json!("bitnet_apple_m4_warm_session"));
     object.insert("operator_command".to_string(), serde_json::json!("mac bitnet-warm"));
     object.insert("model_id".to_string(), serde_json::json!(model.id));
+    object.insert(
+        "bitnet_warm_prompt_source".to_string(),
+        serde_json::json!({
+            "source": prompt_source.as_str(),
+            "variable_prompts": prompt_source.variable_prompts(),
+            "fixed_proof_prompt_count": BITNET_WARM_PROMPTS.len(),
+            "session_prompt_count": prompt_count,
+            "determinism_requires_repeated_prompt": true,
+        }),
+    );
     object.insert(
         "model_cache".to_string(),
         serde_json::json!({

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -864,10 +864,11 @@ fn mac_bitnet_warm_help_documents_fixed_resident_proof() {
         .args(["mac", "bitnet-warm", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("fixed BitNet prompts"))
+        .stdout(predicate::str::contains("BitNet prompts"))
         .stdout(predicate::str::contains("--model-id"))
         .stdout(predicate::str::contains("--model-path"))
         .stdout(predicate::str::contains("--tokenizer"))
+        .stdout(predicate::str::contains("--prompt <TEXT>"))
         .stdout(predicate::str::contains("--json-out"));
 }
 
@@ -927,6 +928,54 @@ fn mac_bitnet_warm_rejects_non_bitnet_model_before_cache_lookup() {
         .stderr(predicate::str::contains(
             "`bitnet mac bitnet-warm` only supports microsoft-bitnet-b1.58-2B-4T-i2s",
         ));
+}
+
+#[test]
+fn mac_bitnet_warm_rejects_single_operator_prompt_before_cache_lookup() {
+    bitnet()
+        .args(["mac", "bitnet-warm", "--prompt", "What is 2+2?"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`bitnet mac bitnet-warm --prompt` requires at least two prompt values",
+        ))
+        .stderr(predicate::str::contains("BitNet warm session requires").not());
+}
+
+#[test]
+fn mac_bitnet_warm_rejects_non_repeated_operator_prompts_before_cache_lookup() {
+    bitnet()
+        .args([
+            "mac",
+            "bitnet-warm",
+            "--prompt",
+            "What is 2+2?",
+            "--prompt",
+            "Name the capital of France.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires at least one exact repeated prompt"))
+        .stderr(predicate::str::contains("BitNet warm session requires").not());
+}
+
+#[test]
+fn mac_bitnet_warm_rejects_empty_operator_prompt_before_cache_lookup() {
+    bitnet()
+        .args([
+            "mac",
+            "bitnet-warm",
+            "--prompt",
+            "What is 2+2?",
+            "--prompt",
+            "",
+            "--prompt",
+            "What is 2+2?",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("value 2 must not be empty"))
+        .stderr(predicate::str::contains("BitNet warm session requires").not());
 }
 
 #[test]

--- a/docs/slm/apple-m4-bitnet-proof-prep.md
+++ b/docs/slm/apple-m4-bitnet-proof-prep.md
@@ -150,6 +150,9 @@ Allowed now:
 - The fixed-prompt `bitnet mac bitnet-warm` route has a committed Apple M4
   CPU/NEON aggregate receipt plus per-prompt receipts for repeated-prompt
   determinism.
+- The `bitnet mac bitnet-warm --prompt ... --prompt ...` route accepts
+  operator-provided warm prompt sets only when at least one exact prompt is
+  repeated, so deterministic warm reuse remains receipt-gated before chat.
 
 Not allowed now:
 

--- a/docs/slm/apple-m4-mini-user-expectation-envelope.md
+++ b/docs/slm/apple-m4-mini-user-expectation-envelope.md
@@ -250,14 +250,27 @@ Those receipts prove one explicit accepted-artifact smoke run, not BitNet chat,
 serve, full Metal inference, QK256 on Apple Silicon, or a broad performance
 envelope.
 
-For BitNet warm reuse proof, use the dedicated fixed-prompt route. It loads the
-accepted model/tokenizer once, runs a small repeated-prompt set, writes per-turn
-receipts plus an aggregate receipt, and still does not enable BitNet chat or
-serve:
+For BitNet warm reuse proof, use the dedicated warm route. With no prompt flags
+it loads the accepted model/tokenizer once, runs the fixed repeated-prompt proof
+set, writes per-turn receipts plus an aggregate receipt, and still does not
+enable BitNet chat or serve:
 
 ```bash
 bitnet mac bitnet-warm
 ```
+
+For operator prompt sets, repeat `--prompt` and include at least one exact
+repeated prompt so the receipt can prove deterministic warm reuse:
+
+```bash
+bitnet mac bitnet-warm \
+  --prompt "Answer with a single digit: 2+2=" \
+  --prompt "Name the capital of France. Answer with one word." \
+  --prompt "Answer with a single digit: 2+2="
+```
+
+The operator-prompt route is still a warm-session proof surface, not BitNet
+chat, BitNet serve, broad BitNet quality, or broad performance evidence.
 
 The committed aggregate warm receipt is:
 

--- a/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-bitnet-eval-and-benchmark`
 
-Status: active
+Status: complete
 
 ## Objective
 

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/CAMPAIGN.md
@@ -1,0 +1,69 @@
+# Apple M4 BitNet Productization Campaign
+
+Campaign ID: `apple-m4-bitnet-productization`
+
+Status: active
+
+## Objective
+
+Move Apple M4 BitNet from fixed one-shot and fixed-warm proof into
+operator-ready warm sessions, then chat and serve only after receipt-backed
+correctness, determinism, timeout, streaming, and failure-mode gates pass.
+
+## Why This Exists
+
+`apple-m4-local-answer` proved one-shot BitNet answers and a fixed-prompt warm
+route for the accepted Microsoft I2_S artifact. `apple-m4-bitnet-eval-and-
+benchmark` added a 100-case BitNet eval report, one-shot/fixed-warm benchmark
+reports, and advisory regression comparison.
+
+That is still not enough to enable BitNet chat or serve. Operators need a warm
+route that can run their own bounded prompt sets, prove repeated-prompt
+determinism, expose slow/failing stages, and preserve exact model/tokenizer/
+backend/fallback receipts.
+
+## Scope Boundary
+
+This is an M4 Mac mini BitNet productization lane. It uses only the accepted
+Microsoft I2_S GGUF, the accepted external Microsoft tokenizer authority, and
+the `bitnetcpp-answer` prompt authority for answer evidence.
+
+Dense Qwen evidence, dense SLM timing, and dense server success are not BitNet
+product evidence. This campaign does not claim full Apple Metal inference,
+QK256, Neural Engine execution, MPSGraph inference, MacBook behavior, speedup,
+broad BitNet quality, or broad Apple Silicon performance.
+
+## End State
+
+- `bitnet mac bitnet-warm` supports operator-provided repeated prompts while
+  preserving the fixed proof prompt default.
+- Warm-session receipts record prompt source, accepted model/tokenizer identity,
+  backend/fallback status, generated text, token IDs, per-turn timing, aggregate
+  timing, memory, and repeated-prompt determinism.
+- Slow or failed BitNet warm runs expose progress, timeout, and partial-failure
+  receipts.
+- BitNet chat remains disabled until variable warm-session receipts prove reuse,
+  determinism, timeout, and failure boundaries.
+- BitNet serve remains out of scope until chat, streaming, request/response, and
+  receipt-export semantics are separately proven.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-BITNET-PROD-001 | in_progress | Allow `bitnet mac bitnet-warm` to run operator-supplied repeated prompts while keeping the fixed proof prompt default. |
+| M4-BITNET-PROD-002 | proposed | Commit a bounded M4 runtime receipt for variable-prompt BitNet warm sessions. |
+| M4-BITNET-PROD-003 | proposed | Add warm-session progress, timeout, partial-failure receipts, and repair guidance. |
+| M4-BITNET-PROD-004 | proposed | Define and enforce the BitNet chat enablement gate before enabling chat. |
+
+## Review Policy
+
+Each PR owns one item. Parser, CLI, fixture, and receipt validation checks belong
+in generic CI. Live M4 model runs, long warm-session soaks, and timing envelopes
+belong in local, advisory, scheduled, or release lanes.
+
+Every item must preserve `apple-m4-cpu-neon`, `fallback_used=false`, exact
+accepted model SHA, accepted tokenizer SHA/authority, `bitnetcpp-answer` prompt
+authority, generated text/token IDs when runtime evidence exists, and explicit
+disabled chat/serve/Metal/QK256/Neural Engine/MPSGraph/MacBook/broad-claim
+boundaries.

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/active.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/active.toml
@@ -1,0 +1,179 @@
+id = "apple-m4-bitnet-productization"
+title = "Apple M4 BitNet productization"
+status = "active"
+
+objective = "Move Apple M4 BitNet from fixed one-shot and fixed-warm proof into operator-ready warm sessions, then chat and serve only after receipt-backed correctness, determinism, timeout, streaming, and failure-mode gates pass."
+
+end_state = [
+  "BitNet warm sessions accept operator-provided prompt sets while preserving the fixed proof prompt default.",
+  "Warm-session receipts record accepted Microsoft I2_S GGUF identity, external tokenizer authority, bitnetcpp-answer prompt authority, backend/fallback identity, generated text, generated token IDs, per-turn timing, aggregate timing, memory, prompt source, and deterministic repeated-prompt evidence.",
+  "Progress, timeout, and partial-failure receipts make slow BitNet runs diagnosable instead of appearing hung.",
+  "BitNet chat is enabled only after variable warm-session receipts prove reuse, determinism, and failure boundaries.",
+  "BitNet serve is considered only after chat, streaming, request/response, and receipt-export semantics are proven.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini BitNet campaign.",
+  "Use only the accepted Microsoft I2_S GGUF paired with external Microsoft tokenizer authority for answer claims.",
+  "Use the bitnetcpp-answer prompt authority for BitNet M4 answer and warm-session reports.",
+  "Do not use dense Qwen or dense SLM evidence as BitNet quality, performance, or UX evidence.",
+  "Do not enable BitNet chat until variable warm-session receipts prove stable correctness, determinism, timeout behavior, and failure boundaries.",
+  "Do not enable BitNet serve until chat and streaming/request receipts pass.",
+  "Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, speedup, broad BitNet quality, or broad Apple Silicon performance.",
+  "Do not add live model downloads, long hardware timing runs, variable warm-session soaks, or model binaries to generic required PR CI.",
+]
+
+[[work_item]]
+id = "M4-BITNET-PROD-001"
+status = "in_progress"
+branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-001-variable-warm-prompts"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Allow `bitnet mac bitnet-warm` to run operator-supplied repeated prompts in one resident Apple M4 CPU/NEON BitNet process while preserving the fixed proof prompt default, accepted model/tokenizer checks, repeated-prompt determinism, per-turn receipts, aggregate prompt-source metadata, and disabled chat/serve/Metal/QK256/Neural Engine/MPSGraph/broad-claim boundaries."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_bitnet_warm",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_receipts_check_accepts_bitnet_warm_session_receipt",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-productization",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-proof-prep.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/**",
+  "docs/tracking/campaigns/apple-m4-bitnet-eval-and-benchmark/CAMPAIGN.md",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "`bitnet mac bitnet-warm` accepts operator-supplied repeated prompts for resident BitNet warm-session runs.",
+]
+must_not_claim = [
+  "A fresh live M4 variable warm-session runtime receipt is committed by this item.",
+  "BitNet chat or serve is enabled.",
+  "Full apple-m4-metal inference works.",
+  "Broad BitNet quality or performance is proven.",
+]
+
+[[work_item]]
+id = "M4-BITNET-PROD-002"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-002-variable-warm-runtime"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-PROD-001"]
+acceptance = "Run the operator-prompt BitNet warm route on the M4 Mac mini with accepted model/tokenizer identity, at least five variable prompts including one exact repeat, fallback_used=false, generated text/token IDs, repeated-prompt determinism, per-turn and aggregate timing/memory receipts, timeout boundary, and no chat/serve/Metal/broad claims."
+commands = [
+  "cargo run --locked --release -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device apple-m4-cpu-neon mac bitnet-warm --model-id microsoft-bitnet-b1.58-2B-4T-i2s --model-path models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json --prompt \"Answer with a single digit: 2+2=\" --prompt \"Name the capital of France. Answer with one word.\" --prompt \"Return exactly: ready\" --prompt \"Answer with a single digit: 3+1=\" --prompt \"Answer with a single digit: 2+2=\" --max-new-tokens 8 --json-out ci/hardware/apple-m4-mac-mini/<date>/bitnet-productization/variable-warm-session.json",
+  "target/release/bitnet mac receipts-check ci/hardware/apple-m4-mac-mini/<date>/bitnet-productization/variable-warm-session.json --json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-productization",
+]
+allowed_paths = [
+  "ci/hardware/apple-m4-mac-mini/**",
+  "docs/slm/apple-m4-bitnet-proof-prep.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "A bounded Apple M4 BitNet variable warm-session runtime receipt exists for the accepted artifact.",
+]
+must_not_claim = [
+  "BitNet chat or serve is enabled.",
+  "Broad BitNet warm-session quality or performance is proven.",
+]
+
+[[work_item]]
+id = "M4-BITNET-PROD-003"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-003-timeout-failure-ux"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-PROD-002"]
+acceptance = "Add BitNet warm-session progress, timeout, and partial-failure receipts that identify model load, tokenizer load, prefill, first-token, decode, and receipt-write stages with repair guidance, while preserving disabled chat/serve/Metal/broad-claim boundaries."
+commands = [
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_bitnet_warm",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-productization",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-proof-prep.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "BitNet warm-session slow and failed runs expose progress, timeout, and repair evidence.",
+]
+must_not_claim = [
+  "BitNet chat or serve is enabled.",
+  "Full apple-m4-metal inference works.",
+]
+
+[[work_item]]
+id = "M4-BITNET-PROD-004"
+status = "proposed"
+branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-004-chat-gate"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-BITNET-PROD-002", "M4-BITNET-PROD-003"]
+acceptance = "Define and enforce the BitNet chat enablement gate from variable warm-session receipts, repeated-prompt determinism, timeout/failure evidence, streaming semantics, and claim boundaries before any `bitnet mac chat --model-family bitnet` route is enabled."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-productization",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-proof-prep.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The BitNet chat gate is explicit and receipt-backed.",
+]
+must_not_claim = [
+  "BitNet serve is enabled.",
+  "Broad BitNet chat quality or performance is proven.",
+]

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/events/2026-05-15T155705Z-M4-BITNET-PROD-001-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/events/2026-05-15T155705Z-M4-BITNET-PROD-001-in-progress.toml
@@ -1,0 +1,36 @@
+timestamp = "2026-05-15T15:57:05Z"
+campaign = "apple-m4-bitnet-productization"
+item = "M4-BITNET-PROD-001"
+event = "in_progress"
+actor = "codex"
+from = "proposed"
+to = "in_progress"
+branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-001-variable-warm-prompts"
+summary = "Started BitNet productization by allowing the M4 warm route to accept operator-supplied repeated prompts without enabling chat or serve."
+
+artifacts = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-proof-prep.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/active.toml",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/CAMPAIGN.md",
+]
+
+notes = [
+  "The fixed proof prompt set remains the default when no --prompt values are supplied.",
+  "Operator prompt mode requires at least two prompts and at least one exact repeated prompt so determinism remains gateable before chat.",
+  "The receipt annotates prompt source and preserves accepted model/tokenizer/backend/fallback and disabled chat/serve/Metal/QK256/Neural Engine/MPSGraph/broad-claim boundaries.",
+  "This item does not commit a fresh live M4 runtime receipt and does not enable BitNet chat or serve.",
+]
+
+[evidence]
+route = "bitnet mac bitnet-warm"
+operator_prompt_flag = "--prompt"
+default_prompt_source = "fixed_proof_prompts"
+variable_prompt_source = "operator_prompts"
+backend = "apple-m4-cpu-neon"
+chat_enabled = false
+serve_enabled = false
+generic_pr_ci_model_free = true
+claim_boundary = "CLI and receipt contract only; no new runtime receipt, chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad quality, or broad Apple Silicon claim"

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/generated/status.md
@@ -1,0 +1,26 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 BitNet productization Campaign Status
+
+- Campaign: `apple-m4-bitnet-productization`
+- State: `active`
+- Objective: Move Apple M4 BitNet from fixed one-shot and fixed-warm proof into operator-ready warm sessions, then chat and serve only after receipt-backed correctness, determinism, timeout, streaming, and failure-mode gates pass.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-BITNET-PROD-001 | in_progress | TBD | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-001-variable-warm-prompts` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Allow `bitnet mac bitnet-warm` to run operator-supplied repeated prompts in one resident Apple M4 CPU/NEON BitNet process while preserving the fixed proof prompt default, accepted model/tokenizer checks, repeated-prompt determinism, per-turn receipts, aggregate prompt-source metadata, and disabled chat/serve/Metal/QK256/Neural Engine/MPSGraph/broad-claim boundaries. |
+| M4-BITNET-PROD-002 | proposed | TBD | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-002-variable-warm-runtime` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run the operator-prompt BitNet warm route on the M4 Mac mini with accepted model/tokenizer identity, at least five variable prompts including one exact repeat, fallback_used=false, generated text/token IDs, repeated-prompt determinism, per-turn and aggregate timing/memory receipts, timeout boundary, and no chat/serve/Metal/broad claims. |
+| M4-BITNET-PROD-003 | proposed | TBD | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-003-timeout-failure-ux` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add BitNet warm-session progress, timeout, and partial-failure receipts that identify model load, tokenizer load, prefill, first-token, decode, and receipt-write stages with repair guidance, while preserving disabled chat/serve/Metal/broad-claim boundaries. |
+| M4-BITNET-PROD-004 | proposed | TBD | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-004-chat-gate` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define and enforce the BitNet chat enablement gate from variable warm-session receipts, repeated-prompt determinism, timeout/failure evidence, streaming semantics, and claim boundaries before any `bitnet mac chat --model-family bitnet` route is enabled. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini BitNet campaign.
+- Use only the accepted Microsoft I2_S GGUF paired with external Microsoft tokenizer authority for answer claims.
+- Use the bitnetcpp-answer prompt authority for BitNet M4 answer and warm-session reports.
+- Do not use dense Qwen or dense SLM evidence as BitNet quality, performance, or UX evidence.
+- Do not enable BitNet chat until variable warm-session receipts prove stable correctness, determinism, timeout behavior, and failure boundaries.
+- Do not enable BitNet serve until chat and streaming/request receipts pass.
+- Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, speedup, broad BitNet quality, or broad Apple Silicon performance.
+- Do not add live model downloads, long hardware timing runs, variable warm-session soaks, or model binaries to generic required PR CI.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -43,6 +43,9 @@
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-003 | M4-BITNET-EVAL-002 | merged |
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-004 | M4-BITNET-EVAL-003 | merged |
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | M4-BITNET-EVAL-003, M4-BITNET-EVAL-004 | merged |
+| apple-m4-bitnet-productization | M4-BITNET-PROD-002 | M4-BITNET-PROD-001 | proposed |
+| apple-m4-bitnet-productization | M4-BITNET-PROD-003 | M4-BITNET-PROD-002 | proposed |
+| apple-m4-bitnet-productization | M4-BITNET-PROD-004 | M4-BITNET-PROD-002, M4-BITNET-PROD-003 | proposed |
 | apple-m4-continuity | M4-CONT-002 | M4-CONT-001 | merged |
 | apple-m4-continuity | M4-CONT-003 | M4-CONT-002 | merged |
 | apple-m4-continuity | M4-CONT-004 | M4-CONT-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -8,6 +8,7 @@
 | apple-m3-macbook-air | M3MBA-007 | TBD | proposed | M3MBA-008 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | #4942 | merged | none | This is an M4 Mac mini BitNet campaign. |
+| apple-m4-bitnet-productization | M4-BITNET-PROD-001 | TBD | in_progress | M4-BITNET-PROD-002 | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -8,6 +8,7 @@
 | apple-m3-macbook-air | Apple M3 MacBook Air | M3MBA-007 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | Apple M4 Mac mini validation | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-bitnet-eval-and-benchmark | Apple M4 BitNet eval and benchmark | M4-BITNET-EVAL-005 | This is an M4 Mac mini BitNet campaign. |
+| apple-m4-bitnet-productization | Apple M4 BitNet productization | M4-BITNET-PROD-001 | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | Apple M4 continuity | M4-CONT-005 | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | Apple M4 local answer usability | M4-BITNET-WARM-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |


### PR DESCRIPTION
## Summary
- start the `apple-m4-bitnet-productization` campaign for the post-eval BitNet warm/chat/serve path
- let `bitnet mac bitnet-warm` accept repeated `--prompt` values while keeping the existing fixed proof prompt set as the default
- require at least two operator prompts and one exact repeat before model/tokenizer lookup so determinism stays gateable
- annotate BitNet warm receipts with prompt-source metadata and preserve chat/serve/Metal/QK256/Neural Engine/MPSGraph/broad-claim boundaries

## Claim boundary
This is CLI and receipt-contract productization only. It does not commit a fresh live M4 variable warm-session receipt, does not enable BitNet chat or serve, and does not claim broad BitNet quality, performance, Metal, QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon behavior.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_bitnet_warm`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_receipts_check_accepts_bitnet_warm_session_receipt`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-productization`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor` (passed with pre-existing warnings for older CPU events missing metadata)
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign next apple-m4-bitnet-productization`
- `git diff --check`