### PR TITLE
Close M4 BitNet productization

### DIFF
--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-bitnet-productization`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -54,7 +54,7 @@ broad BitNet quality, or broad Apple Silicon performance.
 | M4-BITNET-PROD-001 | merged | PR #4946 allowed `bitnet mac bitnet-warm` to run operator-supplied repeated prompts while keeping the fixed proof prompt default. |
 | M4-BITNET-PROD-002 | merged | PR #4950 recorded the 2026-05-15 bounded M4 variable warm-session receipt for five operator prompts with repeated-prompt determinism. |
 | M4-BITNET-PROD-003 | merged | PR #4954 added warm-session progress, timeout, partial-failure receipts, and repair guidance without enabling BitNet chat or serve. |
-| M4-BITNET-PROD-004 | in_progress | Define and enforce the BitNet chat enablement gate before enabling chat. |
+| M4-BITNET-PROD-004 | merged | PR #4957 defined and enforced the BitNet chat enablement gate before enabling chat. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/active.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-bitnet-productization"
 title = "Apple M4 BitNet productization"
-status = "active"
+status = "complete"
 
 objective = "Move Apple M4 BitNet from fixed one-shot and fixed-warm proof into operator-ready warm sessions, then chat and serve only after receipt-backed correctness, determinism, timeout, streaming, and failure-mode gates pass."
 
@@ -150,7 +150,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-BITNET-PROD-004"
-status = "in_progress"
+status = "merged"
+pr = 4957
+merge_sha = "695da886c7ae216dbc54edf03943e3f82ae5a225"
 branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-004-chat-gate"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/events/2026-05-15T171445Z-M4-BITNET-PROD-004-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/events/2026-05-15T171445Z-M4-BITNET-PROD-004-merged.toml
@@ -1,0 +1,41 @@
+timestamp = "2026-05-15T17:14:45Z"
+campaign = "apple-m4-bitnet-productization"
+item = "M4-BITNET-PROD-004"
+event = "merged"
+actor = "codex"
+from = "in_progress"
+to = "merged"
+pr = 4957
+head_sha = "6015f1b12ceaae8c336988c0050302d4eb8449a9"
+merge_sha = "695da886c7ae216dbc54edf03943e3f82ae5a225"
+branch = "codex/apple-m4-bitnet-productization/M4-BITNET-PROD-004-chat-gate"
+summary = "Closed M4-BITNET-PROD-004 after PR #4957 added the explicit BitNet mac chat gate and kept BitNet chat disabled."
+
+artifacts = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-bitnet-proof-prep.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/active.toml",
+  "docs/tracking/campaigns/apple-m4-bitnet-productization/CAMPAIGN.md",
+]
+
+notes = [
+  "`bitnet mac chat --model-family bitnet` fails before prompt collection and points to `bitnet mac bitnet-chat-gate`.",
+  "`bitnet mac bitnet-chat-gate` writes a `bitnet_apple_m4_chat_gate` receipt and validates the blocked gate shape through `mac receipts-check`.",
+  "The gate requires variable warm-session determinism, timeout/failure evidence, streaming-semantics evidence, and preserved chat/serve=false claim boundaries before any future BitNet chat route can be enabled.",
+  "BitNet chat and serve remain disabled; no full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad BitNet quality, or broad Apple Silicon claim was added.",
+  "All listed apple-m4-bitnet-productization work items are merged; the campaign is complete for this bounded warm-session and chat-gate scope.",
+]
+
+[evidence]
+route = "bitnet mac chat --model-family bitnet"
+gate_command = "bitnet mac bitnet-chat-gate"
+gate_artifact_kind = "bitnet_apple_m4_chat_gate"
+backend = "apple-m4-cpu-neon"
+runtime_api = "cpu"
+fallback_used = false
+chat_enabled = false
+serve_enabled = false
+next_item = "none"
+claim_boundary = "chat gate only; no BitNet chat, serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad BitNet quality, or broad Apple Silicon claim"

--- a/docs/tracking/campaigns/apple-m4-bitnet-productization/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-bitnet-productization/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 BitNet productization Campaign Status
 
 - Campaign: `apple-m4-bitnet-productization`
-- State: `active`
+- State: `complete`
 - Objective: Move Apple M4 BitNet from fixed one-shot and fixed-warm proof into operator-ready warm sessions, then chat and serve only after receipt-backed correctness, determinism, timeout, streaming, and failure-mode gates pass.
 
 ## Work Items
@@ -12,7 +12,7 @@
 | M4-BITNET-PROD-001 | merged | #4946 | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-001-variable-warm-prompts` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Allow `bitnet mac bitnet-warm` to run operator-supplied repeated prompts in one resident Apple M4 CPU/NEON BitNet process while preserving the fixed proof prompt default, accepted model/tokenizer checks, repeated-prompt determinism, per-turn receipts, aggregate prompt-source metadata, and disabled chat/serve/Metal/QK256/Neural Engine/MPSGraph/broad-claim boundaries. |
 | M4-BITNET-PROD-002 | merged | #4950 | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-002-variable-warm-runtime` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run the operator-prompt BitNet warm route on the M4 Mac mini with accepted model/tokenizer identity, at least five variable prompts including one exact repeat, fallback_used=false, generated text/token IDs, repeated-prompt determinism, per-turn and aggregate timing/memory receipts, timeout boundary, and no chat/serve/Metal/broad claims. |
 | M4-BITNET-PROD-003 | merged | #4954 | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-003-timeout-failure-ux` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add BitNet warm-session progress, timeout, and partial-failure receipts that identify model load, tokenizer load, prefill, first-token, decode, and receipt-write stages with repair guidance, while preserving disabled chat/serve/Metal/broad-claim boundaries. |
-| M4-BITNET-PROD-004 | in_progress | TBD | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-004-chat-gate` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define and enforce the BitNet chat enablement gate from variable warm-session receipts, repeated-prompt determinism, timeout/failure evidence, streaming semantics, and claim boundaries before any `bitnet mac chat --model-family bitnet` route is enabled. |
+| M4-BITNET-PROD-004 | merged | #4957 | `codex/apple-m4-bitnet-productization/M4-BITNET-PROD-004-chat-gate` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define and enforce the BitNet chat enablement gate from variable warm-session receipts, repeated-prompt determinism, timeout/failure evidence, streaming semantics, and claim boundaries before any `bitnet mac chat --model-family bitnet` route is enabled. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -45,7 +45,7 @@
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | M4-BITNET-EVAL-003, M4-BITNET-EVAL-004 | merged |
 | apple-m4-bitnet-productization | M4-BITNET-PROD-002 | M4-BITNET-PROD-001 | merged |
 | apple-m4-bitnet-productization | M4-BITNET-PROD-003 | M4-BITNET-PROD-002 | merged |
-| apple-m4-bitnet-productization | M4-BITNET-PROD-004 | M4-BITNET-PROD-002, M4-BITNET-PROD-003 | in_progress |
+| apple-m4-bitnet-productization | M4-BITNET-PROD-004 | M4-BITNET-PROD-002, M4-BITNET-PROD-003 | merged |
 | apple-m4-continuity | M4-CONT-002 | M4-CONT-001 | merged |
 | apple-m4-continuity | M4-CONT-003 | M4-CONT-002 | merged |
 | apple-m4-continuity | M4-CONT-004 | M4-CONT-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -8,7 +8,7 @@
 | apple-m3-macbook-air | M3MBA-007 | TBD | proposed | M3MBA-008 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-bitnet-eval-and-benchmark | M4-BITNET-EVAL-005 | #4942 | merged | none | This is an M4 Mac mini BitNet campaign. |
-| apple-m4-bitnet-productization | M4-BITNET-PROD-004 | TBD | in_progress | none | This is an M4 Mac mini BitNet campaign. |
+| apple-m4-bitnet-productization | M4-BITNET-PROD-004 | #4957 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |


### PR DESCRIPTION
## Summary
- mark `M4-BITNET-PROD-004` merged after PR #4957
- mark `apple-m4-bitnet-productization` complete for the listed warm-session and chat-gate scope
- add the closeout event with PR/merge SHA evidence
- regenerate campaign dashboards and confirm `campaign next` is `none`

## Claim boundaries
Tracker-only closeout. BitNet chat and serve remain disabled. No runtime, model, Metal, QK256, Neural Engine, MPSGraph, MacBook, broad BitNet quality, broad Apple Silicon, performance, or speedup claim changes.

## Validation
- `cargo run --locked -p xtask --no-default-features -- campaign generate`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-bitnet-productization`
- `cargo run --locked -p xtask --no-default-features -- campaign next apple-m4-bitnet-productization`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
