### PR TITLE
Add M4 inference status receipt

### DIFF
--- a/crates/bitnet-cli/src/mac.rs
+++ b/crates/bitnet-cli/src/mac.rs
@@ -24,6 +24,7 @@ const MAC_ASK_DEFAULT_RECEIPT: &str = "target/apple-m4-productization/mac-ask.js
 const MAC_CHAT_DEFAULT_RECEIPT: &str = "target/apple-m4-continuity/mac-chat.json";
 const MAC_SMOKE_DEFAULT_RECEIPT: &str = "target/apple-m4-continuity/mac-smoke.json";
 const MAC_DOCTOR_DEFAULT_RECEIPT: &str = "target/apple-m4-slm-excellence/mac-doctor.json";
+const MAC_STATUS_DEFAULT_RECEIPT: &str = "target/apple-m4-inference-ops/mac-status.json";
 const MAC_BITNET_WARM_DEFAULT_RECEIPT: &str = "target/apple-m4-local-answer/mac-bitnet-warm.json";
 const MAC_BITNET_BENCHMARK_DEFAULT_RECEIPT: &str =
     "target/apple-m4-bitnet-eval-and-benchmark/bitnet-benchmark/summary.json";
@@ -160,6 +161,21 @@ enum MacAction {
         /// Emit JSON instead of text.
         #[arg(long, default_value_t = false)]
         json: bool,
+    },
+
+    /// Summarize Apple M4 dense SLM, BitNet, disk/cache, receipt, and command readiness.
+    Status {
+        /// Override model cache root. Defaults to ~/.cache/bitnet-rs/models.
+        #[arg(long, value_name = "PATH")]
+        cache_dir: Option<PathBuf>,
+
+        /// Emit JSON to stdout after writing --json-out.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+
+        /// Output strict Mac status receipt.
+        #[arg(long, value_name = "PATH", default_value = MAC_STATUS_DEFAULT_RECEIPT)]
+        json_out: PathBuf,
     },
 
     /// Check the cached Apple M4 SLM model artifact and routing boundary.
@@ -789,6 +805,10 @@ impl MacCommand {
                 ensure_supported_mac_device(explicit_device_label, "mac models")?;
                 model_cache::list_apple_m4_models(cache_dir, json)
             }
+            MacAction::Status { cache_dir, json, json_out } => {
+                ensure_supported_mac_device(explicit_device_label, "mac status")?;
+                run_status(cache_dir, json_out, json)
+            }
             MacAction::Check { model_id, cache_dir, json } => {
                 ensure_supported_mac_device(explicit_device_label, "mac check")?;
                 run_check(&model_id, cache_dir, json)
@@ -1132,6 +1152,203 @@ fn resolve_mac_question(positional: Option<String>, flag: Option<String>) -> Res
         _ => anyhow::bail!(
             "missing Mac question; pass it positionally, e.g. `bitnet mac ask \"What is 2+2?\"`, or with --question"
         ),
+    }
+}
+
+fn run_status(cache_dir: Option<PathBuf>, json_out: PathBuf, json: bool) -> Result<()> {
+    let catalog = model_cache::apple_m4_models_catalog_json(cache_dir.clone())
+        .context("failed to build Apple M4 model catalog for mac status")?;
+    let bitnet = bitnet_mac_ask_readiness_json(cache_dir);
+    let receipt = apple_m4_inference_status_receipt(&json_out, catalog, bitnet);
+    validate_mac_receipt_value(&json_out, &receipt)?;
+    write_json_receipt(&json_out, &receipt)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&receipt)?);
+    } else {
+        print_mac_status_summary(&receipt, &json_out);
+    }
+    Ok(())
+}
+
+fn apple_m4_inference_status_receipt(
+    json_out: &Path,
+    catalog: serde_json::Value,
+    bitnet: serde_json::Value,
+) -> serde_json::Value {
+    let rows = catalog["rows"].as_array().cloned().unwrap_or_default();
+    let dense_rows = rows
+        .iter()
+        .filter(|row| matches!(row["state"].as_str(), Some("default" | "supported")))
+        .cloned()
+        .collect::<Vec<_>>();
+    let dense_ready =
+        dense_rows.iter().filter(|row| row["cache_state"].as_str() == Some("ready")).count();
+    let supported_dense_model_ids = dense_rows
+        .iter()
+        .filter_map(|row| row["id"].as_str().map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
+    let default_model_id = catalog["default_model_id"]
+        .as_str()
+        .unwrap_or(model_cache::M4_SLM_RUNTIME_MODEL_ID)
+        .to_string();
+    let default_row = rows
+        .iter()
+        .find(|row| row["id"].as_str() == Some(default_model_id.as_str()))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let default_cache_ready = default_row["cache_state"].as_str() == Some("ready");
+    let disk_available = catalog["disk"]["available"].clone();
+    let disk_low = catalog["disk"]["low_disk"].clone();
+    let recommended_first_model_id = catalog["disk"]["recommended_first_model_id"].clone();
+    let commands = serde_json::json!({
+        "models": "bitnet mac models",
+        "status": "bitnet mac status",
+        "fetch_default": format!("bitnet model fetch {default_model_id}"),
+        "verify_default": format!("bitnet model verify {default_model_id}"),
+        "ask_default": "bitnet mac ask \"What is 2+2?\"",
+        "chat_dense": "bitnet mac chat --prompt \"What is 2+2?\" --prompt \"Name the capital of France.\"",
+        "serve_dense": "bitnet mac serve --host 127.0.0.1 --port 8080",
+        "doctor": "bitnet mac doctor",
+        "smoke_dense": "bitnet mac smoke",
+        "smoke_bitnet": "bitnet mac smoke --model-family bitnet",
+        "regression": "bitnet mac regression <receipt.json> --baseline <baseline.json>",
+        "bitnet_ask": bitnet["commands"]["ask_cached_model"].clone(),
+        "bitnet_warm": bitnet["commands"]["warm_cached_model"].clone(),
+        "bitnet_chat_gate": "bitnet mac bitnet-chat-gate --warm-receipt <warm.json> --failure-receipt <failure.json> --streaming-receipt <streaming.json>",
+    });
+    serde_json::json!({
+        "schema_version": "1.0.0",
+        "artifact_kind": "apple_m4_inference_status",
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "operator_command": "mac status",
+        "status": "ok",
+        "receipt_path": json_out,
+        "requested_backend": APPLE_M4_CPU_NEON,
+        "selected_backend": APPLE_M4_CPU_NEON,
+        "runtime_api": "cpu",
+        "fallback_used": false,
+        "machine": {
+            "id": "apple-m4-mac-mini",
+            "scope": "local operator readiness summary",
+        },
+        "disk": {
+            "available": disk_available,
+            "low_disk": disk_low,
+            "recommendation": catalog["disk"]["recommendation"].clone(),
+            "guidance": catalog["disk"]["guidance"].clone(),
+            "recommended_first_model_id": recommended_first_model_id,
+        },
+        "dense_slm": {
+            "default_model_id": default_model_id,
+            "supported_model_ids": supported_dense_model_ids,
+            "supported_model_count": dense_rows.len(),
+            "ready_model_count": dense_ready,
+            "default_cache_ready": default_cache_ready,
+            "default_row": default_row,
+            "ask_enabled": true,
+            "chat_enabled": true,
+            "serve_enabled": true,
+            "claim_boundary": {
+                "dense_slm_only": true,
+                "supported_qwen_models_only": true,
+                "broad_model_quality_claim": false,
+                "broad_performance_claim": false,
+            },
+        },
+        "bitnet": {
+            "readiness": bitnet,
+            "ask_enabled": true,
+            "warm_enabled": true,
+            "chat_enabled": false,
+            "serve_enabled": false,
+            "claim_boundary": bitnet_mac_ask_readiness_claim_boundary(),
+        },
+        "report_inventory": apple_m4_report_inventory_json(),
+        "commands": commands,
+        "claim_boundary": {
+            "status_only": true,
+            "no_live_model_run": true,
+            "fallback_used": false,
+            "dense_slm_and_bitnet_evidence_separated": true,
+            "bitnet_chat_enabled": false,
+            "bitnet_serve_enabled": false,
+            "full_metal_inference_claimed": false,
+            "qk256_apple_claimed": false,
+            "neural_engine_execution_claimed": false,
+            "mpsgraph_inference_claimed": false,
+            "macbook_evidence": false,
+            "broad_apple_silicon_claim": false,
+            "broad_performance_claim": false,
+            "speedup_claim": false,
+        },
+    })
+}
+
+fn print_mac_status_summary(receipt: &serde_json::Value, json_out: &Path) {
+    let dense = &receipt["dense_slm"];
+    let disk = &receipt["disk"];
+    let bitnet = &receipt["bitnet"];
+    println!("Apple M4 inference status: {}", receipt["status"].as_str().unwrap_or("unknown"));
+    println!(
+        "Disk: available={}, low_disk={}, recommendation={}",
+        disk["available"].as_str().unwrap_or("unknown"),
+        disk["low_disk"]
+            .as_bool()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
+        disk["recommendation"].as_str().unwrap_or("unknown")
+    );
+    println!(
+        "Dense SLM: default={}, ready={}/{}, ask=true, chat=true, serve=true",
+        dense["default_model_id"].as_str().unwrap_or("<unknown>"),
+        dense["ready_model_count"].as_u64().unwrap_or(0),
+        dense["supported_model_count"].as_u64().unwrap_or(0)
+    );
+    println!(
+        "BitNet: ask={}, warm={}, chat=false, serve=false, ready={}",
+        bitnet["ask_enabled"].as_bool().unwrap_or(false),
+        bitnet["warm_enabled"].as_bool().unwrap_or(false),
+        bitnet["readiness"]["ready"].as_bool().unwrap_or(false)
+    );
+    println!("Next: {}", receipt["commands"]["models"].as_str().unwrap_or("bitnet mac models"));
+    println!("Receipt: {}", json_out.display());
+    println!(
+        "Claim boundary: status only; no live model run, no BitNet chat/serve, no full Metal/QK256/Neural Engine/MPSGraph/MacBook/broad performance claim."
+    );
+}
+
+fn apple_m4_report_inventory_json() -> serde_json::Value {
+    let root = Path::new("ci/hardware/apple-m4-mac-mini");
+    serde_json::json!({
+        "root": root,
+        "dense_slm_eval_v2": latest_matching_report(root, "slm-eval-v2", "summary.json"),
+        "dense_slm_benchmark_v2": latest_matching_report(root, "slm-benchmark-v2", "summary.json"),
+        "bitnet_eval": latest_matching_report(root, "bitnet-eval", "answer-corpus.json"),
+        "bitnet_benchmark": latest_matching_report(root, "bitnet-benchmark", "summary.json"),
+        "bitnet_variable_warm": latest_matching_report(root, "bitnet-productization", "variable-warm-session.json"),
+    })
+}
+
+fn latest_matching_report(root: &Path, segment: &str, filename: &str) -> Option<String> {
+    let mut matches = Vec::new();
+    collect_matching_reports(root, segment, filename, &mut matches);
+    matches.sort();
+    matches.pop().map(|path| path.to_string_lossy().to_string())
+}
+
+fn collect_matching_reports(root: &Path, segment: &str, filename: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_matching_reports(&path, segment, filename, out);
+        } else if path.file_name().and_then(|name| name.to_str()) == Some(filename)
+            && path.components().any(|component| component.as_os_str() == segment)
+        {
+            out.push(path);
+        }
     }
 }
 
@@ -9766,6 +9983,8 @@ fn validate_mac_receipt_value(
         validate_bitnet_warm_session_failure_receipt(path, receipt)?
     } else if artifact_kind == "bitnet_apple_m4_chat_gate" {
         validate_bitnet_chat_gate_receipt(path, receipt)?
+    } else if artifact_kind == "apple_m4_inference_status" {
+        validate_apple_m4_inference_status_receipt(path, receipt)?
     } else {
         validate_one_shot_receipt(path, receipt)?
     };
@@ -10117,6 +10336,84 @@ fn validate_bitnet_chat_gate_receipt(
     )?;
     require_bool_at(path, receipt, &["mac_bitnet_claim_boundary", "speedup_claim"], false)?;
     require_bool_at(path, receipt, &["bitnet_quality_claimed"], false)?;
+    Ok((Some(0), Some(0)))
+}
+
+fn validate_apple_m4_inference_status_receipt(
+    path: &Path,
+    receipt: &serde_json::Value,
+) -> Result<(Option<usize>, Option<usize>)> {
+    require_exact_string_at(path, receipt, &["schema_version"], "1.0.0")?;
+    require_exact_string_at(path, receipt, &["artifact_kind"], "apple_m4_inference_status")?;
+    require_exact_string_at(path, receipt, &["operator_command"], "mac status")?;
+    require_exact_string_at(path, receipt, &["machine", "id"], "apple-m4-mac-mini")?;
+    require_bool_at(path, receipt, &["claim_boundary", "status_only"], true)?;
+    require_bool_at(path, receipt, &["claim_boundary", "no_live_model_run"], true)?;
+    require_bool_at(
+        path,
+        receipt,
+        &["claim_boundary", "dense_slm_and_bitnet_evidence_separated"],
+        true,
+    )?;
+    require_bool_at(path, receipt, &["claim_boundary", "bitnet_chat_enabled"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "bitnet_serve_enabled"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "full_metal_inference_claimed"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "qk256_apple_claimed"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "neural_engine_execution_claimed"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "mpsgraph_inference_claimed"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "macbook_evidence"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "broad_apple_silicon_claim"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "broad_performance_claim"], false)?;
+    require_bool_at(path, receipt, &["claim_boundary", "speedup_claim"], false)?;
+
+    require_non_empty_string_at(path, receipt, &["dense_slm", "default_model_id"])?;
+    let supported_count =
+        require_u64_at(path, receipt, &["dense_slm", "supported_model_count"], true)?;
+    let ready_count = require_u64_at(path, receipt, &["dense_slm", "ready_model_count"], false)?;
+    if ready_count > supported_count {
+        anyhow::bail!(
+            "{} M4 inference status ready_model_count must not exceed supported_model_count",
+            path.display()
+        );
+    }
+    require_bool_at(path, receipt, &["dense_slm", "ask_enabled"], true)?;
+    require_bool_at(path, receipt, &["dense_slm", "chat_enabled"], true)?;
+    require_bool_at(path, receipt, &["dense_slm", "serve_enabled"], true)?;
+    require_bool_at(
+        path,
+        receipt,
+        &["dense_slm", "claim_boundary", "broad_model_quality_claim"],
+        false,
+    )?;
+    require_bool_at(
+        path,
+        receipt,
+        &["dense_slm", "claim_boundary", "broad_performance_claim"],
+        false,
+    )?;
+
+    require_bool_at(path, receipt, &["bitnet", "ask_enabled"], true)?;
+    require_bool_at(path, receipt, &["bitnet", "warm_enabled"], true)?;
+    require_bool_at(path, receipt, &["bitnet", "chat_enabled"], false)?;
+    require_bool_at(path, receipt, &["bitnet", "serve_enabled"], false)?;
+    require_bool_at(path, receipt, &["bitnet", "claim_boundary", "chat_enabled"], false)?;
+    require_bool_at(path, receipt, &["bitnet", "claim_boundary", "serve_enabled"], false)?;
+    require_bool_at(path, receipt, &["bitnet", "claim_boundary", "bitnet_quality_claimed"], false)?;
+
+    for field in [
+        "models",
+        "status",
+        "ask_default",
+        "chat_dense",
+        "serve_dense",
+        "doctor",
+        "smoke_dense",
+        "regression",
+        "bitnet_chat_gate",
+    ] {
+        require_non_empty_string_at(path, receipt, &["commands", field])?;
+    }
+    require_non_empty_string_at(path, receipt, &["report_inventory", "root"])?;
     Ok((Some(0), Some(0)))
 }
 

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -304,6 +304,7 @@ fn mac_help_documents_operator_wrappers() {
         .assert()
         .success()
         .stdout(predicate::str::contains("models"))
+        .stdout(predicate::str::contains("status"))
         .stdout(predicate::str::contains("check"))
         .stdout(predicate::str::contains("ask"))
         .stdout(predicate::str::contains("smoke"))
@@ -414,6 +415,60 @@ fn mac_models_json_exposes_claim_boundaries_without_fetching()
     }));
     assert!(rows.iter().any(|row| row["state"] == "candidate"));
     assert!(rows.iter().any(|row| row["state"] == "rejected"));
+    Ok(())
+}
+
+#[test]
+fn mac_status_writes_operator_readiness_receipt() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let cache = dir.path().join("models");
+    let receipt = dir.path().join("mac-status.json");
+    let cache_str = cache.to_string_lossy().into_owned();
+    let receipt_str = receipt.to_string_lossy().into_owned();
+
+    bitnet()
+        .args([
+            "mac",
+            "status",
+            "--cache-dir",
+            cache_str.as_str(),
+            "--json-out",
+            receipt_str.as_str(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Apple M4 inference status"))
+        .stdout(predicate::str::contains("Dense SLM:"))
+        .stdout(predicate::str::contains("BitNet:"))
+        .stdout(predicate::str::contains("no live model run"));
+
+    let receipt_json: serde_json::Value = serde_json::from_slice(&std::fs::read(&receipt)?)?;
+    assert_eq!(receipt_json["artifact_kind"], "apple_m4_inference_status");
+    assert_eq!(receipt_json["operator_command"], "mac status");
+    assert_eq!(receipt_json["fallback_used"], false);
+    assert_eq!(receipt_json["dense_slm"]["supported_model_count"], 3);
+    assert_eq!(receipt_json["dense_slm"]["ask_enabled"], true);
+    assert_eq!(receipt_json["dense_slm"]["chat_enabled"], true);
+    assert_eq!(receipt_json["dense_slm"]["serve_enabled"], true);
+    assert_eq!(receipt_json["bitnet"]["ask_enabled"], true);
+    assert_eq!(receipt_json["bitnet"]["warm_enabled"], true);
+    assert_eq!(receipt_json["bitnet"]["chat_enabled"], false);
+    assert_eq!(receipt_json["bitnet"]["serve_enabled"], false);
+    assert_eq!(receipt_json["claim_boundary"]["no_live_model_run"], true);
+    assert_eq!(receipt_json["claim_boundary"]["dense_slm_and_bitnet_evidence_separated"], true);
+    assert_eq!(receipt_json["claim_boundary"]["full_metal_inference_claimed"], false);
+    assert!(
+        receipt_json["commands"]["bitnet_chat_gate"]
+            .as_str()
+            .is_some_and(|command| command.contains("bitnet mac bitnet-chat-gate"))
+    );
+
+    bitnet()
+        .args(["mac", "receipts-check", receipt_str.as_str(), "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apple_m4_inference_status"))
+        .stdout(predicate::str::contains("\"prompt_count\": 0"));
     Ok(())
 }
 

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__mac_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__mac_help.snap
@@ -9,10 +9,12 @@ Usage: bitnet mac [OPTIONS] <COMMAND>
 
 Commands:
   models            List Apple M4 model states, cache status, and selection guidance
+  status            Summarize Apple M4 dense SLM, BitNet, disk/cache, receipt, and command readiness
   check             Check the cached Apple M4 SLM model artifact and routing boundary
   ask               Ask one question through the Rust-native Apple M4 CPU/NEON SLM path
   smoke             Run a compact Apple M4 model-family health smoke with cache and receipt checks
-  bitnet-warm       Run fixed BitNet prompts in one warm Apple M4 CPU/NEON process without enabling chat
+  bitnet-warm       Run BitNet prompts in one warm Apple M4 CPU/NEON process without enabling chat
+  bitnet-chat-gate  Evaluate the receipt-backed gate for future BitNet Mac chat without enabling chat
   bitnet-benchmark  Benchmark BitNet one-shot ask and fixed warm paths without enabling chat or serve
   doctor            Run one local health verdict for the supported Apple M4 dense-SLM path
   serve             Serve local M4 dense-SLM health and readiness endpoints without generation
@@ -22,7 +24,7 @@ Commands:
   benchmark         Run release-mode dense SLM benchmark profiles for v2 M4 receipts
   bitnet-proof      Validate M4 BitNet proof inputs without enabling BitNet chat/serve routing
   receipts-check    Check Apple M4 SLM answer/warm-session receipts for hidden fallback or overclaims
-  regression        Compare Apple M4 dense-SLM receipts against a stored local envelope
+  regression        Compare Apple M4 dense-SLM or BitNet receipts against a stored local envelope
   help              Print this message or the help of the given subcommand(s)
 
 Options:

--- a/docs/slm/apple-m4-inference-ops.md
+++ b/docs/slm/apple-m4-inference-ops.md
@@ -1,0 +1,63 @@
+# Apple M4 Inference Ops
+
+This page tracks the operator layer above the completed Apple M4 dense SLM,
+server, Metal phase, BitNet local-answer, BitNet eval/benchmark, and BitNet
+productization campaigns. The goal is to make the Mac mini easy to operate and
+easy to audit without turning generic PR CI into live hardware evaluation.
+
+## Status Receipt
+
+`M4-INF-OPS-001` adds a model-free status command:
+
+```bash
+bitnet mac status
+```
+
+The command writes an `apple_m4_inference_status` receipt to
+`target/apple-m4-inference-ops/mac-status.json` by default. It summarizes:
+
+- disk/cache recommendation from `bitnet mac models`;
+- dense SLM default/support/cache readiness and ask/chat/serve availability;
+- BitNet ask/warm readiness and explicit disabled chat/serve state;
+- current local report inventory for dense eval v2, dense benchmark v2, BitNet
+  eval, BitNet benchmark, and variable warm-session evidence;
+- known operator commands for model fetch/verify, ask, chat, serve, doctor,
+  smoke, regression, BitNet warm, and the BitNet chat gate.
+
+The status receipt is not a live model run. It records
+`requested_backend=apple-m4-cpu-neon`, `runtime_api=cpu`, `fallback_used=false`,
+and an explicit claim boundary:
+
+```text
+status_only=true
+no_live_model_run=true
+dense_slm_and_bitnet_evidence_separated=true
+bitnet_chat_enabled=false
+bitnet_serve_enabled=false
+full_metal_inference_claimed=false
+qk256_apple_claimed=false
+neural_engine_execution_claimed=false
+mpsgraph_inference_claimed=false
+macbook_evidence=false
+broad_apple_silicon_claim=false
+broad_performance_claim=false
+speedup_claim=false
+```
+
+Validate the receipt with:
+
+```bash
+bitnet mac receipts-check target/apple-m4-inference-ops/mac-status.json --json
+```
+
+## Remaining Ops Work
+
+The remaining inference-ops lane should stay model-free in generic PR CI:
+
+- refresh advisory/nightly report manifests from committed M4 receipt bundles;
+- build compact regression dashboard artifacts across dense SLM and BitNet
+  reports while preserving separate evidence families;
+- publish an operator envelope v2 that maps supported commands to receipt
+  requirements and claim boundaries.
+
+Live M4 model runs belong in local, advisory, scheduled, or release lanes.

--- a/docs/slm/apple-m4-mini-user-expectation-envelope.md
+++ b/docs/slm/apple-m4-mini-user-expectation-envelope.md
@@ -11,6 +11,7 @@ Primary commands:
 
 ```bash
 bitnet mac models
+bitnet mac status
 bitnet mac ask "What is 2+2?"
 bitnet mac chat
 bitnet mac smoke
@@ -27,6 +28,12 @@ supported model when disk headroom is adequate. The BitNet row includes receipt
 bridge commands for validating the strict `answer-corpus` proof and the
 fixed-prompt warm-session proof. It is limited to explicit one-shot ask or
 fixed-prompt warm reuse with a verified GGUF plus external tokenizer:
+
+`bitnet mac status` is the model-free operator summary. It writes an
+`apple_m4_inference_status` receipt with disk/cache posture, dense SLM readiness,
+BitNet ask/warm readiness, local report inventory, supported command examples,
+and explicit claim boundaries. It does not run live inference and keeps BitNet
+chat and serve disabled.
 
 ```bash
 bitnet mac ask \

--- a/docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md
@@ -1,0 +1,48 @@
+# Apple M4 Inference Ops Campaign
+
+Campaign ID: `apple-m4-inference-ops`
+
+Status: active
+
+## Objective
+
+Turn the completed Apple M4 dense SLM and BitNet proof surfaces into a durable
+operator layer: status, report inventory, advisory refresh, regression
+dashboarding, disk/cache posture, and an operator envelope v2 with explicit
+claim boundaries.
+
+## Scope Boundary
+
+This is an M4 Mac mini operations campaign. It consumes existing dense SLM and
+BitNet evidence but does not reopen completed runtime proof campaigns. It must
+not use dense Qwen evidence as BitNet evidence, and it must not enable BitNet
+chat or serve.
+
+No generic required PR check may download models, run live M4 inference, run
+long resident soaks, or claim broad performance. Live M4 refreshes stay local,
+advisory, scheduled, or release-only.
+
+## End State
+
+- `bitnet mac status` gives operators one receipt-backed readiness summary.
+- Advisory/nightly report refresh manifests cover dense SLM and BitNet report
+  families without mixing claim scopes.
+- Regression dashboard artifacts compare matching reports over time for
+  quality, TTFT, input/output/decode throughput, memory, and reliability drift.
+- Operator envelope v2 maps supported M4 commands to model/tokenizer/backend/
+  fallback/timing/memory/token-ID receipt requirements and claim boundaries.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-INF-OPS-001 | in_progress | Add `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and claim boundaries. |
+| M4-INF-OPS-002 | proposed | Add advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families. |
+| M4-INF-OPS-003 | proposed | Add compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families separate. |
+| M4-INF-OPS-004 | proposed | Publish operator envelope v2 mapping commands to receipts, gates, and unsupported claims. |
+
+## Review Policy
+
+Each PR owns one item. Parser, schema, fixture, and receipt validation belong in
+generic CI. Live model execution and timing refreshes belong in local,
+advisory, scheduled, or release lanes.

--- a/docs/tracking/campaigns/apple-m4-inference-ops/active.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/active.toml
@@ -1,0 +1,153 @@
+id = "apple-m4-inference-ops"
+title = "Apple M4 inference ops"
+status = "active"
+
+objective = "Turn the completed Apple M4 dense SLM and BitNet proof surfaces into a durable operator layer: status, report inventory, advisory refresh, regression dashboarding, disk/cache posture, and an operator envelope v2 with explicit claim boundaries."
+
+end_state = [
+  "`bitnet mac status` gives operators one receipt-backed readiness summary.",
+  "Advisory/nightly report refresh manifests cover dense SLM and BitNet report families without mixing claim scopes.",
+  "Regression dashboard artifacts compare matching reports over time for quality, TTFT, input/output/decode throughput, memory, and reliability drift.",
+  "Operator envelope v2 maps supported M4 commands to model/tokenizer/backend/fallback/timing/memory/token-ID receipt requirements and claim boundaries.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini operations campaign.",
+  "Do not reopen completed Apple M4 dense SLM, local server, Metal phase, BitNet local-answer, BitNet eval/benchmark, or BitNet productization campaigns unless a regression proves they are wrong.",
+  "Do not use dense Qwen evidence as BitNet evidence.",
+  "Do not enable BitNet chat or BitNet serve in this campaign.",
+  "Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, broad Apple Silicon performance, or speedup.",
+  "Do not add live model downloads, hardware timing runs, or long resident soaks to generic required PR CI.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "M4-INF-OPS-001"
+status = "in_progress"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-001-mac-status"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and explicit claim boundaries without running live inference."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_status",
+  "cargo test --locked -p bitnet-cli --test cli_snapshot_tests mac_help",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__mac_help.snap",
+  "docs/slm/apple-m4-inference-ops.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-inference-ops/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "`bitnet mac status` emits a model-free M4 inference readiness receipt.",
+]
+must_not_claim = [
+  "A live M4 model run was executed.",
+  "BitNet chat or serve is enabled.",
+  "Broad model quality or performance is proven.",
+]
+
+[[work_item]]
+id = "M4-INF-OPS-002"
+status = "proposed"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-002-report-refresh"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-INF-OPS-001"]
+acceptance = "Add advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families without running live models in generic PR CI."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops",
+]
+allowed_paths = [
+  ".github/workflows/**",
+  "crates/bitnet-cli/**",
+  "docs/slm/apple-m4-inference-ops.md",
+  "docs/tracking/campaigns/apple-m4-inference-ops/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "M4 report refresh manifests can be generated without live model runs in generic PR CI.",
+]
+must_not_claim = [
+  "Fresh live M4 performance was measured.",
+]
+
+[[work_item]]
+id = "M4-INF-OPS-003"
+status = "proposed"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-003-regression-dashboard"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-INF-OPS-002"]
+acceptance = "Add compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families, model identity, tokenizer authority, backend, fallback, and claim boundaries separate."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "docs/slm/apple-m4-inference-ops.md",
+  "docs/tracking/campaigns/apple-m4-inference-ops/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "M4 ops dashboards can compare matching dense SLM and BitNet report families separately.",
+]
+must_not_claim = [
+  "Dense SLM evidence proves BitNet behavior.",
+]
+
+[[work_item]]
+id = "M4-INF-OPS-004"
+status = "proposed"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-INF-OPS-003"]
+acceptance = "Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops",
+]
+allowed_paths = [
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-inference-ops/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The M4 operator envelope v2 maps commands to receipt requirements and claim boundaries.",
+]
+must_not_claim = [
+  "Any unsupported runtime capability is enabled.",
+]

--- a/docs/tracking/campaigns/apple-m4-inference-ops/events/2026-05-15T172206Z-M4-INF-OPS-001-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/events/2026-05-15T172206Z-M4-INF-OPS-001-in-progress.toml
@@ -1,0 +1,30 @@
+timestamp = "2026-05-15T17:22:06Z"
+campaign = "apple-m4-inference-ops"
+item = "M4-INF-OPS-001"
+event = "in_progress"
+actor = "codex"
+from = "proposed"
+to = "in_progress"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-001-mac-status"
+summary = "Started model-free Apple M4 inference status receipt work."
+
+artifacts = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "docs/slm/apple-m4-inference-ops.md",
+  "docs/tracking/campaigns/apple-m4-inference-ops/active.toml",
+  "docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md",
+]
+
+notes = [
+  "The status command must summarize dense SLM, BitNet, disk/cache, report inventory, and operator commands without running live inference.",
+  "The status receipt must keep dense SLM and BitNet evidence separated.",
+  "BitNet chat and serve remain disabled; no full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad model quality, or broad Apple Silicon claim is allowed.",
+]
+
+[evidence]
+route = "bitnet mac status"
+artifact_kind = "apple_m4_inference_status"
+backend = "apple-m4-cpu-neon"
+fallback_used = false
+claim_boundary = "status only; no live model run, BitNet chat, serve, full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad model quality, or broad Apple Silicon claim"

--- a/docs/tracking/campaigns/apple-m4-inference-ops/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/generated/status.md
@@ -1,0 +1,25 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 inference ops Campaign Status
+
+- Campaign: `apple-m4-inference-ops`
+- State: `active`
+- Objective: Turn the completed Apple M4 dense SLM and BitNet proof surfaces into a durable operator layer: status, report inventory, advisory refresh, regression dashboarding, disk/cache posture, and an operator envelope v2 with explicit claim boundaries.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-INF-OPS-001 | in_progress | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-001-mac-status` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and explicit claim boundaries without running live inference. |
+| M4-INF-OPS-002 | proposed | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-002-report-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families without running live models in generic PR CI. |
+| M4-INF-OPS-003 | proposed | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-003-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families, model identity, tokenizer authority, backend, fallback, and claim boundaries separate. |
+| M4-INF-OPS-004 | proposed | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini operations campaign.
+- Do not reopen completed Apple M4 dense SLM, local server, Metal phase, BitNet local-answer, BitNet eval/benchmark, or BitNet productization campaigns unless a regression proves they are wrong.
+- Do not use dense Qwen evidence as BitNet evidence.
+- Do not enable BitNet chat or BitNet serve in this campaign.
+- Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, broad Apple Silicon performance, or speedup.
+- Do not add live model downloads, hardware timing runs, or long resident soaks to generic required PR CI.
+- Never commit model binaries.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -54,6 +54,9 @@
 | apple-m4-dense-slm-regression | M4-SLM-REG-003 | M4-SLM-REG-002 | merged |
 | apple-m4-dense-slm-regression | M4-SLM-REG-004 | M4-SLM-REG-003 | merged |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | M4-SLM-REG-004 | merged |
+| apple-m4-inference-ops | M4-INF-OPS-002 | M4-INF-OPS-001 | proposed |
+| apple-m4-inference-ops | M4-INF-OPS-003 | M4-INF-OPS-002 | proposed |
+| apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | proposed |
 | apple-m4-local-answer | M4-QA-MODEL-001 | M4-QA-ROOT-001 | merged |
 | apple-m4-local-answer | M4-QA-MODEL-002 | M4-QA-MODEL-001 | merged |
 | apple-m4-local-answer | M4-QA-002 | M4-QA-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,6 +11,7 @@
 | apple-m4-bitnet-productization | M4-BITNET-PROD-004 | #4957 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
+| apple-m4-inference-ops | M4-INF-OPS-001 | TBD | in_progress | M4-INF-OPS-002 | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | M4-SERVE-005 | #4374 | merged | none | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -11,6 +11,7 @@
 | apple-m4-bitnet-productization | Apple M4 BitNet productization | M4-BITNET-PROD-004 | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | Apple M4 continuity | M4-CONT-005 | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
+| apple-m4-inference-ops | Apple M4 inference ops | M4-INF-OPS-001 | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | Apple M4 local answer usability | M4-BITNET-WARM-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | Apple M4 local server | M4-SERVE-005 | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | Apple M4 operational readiness | M4-OP-006 | Do not reopen the completed apple-m4 proof campaign. |


### PR DESCRIPTION
## Summary
- add the `apple-m4-inference-ops` campaign
- add `bitnet mac status` with a model-free `apple_m4_inference_status` receipt
- summarize dense SLM readiness, BitNet ask/warm readiness, disk/cache posture, report inventory, and operator commands
- validate status receipts through `bitnet mac receipts-check`
- update the M4 operator envelope docs and Mac help snapshot

## Claim boundaries
- no live M4 model run
- dense SLM and BitNet evidence remain separate
- BitNet chat and serve remain disabled
- no full Metal, QK256, Neural Engine, MPSGraph, MacBook, broad quality, broad Apple Silicon, performance, or speedup claim

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_status -- --nocapture`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_help_documents_operator_wrappers -- --nocapture`
- `cargo test --locked -p bitnet-cli --test cli_snapshot_tests mac_help -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- campaign generate`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
