### PR TITLE
diag(bitnet): capture reference trace values during eval

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -6,10 +6,13 @@
 # Author: BitNet-rs maintainers
 
 diff --git a/src/llama.cpp b/src/llama.cpp
-index 66f4791e..2f0c21d4 100644
+index 666fcc4d..23ee29ff 100644
 --- a/src/llama.cpp
 +++ b/src/llama.cpp
-@@ -64,6 +64,8 @@
+@@ -74,9 +74,11 @@
+ #include <cstddef>
+ #include <cstdint>
+ #include <cstdio>
 +#include <cstdlib>
  #include <cstring>
  #include <ctime>
@@ -18,7 +21,7 @@ index 66f4791e..2f0c21d4 100644
  #include <functional>
  #include <future>
  #include <initializer_list>
-@@ -75,6 +76,7 @@
+@@ -84,6 +86,7 @@
  #include <map>
  #include <memory>
  #include <mutex>
@@ -26,7 +29,7 @@ index 66f4791e..2f0c21d4 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3434,6 +3436,439 @@ struct llama_context {
+@@ -3441,6 +3444,494 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -373,7 +376,9 @@ index 66f4791e..2f0c21d4 100644
 +    }
 +
 +    out << ",\"first_values\":[";
-+    const size_t sample_count = sample_nelements < 16 ? (size_t) sample_nelements : 16;
++    const size_t sample_count = values_available
++        ? (sample_nelements < 16 ? (size_t) sample_nelements : 16)
++        : 0;
 +    for (size_t i = 0; i < sample_count; ++i) {
 +        if (i > 0) {
 +            out << ",";
@@ -383,13 +388,56 @@ index 66f4791e..2f0c21d4 100644
 +    out << "]}";
 +}
 +
++struct bitnet_rs_reference_layer_trace_callback_context {
++    llama_context * lctx = nullptr;
++    uint32_t n_tokens = 0;
++    int32_t n_outputs = 0;
++    std::map<struct ggml_tensor *, int> graph_indices;
++    std::vector<std::string> * records = nullptr;
++    ggml_backend_sched_eval_callback prior_cb_eval = nullptr;
++    void * prior_cb_eval_user_data = nullptr;
++};
++
++static bool bitnet_rs_reference_layer_trace_eval_callback(
++    struct ggml_tensor * tensor,
++    bool ask,
++    void * user_data
++) {
++    auto * ctx = (bitnet_rs_reference_layer_trace_callback_context *) user_data;
++    const bool trace_target = bitnet_rs_reference_layer_trace_target(ggml_get_name(tensor));
++    bool prior_need = false;
++    if (ctx != nullptr && ctx->prior_cb_eval != nullptr) {
++        prior_need = ctx->prior_cb_eval(tensor, ask, ctx->prior_cb_eval_user_data);
++    }
++    if (ask) {
++        return trace_target || prior_need;
++    }
++    if (trace_target && ctx != nullptr && ctx->lctx != nullptr && ctx->records != nullptr) {
++        auto index_it = ctx->graph_indices.find(tensor);
++        const int graph_index = index_it == ctx->graph_indices.end() ? -1 : index_it->second;
++        std::ostringstream record;
++        bitnet_rs_reference_layer_trace_write_record(
++            record,
++            *ctx->lctx,
++            tensor,
++            graph_index,
++            ctx->n_tokens,
++            ctx->n_outputs,
++            true
++        );
++        ctx->records->push_back(record.str());
++    }
++    return true;
++}
++
 +static void bitnet_rs_reference_layer_trace_dump(
 +    llama_context & lctx,
 +    struct ggml_cgraph * gf,
 +    const llama_ubatch & ubatch,
 +    uint32_t n_tokens,
 +    int32_t n_outputs,
-+    const char * path
++    const char * path,
++    const std::vector<std::string> * callback_records
 +) {
 +    if (path == nullptr || path[0] == '\0' || n_outputs <= 0) {
 +        return;
@@ -407,6 +455,7 @@ index 66f4791e..2f0c21d4 100644
 +        << "\"source\":\"BITNET_RS_REFERENCE_LAYER_TRACE\","
 +        << "\"capture_scope\":\"first_non_warmup_decode_last_output_token_slice\","
 +        << "\"warmup_skip_policy\":\"skip_bos_eos_warmup_decode\","
++        << "\"capture_synchronization_policy\":\"scheduler_eval_callback_after_each_target_node\","
 +        << "\"n_tokens\":" << n_tokens << ","
 +        << "\"n_outputs\":" << n_outputs << ",";
 +
@@ -436,15 +485,24 @@ index 66f4791e..2f0c21d4 100644
 +    out << ","
 +        << "\"records\":[";
 +
-+    bool first = true;
-+    for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
-+        struct ggml_tensor * tensor = ggml_graph_node(gf, i);
-+        const char * name = ggml_get_name(tensor);
-+        if (!bitnet_rs_reference_layer_trace_target(name)) {
-+            continue;
++    if (callback_records != nullptr) {
++        for (size_t i = 0; i < callback_records->size(); ++i) {
++            if (i > 0) {
++                out << ",";
++            }
++            out << (*callback_records)[i];
 +        }
-+        bitnet_rs_reference_layer_trace_write_record(out, lctx, tensor, i, n_tokens, n_outputs, first);
-+        first = false;
++    } else {
++        bool first = true;
++        for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
++            struct ggml_tensor * tensor = ggml_graph_node(gf, i);
++            const char * name = ggml_get_name(tensor);
++            if (!bitnet_rs_reference_layer_trace_target(name)) {
++                continue;
++            }
++            bitnet_rs_reference_layer_trace_write_record(out, lctx, tensor, i, n_tokens, n_outputs, first);
++            first = false;
++        }
 +    }
 +
 +    out << "],\"not_claims\":["
@@ -466,14 +524,38 @@ index 66f4791e..2f0c21d4 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -17658,6 +18092,13 @@ static int llama_decode_internal(
+@@ -17655,8 +18146,37 @@ static int llama_decode_internal(
  
-         llama_graph_compute(lctx, gf, n_threads, threadpool);
+         llama_set_inputs(lctx, ubatch);
  
 +        static bool bitnet_rs_reference_layer_trace_dumped = false;
 +        const char * bitnet_rs_reference_layer_trace_path = std::getenv("BITNET_RS_REFERENCE_LAYER_TRACE");
-+        if (!bitnet_rs_reference_layer_trace_dumped && bitnet_rs_reference_layer_trace_path != nullptr && bitnet_rs_reference_layer_trace_path[0] != '\0' && lctx.n_outputs > 0 && !bitnet_rs_reference_layer_trace_is_warmup(lctx, ubatch, n_tokens, lctx.n_outputs)) {
-+            bitnet_rs_reference_layer_trace_dump(lctx, gf, ubatch, n_tokens, lctx.n_outputs, bitnet_rs_reference_layer_trace_path);
++        std::vector<std::string> bitnet_rs_reference_layer_trace_records;
++        bitnet_rs_reference_layer_trace_callback_context bitnet_rs_reference_layer_trace_ctx;
++        const bool bitnet_rs_reference_layer_trace_active =
++            !bitnet_rs_reference_layer_trace_dumped
++            && bitnet_rs_reference_layer_trace_path != nullptr
++            && bitnet_rs_reference_layer_trace_path[0] != '\0'
++            && lctx.n_outputs > 0
++            && !bitnet_rs_reference_layer_trace_is_warmup(lctx, ubatch, n_tokens, lctx.n_outputs);
++        if (bitnet_rs_reference_layer_trace_active) {
++            bitnet_rs_reference_layer_trace_ctx.lctx = &lctx;
++            bitnet_rs_reference_layer_trace_ctx.n_tokens = n_tokens;
++            bitnet_rs_reference_layer_trace_ctx.n_outputs = lctx.n_outputs;
++            bitnet_rs_reference_layer_trace_ctx.records = &bitnet_rs_reference_layer_trace_records;
++            bitnet_rs_reference_layer_trace_ctx.prior_cb_eval = lctx.cparams.cb_eval;
++            bitnet_rs_reference_layer_trace_ctx.prior_cb_eval_user_data = lctx.cparams.cb_eval_user_data;
++            for (int i = 0; i < ggml_graph_n_nodes(gf); ++i) {
++                bitnet_rs_reference_layer_trace_ctx.graph_indices[ggml_graph_node(gf, i)] = i;
++            }
++            ggml_backend_sched_set_eval_callback(lctx.sched, bitnet_rs_reference_layer_trace_eval_callback, &bitnet_rs_reference_layer_trace_ctx);
++        }
++
+         llama_graph_compute(lctx, gf, n_threads, threadpool);
+ 
++        if (bitnet_rs_reference_layer_trace_active) {
++            ggml_backend_sched_set_eval_callback(lctx.sched, lctx.cparams.cb_eval, lctx.cparams.cb_eval_user_data);
++            bitnet_rs_reference_layer_trace_dump(lctx, gf, ubatch, n_tokens, lctx.n_outputs, bitnet_rs_reference_layer_trace_path, &bitnet_rs_reference_layer_trace_records);
 +            bitnet_rs_reference_layer_trace_dumped = true;
 +        }
 +


### PR DESCRIPTION
## Summary
- capture target reference layer-trace tensors through the scheduler eval callback immediately after each target node computes
- record `capture_synchronization_policy=scheduler_eval_callback_after_each_target_node`
- keep the post-graph dump path as a fallback for precomputed records, and avoid reading `first_values` when tensor values are unavailable

## Target-local result
- reference layer trace run: `available=true`, `records=17`
- `inp_embd` RMS moved to `0.899372412` with sane embedding-scale values
- embedding row authority now reports `reference_trace_match=true` and `rust_loaded_match=true`
- next action moves past prompt embedding; remaining compare mismatch is a separate reference/Rust trace-scope alignment issue

## Not claims
- diagnostic only; `claim_allowed=false`
- no A770 semantic quality promotion
- no selected attention, resident KV, attention scores, softmax, value mix, full support residency, full device residency, or completion promotion

## Validation
- `git apply --check ..\..\..\..\..\ci\reference-instrumentation\bitnet-rs-layer-trace-main.patch` from `target\external\BitNet-reference\3rdparty\llama.cpp`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-run --format human`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-embedding-row-authority --reference target\a770-diagnostic\bitnet-reference-layer-trace-run.json --output target\a770-diagnostic\bitnet-reference-embedding-row-authority.json --format human`
- `git diff --check`