### PR TITLE
diag(bitnet): expose reference value cache in Rust layout

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,746 @@ struct llama_context {
+@@ -3441,6 +3444,815 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -636,6 +636,75 @@ index 666fcc4d..23ee29ff 100644
 +                bitnet_rs_reference_layer_trace_json_number(out, head_values[i]);
 +            }
 +            out << "]}";
++            if (tensor->ne[0] >= (int64_t) n_tokens && tensor->ne[1] > 0) {
++                const int64_t rust_layout_nelements = tensor->ne[1] * (int64_t) n_tokens;
++                double rust_layout_sum = 0.0;
++                double rust_layout_sq_sum = 0.0;
++                double rust_layout_min = std::numeric_limits<double>::infinity();
++                double rust_layout_max = -std::numeric_limits<double>::infinity();
++                std::vector<float> rust_layout_values;
++                rust_layout_values.reserve((size_t) rust_layout_nelements);
++                for (int64_t dim = 0; dim < tensor->ne[1]; ++dim) {
++                    for (int64_t token = 0; token < (int64_t) n_tokens; ++token) {
++                        const float value_f32 = values[(size_t) (head_offset + tensor->ne[0] * dim + token)];
++                        const double value = value_f32;
++                        rust_layout_sum += value;
++                        rust_layout_sq_sum += value * value;
++                        rust_layout_min = value < rust_layout_min ? value : rust_layout_min;
++                        rust_layout_max = value > rust_layout_max ? value : rust_layout_max;
++                        rust_layout_values.push_back(value_f32);
++                    }
++                }
++                const uint64_t rust_layout_hash = bitnet_rs_reference_layer_trace_hash(rust_layout_values);
++                const double rust_layout_mean = rust_layout_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : rust_layout_sum / (double) rust_layout_nelements;
++                const double rust_layout_rms = rust_layout_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : std::sqrt(rust_layout_sq_sum / (double) rust_layout_nelements);
++                std::ostringstream rust_layout_name;
++                rust_layout_name << "v_cache_rust_layout_head" << head << "_live-0";
++                std::ostringstream rust_layout_stage;
++                rust_layout_stage << "v_cache_rust_layout_head" << head << "_live";
++                out << ",{";
++                out << "\"graph_index\":" << graph_index;
++                out << ",\"name\":";
++                bitnet_rs_reference_layer_trace_json_string(out, rust_layout_name.str().c_str());
++                out << ",\"stage\":";
++                bitnet_rs_reference_layer_trace_json_string(out, rust_layout_stage.str().c_str());
++                out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);
++                out << ",\"graph_op\":";
++                bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++                out << ",\"graph_sources\":[]";
++                out << ",\"view_source\":null";
++                out << ",\"view_offset\":0";
++                out << ",\"dtype\":\"f32_from_f16\"";
++                out << ",\"shape\":[" << tensor->ne[1] << "," << n_tokens << ",1,1]";
++                out << ",\"nelements\":" << rust_layout_nelements;
++                out << ",\"full_shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++                out << ",\"full_nelements\":" << nelements;
++                out << ",\"token_axis\":-1";
++                out << ",\"sample_offset\":" << head_offset;
++                out << ",\"head_index\":" << head;
++                out << ",\"nbytes\":" << nbytes;
++                out << ",\"contiguous\":" << (ggml_is_contiguous(tensor) ? "true" : "false");
++                out << ",\"values_available\":true";
++                out << ",\"values_unavailable_reason\":null";
++                out << ",\"stats\":{\"mean\":";
++                bitnet_rs_reference_layer_trace_json_number(out, rust_layout_mean);
++                out << ",\"rms\":";
++                bitnet_rs_reference_layer_trace_json_number(out, rust_layout_rms);
++                out << ",\"min\":";
++                bitnet_rs_reference_layer_trace_json_number(out, rust_layout_min);
++                out << ",\"max\":";
++                bitnet_rs_reference_layer_trace_json_number(out, rust_layout_max);
++                out << ",\"fnv1a64\":\"" << std::hex << rust_layout_hash << std::dec << "\"}";
++                out << ",\"first_values\":[";
++                const size_t rust_layout_sample_count = bitnet_rs_reference_layer_trace_first_values_limit((size_t) rust_layout_nelements);
++                for (size_t i = 0; i < rust_layout_sample_count; ++i) {
++                    if (i > 0) {
++                        out << ",";
++                    }
++                    bitnet_rs_reference_layer_trace_json_number(out, rust_layout_values[i]);
++                }
++                out << "]}";
++            }
 +        }
 +    }
 +}
@@ -776,7 +845,7 @@ index 666fcc4d..23ee29ff 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -15460,6 +16203,7 @@ struct ggml_cgraph * build_bitnet_158() {
+@@ -15460,6 +16272,7 @@ struct ggml_cgraph * build_bitnet_158() {
                  cur = llm_build_kv(ctx0, lctx, kv_self, gf,
                          NULL, NULL,
                          Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
@@ -784,7 +853,7 @@ index 666fcc4d..23ee29ff 100644
              
                  cur = llm_build_norm(ctx0, cur, hparams,
                          model.layers[il].attn_sub_norm, NULL,
-@@ -17655,8 +18399,37 @@ static int llama_decode_internal(
+@@ -17655,8 +18468,37 @@ static int llama_decode_internal(
  
          llama_set_inputs(lctx, ubatch);
  

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -2010,6 +2010,11 @@ fn reference_stage_mapping() -> Vec<(&'static str, &'static str)> {
         ("v_kv_head2_live", "attention_v_cache_kv_head2_live_ref_layout"),
         ("v_kv_head3_live", "attention_v_cache_kv_head3_live_ref_layout"),
         ("v_kv_head4_live", "attention_v_cache_kv_head4_live_ref_layout"),
+        ("v_cache_rust_layout_head0_live", "attention_v_cache_kv_head0_live_ref_layout"),
+        ("v_cache_rust_layout_head1_live", "attention_v_cache_kv_head1_live_ref_layout"),
+        ("v_cache_rust_layout_head2_live", "attention_v_cache_kv_head2_live_ref_layout"),
+        ("v_cache_rust_layout_head3_live", "attention_v_cache_kv_head3_live_ref_layout"),
+        ("v_cache_rust_layout_head4_live", "attention_v_cache_kv_head4_live_ref_layout"),
         ("kqv", "attention_value_mix_head0"),
         ("kqv_head0", "attention_value_mix_head0"),
         ("kqv_head1", "attention_value_mix_head1"),
@@ -2150,6 +2155,7 @@ fn compare_reference_to_rust(
         "attention_score_raw_head_lane_best_matches": attention_score_raw_head_lane_best_matches(reference_records, rust_records),
         "attention_probability_head_lane_best_matches": attention_probability_head_lane_best_matches(reference_records, rust_records),
         "attention_value_cache_kv_head_best_matches": attention_value_cache_kv_head_best_matches(reference_records, rust_records),
+        "attention_value_cache_rust_layout_best_matches": attention_value_cache_rust_layout_best_matches(reference_records, rust_records),
         "attention_value_mix_head_lane_best_matches": attention_value_mix_head_lane_best_matches(reference_records, rust_records),
         "stages": stages,
     })
@@ -2213,6 +2219,19 @@ fn attention_value_cache_kv_head_best_matches(
         "v_kv_head",
         "attention_v_cache_kv_head",
         "value-cache KV-head best matches are diagnostic mapping evidence only; they do not promote reference parity, A770 semantic quality, value mix residency, resident KV, selected attention, or any support claim",
+    )
+}
+
+fn attention_value_cache_rust_layout_best_matches(
+    reference_records: &[ReferenceTraceRecord],
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    head_lane_best_matches(
+        reference_records,
+        rust_records,
+        "v_cache_rust_layout_head",
+        "attention_v_cache_kv_head",
+        "value-cache Rust-layout best matches are diagnostic layout-transform evidence only; they do not promote reference parity, A770 semantic quality, value mix residency, resident KV, selected attention, or any support claim",
     )
 }
 
@@ -2654,6 +2673,13 @@ fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
             "reference": format!("v_kv_head{kv_head}_live"),
             "rust": format!("attention_v_cache_kv_head{kv_head}_live_ref_layout"),
             "scope": format!("layer0 live value-cache matrix KV head{kv_head} in reference layout"),
+        }));
+    }
+    for kv_head in 0..5 {
+        stage_mapping.push(json!({
+            "reference": format!("v_cache_rust_layout_head{kv_head}_live"),
+            "rust": format!("attention_v_cache_kv_head{kv_head}_live_ref_layout"),
+            "scope": format!("layer0 live value-cache matrix KV head{kv_head} transposed into Rust diagnostic layout"),
         }));
     }
     for head in 0..20 {
@@ -3560,6 +3586,11 @@ mod tests {
                 && entry.pointer("/rust")
                     == Some(&json!("attention_v_cache_kv_head4_live_ref_layout"))
         }));
+        assert!(stage_mapping.iter().any(|entry| {
+            entry.pointer("/reference") == Some(&json!("v_cache_rust_layout_head4_live"))
+                && entry.pointer("/rust")
+                    == Some(&json!("attention_v_cache_kv_head4_live_ref_layout"))
+        }));
     }
 
     #[test]
@@ -4327,6 +4358,8 @@ mod tests {
         let reference_records = vec![
             test_reference_trace_record("v_kv_head0_live", vec![1.0, 2.0]),
             test_reference_trace_record("v_kv_head1_live", vec![9.0, 9.0]),
+            test_reference_trace_record("v_cache_rust_layout_head0_live", vec![1.0, 2.0]),
+            test_reference_trace_record("v_cache_rust_layout_head1_live", vec![9.0, 9.0]),
         ];
         let mut rust_records = BTreeMap::new();
         rust_records.insert(
@@ -4355,6 +4388,22 @@ mod tests {
         assert_eq!(value_cache.pointer("/identity_best_count"), Some(&json!(1)));
         assert_eq!(value_cache.pointer("/non_identity_best_count"), Some(&json!(1)));
         assert_eq!(value_cache.pointer("/rows/1/best_rust_head"), Some(&json!(2)));
+
+        let rust_layout =
+            report.pointer("/attention_value_cache_rust_layout_best_matches").unwrap();
+        assert_eq!(rust_layout.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(rust_layout.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(
+            rust_layout.pointer("/reference_stage_prefix"),
+            Some(&json!("v_cache_rust_layout_head"))
+        );
+        assert_eq!(
+            rust_layout.pointer("/rust_stage_prefix"),
+            Some(&json!("attention_v_cache_kv_head"))
+        );
+        assert_eq!(rust_layout.pointer("/identity_best_count"), Some(&json!(1)));
+        assert_eq!(rust_layout.pointer("/non_identity_best_count"), Some(&json!(1)));
+        assert_eq!(rust_layout.pointer("/rows/1/best_rust_head"), Some(&json!(2)));
     }
 
     #[test]
@@ -4395,6 +4444,47 @@ mod tests {
             Some(&json!("reference_value_cache_live_head_layout_not_direct_rust_kv_head_layout"))
         );
         assert!(report.pointer("/first_material_mismatch").unwrap().is_null());
+    }
+
+    #[test]
+    fn compare_maps_value_cache_rust_layout_as_material_evidence() {
+        let reference = ReferenceTraceRecord {
+            shape: vec![128, 18, 1, 1],
+            full_shape: vec![128, 18, 1, 1],
+            nelements: 128 * 18,
+            token_axis: Some(-1),
+            first_values: vec![0.25; 32],
+            ..test_reference_trace_record("v_cache_rust_layout_head3_live", vec![0.25; 32])
+        };
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_v_cache_kv_head3_live_ref_layout".to_string(),
+            RustTraceRecord {
+                name: "t17/blk0/attention_v_cache_kv_head3_live_ref_layout".to_string(),
+                shape: vec![128, 18],
+                dtype: "F32".to_string(),
+                blake3: "abc".to_string(),
+                rms: 0.25,
+                num_elements: 128 * 18,
+                first_values: vec![0.25; 32],
+                seq: Some(17),
+                layer: Some(0),
+                stage: Some("attention_v_cache_kv_head3_live_ref_layout".to_string()),
+            },
+        );
+
+        let report = compare_reference_to_rust(
+            &[reference],
+            &rust_records,
+            &[("v_cache_rust_layout_head3_live", "attention_v_cache_kv_head3_live_ref_layout")],
+        );
+
+        assert_eq!(report.pointer("/scope_mismatch_count"), Some(&json!(0)));
+        assert_eq!(report.pointer("/material_mismatch_count"), Some(&json!(0)));
+        assert_eq!(report.pointer("/stages/0/status"), Some(&json!("summary_match")));
+        assert!(report.pointer("/first_scope_mismatch").unwrap().is_null());
+        assert!(report.pointer("/first_material_mismatch").unwrap().is_null());
+        assert_eq!(report.pointer("/stages/0/first_values_delta/max_abs_delta"), Some(&json!(0.0)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- emit reference `v_cache_rust_layout_headN_live` records by transposing llama.cpp non-flash V-cache samples into Rust's `[head_dim, live_tokens]` diagnostic layout
- map those records to existing Rust `attention_v_cache_kv_headN_live_ref_layout` traces
- add diagnostic-only best-match reporting and tests for the comparable value-cache layout

## Target-local evidence
- reference run emitted 93 records, including 5 `v_cache_rust_layout_headN_live` records
- CPU/A770 compare now moves first material mismatch to `v_cache_rust_layout_head0_live`
- Rust-layout value-cache best matches are identity for all 5 KV heads
- worst identity RMS delta observed locally: CPU head3 `0.0036488408138563096`, A770 head3 `0.003648704818705928`

## Not claims
- does not change model math
- does not promote reference parity, A770 semantic quality, selected attention, resident KV, attention scores, softmax, value mix residency, full support residency, full device residency, or completion

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `rustfmt --edition 2024 --check crates\\bitnet-transformer\\src\\lib.rs xtask\\src\\bitnet_reference_layer_trace.rs`
- `git -C target\\external\\BitNet-reference\\3rdparty\\llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `git diff --check`