### PR TITLE
test(cli): avoid panic-family stage taxonomy assertion

### DIFF
--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -1210,13 +1210,9 @@ fn mac_bitnet_warm_writes_failure_receipt_for_missing_tokenizer()
     assert_eq!(receipt_json["timeout_boundary"]["enforced"], true);
     assert_eq!(receipt_json["timeout_boundary"]["reached"], false);
     assert_eq!(receipt_json["progress"]["enabled"], true);
-    assert!(
-        receipt_json["progress"]["stage_taxonomy"]
-            .as_array()
-            .expect("stage taxonomy")
-            .iter()
-            .any(|stage| stage.as_str() == Some("receipt_write"))
-    );
+    let stage_taxonomy =
+        receipt_json["progress"]["stage_taxonomy"].as_array().ok_or("stage taxonomy missing")?;
+    assert!(stage_taxonomy.iter().any(|stage| stage.as_str() == Some("receipt_write")));
     assert_eq!(receipt_json["mac_bitnet_claim_boundary"]["chat_enabled"], false);
     assert_eq!(receipt_json["mac_bitnet_claim_boundary"]["serve_enabled"], false);
 


### PR DESCRIPTION
## Summary
- replace the new `expect("stage taxonomy")` assertion in the CLI warm-session failure receipt test with the existing `Result`-returning error path

## Why
The no-panic policy now treats this as new unallowlisted panic-family debt on PRs rebased over current main. This small fix unblocks the M3 device-label PR without mixing unrelated policy cleanup into that branch.

## Validation
- `CARGO_TARGET_DIR=/tmp/bitnet-policy-fix-target CARGO_INCREMENTAL=0 cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/bitnet-policy-fix-target CARGO_INCREMENTAL=0 cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli mac_bitnet_warm_writes_failure_receipt_on_tokenizer_repair_stop --quiet`
- `CARGO_TARGET_DIR=/tmp/bitnet-policy-fix-target CARGO_INCREMENTAL=0 cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir /tmp/policy-fix-report`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CLI argument test with improved error handling for better test reliability and clearer failure diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/4965)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->