### PR TITLE
diag(bitnet): expose reference value cache layout

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,621 @@ struct llama_context {
+@@ -3441,6 +3444,746 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -264,6 +264,63 @@ index 666fcc4d..23ee29ff 100644
 +    out << "]";
 +}
 +
++static bool bitnet_rs_reference_layer_trace_read_f32_values(
++    llama_context & lctx,
++    struct ggml_tensor * tensor,
++    std::vector<float> & values
++) {
++    if (tensor == nullptr || ggml_nelements(tensor) <= 0) {
++        return false;
++    }
++    if (tensor->type != GGML_TYPE_F32 && tensor->type != GGML_TYPE_F16) {
++        return false;
++    }
++    struct ggml_tensor * storage = tensor->view_src != nullptr ? tensor->view_src : tensor;
++    const size_t storage_nbytes = ggml_nbytes(storage);
++    if (storage_nbytes > 64ULL * 1024ULL * 1024ULL) {
++        return false;
++    }
++    ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(lctx.sched, storage);
++    if (backend == nullptr) {
++        backend = ggml_backend_sched_get_tensor_backend(lctx.sched, tensor);
++    }
++    if (backend == nullptr) {
++        return false;
++    }
++    std::vector<uint8_t> bytes(storage_nbytes);
++    ggml_backend_tensor_get(storage, bytes.data(), 0, storage_nbytes);
++    values.clear();
++    values.reserve((size_t) ggml_nelements(tensor));
++    const size_t base = tensor->view_src != nullptr ? tensor->view_offs : 0;
++    const size_t type_size = tensor->type == GGML_TYPE_F32 ? sizeof(float) : sizeof(ggml_fp16_t);
++    for (int64_t i3 = 0; i3 < tensor->ne[3]; ++i3) {
++        for (int64_t i2 = 0; i2 < tensor->ne[2]; ++i2) {
++            for (int64_t i1 = 0; i1 < tensor->ne[1]; ++i1) {
++                for (int64_t i0 = 0; i0 < tensor->ne[0]; ++i0) {
++                    const size_t offset = base
++                        + (size_t) i0 * tensor->nb[0]
++                        + (size_t) i1 * tensor->nb[1]
++                        + (size_t) i2 * tensor->nb[2]
++                        + (size_t) i3 * tensor->nb[3];
++                    if (offset + type_size > bytes.size()) {
++                        return false;
++                    }
++                    if (tensor->type == GGML_TYPE_F32) {
++                        float value = 0.0f;
++                        memcpy(&value, bytes.data() + offset, sizeof(float));
++                        values.push_back(value);
++                    } else {
++                        ggml_fp16_t value = 0;
++                        memcpy(&value, bytes.data() + offset, sizeof(ggml_fp16_t));
++                        values.push_back(ggml_fp16_to_fp32(value));
++                    }
++                }
++            }
++        }
++    }
++    return true;
++}
++
 +static bool bitnet_rs_reference_layer_trace_is_warmup(
 +    llama_context & lctx,
 +    const llama_ubatch & ubatch,
@@ -291,8 +348,8 @@ index 666fcc4d..23ee29ff 100644
 +    const char * name = ggml_get_name(tensor);
 +    const int64_t nelements = ggml_nelements(tensor);
 +    const size_t nbytes = ggml_nbytes(tensor);
-+    const bool f32_contiguous = tensor->type == GGML_TYPE_F32 && ggml_is_contiguous(tensor);
-+    const bool copy_size_ok = nbytes <= 64ULL * 1024ULL * 1024ULL;
++    struct ggml_tensor * storage = tensor->view_src != nullptr ? tensor->view_src : tensor;
++    const size_t storage_nbytes = ggml_nbytes(storage);
 +    bool values_available = false;
 +    std::vector<float> values;
 +    int token_axis = -1;
@@ -305,11 +362,7 @@ index 666fcc4d..23ee29ff 100644
 +    double max_value = -std::numeric_limits<double>::infinity();
 +    uint64_t value_hash = 0;
 +
-+    if (f32_contiguous && copy_size_ok && nelements > 0) {
-+        ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(lctx.sched, tensor);
-+        if (backend != nullptr) {
-+            values.resize((size_t) nelements);
-+            ggml_backend_tensor_get(tensor, values.data(), 0, nbytes);
++    if (bitnet_rs_reference_layer_trace_read_f32_values(lctx, tensor, values)) {
 +            if (n_outputs == 1 && n_tokens > 1) {
 +                if (tensor->ne[1] == (int64_t) n_tokens) {
 +                    token_axis = 1;
@@ -347,7 +400,6 @@ index 666fcc4d..23ee29ff 100644
 +                sample_values.push_back(values[(size_t) (sample_offset + i)]);
 +            }
 +            value_hash = bitnet_rs_reference_layer_trace_hash(sample_values);
-+        }
 +    }
 +
 +    if (!first) {
@@ -396,14 +448,12 @@ index 666fcc4d..23ee29ff 100644
 +    out << ",\"values_unavailable_reason\":";
 +    if (values_available) {
 +        out << "null";
-+    } else if (tensor->type != GGML_TYPE_F32) {
-+        bitnet_rs_reference_layer_trace_json_string(out, "non_f32_tensor");
-+    } else if (!ggml_is_contiguous(tensor)) {
-+        bitnet_rs_reference_layer_trace_json_string(out, "non_contiguous_tensor");
-+    } else if (!copy_size_ok) {
++    } else if (tensor->type != GGML_TYPE_F32 && tensor->type != GGML_TYPE_F16) {
++        bitnet_rs_reference_layer_trace_json_string(out, "non_f32_or_f16_tensor");
++    } else if (storage_nbytes > 64ULL * 1024ULL * 1024ULL) {
 +        bitnet_rs_reference_layer_trace_json_string(out, "tensor_too_large_for_diagnostic_copy");
 +    } else {
-+        bitnet_rs_reference_layer_trace_json_string(out, "backend_unavailable");
++        bitnet_rs_reference_layer_trace_json_string(out, "backend_or_view_copy_unavailable");
 +    }
 +
 +    out << ",\"stats\":";
@@ -509,6 +559,81 @@ index 666fcc4d..23ee29ff 100644
 +                    out << ",";
 +                }
 +                bitnet_rs_reference_layer_trace_json_number(out, values[(size_t) head_offset + i]);
++            }
++            out << "]}";
++        }
++    }
++    if (strcmp(name, "v-0") == 0 && values_available && n_tokens > 0 && tensor->ne[0] > 0 && tensor->ne[1] >= (int64_t) n_tokens && tensor->ne[2] > 0) {
++        for (int64_t head = 0; head < tensor->ne[2]; ++head) {
++            const int64_t head_offset = tensor->ne[0] * tensor->ne[1] * head;
++            const int64_t head_nelements = tensor->ne[0] * (int64_t) n_tokens;
++            if (head_offset < 0 || head_nelements <= 0 || head_offset + tensor->ne[0] * ((int64_t) n_tokens - 1) + tensor->ne[0] > nelements) {
++                continue;
++            }
++            double head_sum = 0.0;
++            double head_sq_sum = 0.0;
++            double head_min = std::numeric_limits<double>::infinity();
++            double head_max = -std::numeric_limits<double>::infinity();
++            std::vector<float> head_values;
++            head_values.reserve((size_t) head_nelements);
++            for (int64_t token = 0; token < (int64_t) n_tokens; ++token) {
++                for (int64_t dim = 0; dim < tensor->ne[0]; ++dim) {
++                    const float value_f32 = values[(size_t) (head_offset + tensor->ne[0] * token + dim)];
++                    const double value = value_f32;
++                    head_sum += value;
++                    head_sq_sum += value * value;
++                    head_min = value < head_min ? value : head_min;
++                    head_max = value > head_max ? value : head_max;
++                    head_values.push_back(value_f32);
++                }
++            }
++            const uint64_t head_hash = bitnet_rs_reference_layer_trace_hash(head_values);
++            const double head_mean = head_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : head_sum / (double) head_nelements;
++            const double head_rms = head_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : std::sqrt(head_sq_sum / (double) head_nelements);
++            std::ostringstream head_name;
++            head_name << "v_kv_head" << head << "_live-0";
++            std::ostringstream head_stage;
++            head_stage << "v_kv_head" << head << "_live";
++            out << ",{";
++            out << "\"graph_index\":" << graph_index;
++            out << ",\"name\":";
++            bitnet_rs_reference_layer_trace_json_string(out, head_name.str().c_str());
++            out << ",\"stage\":";
++            bitnet_rs_reference_layer_trace_json_string(out, head_stage.str().c_str());
++            out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);
++            out << ",\"graph_op\":";
++            bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++            out << ",\"graph_sources\":[]";
++            out << ",\"view_source\":null";
++            out << ",\"view_offset\":0";
++            out << ",\"dtype\":\"f32_from_f16\"";
++            out << ",\"shape\":[" << tensor->ne[0] << "," << n_tokens << ",1,1]";
++            out << ",\"nelements\":" << head_nelements;
++            out << ",\"full_shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++            out << ",\"full_nelements\":" << nelements;
++            out << ",\"token_axis\":-1";
++            out << ",\"sample_offset\":" << head_offset;
++            out << ",\"head_index\":" << head;
++            out << ",\"nbytes\":" << nbytes;
++            out << ",\"contiguous\":" << (ggml_is_contiguous(tensor) ? "true" : "false");
++            out << ",\"values_available\":true";
++            out << ",\"values_unavailable_reason\":null";
++            out << ",\"stats\":{\"mean\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_mean);
++            out << ",\"rms\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_rms);
++            out << ",\"min\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_min);
++            out << ",\"max\":";
++            bitnet_rs_reference_layer_trace_json_number(out, head_max);
++            out << ",\"fnv1a64\":\"" << std::hex << head_hash << std::dec << "\"}";
++            out << ",\"first_values\":[";
++            const size_t head_sample_count = bitnet_rs_reference_layer_trace_first_values_limit((size_t) head_nelements);
++            for (size_t i = 0; i < head_sample_count; ++i) {
++                if (i > 0) {
++                    out << ",";
++                }
++                bitnet_rs_reference_layer_trace_json_number(out, head_values[i]);
 +            }
 +            out << "]}";
 +        }
@@ -651,7 +776,7 @@ index 666fcc4d..23ee29ff 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -15460,6 +16078,7 @@ struct ggml_cgraph * build_bitnet_158() {
+@@ -15460,6 +16203,7 @@ struct ggml_cgraph * build_bitnet_158() {
                  cur = llm_build_kv(ctx0, lctx, kv_self, gf,
                          NULL, NULL,
                          Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
@@ -659,7 +784,7 @@ index 666fcc4d..23ee29ff 100644
              
                  cur = llm_build_norm(ctx0, cur, hparams,
                          model.layers[il].attn_sub_norm, NULL,
-@@ -17655,8 +18274,37 @@ static int llama_decode_internal(
+@@ -17655,8 +18399,37 @@ static int llama_decode_internal(
  
          llama_set_inputs(lctx, ubatch);
  

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -574,6 +574,19 @@ impl MultiHeadAttention {
             .reshape(&[batch_size, self.n_heads, t_k, self.head_dim])?; // [B, Hq, Tk, D]
         #[cfg(feature = "trace")]
         if self.layer_idx == 0 {
+            for kv_head_idx in 0..self.n_kv_heads {
+                let kv_live = v_ctx
+                    .narrow(1, kv_head_idx, 1)?
+                    .reshape(&[t_k, self.head_dim])?
+                    .transpose(0, 1)?
+                    .to_dtype(DType::F32)?;
+                let trace_seq = trace_target_seq().unwrap_or(_trace_base_seq);
+                let trace_name = format!(
+                    "t{trace_seq}/blk0/attention_v_cache_kv_head{kv_head_idx}_live_ref_layout"
+                );
+                let stage = format!("attention_v_cache_kv_head{kv_head_idx}_live_ref_layout");
+                trace_tensor_record(&trace_name, &kv_live, trace_seq, Some(0), &stage)?;
+            }
             let head0_ref_layout =
                 v_expanded.narrow(1, 0, 1)?.reshape(&[t_k, self.head_dim])?.transpose(0, 1)?;
             let reference_padded_tk = t_k.next_power_of_two().max(t_k);

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -82,6 +82,7 @@ const RUST_REQUIRED_ANCHORS: &[(&str, &str)] = &[
     ("attention_scores_raw_head_lanes", "attention_scores_raw_head"),
     ("attention_scores_softmax_head_lanes", "attn_scores_softmax_head"),
     ("attention_value_cache_head0_ref_layout", "attention_v_cache_head0_ref_layout_padded"),
+    ("attention_value_cache_kv_head_live", "attention_v_cache_kv_head"),
     ("attention_value_mix_head_lanes", "attention_value_mix_head"),
     ("attention_value_mix_merged", "attention_value_mix_merged"),
     ("attention_value_mix", "attention_value_mix"),
@@ -2004,6 +2005,11 @@ fn reference_stage_mapping() -> Vec<(&'static str, &'static str)> {
         ("kq_soft_max_ext_head18", "attn_scores_softmax_head18"),
         ("kq_soft_max_ext_head19", "attn_scores_softmax_head19"),
         ("v", "attention_v_cache_head0_ref_layout_padded"),
+        ("v_kv_head0_live", "attention_v_cache_kv_head0_live_ref_layout"),
+        ("v_kv_head1_live", "attention_v_cache_kv_head1_live_ref_layout"),
+        ("v_kv_head2_live", "attention_v_cache_kv_head2_live_ref_layout"),
+        ("v_kv_head3_live", "attention_v_cache_kv_head3_live_ref_layout"),
+        ("v_kv_head4_live", "attention_v_cache_kv_head4_live_ref_layout"),
         ("kqv", "attention_value_mix_head0"),
         ("kqv_head0", "attention_value_mix_head0"),
         ("kqv_head1", "attention_value_mix_head1"),
@@ -2143,6 +2149,7 @@ fn compare_reference_to_rust(
         "first_material_mismatch": first_material_mismatch,
         "attention_score_raw_head_lane_best_matches": attention_score_raw_head_lane_best_matches(reference_records, rust_records),
         "attention_probability_head_lane_best_matches": attention_probability_head_lane_best_matches(reference_records, rust_records),
+        "attention_value_cache_kv_head_best_matches": attention_value_cache_kv_head_best_matches(reference_records, rust_records),
         "attention_value_mix_head_lane_best_matches": attention_value_mix_head_lane_best_matches(reference_records, rust_records),
         "stages": stages,
     })
@@ -2193,6 +2200,19 @@ fn attention_probability_head_lane_best_matches(
         "kq_soft_max_ext_head",
         "attn_scores_softmax_head",
         "softmax probability head-lane best matches are diagnostic mapping evidence only; they do not promote reference parity, A770 semantic quality, softmax residency, selected attention, or any support claim",
+    )
+}
+
+fn attention_value_cache_kv_head_best_matches(
+    reference_records: &[ReferenceTraceRecord],
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    head_lane_best_matches(
+        reference_records,
+        rust_records,
+        "v_kv_head",
+        "attention_v_cache_kv_head",
+        "value-cache KV-head best matches are diagnostic mapping evidence only; they do not promote reference parity, A770 semantic quality, value mix residency, resident KV, selected attention, or any support claim",
     )
 }
 
@@ -2289,7 +2309,16 @@ fn head_lane_best_matches(
 }
 
 fn parse_stage_head(stage: &str, prefix: &str) -> Option<usize> {
-    stage.strip_prefix(prefix)?.parse::<usize>().ok()
+    let suffix = stage.strip_prefix(prefix)?;
+    let digit_count = suffix.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    if digit_count == 0 {
+        return None;
+    }
+    let rest = &suffix[digit_count..];
+    if !rest.is_empty() && !rest.starts_with('_') {
+        return None;
+    }
+    suffix[..digit_count].parse::<usize>().ok()
 }
 
 fn head_lane_delta(
@@ -2343,6 +2372,7 @@ fn trace_scope_mismatch(
     let reference = reference?;
     let rust = rust?;
     if let Some(scope) = reference_value_cache_head0_scope(reference, rust)
+        .or_else(|| reference_value_cache_kv_live_scope(reference, rust))
         .or_else(|| reference_value_mix_merged_scope(reference, rust))
     {
         return Some(scope);
@@ -2396,6 +2426,38 @@ fn reference_value_cache_head0_scope(
         "reference_token_axis": reference.token_axis,
         "rust_seq": rust.seq,
         "policy": "reference cached-value tensors include all KV heads; the Rust diagnostic samples head0 in reference key-padded layout, so prefix deltas are head0 evidence but not full-cache equality claims",
+    }))
+}
+
+fn reference_value_cache_kv_live_scope(
+    reference: &ReferenceTraceRecord,
+    rust: &RustTraceRecord,
+) -> Option<Value> {
+    parse_stage_head(&reference.stage, "v_kv_head")?;
+    let rust_stage = rust.stage.as_deref()?;
+    parse_stage_head(rust_stage, "attention_v_cache_kv_head")?;
+    let reference_shape0 = reference.shape.first().copied();
+    let rust_shape0 = rust.shape.first().copied().map(|dim| dim as i64);
+    let element_count_match = reference.nelements == rust.num_elements as u64;
+    let head_dim_match =
+        reference_shape0.is_some() && rust_shape0.is_some() && reference_shape0 == rust_shape0;
+    if element_count_match && head_dim_match {
+        return None;
+    }
+    Some(json!({
+        "reason": "reference_value_cache_live_head_layout_not_direct_rust_kv_head_layout",
+        "reference_stage": reference.stage,
+        "rust_stage": rust_stage,
+        "reference_shape": reference.shape,
+        "rust_shape": rust.shape,
+        "reference_nelements": reference.nelements,
+        "rust_num_elements": rust.num_elements,
+        "reference_dtype": reference.dtype,
+        "rust_dtype": rust.dtype,
+        "reference_values_available": reference.values_available,
+        "reference_first_values_count": reference.first_values.len(),
+        "rust_first_values_count": rust.first_values.len(),
+        "policy": "reference value-cache live KV heads use the llama.cpp cache representation and are diagnostic layout evidence, not direct Rust KV-head numeric parity evidence until the value-cache layout transform is named",
     }))
 }
 
@@ -2585,6 +2647,13 @@ fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
             "reference": format!("kq_soft_max_ext_head{head}"),
             "rust": format!("attn_scores_softmax_head{head}"),
             "scope": format!("layer0 sampled-query probability row head{head}"),
+        }));
+    }
+    for kv_head in 0..5 {
+        stage_mapping.push(json!({
+            "reference": format!("v_kv_head{kv_head}_live"),
+            "rust": format!("attention_v_cache_kv_head{kv_head}_live_ref_layout"),
+            "scope": format!("layer0 live value-cache matrix KV head{kv_head} in reference layout"),
         }));
     }
     for head in 0..20 {
@@ -3486,6 +3555,11 @@ mod tests {
             entry.pointer("/reference") == Some(&json!("kq_soft_max_ext_head19"))
                 && entry.pointer("/rust") == Some(&json!("attn_scores_softmax_head19"))
         }));
+        assert!(stage_mapping.iter().any(|entry| {
+            entry.pointer("/reference") == Some(&json!("v_kv_head4_live"))
+                && entry.pointer("/rust")
+                    == Some(&json!("attention_v_cache_kv_head4_live_ref_layout"))
+        }));
     }
 
     #[test]
@@ -4246,6 +4320,81 @@ mod tests {
         assert_eq!(prob.pointer("/rust_stage_prefix"), Some(&json!("attn_scores_softmax_head")));
         assert_eq!(prob.pointer("/identity_best_count"), Some(&json!(2)));
         assert_eq!(prob.pointer("/all_identity_best"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn compare_reports_value_cache_kv_head_best_matches_with_suffix_stages() {
+        let reference_records = vec![
+            test_reference_trace_record("v_kv_head0_live", vec![1.0, 2.0]),
+            test_reference_trace_record("v_kv_head1_live", vec![9.0, 9.0]),
+        ];
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_v_cache_kv_head0_live_ref_layout".to_string(),
+            test_rust_trace_record("attention_v_cache_kv_head0_live_ref_layout", vec![1.0, 2.0]),
+        );
+        rust_records.insert(
+            "attention_v_cache_kv_head1_live_ref_layout".to_string(),
+            test_rust_trace_record("attention_v_cache_kv_head1_live_ref_layout", vec![0.0, 0.0]),
+        );
+        rust_records.insert(
+            "attention_v_cache_kv_head2_live_ref_layout".to_string(),
+            test_rust_trace_record("attention_v_cache_kv_head2_live_ref_layout", vec![9.0, 9.0]),
+        );
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let value_cache = report.pointer("/attention_value_cache_kv_head_best_matches").unwrap();
+
+        assert_eq!(value_cache.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(value_cache.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(value_cache.pointer("/reference_stage_prefix"), Some(&json!("v_kv_head")));
+        assert_eq!(
+            value_cache.pointer("/rust_stage_prefix"),
+            Some(&json!("attention_v_cache_kv_head"))
+        );
+        assert_eq!(value_cache.pointer("/identity_best_count"), Some(&json!(1)));
+        assert_eq!(value_cache.pointer("/non_identity_best_count"), Some(&json!(1)));
+        assert_eq!(value_cache.pointer("/rows/1/best_rust_head"), Some(&json!(2)));
+    }
+
+    #[test]
+    fn compare_marks_value_cache_live_layout_as_scope_evidence() {
+        let reference = ReferenceTraceRecord {
+            shape: vec![32, 18, 1, 1],
+            nelements: 32 * 18,
+            first_values: vec![0.0; 32],
+            ..test_reference_trace_record("v_kv_head3_live", vec![0.0; 32])
+        };
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_v_cache_kv_head3_live_ref_layout".to_string(),
+            RustTraceRecord {
+                name: "t17/blk0/attention_v_cache_kv_head3_live_ref_layout".to_string(),
+                shape: vec![128, 18],
+                dtype: "F32".to_string(),
+                blake3: "abc".to_string(),
+                rms: 1.0,
+                num_elements: 128 * 18,
+                first_values: vec![0.0; 32],
+                seq: Some(17),
+                layer: Some(0),
+                stage: Some("attention_v_cache_kv_head3_live_ref_layout".to_string()),
+            },
+        );
+
+        let report = compare_reference_to_rust(
+            &[reference],
+            &rust_records,
+            &[("v_kv_head3_live", "attention_v_cache_kv_head3_live_ref_layout")],
+        );
+
+        assert_eq!(report.pointer("/scope_mismatch_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/material_mismatch_count"), Some(&json!(0)));
+        assert_eq!(
+            report.pointer("/first_scope_mismatch/scope/reason"),
+            Some(&json!("reference_value_cache_live_head_layout_not_direct_rust_kv_head_layout"))
+        );
+        assert!(report.pointer("/first_material_mismatch").unwrap().is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- teach the reference trace patch to copy f32/f16 tensor values through the underlying view storage, including non-contiguous f16 cache views
- emit live `v_kv_headN_live` records from the reference `v` cache and matching Rust `attention_v_cache_kv_headN_live_ref_layout` records
- mark the live reference value-cache KV heads as scope/layout evidence when their cache representation is not directly comparable to Rust's direct KV-head layout
- add diagnostic-only best-match reporting and tests for value-cache KV-head lane records

## Target-local result
Using fresh 4096-prefix reference/Rust CPU/strict A770 traces:
- reference `v` is now numeric: dtype `f16`, shape `32x128x5x1`, values available
- reference emitted 5 `v_kv_headN_live` records
- Rust CPU and strict A770 each emitted 5 live KV-head value-cache records
- all `v_kv_headN_live` rows are classified as scope/layout evidence, not material parity, because reference uses the llama.cpp value-cache representation while Rust emits direct `128 x tokens` KV-head layout
- first material mismatch remains `kqv_head5`
- worst value-mix identity RMS delta remains head 13 (`cpu=0.008856478549694069`, `a770=0.008858298859580359`)

This gives the next concrete target: name the reference value-cache layout transform that feeds `llm_build_kv`, rather than changing A770 dispatch or selected-attention claims.

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `rustfmt --edition 2024 --check crates\bitnet-transformer\src\lib.rs xtask\src\bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claim boundary
Diagnostic-only. This does not promote A770 semantic quality, resident KV, attention scores, softmax, value mix residency, selected attention, full support residency, full device residency, or completion.