### PR TITLE
diag(bitnet): trace reference attention value mix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Enforce LF line endings for shell scripts
 *.sh text eol=lf
 
-# Stored reference-instrumentation patches need unified-diff blank context lines.
-ci/reference-instrumentation/*.patch whitespace=-blank-at-eol
+# Stored reference-instrumentation patches need LF and unified-diff blank context lines.
+ci/reference-instrumentation/*.patch text eol=lf whitespace=-blank-at-eol

--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,514 @@ struct llama_context {
+@@ -3441,6 +3444,518 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -44,6 +44,7 @@ index 666fcc4d..23ee29ff 100644
 +        "Qcur-0",
 +        "Kcur-0",
 +        "Vcur-0",
++        "attn_value_mix-0",
 +        "attn_sub_norm-0",
 +        "attn_o_out-0",
 +        "ffn_inp-0",
@@ -79,6 +80,9 @@ index 666fcc4d..23ee29ff 100644
 +    }
 +    if (strcmp(name, "Vcur-0") == 0) {
 +        return "Vcur";
++    }
++    if (strcmp(name, "attn_value_mix-0") == 0) {
++        return "attn_value_mix";
 +    }
 +    if (strcmp(name, "attn_sub_norm-0") == 0) {
 +        return "attn_sub_norm";
@@ -544,7 +548,15 @@ index 666fcc4d..23ee29ff 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -17655,8 +18166,37 @@ static int llama_decode_internal(
+@@ -15460,6 +15975,7 @@ struct ggml_cgraph * build_bitnet_158() {
+                 cur = llm_build_kv(ctx0, lctx, kv_self, gf,
+                         NULL, NULL,
+                         Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
++                cb(cur, "attn_value_mix", il);
+             
+                 cur = llm_build_norm(ctx0, cur, hparams,
+                         model.layers[il].attn_sub_norm, NULL,
+@@ -17655,8 +18171,37 @@ static int llama_decode_internal(
  
          llama_set_inputs(lctx, ubatch);
  

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -52,6 +52,7 @@ const REFERENCE_REQUIRED_ANCHORS: &[(&str, &str)] = &[
     ("query_projection", "cb(Qcur, \"Qcur\", il)"),
     ("key_projection", "cb(Kcur, \"Kcur\", il)"),
     ("value_projection", "cb(Vcur, \"Vcur\", il)"),
+    ("attention_value_mix_insertion_point", "cur = llm_build_kv(ctx0, lctx, kv_self, gf"),
     ("attention_subnorm", "cb(cur, \"attn_sub_norm\", il)"),
     ("attention_output", "cb(cur, \"attn_o_out\", il)"),
     ("attention_residual", "cb(ffn_inp, \"ffn_inp\", il)"),
@@ -67,7 +68,7 @@ const REFERENCE_REQUIRED_ANCHORS: &[(&str, &str)] = &[
 const RUST_REQUIRED_ANCHORS: &[(&str, &str)] = &[
     ("trace_feature_gate", "#[cfg(feature = \"trace\")]"),
     ("trace_layer0_helper", "fn trace_layer0_tensor"),
-    ("input_embedding", "t0/embeddings"),
+    ("input_embedding", "trace_tensor_token_axis_record(\"embeddings\""),
     ("attention_norm", "attn_norm"),
     ("query_projection", "attention_q"),
     ("key_projection", "attention_k"),
@@ -1949,6 +1950,7 @@ fn reference_stage_mapping() -> Vec<(&'static str, &'static str)> {
         ("Qcur", "attention_q"),
         ("Kcur", "attention_k"),
         ("Vcur", "attention_v"),
+        ("attn_value_mix", "attention_value_mix"),
         ("attn_sub_norm", "post_attention_subnorm"),
         ("attn_o_out", "post_o_proj"),
         ("ffn_inp", "post_attention_residual"),
@@ -2204,6 +2206,7 @@ fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
             {"reference": "Qcur", "rust": "attention_q", "scope": "layer0"},
             {"reference": "Kcur", "rust": "attention_k", "scope": "layer0"},
             {"reference": "Vcur", "rust": "attention_v", "scope": "layer0"},
+            {"reference": "attn_value_mix", "rust": "attention_value_mix", "scope": "layer0"},
             {"reference": "attn_sub_norm", "rust": "post_attention_subnorm", "scope": "layer0"},
             {"reference": "attn_o_out", "rust": "post_o_proj", "scope": "layer0"},
             {"reference": "ffn_inp", "rust": "post_attention_residual", "scope": "layer0"},
@@ -3318,6 +3321,65 @@ mod tests {
         );
         assert_eq!(report.pointer("/first_scope_mismatch/scope/rust_seq"), Some(&json!(0)));
         assert!(report.pointer("/first_material_mismatch").unwrap().is_null());
+    }
+
+    #[test]
+    fn compare_maps_reference_attention_value_mix_to_rust_trace() {
+        let reference = ReferenceTraceRecord {
+            name: "attn_value_mix-0".to_string(),
+            stage: "attn_value_mix".to_string(),
+            graph_index: Some(42),
+            layer: Some(0),
+            graph_op: Some("MUL_MAT".to_string()),
+            graph_sources: json!([]),
+            view_source: Value::Null,
+            view_offset: Some(0),
+            full_shape: vec![2, 2, 1, 1],
+            sample_offset: None,
+            token_axis: None,
+            dtype: "f32".to_string(),
+            shape: vec![2, 2, 1, 1],
+            nelements: 4,
+            rms: Some(3.0),
+            values_available: true,
+            first_values: vec![1.0, 2.0, 3.0, 4.0],
+        };
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_value_mix".to_string(),
+            RustTraceRecord {
+                name: "t0/blk0/attention_value_mix".to_string(),
+                shape: vec![2, 2],
+                dtype: "F32".to_string(),
+                blake3: "abc".to_string(),
+                rms: 2.5,
+                num_elements: 4,
+                first_values: vec![1.0, 2.5, 3.0, 4.0],
+                seq: Some(0),
+                layer: Some(0),
+                stage: Some("attention_value_mix".to_string()),
+            },
+        );
+
+        let report = compare_reference_to_rust(
+            &[reference],
+            &rust_records,
+            &[("attn_value_mix", "attention_value_mix")],
+        );
+
+        assert_eq!(
+            report.pointer("/first_material_mismatch/reference_stage"),
+            Some(&json!("attn_value_mix"))
+        );
+        assert_eq!(
+            report.pointer("/first_material_mismatch/rust_stage"),
+            Some(&json!("attention_value_mix"))
+        );
+        assert_eq!(
+            report.pointer("/first_material_mismatch/first_values_delta/max_abs_delta"),
+            Some(&json!(0.5))
+        );
+        assert_eq!(report.pointer("/scope_mismatch_count"), Some(&json!(0)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a reference layer-trace anchor for layer0 `attn_value_mix` immediately after `llm_build_kv` and before `attn_sub_norm`
- map reference `attn_value_mix` to Rust `attention_value_mix` in the trace compare receipt
- keep reference instrumentation patches LF-normalized so `git apply` consumes them reliably on Windows

## Evidence
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-plan --output target/a770-diagnostic/bitnet-reference-layer-trace-plan-attn-value-mix.json --format json`
- `BITNET_RS_REFERENCE_LAYER_TRACE_FIRST_VALUES_LIMIT=2560 cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-run --sidecar target/a770-diagnostic/reference-first-token-layer-trace-attn-value-mix-2560.json --output target/a770-diagnostic/bitnet-reference-layer-trace-run-attn-value-mix-2560.json --format json`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-compare --reference target/a770-diagnostic/bitnet-reference-layer-trace-run-attn-value-mix-2560.json --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu-prefix2560 --a770-trace-dir target/a770-diagnostic/reference-layer-trace-rust-a770-prefix2560 --output target/a770-diagnostic/bitnet-reference-layer-trace-compare-attn-value-mix-2560.json --format json`
- `cargo check --locked -p bitnet-transformer --features trace`
- `rustfmt --edition 2024 --check xtask\\src\\bitnet_reference_layer_trace.rs`
- `git diff --check`

## Diagnostic Result
The first material mismatch now moves upstream to `attn_value_mix` / `attention_value_mix` for both Rust CPU and strict A770:

- CPU: `max_abs_delta=0.020580291748046875`, `rms_abs_delta=0.002154084716315646`
- A770: `max_abs_delta=0.0205841064453125`, `rms_abs_delta=0.0021544707971157904`

The preceding Q/K/V stages remain summary matches, so the next target is attention score / softmax / value-mix semantics, not `attn_output/o_proj` projection math.

## Claim Boundary
Diagnostic-only. Does not promote semantic quality, selected attention, resident KV, attention scores, softmax, value mix residency, full support-op residency, full device residency, or completion.