### PR TITLE
diag(bitnet): report Rust probability softmax recompute

### DIFF
--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -2243,6 +2243,7 @@ fn compare_reference_to_rust(
         "attention_score_rust_scalar_recompute": attention_score_rust_scalar_recompute(rust_records),
         "attention_score_raw_head_lane_best_matches": attention_score_raw_head_lane_best_matches(reference_records, rust_records),
         "attention_probability_reference_softmax_variants": attention_probability_reference_softmax_variants(reference_records),
+        "attention_probability_rust_softmax_recompute": attention_probability_rust_softmax_recompute(rust_records),
         "attention_probability_head_lane_best_matches": attention_probability_head_lane_best_matches(reference_records, rust_records),
         "attention_key_cache_kv_head_best_matches": attention_key_cache_kv_head_best_matches(reference_records, rust_records),
         "attention_key_cache_f16_roundtrip_best_matches": attention_key_cache_f16_roundtrip_best_matches(reference_records, rust_records),
@@ -3948,17 +3949,37 @@ fn reference_probability_softmax_values(
     scale: f64,
     variant: ReferenceProbabilitySoftmaxVariantSpec,
 ) -> Option<Vec<f32>> {
+    probability_softmax_values_from_scores(
+        &score.first_values,
+        live_token_count,
+        target_token_count,
+        scale,
+        variant.length_policy,
+        variant.score_f16_roundtrip,
+        variant.output_f16_roundtrip,
+    )
+}
+
+fn probability_softmax_values_from_scores(
+    score_values: &[f32],
+    live_token_count: usize,
+    target_token_count: usize,
+    scale: f64,
+    length_policy: ReferenceScoreLengthPolicy,
+    score_f16_roundtrip: bool,
+    output_f16_roundtrip: bool,
+) -> Option<Vec<f32>> {
     if live_token_count == 0 || target_token_count == 0 {
         return None;
     }
-    let live_len = live_token_count.min(score.first_values.len()).min(target_token_count);
+    let live_len = live_token_count.min(score_values.len()).min(target_token_count);
     if live_len == 0 {
         return None;
     }
 
     let mut scaled_scores = Vec::with_capacity(live_len);
     for token in 0..live_len {
-        let score = numeric_variant_value(score.first_values[token], variant.score_f16_roundtrip);
+        let score = numeric_variant_value(score_values[token], score_f16_roundtrip);
         scaled_scores.push(score as f64 * scale);
     }
     let row_max = scaled_scores.iter().copied().fold(f64::NEG_INFINITY, f64::max);
@@ -3977,11 +3998,11 @@ fn reference_probability_softmax_values(
         .into_iter()
         .map(|value| {
             let probability = (value / exp_sum) as f32;
-            if variant.output_f16_roundtrip { f16_roundtrip(probability) } else { probability }
+            if output_f16_roundtrip { f16_roundtrip(probability) } else { probability }
         })
         .collect::<Vec<_>>();
 
-    match variant.length_policy {
+    match length_policy {
         ReferenceScoreLengthPolicy::LiveKeyCountOnly => {}
         ReferenceScoreLengthPolicy::PaddedTailZeroed | ReferenceScoreLengthPolicy::MaskApplied => {
             probabilities.resize(target_token_count, 0.0);
@@ -4137,6 +4158,176 @@ fn attention_probability_reference_softmax_variants(
         "diagnostic_only": true,
         "claim_allowed": false,
         "policy": "reference probability softmax variants are diagnostic-only probes for reproducing reference kq_soft_max_ext_head rows from reference kq_head rows; they do not promote reference parity, A770 semantic quality, softmax residency, selected attention, resident KV, or any support claim",
+        "score_head_count": score_heads.len(),
+        "probability_head_count": probability_heads.len(),
+        "head_dim": if head_dim == 0 { Value::Null } else { json!(head_dim) },
+        "head_count": if head_count == 0 { Value::Null } else { json!(head_count) },
+        "variant_count": variants.len(),
+        "variants_tested": variants.iter().map(|variant| variant.id).collect::<Vec<_>>(),
+        "explanation_abs_threshold": 1.0e-4,
+        "explanation_rms_threshold": 1.0e-4,
+        "compared_count": compared_count,
+        "missing_input_count": missing_input_count,
+        "unexplained_head_count": unexplained_head_count,
+        "max_best_abs_delta": max_best_abs_delta,
+        "max_best_rms_delta": max_best_rms_delta,
+        "best_variant_counts": best_variant_counts,
+        "all_heads_explained": !probability_heads.is_empty()
+            && missing_input_count == 0
+            && unexplained_head_count == 0,
+        "rows": rows,
+    })
+}
+
+fn attention_probability_rust_softmax_recompute(
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    let query = rust_records.get("attention_q_rope");
+    let score_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, "attention_scores_raw_head").map(|head| (head, record))
+        })
+        .filter(|(_, record)| !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+    let probability_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, "attn_scores_softmax_head").map(|head| (head, record))
+        })
+        .filter(|(_, record)| !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+    let variants = reference_probability_softmax_variant_specs();
+    let (head_dim, head_count) = query.and_then(rust_query_head_dim_count).unwrap_or((0, 0));
+
+    let mut rows = Vec::new();
+    let mut compared_count = 0usize;
+    let mut missing_input_count = 0usize;
+    let mut unexplained_head_count = 0usize;
+    let mut max_best_abs_delta = 0.0f64;
+    let mut max_best_rms_delta = 0.0f64;
+    let mut best_variant_counts = BTreeMap::<String, usize>::new();
+
+    for (&head, probability) in &probability_heads {
+        let score = score_heads.get(&head).copied();
+        if let Some(score) = score {
+            let target_token_count = probability.first_values.len();
+            let live_token_count = target_token_count.min(score.first_values.len());
+            let padded_token_count = target_token_count.saturating_sub(live_token_count);
+            let mut variant_rows = Vec::new();
+            let mut best_variant_id = "";
+            let mut best_delta = Value::Null;
+            let mut best_rank = (f64::INFINITY, f64::INFINITY, true);
+            let mut best_scale = 1.0f64;
+            let mut best_scale_policy = "";
+            let mut best_mask_policy = "";
+            let mut best_length_policy = "";
+            let mut best_score_f16_roundtrip = false;
+            let mut best_output_f16_roundtrip = false;
+
+            for variant in variants {
+                let scale = variant.scale_policy.scale(head_dim);
+                if let Some(values) = probability_softmax_values_from_scores(
+                    &score.first_values,
+                    live_token_count,
+                    target_token_count,
+                    scale,
+                    variant.length_policy,
+                    variant.score_f16_roundtrip,
+                    variant.output_f16_roundtrip,
+                ) {
+                    let delta = compare_vectors(&values, &probability.first_values);
+                    let rms = delta_metric(&delta, "/rms_abs_delta");
+                    let max_abs = delta_metric(&delta, "/max_abs_delta");
+                    let count_mismatch =
+                        !delta.pointer("/count_match").and_then(Value::as_bool).unwrap_or(false);
+                    let rank = (rms, max_abs, count_mismatch);
+                    if rank < best_rank {
+                        best_rank = rank;
+                        best_variant_id = variant.id;
+                        best_delta = delta.clone();
+                        best_scale = scale;
+                        best_scale_policy = variant.scale_policy.label();
+                        best_mask_policy = variant.length_policy.mask_policy();
+                        best_length_policy = variant.length_policy.label();
+                        best_score_f16_roundtrip = variant.score_f16_roundtrip;
+                        best_output_f16_roundtrip = variant.output_f16_roundtrip;
+                    }
+                    variant_rows.push(json!({
+                        "variant": variant.id,
+                        "head": head,
+                        "token_count": target_token_count,
+                        "live_token_count": live_token_count,
+                        "padded_token_count": padded_token_count,
+                        "scale": scale,
+                        "scale_policy": variant.scale_policy.label(),
+                        "scale_source": variant.scale_policy.source(),
+                        "mask_policy": variant.length_policy.mask_policy(),
+                        "length_policy": variant.length_policy.label(),
+                        "score_f16_roundtrip": variant.score_f16_roundtrip,
+                        "output_f16_roundtrip": variant.output_f16_roundtrip,
+                        "max_abs_delta": max_abs,
+                        "rms_delta": rms,
+                        "delta": delta,
+                    }));
+                }
+            }
+
+            if variant_rows.is_empty() {
+                missing_input_count += 1;
+                rows.push(json!({
+                    "head": head,
+                    "status": "missing_input",
+                    "score_stage_present": true,
+                    "probability_stage_present": true,
+                }));
+                continue;
+            }
+
+            let head_explained = reference_score_variant_explained(&best_delta);
+            if !head_explained {
+                unexplained_head_count += 1;
+            }
+            max_best_abs_delta =
+                max_best_abs_delta.max(delta_metric(&best_delta, "/max_abs_delta"));
+            max_best_rms_delta =
+                max_best_rms_delta.max(delta_metric(&best_delta, "/rms_abs_delta"));
+            *best_variant_counts.entry(best_variant_id.to_string()).or_insert(0) += 1;
+            compared_count += 1;
+            rows.push(json!({
+                "head": head,
+                "status": "compared",
+                "token_count": target_token_count,
+                "live_token_count": live_token_count,
+                "padded_token_count": padded_token_count,
+                "best_variant": best_variant_id,
+                "scale": best_scale,
+                "scale_policy": best_scale_policy,
+                "mask_policy": best_mask_policy,
+                "length_policy": best_length_policy,
+                "score_f16_roundtrip": best_score_f16_roundtrip,
+                "output_f16_roundtrip": best_output_f16_roundtrip,
+                "max_abs_delta": delta_metric(&best_delta, "/max_abs_delta"),
+                "rms_delta": delta_metric(&best_delta, "/rms_abs_delta"),
+                "best_delta": best_delta,
+                "head_explained": head_explained,
+                "variants": variant_rows,
+            }));
+        } else {
+            missing_input_count += 1;
+            rows.push(json!({
+                "head": head,
+                "status": "missing_input",
+                "score_stage_present": false,
+                "probability_stage_present": true,
+            }));
+        }
+    }
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "Rust probability softmax recompute is diagnostic-only evidence for whether Rust attn_scores_softmax_head rows are internally explained by Rust attention_scores_raw_head rows; it does not promote reference parity, A770 semantic quality, softmax residency, selected attention, resident KV, or any support claim",
         "score_head_count": score_heads.len(),
         "probability_head_count": probability_heads.len(),
         "head_dim": if head_dim == 0 { Value::Null } else { json!(head_dim) },
@@ -6865,6 +7056,65 @@ mod tests {
         assert_eq!(
             compare_report
                 .pointer("/attention_probability_reference_softmax_variants/all_heads_explained"),
+            Some(&json!(true))
+        );
+    }
+
+    #[test]
+    fn rust_probability_softmax_recompute_pins_scaled_live_policy() {
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_q_rope".to_string(),
+            RustTraceRecord {
+                shape: vec![1, 1, 1, 4],
+                num_elements: 4,
+                first_values: vec![0.0, 0.0, 0.0, 0.0],
+                ..test_rust_trace_record("attention_q_rope", vec![0.0, 0.0, 0.0, 0.0])
+            },
+        );
+        rust_records.insert(
+            "attention_scores_raw_head0".to_string(),
+            RustTraceRecord {
+                shape: vec![2],
+                num_elements: 2,
+                first_values: vec![0.0, 1.0],
+                ..test_rust_trace_record("attention_scores_raw_head0", vec![0.0, 1.0])
+            },
+        );
+        rust_records.insert(
+            "attn_scores_softmax_head0".to_string(),
+            RustTraceRecord {
+                shape: vec![2],
+                num_elements: 2,
+                first_values: vec![0.37754068, 0.62245935],
+                ..test_rust_trace_record("attn_scores_softmax_head0", vec![0.37754068, 0.62245935])
+            },
+        );
+
+        let report = attention_probability_rust_softmax_recompute(&rust_records);
+
+        assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(report.pointer("/compared_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/missing_input_count"), Some(&json!(0)));
+        assert_eq!(report.pointer("/all_heads_explained"), Some(&json!(true)));
+        assert_eq!(
+            report.pointer("/rows/0/best_variant"),
+            Some(&json!("reference_probability_softmax_scaled_1_sqrt_head_dim_live"))
+        );
+        assert_eq!(report.pointer("/rows/0/live_token_count"), Some(&json!(2)));
+        assert_eq!(report.pointer("/rows/0/padded_token_count"), Some(&json!(0)));
+        assert_eq!(report.pointer("/rows/0/scale_policy"), Some(&json!("1_sqrt_head_dim")));
+        assert_eq!(report.pointer("/rows/0/max_abs_delta"), Some(&json!(0.0)));
+
+        let compare_report = compare_reference_to_rust(&[], &rust_records, &[]);
+        assert_eq!(
+            compare_report.pointer("/attention_probability_rust_softmax_recompute/claim_allowed"),
+            Some(&json!(false))
+        );
+        assert_eq!(
+            compare_report
+                .pointer("/attention_probability_rust_softmax_recompute/all_heads_explained"),
             Some(&json!(true))
         );
     }


### PR DESCRIPTION
## Summary

Adds a diagnostic-only Rust probability softmax recompute report to `bitnet-reference-layer-trace-compare`.

This compares Rust `attn_scores_softmax_headN` rows against recomputed softmax rows from Rust `attention_scores_raw_headN`, testing the same scale/length/F16-roundtrip variants used by the reference probability report. The report is receipt-only and keeps `claim_allowed=false`.

## Target-local result

Using the existing `target/a770-diagnostic/reference-layer-trace-rust-cpu` and `target/a770-diagnostic/reference-layer-trace-rust-a770` traces:

```text
compared_count = 20
missing_input_count = 0
unexplained_head_count = 0
all_heads_explained = true
max_best_abs_delta = 2.384185791015625e-7
max_best_rms_delta = 5.6202451905918874e-8
best_variant_counts = {"reference_probability_softmax_scaled_1_sqrt_head_dim_live":20}
head9 best_variant = reference_probability_softmax_scaled_1_sqrt_head_dim_live
head9 max_abs_delta = 5.960464477539063e-8
head9 rms_delta = 1.5846767699301224e-8
```

This means Rust probability rows are internally explained by scaled live-token softmax. It does not explain Rust/reference raw score drift or promote any runtime claim.

## Claim boundary

Diagnostic only. This does not promote A770 semantic quality, selected attention, resident KV, attention scores, softmax residency, value mix residency, full support residency, full device residency, performance, or completion.

## Validation

```text
cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture
cargo check --locked -p xtask --no-default-features --bin xtask
rustfmt --edition 2024 --check xtask/src/bitnet_reference_layer_trace.rs
git diff --check
```