### PR TITLE
fix(bitnet): match GGML attention score input precision

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -108,6 +108,10 @@ fn dbg_finite(tag: &str, t: &Tensor) -> candle_core::Result<()> {
     Ok(())
 }
 
+fn attention_score_dot_input(tensor: &Tensor) -> Result<Tensor> {
+    Ok(tensor.to_dtype(DType::F16)?.to_dtype(DType::F32)?)
+}
+
 fn qk256_scale_for(
     raw_tensors: &std::collections::HashMap<String, Tensor>,
     qk256_key: &str,
@@ -697,7 +701,19 @@ impl MultiHeadAttention {
             });
         }
 
-        let scores = q.matmul(&k_expanded.transpose(2, 3)?)?;
+        let q_for_scores = attention_score_dot_input(&q)?;
+        let k_for_scores = attention_score_dot_input(&k_expanded)?;
+        #[cfg(feature = "trace")]
+        if self.layer_idx == 0 {
+            trace_layer0_tensor(
+                self.layer_idx,
+                _trace_base_seq,
+                2,
+                "attention_q_rope_f16_roundtrip",
+                &q_for_scores,
+            )?;
+        }
+        let scores = q_for_scores.matmul(&k_for_scores.transpose(2, 3)?)?;
 
         // Convert to fp32 for numerically stable computation
         let scores_f32 = scores.to_dtype(DType::F32)?;
@@ -2040,6 +2056,19 @@ mod tests {
         assert!(!has_nan, "Output should not contain NaN");
         assert!(!has_inf, "Output should not contain Inf");
 
+        Ok(())
+    }
+
+    #[test]
+    fn attention_score_dot_input_uses_f16_roundtrip_values() -> Result<()> {
+        let device = Device::Cpu;
+        let input =
+            Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
+
+        let output = attention_score_dot_input(&input)?;
+        let values = output.flatten_all()?.to_vec1::<f32>()?;
+
+        assert_eq!(values, vec![1.0, -2.0, 3.125, -4.25]);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add `attention_score_dot_input` to round attention score dot inputs through F16 before the raw QK matmul
- use F16-rounded Q and K inputs for the score matmul, matching the reference numeric diagnostic from the parent PR
- trace `attention_q_rope_f16_roundtrip` for layer-0 diagnostics

## Evidence
Parent diagnostic #5008 pins reference raw score rows as:
- padded-tail-zeroed score rows
- f32 sequential accumulation
- Q rounded through F16 before dot
- K as the traced F16-derived values

Target-local diagnostic after this change:
- CPU and strict A770 one-token smoke both emit `2`
- score/probability head lane identity remains true
- first material mismatch moves downstream to `kqv_head9` / `attention_value_mix_head9`
- CPU first mismatch RMS: `0.000292600942709553`, max prefix delta: `0.00258898735046387`
- A770 first mismatch RMS: `0.000292620621117123`, max prefix delta: `0.00258898735046387`

## Validation
- `cargo test --locked -p bitnet-transformer --features trace attention_score_dot_input_uses_f16_roundtrip_values -- --nocapture`
- `cargo test --locked -p bitnet-transformer --features trace -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `rustfmt --edition 2024 --check crates/bitnet-transformer/src/lib.rs`
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-capture-rust --overwrite --format json`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-compare --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu --a770-trace-dir target/a770-diagnostic/reference-layer-trace-rust-a770 --format json`

## Claim boundary
- correctness fix only
- no clean A770 claim sequence was run
- does not promote A770 semantic quality, selected attention, resident KV, attention scores, softmax, value mix residency, full support/device residency, performance, or completion