### PR TITLE
Close M4 inference ops campaign

### DIFF
--- a/docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-inference-ops`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -39,7 +39,7 @@ advisory, scheduled, or release-only.
 | M4-INF-OPS-001 | merged | PR #4960 added `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and claim boundaries. |
 | M4-INF-OPS-002 | merged | PR #4963 added advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families. |
 | M4-INF-OPS-003 | merged | PR #4967 added compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families separate. |
-| M4-INF-OPS-004 | in_progress | Publish operator envelope v2 mapping commands to receipts, gates, and unsupported claims. |
+| M4-INF-OPS-004 | merged | PR #4969 published operator envelope v2 mapping commands to receipts, gates, and unsupported claims. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-inference-ops/active.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-inference-ops"
 title = "Apple M4 inference ops"
-status = "active"
+status = "complete"
 
 objective = "Turn the completed Apple M4 dense SLM and BitNet proof surfaces into a durable operator layer: status, report inventory, advisory refresh, regression dashboarding, disk/cache posture, and an operator envelope v2 with explicit claim boundaries."
 
@@ -152,13 +152,15 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-INF-OPS-004"
-status = "in_progress"
+status = "merged"
 branch = "codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
 blocked_by = ["M4-INF-OPS-003"]
+pr = 4969
+merge_sha = "217e1439fabfa1126badc0850e474aba84bc11e5"
 acceptance = "Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries."
 commands = [
   "cargo run --locked -p xtask --no-default-features -- campaign generate",

--- a/docs/tracking/campaigns/apple-m4-inference-ops/events/2026-05-15T182110Z-M4-INF-OPS-004-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/events/2026-05-15T182110Z-M4-INF-OPS-004-merged.toml
@@ -1,0 +1,30 @@
+timestamp = "2026-05-15T18:21:10Z"
+campaign = "apple-m4-inference-ops"
+item = "M4-INF-OPS-004"
+event = "merged"
+actor = "codex"
+from = "in_progress"
+to = "merged"
+branch = "codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2"
+pr = 4969
+merge_sha = "217e1439fabfa1126badc0850e474aba84bc11e5"
+summary = "Merged Apple M4 operator envelope v2."
+
+artifacts = [
+  "docs/slm/apple-m4-operator-envelope-v2.md",
+  "docs/slm/apple-m4-inference-ops.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-inference-ops/active.toml",
+  "docs/tracking/campaigns/apple-m4-inference-ops/CAMPAIGN.md",
+]
+
+notes = [
+  "PR #4969 published the command-to-receipt operator envelope v2.",
+  "All apple-m4-inference-ops work items are now merged.",
+  "This is docs/tracking only and did not enable BitNet chat, BitNet serve, full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad model quality, or broad Apple Silicon claims.",
+]
+
+[evidence]
+artifact = "docs/slm/apple-m4-operator-envelope-v2.md"
+next_item = "none"
+claim_boundary = "operator envelope only; no runtime, model, BitNet chat, serve, full Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad model quality, or broad Apple Silicon claim"

--- a/docs/tracking/campaigns/apple-m4-inference-ops/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-inference-ops/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 inference ops Campaign Status
 
 - Campaign: `apple-m4-inference-ops`
-- State: `active`
+- State: `complete`
 - Objective: Turn the completed Apple M4 dense SLM and BitNet proof surfaces into a durable operator layer: status, report inventory, advisory refresh, regression dashboarding, disk/cache posture, and an operator envelope v2 with explicit claim boundaries.
 
 ## Work Items
@@ -12,7 +12,7 @@
 | M4-INF-OPS-001 | merged | #4960 | `codex/apple-m4-inference-ops/M4-INF-OPS-001-mac-status` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add `bitnet mac status` with an `apple_m4_inference_status` receipt covering dense SLM, BitNet, disk/cache, report inventory, commands, and explicit claim boundaries without running live inference. |
 | M4-INF-OPS-002 | merged | #4963 | `codex/apple-m4-inference-ops/M4-INF-OPS-002-report-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add advisory/nightly report refresh manifest generation for committed M4 dense SLM and BitNet report families without running live models in generic PR CI. |
 | M4-INF-OPS-003 | merged | #4967 | `codex/apple-m4-inference-ops/M4-INF-OPS-003-regression-dashboard` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add compact regression dashboard artifacts across dense SLM and BitNet reports while keeping evidence families, model identity, tokenizer authority, backend, fallback, and claim boundaries separate. |
-| M4-INF-OPS-004 | in_progress | TBD | `codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries. |
+| M4-INF-OPS-004 | merged | #4969 | `codex/apple-m4-inference-ops/M4-INF-OPS-004-operator-envelope-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish operator envelope v2 mapping supported M4 commands to receipt requirements, gates, report families, and unsupported claim boundaries. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -56,7 +56,7 @@
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | M4-SLM-REG-004 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-002 | M4-INF-OPS-001 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-003 | M4-INF-OPS-002 | merged |
-| apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | in_progress |
+| apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | merged |
 | apple-m4-local-answer | M4-QA-MODEL-001 | M4-QA-ROOT-001 | merged |
 | apple-m4-local-answer | M4-QA-MODEL-002 | M4-QA-MODEL-001 | merged |
 | apple-m4-local-answer | M4-QA-002 | M4-QA-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,7 +11,7 @@
 | apple-m4-bitnet-productization | M4-BITNET-PROD-004 | #4957 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
-| apple-m4-inference-ops | M4-INF-OPS-004 | TBD | in_progress | none | This is an M4 Mac mini operations campaign. |
+| apple-m4-inference-ops | M4-INF-OPS-004 | #4969 | merged | none | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | M4-SERVE-005 | #4374 | merged | none | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |


### PR DESCRIPTION
Tracker-only closeout for `apple-m4-inference-ops`.

- marks `M4-INF-OPS-004` merged from PR #4969
- records merge SHA `217e1439fabfa1126badc0850e474aba84bc11e5`
- marks the campaign complete
- confirms `campaign next apple-m4-inference-ops` returns `none`

No runtime, model, Metal, QK256, Neural Engine, MPSGraph, MacBook, broad Apple Silicon, broad quality, or performance claim change.