### PR TITLE
Publish M4 operator envelope v2

### DIFF
--- a/docs/slm/apple-m4-inference-ops.md
+++ b/docs/slm/apple-m4-inference-ops.md
@@ -110,11 +110,17 @@ The dashboard keeps dense SLM and BitNet families separate and records
 `full_metal_inference_claimed=false`, `qk256_apple_claimed=false`, and no broad
 quality, performance, or speedup claim.
 
+## Operator Envelope V2
+
+`M4-INF-OPS-004` publishes the command-to-receipt contract in
+`docs/slm/apple-m4-operator-envelope-v2.md`. It maps each supported M4 operator
+command to its receipt kind, gate, report family, and unsupported claim
+boundary.
+
 ## Remaining Ops Work
 
-The remaining inference-ops lane should stay model-free in generic PR CI:
-
-- publish an operator envelope v2 that maps supported commands to receipt
-  requirements and claim boundaries.
+The inference-ops lane is complete when the campaign tracker marks
+`M4-INF-OPS-004` merged. Follow-on runtime work should start a separate campaign
+and keep generic PR CI model-free.
 
 Live M4 model runs belong in local, advisory, scheduled, or release lanes.

--- a/docs/slm/apple-m4-mini-user-expectation-envelope.md
+++ b/docs/slm/apple-m4-mini-user-expectation-envelope.md
@@ -49,6 +49,9 @@ evidence family, model identity, tokenizer authority, backend, and fallback
 state before offering regression commands. Groups with only one report are
 marked `insufficient_history`.
 
+The full command-to-receipt operator map lives in
+`docs/slm/apple-m4-operator-envelope-v2.md`.
+
 ```bash
 bitnet mac ask \
   --model-id microsoft-bitnet-b1.58-2B-4T-i2s \

--- a/docs/slm/apple-m4-operator-envelope-v2.md
+++ b/docs/slm/apple-m4-operator-envelope-v2.md
@@ -1,0 +1,117 @@
+# Apple M4 Operator Envelope V2
+
+This envelope maps supported M4 Mac mini operator commands to their receipt
+requirements, gates, report families, and unsupported claim boundaries. It is a
+local operator contract, not a broad Apple Silicon benchmark.
+
+## Global Boundaries
+
+Every supported M4 inference receipt must keep these fields true unless a later
+campaign explicitly proves otherwise:
+
+```text
+selected_backend=apple-m4-cpu-neon
+runtime_api=cpu
+fallback_used=false
+machine_id or machine.id=apple-m4-mac-mini
+```
+
+Still unsupported by this envelope:
+
+```text
+BitNet chat
+BitNet serve
+full apple-m4-metal inference
+QK256 on Apple Silicon
+Neural Engine execution
+MPSGraph model inference
+MacBook evidence
+broad Apple Silicon performance claims
+broad model quality claims
+speedup claims
+```
+
+Dense SLM evidence and BitNet evidence are separate. A dense Qwen receipt never
+proves BitNet behavior, and a BitNet receipt never broadens dense SLM support.
+
+## Command Map
+
+| Command | Family | Receipt or artifact | Gate | Report family |
+|---|---|---|---|---|
+| `bitnet mac models` | operator | model-free catalog JSON when `--json` is used | supported model matrix and cache state only | none |
+| `bitnet mac status` | operator | `apple_m4_inference_status` | no live model run; dense/BitNet readiness separated | local report inventory |
+| `bitnet mac report-refresh` | operator | `apple_m4_report_refresh_manifest` | committed reports only; no model downloads | dense eval, dense benchmark, BitNet eval, BitNet benchmark, BitNet warm |
+| `bitnet mac regression-dashboard` | operator | `apple_m4_regression_dashboard` plus Markdown | matching identity before comparison | same as report-refresh |
+| `bitnet mac ask` with dense model | dense SLM | strict local-answer receipt from the ask path | supported dense model ID, tokenizer, CPU/NEON, fallback false | dense answer/runtime receipts |
+| `bitnet mac chat` with dense model | dense SLM | `slm_apple_m4_warm_session` | resident session, per-turn token IDs, fallback false | dense warm-session receipts |
+| `bitnet mac serve` | dense SLM | server health/ready/completion receipts | local server only; readiness before completion | dense local-server receipts |
+| `bitnet mac smoke` | dense SLM | `apple_m4_slm_golden_smoke` | compact quality smoke, generated text and token IDs | dense smoke |
+| `bitnet mac doctor` | dense SLM | `apple_m4_slm_doctor` | cache, model, backend, and receipt checks | dense health |
+| `bitnet mac validate` | dense SLM | `apple_m4_slm_operator_profiles` or `apple_m4_slm_performance_profiles` | bounded corpus/profile set only | dense quality/profile receipts |
+| `bitnet mac benchmark` | dense SLM | `apple_m4_slm_benchmark_v2` | release-mode profile set; no broad benchmark claim | `slm-benchmark-v2` |
+| `bitnet mac regression` | dense SLM and BitNet | comparison output, optionally via `receipts-check --regression-baseline` | context match before drift checks | matching report pairs only |
+| `bitnet mac ask --model-id microsoft-bitnet-b1.58-2B-4T-i2s ...` | BitNet | one-shot BitNet ask receipt or `bitnet_apple_m4_mac_ask_failure` | accepted I2_S GGUF, external tokenizer SHA, CPU/NEON, fallback false | BitNet ask/runtime receipts |
+| `bitnet mac bitnet-warm` | BitNet | `bitnet_apple_m4_warm_session` or `bitnet_apple_m4_warm_session_failure` | accepted artifact, tokenizer authority, per-turn receipts, timeout evidence | BitNet warm/productization |
+| `bitnet mac bitnet-chat-gate` | BitNet | `bitnet_apple_m4_chat_gate` | warm, failure, and streaming-semantics receipts all valid | BitNet productization gate |
+| `bitnet mac smoke --model-family bitnet` | BitNet | `bitnet_apple_m4_mac_smoke` | accepted artifact and bounded smoke only | BitNet smoke |
+| `bitnet mac bitnet-benchmark` | BitNet | `bitnet_apple_m4_benchmark_v1` | one-shot plus fixed-warm benchmark receipts | `bitnet-benchmark` |
+| `bitnet mac bitnet-proof` | BitNet | `apple_m4_bitnet_proof_preflight` | proof input validation only | BitNet proof preflight |
+| `bitnet mac receipts-check` | all | receipt-check summary | schema, backend, fallback, token, and claim-boundary validation | all supported receipt kinds |
+
+## Report Families
+
+The report-refresh manifest and regression dashboard know these committed
+families:
+
+| Family | Evidence | Expected artifact kind | Comparison boundary |
+|---|---|---|---|
+| `dense_slm_eval_v2` | dense SLM | `apple_m4_slm_eval_summary` | same model ID, model SHA, tokenizer, backend, fallback |
+| `dense_slm_benchmark_v2` | dense SLM | `apple_m4_slm_benchmark_v2` | same model cache identity, profile set, backend, fallback |
+| `bitnet_eval` | BitNet | `bitnet_apple_m4_local_answer_corpus` | same accepted GGUF SHA, tokenizer authority, prompt template, backend, fallback |
+| `bitnet_benchmark` | BitNet | `bitnet_apple_m4_benchmark_v1` | same BitNet artifact/tokenizer, benchmark set, backend, fallback |
+| `bitnet_variable_warm` | BitNet | `bitnet_apple_m4_warm_session` | same artifact/tokenizer, warm-session scope, backend, fallback |
+
+When a family has only one matching report identity, the dashboard must report
+`insufficient_history`. It may offer the self-baseline command for validation,
+but it must not describe a trend until at least two matching reports exist.
+
+## Operator Sequence
+
+Use this order when refreshing the M4 appliance state:
+
+```bash
+bitnet mac models
+bitnet mac status
+bitnet mac report-refresh
+bitnet mac regression-dashboard
+bitnet mac receipts-check <receipt.json> --json
+bitnet mac regression <current.json> --baseline <baseline.json>
+```
+
+Run live dense or BitNet model commands only in local, advisory, scheduled, or
+release lanes. Generic PR CI stays model-free: schema checks, receipt checks,
+manifest generation, and dashboard generation only.
+
+## Claim Language
+
+Allowed:
+
+```text
+The M4 Mac mini has receipt-backed dense SLM local ask/chat/server paths for the
+supported Qwen model IDs.
+The M4 Mac mini has receipt-backed BitNet one-shot ask and warm-session paths
+for the accepted Microsoft I2_S artifact and external tokenizer.
+The report-refresh manifest and regression dashboard can validate committed M4
+receipt families without live model runs.
+```
+
+Not allowed:
+
+```text
+BitNet chat works.
+BitNet serve works.
+Full Apple M4 Metal inference works.
+QK256, Neural Engine, MPSGraph, MacBook, or broad Apple Silicon performance is proven.
+The current reports are a broad model quality benchmark.
+Dense SLM receipts prove BitNet behavior.
+```

--- a/docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md
@@ -39,7 +39,7 @@ advisory, scheduled, or release-only.
 | M4-INF-OPS-001 | merged | PR #4960 added `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and claim boundaries. |
 | M4-INF-OPS-002 | merged | PR #4963 added advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families. |
 | M4-INF-OPS-003 | merged | PR #4967 added compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families separate. |
-| M4-INF-OPS-004 | proposed | Publish operator envelope v2 mapping commands to receipts, gates, and unsupported claims. |
+| M4-INF-OPS-004 | in_progress | Publish operator envelope v2 mapping commands to receipts, gates, and unsupported claims. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-inference-ops/active.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/active.toml
@@ -152,7 +152,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-INF-OPS-004"
-status = "proposed"
+status = "in_progress"
 branch = "codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2"
 stackable = false
 review_mode = "codex_premerge"
@@ -161,7 +161,11 @@ human_gate = "on_blocker_only"
 blocked_by = ["M4-INF-OPS-003"]
 acceptance = "Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries."
 commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign generate",
   "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
 ]
 allowed_paths = [
   "docs/slm/**",

--- a/docs/tracking/campaigns/apple-m4-inference-ops/events/2026-05-15T181837Z-M4-INF-OPS-004-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/events/2026-05-15T181837Z-M4-INF-OPS-004-in-progress.toml
@@ -1,0 +1,27 @@
+timestamp = "2026-05-15T18:18:37Z"
+campaign = "apple-m4-inference-ops"
+item = "M4-INF-OPS-004"
+event = "in_progress"
+actor = "codex"
+from = "proposed"
+to = "in_progress"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2"
+summary = "Started Apple M4 operator envelope v2."
+
+artifacts = [
+  "docs/slm/apple-m4-operator-envelope-v2.md",
+  "docs/slm/apple-m4-inference-ops.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-inference-ops/active.toml",
+  "docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md",
+]
+
+notes = [
+  "The envelope maps supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries.",
+  "This is docs/tracking only and does not change runtime behavior.",
+  "BitNet chat and serve remain disabled; no full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad model quality, or broad Apple Silicon claim is added.",
+]
+
+[evidence]
+artifact = "docs/slm/apple-m4-operator-envelope-v2.md"
+claim_boundary = "operator envelope only; no runtime, model, BitNet chat, serve, full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad model quality, or broad Apple Silicon claim"

--- a/docs/tracking/campaigns/apple-m4-inference-ops/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/generated/status.md
@@ -12,7 +12,7 @@
 | M4-INF-OPS-001 | merged | #4960 | `codex/apple-m4-inference-ops/M4-INF-OPS-001-mac-status` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and explicit claim boundaries without running live inference. |
 | M4-INF-OPS-002 | merged | #4963 | `codex/apple-m4-inference-ops/M4-INF-OPS-002-report-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families without running live models in generic PR CI. |
 | M4-INF-OPS-003 | merged | #4967 | `codex/apple-m4-inference-ops/M4-INF-OPS-003-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families, model identity, tokenizer authority, backend, fallback, and claim boundaries separate. |
-| M4-INF-OPS-004 | proposed | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries. |
+| M4-INF-OPS-004 | in_progress | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -56,7 +56,7 @@
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | M4-SLM-REG-004 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-002 | M4-INF-OPS-001 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-003 | M4-INF-OPS-002 | merged |
-| apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | proposed |
+| apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | in_progress |
 | apple-m4-local-answer | M4-QA-MODEL-001 | M4-QA-ROOT-001 | merged |
 | apple-m4-local-answer | M4-QA-MODEL-002 | M4-QA-MODEL-001 | merged |
 | apple-m4-local-answer | M4-QA-002 | M4-QA-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,7 +11,7 @@
 | apple-m4-bitnet-productization | M4-BITNET-PROD-004 | #4957 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
-| apple-m4-inference-ops | M4-INF-OPS-004 | TBD | proposed | none | This is an M4 Mac mini operations campaign. |
+| apple-m4-inference-ops | M4-INF-OPS-004 | TBD | in_progress | none | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | M4-SERVE-005 | #4374 | merged | none | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |


### PR DESCRIPTION
Implements `M4-INF-OPS-004`.

What changed:
- adds `docs/slm/apple-m4-operator-envelope-v2.md`
- maps supported M4 commands to receipt kinds, gates, report families, and unsupported claim boundaries
- links the envelope from the inference-ops docs and user expectation envelope
- updates campaign state for the final inference-ops item

Validation run locally:
- `cargo run --locked -p xtask --no-default-features -- campaign generate`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-ops`
- `cargo run --locked -p xtask --no-default-features -- campaign next apple-m4-inference-ops`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

Claim boundary: docs/tracking only. No runtime, model, BitNet chat/serve enablement, full Metal, QK256, Neural Engine, MPSGraph, MacBook, broad Apple Silicon, broad model quality, or performance/speedup claim.