### PR TITLE
diag(bitnet): trace attention value mix head lanes

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,542 @@ struct llama_context {
+@@ -3441,6 +3444,617 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -434,6 +434,81 @@ index 666fcc4d..23ee29ff 100644
 +        bitnet_rs_reference_layer_trace_json_number(out, values[(size_t) sample_offset + i]);
 +    }
 +    out << "]}";
++    if (strcmp(name, "kqv-0") == 0 && values_available && token_axis == 1 && tensor->ne[0] > 0 && tensor->ne[1] > 0 && tensor->ne[2] > 1) {
++        const int64_t sampled_token = tensor->ne[1] - 1;
++        for (int64_t head = 0; head < tensor->ne[2]; ++head) {
++            const int64_t head_offset = tensor->ne[0] * sampled_token + tensor->ne[0] * tensor->ne[1] * head;
++            const int64_t head_nelements = tensor->ne[0];
++            if (head_offset < 0 || head_nelements <= 0 || head_offset + head_nelements > nelements) {
++                continue;
++            }
++            double head_sum = 0.0;
++            double head_sq_sum = 0.0;
++            double head_min = std::numeric_limits<double>::infinity();
++            double head_max = -std::numeric_limits<double>::infinity();
++            std::vector<float> head_values;
++            head_values.reserve((size_t) head_nelements);
++            for (int64_t i = 0; i < head_nelements; ++i) {
++                const float value_f32 = values[(size_t) (head_offset + i)];
++                const double value = value_f32;
++                head_sum += value;
++                head_sq_sum += value * value;
++                head_min = value < head_min ? value : head_min;
++                head_max = value > head_max ? value : head_max;
++                head_values.push_back(value_f32);
++            }
++            const uint64_t head_hash = bitnet_rs_reference_layer_trace_hash(head_values);
++            const double head_mean = head_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : head_sum / (double) head_nelements;
++            const double head_rms = head_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : std::sqrt(head_sq_sum / (double) head_nelements);
++            std::ostringstream head_name;
++            head_name << "kqv_head" << head << "-0";
++            std::ostringstream head_stage;
++            head_stage << "kqv_head" << head;
++            out << ",{";
++            out << "\"graph_index\":" << graph_index;
++            out << ",\"name\":";
++            bitnet_rs_reference_layer_trace_json_string(out, head_name.str().c_str());
++            out << ",\"stage\":";
++            bitnet_rs_reference_layer_trace_json_string(out, head_stage.str().c_str());
++            out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);
++            out << ",\"graph_op\":";
++            bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++            out << ",\"graph_sources\":[]";
++            out << ",\"view_source\":null";
++            out << ",\"view_offset\":0";
++            out << ",\"dtype\":";
++            bitnet_rs_reference_layer_trace_json_string(out, ggml_type_name(tensor->type));
++            out << ",\"shape\":[" << tensor->ne[0] << ",1,1,1]";
++            out << ",\"nelements\":" << head_nelements;
++            out << ",\"full_shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++            out << ",\"full_nelements\":" << nelements;
++            out << ",\"token_axis\":1";
++            out << ",\"sample_offset\":" << head_offset;
++            out << ",\"head_index\":" << head;
++            out << ",\"nbytes\":" << nbytes;
++            out << ",\"contiguous\":" << (ggml_is_contiguous(tensor) ? "true" : "false");
++            out << ",\"values_available\":true";
++            out << ",\"values_unavailable_reason\":null";
++            out << ",\"stats\":{\"mean\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_mean);
++            out << ",\"rms\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_rms);
++            out << ",\"min\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_min);
++            out << ",\"max\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_max);
++            out << ",\"fnv1a64\":\"" << std::hex << head_hash << std::dec << "\"}";
++            out << ",\"first_values\":[";
++            const size_t head_sample_count = bitnet_rs_reference_layer_trace_first_values_limit((size_t) head_nelements);
++            for (size_t i = 0; i < head_sample_count; ++i) {
++                if (i > 0) {
++                    out << ",";
++                }
++                bitnet_rs_reference_layer_trace_json_number(out, values[(size_t) head_offset + i]);
++            }
++            out << "]}";
++        }
++    }
 +}
 +
 +struct bitnet_rs_reference_layer_trace_callback_context {
@@ -572,7 +647,7 @@ index 666fcc4d..23ee29ff 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -15460,6 +15999,7 @@ struct ggml_cgraph * build_bitnet_158() {
+@@ -15460,6 +16074,7 @@ struct ggml_cgraph * build_bitnet_158() {
                  cur = llm_build_kv(ctx0, lctx, kv_self, gf,
                          NULL, NULL,
                          Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
@@ -580,7 +655,7 @@ index 666fcc4d..23ee29ff 100644
              
                  cur = llm_build_norm(ctx0, cur, hparams,
                          model.layers[il].attn_sub_norm, NULL,
-@@ -17655,8 +18195,37 @@ static int llama_decode_internal(
+@@ -17655,8 +18270,37 @@ static int llama_decode_internal(
  
          llama_set_inputs(lctx, ubatch);
  

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -732,15 +732,19 @@ impl MultiHeadAttention {
         let attn_value_mix = attn_weights.matmul(&v_expanded)?;
         #[cfg(feature = "trace")]
         if self.layer_idx == 0 {
-            let head0 = attn_value_mix.narrow(1, 0, 1)?;
-            trace_tensor_token_axis_record(
-                "blk0/attention_value_mix_head0",
-                &head0,
-                _trace_base_seq,
-                2,
-                Some(0),
-                "attention_value_mix_head0",
-            )?;
+            for head_idx in 0..self.n_heads {
+                let head = attn_value_mix.narrow(1, head_idx, 1)?;
+                let suffix = format!("blk0/attention_value_mix_head{head_idx}");
+                let stage = format!("attention_value_mix_head{head_idx}");
+                trace_tensor_token_axis_record(
+                    &suffix,
+                    &head,
+                    _trace_base_seq,
+                    2,
+                    Some(0),
+                    &stage,
+                )?;
+            }
         }
         #[cfg(feature = "trace")]
         trace_layer0_tensor(

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -82,7 +82,7 @@ const RUST_REQUIRED_ANCHORS: &[(&str, &str)] = &[
     ("attention_scores_raw_head0", "attention_scores_raw_head0"),
     ("attention_scores_softmax_head0", "attn_scores_softmax_head0"),
     ("attention_value_cache_head0_ref_layout", "attention_v_cache_head0_ref_layout_padded"),
-    ("attention_value_mix_head0", "attention_value_mix_head0"),
+    ("attention_value_mix_head_lanes", "attention_value_mix_head"),
     ("attention_value_mix_merged", "attention_value_mix_merged"),
     ("attention_value_mix", "attention_value_mix"),
     ("attention_subnorm", "post_attention_subnorm"),
@@ -1965,6 +1965,26 @@ fn reference_stage_mapping() -> Vec<(&'static str, &'static str)> {
         ("kq_soft_max_ext", "attn_scores_softmax_head0"),
         ("v", "attention_v_cache_head0_ref_layout_padded"),
         ("kqv", "attention_value_mix_head0"),
+        ("kqv_head0", "attention_value_mix_head0"),
+        ("kqv_head1", "attention_value_mix_head1"),
+        ("kqv_head2", "attention_value_mix_head2"),
+        ("kqv_head3", "attention_value_mix_head3"),
+        ("kqv_head4", "attention_value_mix_head4"),
+        ("kqv_head5", "attention_value_mix_head5"),
+        ("kqv_head6", "attention_value_mix_head6"),
+        ("kqv_head7", "attention_value_mix_head7"),
+        ("kqv_head8", "attention_value_mix_head8"),
+        ("kqv_head9", "attention_value_mix_head9"),
+        ("kqv_head10", "attention_value_mix_head10"),
+        ("kqv_head11", "attention_value_mix_head11"),
+        ("kqv_head12", "attention_value_mix_head12"),
+        ("kqv_head13", "attention_value_mix_head13"),
+        ("kqv_head14", "attention_value_mix_head14"),
+        ("kqv_head15", "attention_value_mix_head15"),
+        ("kqv_head16", "attention_value_mix_head16"),
+        ("kqv_head17", "attention_value_mix_head17"),
+        ("kqv_head18", "attention_value_mix_head18"),
+        ("kqv_head19", "attention_value_mix_head19"),
         ("kqv_merged", "attention_value_mix_merged"),
         ("attn_value_mix", "attention_value_mix_merged"),
         ("attn_sub_norm", "post_attention_subnorm"),
@@ -2217,7 +2237,7 @@ fn reference_sampled_token_index(record: &ReferenceTraceRecord) -> Option<u64> {
     }
     let axis = usize::try_from(axis).ok()?;
     let shape = if record.full_shape.is_empty() { &record.shape } else { &record.full_shape };
-    if axis > shape.len() {
+    if axis >= shape.len() {
         return None;
     }
     let offset = record.sample_offset?;
@@ -2228,7 +2248,11 @@ fn reference_sampled_token_index(record: &ReferenceTraceRecord) -> Option<u64> {
     if stride == 0 || offset % stride != 0 {
         return None;
     }
-    Some(offset / stride)
+    let axis_dim = u64::try_from(shape[axis]).ok()?;
+    if axis_dim == 0 {
+        return None;
+    }
+    Some((offset / stride) % axis_dim)
 }
 
 fn reference_record_summary(record: &ReferenceTraceRecord) -> Value {
@@ -2300,6 +2324,39 @@ fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
     let source_anchors_ready =
         blocked_reasons.iter().all(|reason| reason == "reference_layer_trace_patch_not_applied");
 
+    let mut stage_mapping = vec![
+        json!({"reference": "inp_embd", "rust": "embeddings", "scope": "prompt embedding"}),
+        json!({"reference": "attn_norm", "rust": "attn_norm", "scope": "layer0"}),
+        json!({"reference": "Qcur", "rust": "attention_q", "scope": "layer0"}),
+        json!({"reference": "Kcur", "rust": "attention_k", "scope": "layer0"}),
+        json!({"reference": "Vcur", "rust": "attention_v", "scope": "layer0"}),
+        json!({"reference": "kq", "rust": "attention_scores_raw_head0", "scope": "layer0 head0 sampled-query scores before scale/mask"}),
+        json!({"reference": "kq_soft_max_ext", "rust": "attn_scores_softmax_head0", "scope": "layer0 head0 sampled-query probabilities"}),
+        json!({"reference": "v", "rust": "attention_v_cache_head0_ref_layout_padded", "scope": "layer0 head0 cached value matrix in reference padded layout"}),
+        json!({"reference": "kqv", "rust": "attention_value_mix_head0", "scope": "layer0 head0 value-mix output before head merge"}),
+    ];
+    for head in 0..20 {
+        stage_mapping.push(json!({
+            "reference": format!("kqv_head{head}"),
+            "rust": format!("attention_value_mix_head{head}"),
+            "scope": format!("layer0 value-mix sampled token head{head}"),
+        }));
+    }
+    stage_mapping.extend([
+        json!({"reference": "kqv_merged", "rust": "attention_value_mix_merged", "scope": "layer0 non-contiguous all-token value-mix merge view"}),
+        json!({"reference": "attn_value_mix", "rust": "attention_value_mix_merged", "scope": "layer0 contiguous merged value-mix before subnorm"}),
+        json!({"reference": "attn_sub_norm", "rust": "post_attention_subnorm", "scope": "layer0"}),
+        json!({"reference": "attn_o_out", "rust": "post_o_proj", "scope": "layer0"}),
+        json!({"reference": "ffn_inp", "rust": "post_attention_residual", "scope": "layer0"}),
+        json!({"reference": "ffn_norm", "rust": "post_ffn_norm", "scope": "layer0"}),
+        json!({"reference": "ffn_out", "rust": "post_swiglu", "scope": "layer0"}),
+        json!({"reference": "ffn_sub_norm", "rust": "post_ffn_subnorm", "scope": "layer0"}),
+        json!({"reference": "ffn_down", "rust": "post_down_proj", "scope": "layer0"}),
+        json!({"reference": "l_out", "rust": "post_layer", "scope": "layer0"}),
+        json!({"reference": "result_norm", "rust": "final_norm", "scope": "final token"}),
+        json!({"reference": "result_output", "rust": "logits", "scope": "final token"}),
+    ]);
+
     Ok(json!({
         "schema_version": 1,
         "diagnostic": "bitnet_reference_layer_trace_plan",
@@ -2320,29 +2377,7 @@ fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
             "source_anchors_ready_for_target_local_patch": source_anchors_ready,
             "reason": "reference llama.cpp names the BitNet b1.58 graph stages through llm_build_cb while Rust already exposes comparable layer-0 trace labels behind the trace feature",
         },
-        "stage_mapping": [
-            {"reference": "inp_embd", "rust": "embeddings", "scope": "prompt embedding"},
-            {"reference": "attn_norm", "rust": "attn_norm", "scope": "layer0"},
-            {"reference": "Qcur", "rust": "attention_q", "scope": "layer0"},
-            {"reference": "Kcur", "rust": "attention_k", "scope": "layer0"},
-            {"reference": "Vcur", "rust": "attention_v", "scope": "layer0"},
-            {"reference": "kq", "rust": "attention_scores_raw_head0", "scope": "layer0 head0 sampled-query scores before scale/mask"},
-            {"reference": "kq_soft_max_ext", "rust": "attn_scores_softmax_head0", "scope": "layer0 head0 sampled-query probabilities"},
-            {"reference": "v", "rust": "attention_v_cache_head0_ref_layout_padded", "scope": "layer0 head0 cached value matrix in reference padded layout"},
-            {"reference": "kqv", "rust": "attention_value_mix_head0", "scope": "layer0 head0 value-mix output before head merge"},
-            {"reference": "kqv_merged", "rust": "attention_value_mix_merged", "scope": "layer0 non-contiguous all-token value-mix merge view"},
-            {"reference": "attn_value_mix", "rust": "attention_value_mix_merged", "scope": "layer0 contiguous merged value-mix before subnorm"},
-            {"reference": "attn_sub_norm", "rust": "post_attention_subnorm", "scope": "layer0"},
-            {"reference": "attn_o_out", "rust": "post_o_proj", "scope": "layer0"},
-            {"reference": "ffn_inp", "rust": "post_attention_residual", "scope": "layer0"},
-            {"reference": "ffn_norm", "rust": "post_ffn_norm", "scope": "layer0"},
-            {"reference": "ffn_out", "rust": "post_swiglu", "scope": "layer0"},
-            {"reference": "ffn_sub_norm", "rust": "post_ffn_subnorm", "scope": "layer0"},
-            {"reference": "ffn_down", "rust": "post_down_proj", "scope": "layer0"},
-            {"reference": "l_out", "rust": "post_layer", "scope": "layer0"},
-            {"reference": "result_norm", "rust": "final_norm", "scope": "final token"},
-            {"reference": "result_output", "rust": "logits", "scope": "final token"}
-        ],
+        "stage_mapping": stage_mapping,
         "instrumentation_plan": {
             "target_local_only": true,
             "target_files": [
@@ -3671,6 +3706,31 @@ mod tests {
             ))
         );
         assert!(report.pointer("/first_material_mismatch").unwrap().is_null());
+    }
+
+    #[test]
+    fn reference_sampled_token_index_ignores_later_head_stride() {
+        let record = ReferenceTraceRecord {
+            name: "kqv_head19-0".to_string(),
+            stage: "kqv_head19".to_string(),
+            graph_index: Some(45),
+            layer: Some(0),
+            graph_op: Some("MUL_MAT".to_string()),
+            graph_sources: json!([]),
+            view_source: Value::Null,
+            view_offset: Some(0),
+            full_shape: vec![128, 18, 20, 1],
+            sample_offset: Some(128 * 17 + 128 * 18 * 19),
+            token_axis: Some(1),
+            dtype: "f32".to_string(),
+            shape: vec![128, 1, 1, 1],
+            nelements: 128,
+            rms: Some(3.0),
+            values_available: true,
+            first_values: vec![1.0],
+        };
+
+        assert_eq!(reference_sampled_token_index(&record), Some(17));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Emits Rust layer-0 `attention_value_mix_headN` trace records for all 20 attention heads.
- Extends the reference instrumentation patch to add synthetic sampled-token `kqv_headN` records from the reference `kqv` tensor.
- Fixes sampled-token index derivation for reference records whose sample offset includes later head-axis stride.
- Adds the 20 head-lane mappings to the reference/Rust comparator and plan receipt.

## Target-local evidence
Refreshed receipts:
- `target/a770-diagnostic/bitnet-reference-layer-trace-run-head-lanes-4096.json`
- `target/a770-diagnostic/bitnet-reference-layer-trace-rust-capture-head-lanes-4096.json`
- `target/a770-diagnostic/bitnet-reference-layer-trace-compare-head-lanes-4096.json`

Reference trace:
- `kqv_head_count = 20`
- `kqv_head0`: token axis `1`, sample offset `2176`, `128` values
- `kqv_head19`: token axis `1`, sample offset `45952`, `128` values

Rust traces:
- CPU emitted 20 `attention_value_mix_headN` records.
- Strict A770 emitted 20 `attention_value_mix_headN` records.

Compare result:
- CPU first material head-lane mismatch: `kqv_head5` vs `attention_value_mix_head5`, prefix max abs delta `0.00357818603515625`, prefix RMS delta `0.00043007095021910333`.
- A770 first material head-lane mismatch: `kqv_head5` vs `attention_value_mix_head5`, prefix max abs delta `0.0035791397094726562`, prefix RMS delta `0.00043010210888893495`.
- Worst CPU head lane: `kqv_head13`, prefix max abs delta `0.020580291748046875`, prefix RMS delta `0.008856478549694069`.
- 11 head lanes are summary matches; 9 cross the material threshold.

This rules out a pure final reshape/merge-only explanation: the value-mix drift is already present in some per-head value-mix lanes, while CPU and strict A770 continue to track each other.

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `rustfmt --edition 2024 --check crates\bitnet-transformer\src\lib.rs xtask\src\bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claim boundary
Diagnostic only. This does not promote A770 semantic quality, selected attention, resident KV, attention scores, softmax, value mix residency, full support-op residency, full device residency, or completion.