### PR TITLE
Add M4 durable evidence tracking

### DIFF
--- a/crates/bitnet-cli/src/mac.rs
+++ b/crates/bitnet-cli/src/mac.rs
@@ -79,6 +79,7 @@ const M4_SLM_BENCHMARK_V2_PROFILES: &[&str] = &[
     "context_4k",
     "resident_25",
     "resident_50",
+    "resident_100",
 ];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -133,6 +134,9 @@ enum MacBenchmarkProfile {
     /// Resident 50-prompt warm-session profile.
     #[value(name = "resident_50")]
     Resident50,
+    /// Resident 100-prompt warm-session profile.
+    #[value(name = "resident_100")]
+    Resident100,
 }
 
 impl MacBenchmarkProfile {
@@ -146,6 +150,7 @@ impl MacBenchmarkProfile {
             Self::Context4k => "context_4k",
             Self::Resident25 => "resident_25",
             Self::Resident50 => "resident_50",
+            Self::Resident100 => "resident_100",
         }
     }
 }
@@ -7131,6 +7136,13 @@ fn benchmark_profile_spec(profile: MacBenchmarkProfile) -> BenchmarkProfileSpec 
             profile,
             max_new_tokens: 16,
             prompts: resident_benchmark_prompts(50),
+            target_context_tokens: None,
+            scenario: "resident_session",
+        },
+        MacBenchmarkProfile::Resident100 => BenchmarkProfileSpec {
+            profile,
+            max_new_tokens: 16,
+            prompts: resident_benchmark_prompts(100),
             target_context_tokens: None,
             scenario: "resident_session",
         },

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -2742,6 +2742,15 @@ fn mac_benchmark_requires_release_build() {
 }
 
 #[test]
+fn mac_benchmark_accepts_resident_100_profile_before_release_gate() {
+    bitnet()
+        .args(["mac", "benchmark", "--profile", "resident_100"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("mac benchmark must be run from a release build"));
+}
+
+#[test]
 fn mac_receipts_check_accepts_slm_benchmark_v2_summary() {
     let dir = tempfile::tempdir().expect("tempdir");
     let receipt_path = dir.path().join("slm-benchmark-v2.json");
@@ -2806,6 +2815,25 @@ fn mac_receipts_check_accepts_slm_benchmark_v2_summary() {
         .expect("json"),
     )
     .expect("write receipt");
+    let receipt_str = receipt_path.to_string_lossy().into_owned();
+
+    bitnet()
+        .args(["mac", "receipts-check", receipt_str.as_str(), "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apple_m4_slm_benchmark_v2"))
+        .stdout(predicate::str::contains("\"prompt_count\": 3"));
+}
+
+#[test]
+fn mac_receipts_check_accepts_slm_benchmark_v2_resident_100_profile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let receipt_path = dir.path().join("slm-benchmark-v2-resident-100.json");
+    let mut receipt = slm_benchmark_v2_summary();
+    receipt["profiles_required"] = serde_json::json!(["resident_100"]);
+    receipt["profiles"] = serde_json::json!([benchmark_profile_v2_json("resident_100")]);
+    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).expect("json"))
+        .expect("write receipt");
     let receipt_str = receipt_path.to_string_lossy().into_owned();
 
     bitnet()

--- a/docs/slm/apple-m4-durable-inference-evidence.md
+++ b/docs/slm/apple-m4-durable-inference-evidence.md
@@ -1,0 +1,74 @@
+# Apple M4 Durable Inference Evidence
+
+This page tracks the follow-on proof layer after the dense SLM eval v2, BitNet
+eval/benchmark, BitNet productization, and inference-ops campaigns. Those
+campaigns made the M4 path measured and operable; this lane keeps the evidence
+fresh enough to support regression trends instead of one-time snapshots.
+
+## Current Gap
+
+The committed M4 report families are valid, but several dashboard groups still
+have only one matching report identity. That is intentionally reported as
+`insufficient_history`. To become a better appliance, the Mac mini needs repeat
+refreshes under the same model/tokenizer/backend/fallback identity so the
+dashboard can compare real drift.
+
+Dense SLM stability also needs a longer resident benchmark profile. The v2
+benchmark contract covered `resident_25` and `resident_50`; the durable refresh
+adds `resident_100` as a bounded local/advisory profile. Adding the profile does
+not by itself claim a new 100-prompt result.
+
+## Dense SLM Refresh Contract
+
+Run the full dense benchmark profile set in release mode:
+
+```bash
+target/release/bitnet --device apple-m4-cpu-neon mac benchmark \
+  --model-id <model-id> \
+  --profile short_prompt_16_out \
+  --profile short_prompt_64_out \
+  --profile long_prompt_16_out \
+  --profile long_prompt_128_out \
+  --profile context_1k \
+  --profile context_4k \
+  --profile resident_25 \
+  --profile resident_50 \
+  --profile resident_100 \
+  --json-out ci/hardware/apple-m4-mac-mini/<date>/slm-benchmark-v2/<model-id>/summary.json
+```
+
+Each summary must validate as `apple_m4_slm_benchmark_v2`, record generated text
+and token IDs in profile receipts, keep `fallback_used=false`, and retain the
+claim boundary that this is bounded M4 Mac mini evidence, not a broad Apple
+Silicon benchmark.
+
+## Refresh Sequence
+
+Use this order for the next durable evidence run:
+
+```bash
+bitnet mac status
+bitnet mac report-refresh
+bitnet mac regression-dashboard
+target/release/bitnet mac benchmark ... --profile resident_100 ...
+target/release/bitnet mac bitnet-benchmark ...
+bitnet mac report-refresh
+bitnet mac regression-dashboard
+bitnet mac receipts-check <new-summary.json> --json
+bitnet mac regression <new-summary.json> --baseline <previous-summary.json>
+```
+
+Do not put live model downloads, long resident sessions, or hardware timing runs
+in generic required PR CI. Keep them local, advisory, scheduled, or release-only.
+
+## Claim Boundary
+
+This lane may claim only that the tooling and committed receipts support durable
+M4 report refreshes and matching-identity comparisons. It must not claim:
+
+- broad dense SLM quality;
+- broad Apple Silicon performance;
+- dense SLM evidence as BitNet evidence;
+- BitNet chat or serve readiness beyond the existing gates;
+- full `apple-m4-metal` inference;
+- QK256, Neural Engine, MPSGraph, or MacBook evidence.

--- a/docs/slm/apple-m4-inference-ops.md
+++ b/docs/slm/apple-m4-inference-ops.md
@@ -120,7 +120,8 @@ boundary.
 ## Remaining Ops Work
 
 The inference-ops lane is complete when the campaign tracker marks
-`M4-INF-OPS-004` merged. Follow-on runtime work should start a separate campaign
-and keep generic PR CI model-free.
+`M4-INF-OPS-004` merged. Follow-on refresh work is tracked in
+`apple-m4-durable-inference-evidence`; it keeps generic PR CI model-free and
+uses matching report history before describing trends.
 
 Live M4 model runs belong in local, advisory, scheduled, or release lanes.

--- a/docs/slm/apple-m4-slm-eval-v2.md
+++ b/docs/slm/apple-m4-slm-eval-v2.md
@@ -141,6 +141,7 @@ context_1k
 context_4k
 resident_25
 resident_50
+resident_100
 ```
 
 Reports should summarize p50, p90, and p99 for:
@@ -162,9 +163,8 @@ memory_drift_mb
 The operator command is:
 
 ```bash
-target/release/bitnet mac benchmark \
+target/release/bitnet --device apple-m4-cpu-neon mac benchmark \
   --model-id <model-id> \
-  --device apple-m4-cpu-neon \
   --profile short_prompt_16_out \
   --profile short_prompt_64_out \
   --profile long_prompt_16_out \
@@ -173,6 +173,7 @@ target/release/bitnet mac benchmark \
   --profile context_4k \
   --profile resident_25 \
   --profile resident_50 \
+  --profile resident_100 \
   --json-out ci/hardware/apple-m4-mac-mini/<date>/slm-benchmark-v2/<model-id>/summary.json
 ```
 
@@ -190,10 +191,15 @@ dense M4 model ID:
 ci/hardware/apple-m4-mac-mini/2026-05-15/slm-benchmark-v2/<model-id>/summary.json
 ```
 
-The runs use `apple-m4-cpu-neon`, `fallback_used=false`, the catalog-pinned
-model identity for each dense model, and the full benchmark profile set listed
-above. Each summary validated with `bitnet mac receipts-check` as
-`apple_m4_slm_benchmark_v2` and records 101 prompts. These receipts are a
+Those reports cover the original v2 profile set through `resident_50`. The
+follow-on durable evidence refresh adds `resident_100` to the contract; a new
+live M4 refresh is required before any 100-prompt dense SLM stability claim is
+made.
+
+The 2026-05-15 runs use `apple-m4-cpu-neon`, `fallback_used=false`, the
+catalog-pinned model identity for each dense model, and the original v2
+benchmark profile set. Each summary validated with `bitnet mac receipts-check`
+as `apple_m4_slm_benchmark_v2` and records 101 prompts. These receipts are a
 recorded M4 Mac mini benchmark envelope for the supported dense model IDs, not a
 broad Apple Silicon benchmark.
 

--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/CAMPAIGN.md
@@ -1,0 +1,54 @@
+# Apple M4 Durable Inference Evidence Campaign
+
+Campaign ID: `apple-m4-durable-inference-evidence`
+
+Status: active
+
+## Objective
+
+Turn the completed Apple M4 dense SLM and BitNet proof surfaces into durable,
+repeatable evidence: longer resident dense SLM benchmark profiles, refreshed
+matching-identity report pairs, dashboard comparisons with real history, and
+operator envelopes that describe measured drift without broad Apple Silicon or
+model-quality claims.
+
+## Scope Boundary
+
+This campaign sits after dense SLM eval v2, BitNet eval/benchmark, BitNet
+productization, and inference ops. It does not reopen those campaigns unless a
+regression proves they were wrong. It may add evidence-refresh contracts and
+new receipts, but it must keep dense SLM and BitNet evidence separate.
+
+Live M4 model runs, hardware timing refreshes, and long resident soaks stay in
+local, advisory, scheduled, or release lanes. Generic required PR CI remains
+model-free.
+
+## End State
+
+- `bitnet mac benchmark` includes a bounded `resident_100` dense SLM profile.
+- Dense SLM benchmark v2 reports have matching-history pairs for each supported
+  model identity.
+- BitNet eval, benchmark, and variable warm-session reports have matching
+  history for the accepted artifact/tokenizer identity.
+- `bitnet mac regression-dashboard` has comparable dense SLM and BitNet groups
+  instead of only `insufficient_history`.
+- The operator envelope records refresh cadence, thresholds, and boundaries
+  from matching-identity comparisons.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-DURABLE-001 | ready | Add `resident_100` to the dense M4 SLM benchmark v2 profile contract, parser, validator, tests, and docs without claiming a fresh live run. |
+| M4-DURABLE-002 | proposed | Refresh dense SLM eval/benchmark reports for every supported M4 model, including `resident_100`, and compare against previous matching reports. |
+| M4-DURABLE-003 | proposed | Refresh BitNet eval, benchmark, and variable warm-session reports for the accepted artifact/tokenizer identity. |
+| M4-DURABLE-004 | proposed | Regenerate report-refresh and regression-dashboard artifacts with real comparable history groups. |
+| M4-DURABLE-005 | proposed | Publish an operator envelope refresh from the durable evidence run. |
+
+## Review Policy
+
+Each PR owns one item. Parser, schema, fixture, receipt-validation, and docs
+changes belong in ordinary PR validation. Live model refreshes and timing
+comparisons belong in local, advisory, scheduled, or release lanes and must
+record exact model/tokenizer/backend/fallback identity before any drift claim is
+made.

--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/active.toml
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/active.toml
@@ -1,0 +1,195 @@
+id = "apple-m4-durable-inference-evidence"
+title = "Apple M4 durable inference evidence"
+status = "active"
+
+objective = "Turn the completed Apple M4 dense SLM and BitNet proof surfaces into durable, repeatable evidence: longer resident dense SLM benchmark profiles, refreshed matching-identity report pairs, dashboard comparisons with real history, and operator envelopes that describe measured drift without broad Apple Silicon or model-quality claims."
+
+end_state = [
+  "`bitnet mac benchmark` includes a bounded `resident_100` dense SLM profile for local/advisory stability refreshes.",
+  "Dense SLM benchmark v2 reports have at least two matching committed report timestamps for each supported model identity.",
+  "BitNet eval, benchmark, and variable warm-session reports have at least two matching committed report timestamps for the accepted artifact/tokenizer identity.",
+  "`bitnet mac regression-dashboard` reports comparable groups for dense SLM and BitNet families instead of only `insufficient_history`.",
+  "The operator envelope records refresh cadence, thresholds, and claim boundaries from matching-identity report comparisons.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini evidence-refresh campaign.",
+  "Do not reopen completed Apple M4 dense SLM eval v2, BitNet eval/benchmark, BitNet productization, inference-ops, local server, or Metal campaigns unless a regression proves they are wrong.",
+  "Do not use dense Qwen evidence as BitNet evidence.",
+  "Do not enable BitNet chat or BitNet serve in this campaign.",
+  "Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, broad Apple Silicon performance, broad model quality, or speedup.",
+  "Do not add live model downloads, hardware timing runs, BitNet runtime runs, or long resident soaks to generic required PR CI.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "M4-DURABLE-001"
+status = "ready"
+branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-001-resident-100-profile"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add `resident_100` to the dense Apple M4 SLM benchmark v2 profile contract, CLI parser, receipt validator allowlist, tests, and operator docs without claiming that a fresh 100-prompt live M4 run has been recorded."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_benchmark_accepts_resident_100_profile_before_release_gate -- --nocapture",
+  "cargo test --locked -p bitnet-cli --test cli_arg_tests mac_receipts_check_accepts_slm_benchmark_v2_resident_100_profile -- --nocapture",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/mac.rs",
+  "crates/bitnet-cli/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-durable-inference-evidence/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "`resident_100` is available as a dense M4 SLM benchmark v2 profile contract.",
+]
+must_not_claim = [
+  "A fresh 100-prompt M4 dense SLM run was executed.",
+  "Dense SLM 100-prompt stability is proven for any model.",
+  "BitNet behavior is proven by dense SLM evidence.",
+]
+
+[[work_item]]
+id = "M4-DURABLE-002"
+status = "proposed"
+branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-002-dense-refresh"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-DURABLE-001"]
+acceptance = "Run and commit a fresh dense SLM eval/benchmark refresh for every supported M4 model identity, including `resident_100`, with receipt validation and regression comparison against the previous matching reports."
+commands = [
+  "target/release/bitnet --device apple-m4-cpu-neon mac benchmark --model-id <model-id> --profile short_prompt_16_out --profile short_prompt_64_out --profile long_prompt_16_out --profile long_prompt_128_out --profile context_1k --profile context_4k --profile resident_25 --profile resident_50 --profile resident_100 --json-out ci/hardware/apple-m4-mac-mini/<date>/slm-benchmark-v2/<model-id>/summary.json",
+  "target/release/bitnet mac receipts-check ci/hardware/apple-m4-mac-mini/<date>/slm-benchmark-v2/<model-id>/summary.json --json",
+  "target/release/bitnet mac regression ci/hardware/apple-m4-mac-mini/<date>/slm-benchmark-v2/<model-id>/summary.json --baseline ci/hardware/apple-m4-mac-mini/<baseline-date>/slm-benchmark-v2/<model-id>/summary.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence",
+]
+allowed_paths = [
+  "ci/hardware/apple-m4-mac-mini/**/slm-eval-v2/**",
+  "ci/hardware/apple-m4-mac-mini/**/slm-benchmark-v2/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-durable-inference-evidence/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "Fresh dense M4 benchmark receipts exist for the recorded supported models and profile set.",
+]
+must_not_claim = [
+  "The reports are broad Apple Silicon benchmarks.",
+  "The reports prove BitNet behavior.",
+]
+
+[[work_item]]
+id = "M4-DURABLE-003"
+status = "proposed"
+branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-003-bitnet-refresh"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-DURABLE-001"]
+acceptance = "Run and commit a fresh BitNet eval, benchmark, and variable warm-session refresh for the accepted artifact/tokenizer identity with receipt validation and matching-identity regression comparison."
+commands = [
+  "target/release/bitnet --device apple-m4-cpu-neon mac bitnet-benchmark --model-id microsoft-bitnet-b1.58-2B-4T-i2s --json-out ci/hardware/apple-m4-mac-mini/<date>/bitnet-benchmark/summary.json",
+  "target/release/bitnet mac receipts-check ci/hardware/apple-m4-mac-mini/<date>/bitnet-benchmark/summary.json --json",
+  "target/release/bitnet mac regression ci/hardware/apple-m4-mac-mini/<date>/bitnet-benchmark/summary.json --baseline ci/hardware/apple-m4-mac-mini/<baseline-date>/bitnet-benchmark/summary.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence",
+]
+allowed_paths = [
+  "ci/hardware/apple-m4-mac-mini/**/bitnet-eval/**",
+  "ci/hardware/apple-m4-mac-mini/**/bitnet-benchmark/**",
+  "ci/hardware/apple-m4-mac-mini/**/bitnet-warm/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-durable-inference-evidence/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "Fresh BitNet receipts exist for the accepted artifact/tokenizer identity.",
+]
+must_not_claim = [
+  "BitNet chat or serve is enabled.",
+  "Full Metal BitNet inference works.",
+]
+
+[[work_item]]
+id = "M4-DURABLE-004"
+status = "proposed"
+branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-004-dashboard-history"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-DURABLE-002", "M4-DURABLE-003"]
+acceptance = "Regenerate M4 report-refresh and regression-dashboard artifacts so dense SLM and BitNet families have comparable matching-history groups with explicit thresholds, warnings, or failures."
+commands = [
+  "bitnet mac report-refresh --json-out target/apple-m4-durable-inference-evidence/report-refresh-manifest.json --json",
+  "bitnet mac regression-dashboard --json-out target/apple-m4-durable-inference-evidence/regression-dashboard.json --markdown-out target/apple-m4-durable-inference-evidence/regression-dashboard.md --json",
+  "bitnet mac receipts-check target/apple-m4-durable-inference-evidence/regression-dashboard.json --json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence",
+]
+allowed_paths = [
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-durable-inference-evidence/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "M4 dashboards compare matching dense SLM and BitNet report groups with real history.",
+]
+must_not_claim = [
+  "A trend exists for any group that still has insufficient matching history.",
+]
+
+[[work_item]]
+id = "M4-DURABLE-005"
+status = "proposed"
+branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-DURABLE-004"]
+acceptance = "Publish an operator envelope refresh describing the durable M4 refresh cadence, regression thresholds, resident-100 status, disk/cache guidance, and claim boundaries from matching-history reports."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-durable-inference-evidence/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The operator envelope describes the durable M4 evidence refresh process and boundaries.",
+]
+must_not_claim = [
+  "Unsupported runtime capabilities are enabled.",
+]

--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/generated/status.md
@@ -1,0 +1,26 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 durable inference evidence Campaign Status
+
+- Campaign: `apple-m4-durable-inference-evidence`
+- State: `active`
+- Objective: Turn the completed Apple M4 dense SLM and BitNet proof surfaces into durable, repeatable evidence: longer resident dense SLM benchmark profiles, refreshed matching-identity report pairs, dashboard comparisons with real history, and operator envelopes that describe measured drift without broad Apple Silicon or model-quality claims.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-DURABLE-001 | ready | TBD | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-001-resident-100-profile` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add `resident_100` to the dense Apple M4 SLM benchmark v2 profile contract, CLI parser, receipt validator allowlist, tests, and operator docs without claiming that a fresh 100-prompt live M4 run has been recorded. |
+| M4-DURABLE-002 | proposed | TBD | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-002-dense-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run and commit a fresh dense SLM eval/benchmark refresh for every supported M4 model identity, including `resident_100`, with receipt validation and regression comparison against the previous matching reports. |
+| M4-DURABLE-003 | proposed | TBD | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-003-bitnet-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run and commit a fresh BitNet eval, benchmark, and variable warm-session refresh for the accepted artifact/tokenizer identity with receipt validation and matching-identity regression comparison. |
+| M4-DURABLE-004 | proposed | TBD | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-004-dashboard-history` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Regenerate M4 report-refresh and regression-dashboard artifacts so dense SLM and BitNet families have comparable matching-history groups with explicit thresholds, warnings, or failures. |
+| M4-DURABLE-005 | proposed | TBD | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish an operator envelope refresh describing the durable M4 refresh cadence, regression thresholds, resident-100 status, disk/cache guidance, and claim boundaries from matching-history reports. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini evidence-refresh campaign.
+- Do not reopen completed Apple M4 dense SLM eval v2, BitNet eval/benchmark, BitNet productization, inference-ops, local server, or Metal campaigns unless a regression proves they are wrong.
+- Do not use dense Qwen evidence as BitNet evidence.
+- Do not enable BitNet chat or BitNet serve in this campaign.
+- Do not claim full apple-m4-metal inference, QK256 support, Neural Engine execution, MPSGraph model inference, MacBook evidence, broad Apple Silicon performance, broad model quality, or speedup.
+- Do not add live model downloads, hardware timing runs, BitNet runtime runs, or long resident soaks to generic required PR CI.
+- Never commit model binaries.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -54,6 +54,10 @@
 | apple-m4-dense-slm-regression | M4-SLM-REG-003 | M4-SLM-REG-002 | merged |
 | apple-m4-dense-slm-regression | M4-SLM-REG-004 | M4-SLM-REG-003 | merged |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | M4-SLM-REG-004 | merged |
+| apple-m4-durable-inference-evidence | M4-DURABLE-002 | M4-DURABLE-001 | proposed |
+| apple-m4-durable-inference-evidence | M4-DURABLE-003 | M4-DURABLE-001 | proposed |
+| apple-m4-durable-inference-evidence | M4-DURABLE-004 | M4-DURABLE-002, M4-DURABLE-003 | proposed |
+| apple-m4-durable-inference-evidence | M4-DURABLE-005 | M4-DURABLE-004 | proposed |
 | apple-m4-inference-ops | M4-INF-OPS-002 | M4-INF-OPS-001 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-003 | M4-INF-OPS-002 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,6 +11,7 @@
 | apple-m4-bitnet-productization | M4-BITNET-PROD-004 | #4957 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
+| apple-m4-durable-inference-evidence | M4-DURABLE-001 | TBD | ready | M4-DURABLE-002 | This is an M4 Mac mini evidence-refresh campaign. |
 | apple-m4-inference-ops | M4-INF-OPS-004 | #4969 | merged | none | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | M4-SERVE-005 | #4374 | merged | none | This is an M4 Mac mini dense SLM service campaign. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -11,6 +11,7 @@
 | apple-m4-bitnet-productization | Apple M4 BitNet productization | M4-BITNET-PROD-004 | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | Apple M4 continuity | M4-CONT-005 | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
+| apple-m4-durable-inference-evidence | Apple M4 durable inference evidence | M4-DURABLE-001 | This is an M4 Mac mini evidence-refresh campaign. |
 | apple-m4-inference-ops | Apple M4 inference ops | M4-INF-OPS-004 | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | Apple M4 local answer usability | M4-BITNET-WARM-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | Apple M4 local server | M4-SERVE-005 | This is an M4 Mac mini dense SLM service campaign. |


### PR DESCRIPTION
## Summary
- add `resident_100` to the dense Apple M4 SLM benchmark v2 profile contract and receipt allowlist
- add parser/receipt tests for the new profile
- start `apple-m4-durable-inference-evidence` to track repeat refreshes, matching-history dashboards, and the operator envelope follow-up

## Claim boundary
- no live M4 model run executed
- no fresh 100-prompt stability claim
- no BitNet chat/serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, broad quality, or broad performance claim

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_benchmark_accepts_resident_100_profile_before_release_gate -- --nocapture`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_receipts_check_accepts_slm_benchmark_v2_resident_100_profile -- --nocapture`
- `cargo test --locked -p bitnet-cli --test cli_snapshot_tests mac_help -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`