### PR TITLE
diag(bitnet): trace value mix with F16 cache input

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -767,6 +767,43 @@ impl MultiHeadAttention {
         let attn_value_mix = attn_weights.matmul(&v_expanded)?;
         #[cfg(feature = "trace")]
         if self.layer_idx == 0 {
+            let v_expanded_f16_roundtrip = v_expanded.to_dtype(DType::F16)?.to_dtype(DType::F32)?;
+            let attn_value_mix_f16_cache = attn_weights.matmul(&v_expanded_f16_roundtrip)?;
+            for head_idx in 0..self.n_heads {
+                let head = attn_value_mix_f16_cache.narrow(1, head_idx, 1)?;
+                let suffix = format!("blk0/attention_value_mix_f16_cache_head{head_idx}");
+                let stage = format!("attention_value_mix_f16_cache_head{head_idx}");
+                trace_tensor_token_axis_record(
+                    &suffix,
+                    &head,
+                    _trace_base_seq,
+                    2,
+                    Some(0),
+                    &stage,
+                )?;
+            }
+            trace_layer0_tensor(
+                self.layer_idx,
+                _trace_base_seq,
+                2,
+                "attention_value_mix_f16_cache",
+                &attn_value_mix_f16_cache,
+            )?;
+            let attn_output_f16_cache = attn_value_mix_f16_cache.transpose(1, 2)?.reshape(&[
+                batch_size,
+                seq_len,
+                self.n_heads * self.head_dim,
+            ])?;
+            trace_layer0_tensor(
+                self.layer_idx,
+                _trace_base_seq,
+                1,
+                "attention_value_mix_f16_cache_merged",
+                &attn_output_f16_cache,
+            )?;
+        }
+        #[cfg(feature = "trace")]
+        if self.layer_idx == 0 {
             for head_idx in 0..self.n_heads {
                 let head = attn_value_mix.narrow(1, head_idx, 1)?;
                 let suffix = format!("blk0/attention_value_mix_head{head_idx}");

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -84,6 +84,8 @@ const RUST_REQUIRED_ANCHORS: &[(&str, &str)] = &[
     ("attention_value_cache_head0_ref_layout", "attention_v_cache_head0_ref_layout_padded"),
     ("attention_value_cache_kv_head_live", "attention_v_cache_kv_head"),
     ("attention_value_cache_f16_roundtrip", "attention_v_cache_f16_roundtrip_kv_head"),
+    ("attention_value_mix_f16_cache_head_lanes", "attention_value_mix_f16_cache_head"),
+    ("attention_value_mix_f16_cache_merged", "attention_value_mix_f16_cache_merged"),
     ("attention_value_mix_head_lanes", "attention_value_mix_head"),
     ("attention_value_mix_merged", "attention_value_mix_merged"),
     ("attention_value_mix", "attention_value_mix"),
@@ -2173,6 +2175,7 @@ fn compare_reference_to_rust(
         "attention_value_cache_kv_head_best_matches": attention_value_cache_kv_head_best_matches(reference_records, rust_records),
         "attention_value_cache_rust_layout_best_matches": attention_value_cache_rust_layout_best_matches(reference_records, rust_records),
         "attention_value_cache_f16_roundtrip_best_matches": attention_value_cache_f16_roundtrip_best_matches(reference_records, rust_records),
+        "attention_value_mix_f16_cache_head_lane_best_matches": attention_value_mix_f16_cache_head_lane_best_matches(reference_records, rust_records),
         "attention_value_mix_head_lane_best_matches": attention_value_mix_head_lane_best_matches(reference_records, rust_records),
         "stages": stages,
     })
@@ -2197,6 +2200,19 @@ fn attention_value_mix_head_lane_best_matches(
         "kqv_head",
         "attention_value_mix_head",
         "head-lane best matches are diagnostic mapping evidence only; they do not promote reference parity, A770 semantic quality, selected attention, value mix residency, or any support claim",
+    )
+}
+
+fn attention_value_mix_f16_cache_head_lane_best_matches(
+    reference_records: &[ReferenceTraceRecord],
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    head_lane_best_matches(
+        reference_records,
+        rust_records,
+        "kqv_head",
+        "attention_value_mix_f16_cache_head",
+        "F16-cache value-mix head-lane best matches are diagnostic alternate-path evidence only; they do not promote reference parity, A770 semantic quality, value mix residency, resident KV, selected attention, or any support claim",
     )
 }
 
@@ -4320,6 +4336,18 @@ mod tests {
             "attention_value_mix_head2".to_string(),
             test_rust_trace_record("attention_value_mix_head2", vec![8.0, 8.0, 8.0]),
         );
+        rust_records.insert(
+            "attention_value_mix_f16_cache_head0".to_string(),
+            test_rust_trace_record("attention_value_mix_f16_cache_head0", vec![1.0, 2.0, 3.0]),
+        );
+        rust_records.insert(
+            "attention_value_mix_f16_cache_head1".to_string(),
+            test_rust_trace_record("attention_value_mix_f16_cache_head1", vec![0.0, 0.0, 0.0]),
+        );
+        rust_records.insert(
+            "attention_value_mix_f16_cache_head2".to_string(),
+            test_rust_trace_record("attention_value_mix_f16_cache_head2", vec![8.0, 8.0, 8.0]),
+        );
 
         let report = compare_reference_to_rust(
             &reference_records,
@@ -4342,6 +4370,19 @@ mod tests {
         assert_eq!(matches.pointer("/rows/1/best_rust_head"), Some(&json!(2)));
         assert_eq!(matches.pointer("/rows/1/identity_is_best"), Some(&json!(false)));
         assert_eq!(matches.pointer("/rows/1/identity_rank"), Some(&json!(3)));
+
+        let f16_matches =
+            report.pointer("/attention_value_mix_f16_cache_head_lane_best_matches").unwrap();
+        assert_eq!(f16_matches.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(f16_matches.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(f16_matches.pointer("/reference_stage_prefix"), Some(&json!("kqv_head")));
+        assert_eq!(
+            f16_matches.pointer("/rust_stage_prefix"),
+            Some(&json!("attention_value_mix_f16_cache_head"))
+        );
+        assert_eq!(f16_matches.pointer("/identity_best_count"), Some(&json!(1)));
+        assert_eq!(f16_matches.pointer("/non_identity_best_count"), Some(&json!(1)));
+        assert_eq!(f16_matches.pointer("/rows/1/best_rust_head"), Some(&json!(2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a trace-only alternate value-mix path that uses F16-roundtripped V cache input
- report `attention_value_mix_f16_cache_headN` best matches separately from the production value-mix stages
- keep default first-material mismatch accounting on the production path

## Target-local evidence
- CPU and strict A770 each emitted 20 `attention_value_mix_f16_cache_headN` traces
- first production material mismatch remains `kqv_head5`
- regular value-mix worst head remains head13: CPU RMS `0.008856478549694069`, A770 RMS `0.008858298859580359`
- F16-cache alternate improves but does not close head13: CPU RMS `0.0058305225248534865`, A770 RMS `0.005833571991469239`

## Not claims
- trace-only alternate path; does not change runtime attention output
- does not promote reference parity, A770 semantic quality, selected attention, resident KV, attention scores, softmax, value mix residency, full support residency, full device residency, or completion

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `rustfmt --edition 2024 --check crates\\bitnet-transformer\\src\\lib.rs xtask\\src\\bitnet_reference_layer_trace.rs`
- target-local Rust capture + compare for CPU/A770 F16-cache-input value-mix traces
- `git diff --check`