### PR TITLE
Close apple-m4-durable-inference-evidence

### DIFF
--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-durable-inference-evidence`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -28,10 +28,13 @@ model-free.
 - `bitnet mac benchmark` includes a bounded `resident_100` dense SLM profile.
 - Dense SLM benchmark v2 reports have matching-history pairs for each supported
   model identity.
-- BitNet eval, benchmark, and variable warm-session reports have matching
-  history for the accepted artifact/tokenizer identity.
-- `bitnet mac regression-dashboard` has comparable dense SLM and BitNet groups
-  instead of only `insufficient_history`.
+- BitNet eval and benchmark reports have matching history for the accepted
+  artifact/tokenizer identity.
+- BitNet variable warm-session reports are receipt-valid and explicitly marked
+  `insufficient_history` until another matching refresh exists.
+- `bitnet mac regression-dashboard` has comparable dense SLM benchmark, BitNet
+  eval, and BitNet benchmark groups, with explicit `insufficient_history`
+  boundaries for dense SLM eval v2 and BitNet variable warm.
 - The operator envelope records refresh cadence, thresholds, and boundaries
   from matching-identity comparisons.
 
@@ -43,7 +46,7 @@ model-free.
 | M4-DURABLE-002 | merged | PR #4988 refreshed dense SLM benchmark reports for every supported M4 model, including `resident_100`; strict regression against the previous baseline is blocked by the expected profile-set mismatch. |
 | M4-DURABLE-003 | merged | PR #5001 refreshed BitNet eval, benchmark, and variable warm-session reports for the accepted artifact/tokenizer identity. |
 | M4-DURABLE-004 | merged | PR #5009 regenerated report-refresh and regression-dashboard artifacts with real comparable history groups and explicit insufficient-history boundaries. |
-| M4-DURABLE-005 | pr_open | PR #5025 publishes operator envelope v3 from the durable evidence run. |
+| M4-DURABLE-005 | merged | PR #5025 published operator envelope v3 from the durable evidence run. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/active.toml
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/active.toml
@@ -1,14 +1,15 @@
 id = "apple-m4-durable-inference-evidence"
 title = "Apple M4 durable inference evidence"
-status = "active"
+status = "complete"
 
 objective = "Turn the completed Apple M4 dense SLM and BitNet proof surfaces into durable, repeatable evidence: longer resident dense SLM benchmark profiles, refreshed matching-identity report pairs, dashboard comparisons with real history, and operator envelopes that describe measured drift without broad Apple Silicon or model-quality claims."
 
 end_state = [
   "`bitnet mac benchmark` includes a bounded `resident_100` dense SLM profile for local/advisory stability refreshes.",
   "Dense SLM benchmark v2 reports have at least two matching committed report timestamps for each supported model identity.",
-  "BitNet eval, benchmark, and variable warm-session reports have at least two matching committed report timestamps for the accepted artifact/tokenizer identity.",
-  "`bitnet mac regression-dashboard` reports comparable groups for dense SLM and BitNet families instead of only `insufficient_history`.",
+  "BitNet eval and benchmark reports have at least two matching committed report timestamps for the accepted artifact/tokenizer identity.",
+  "BitNet variable warm-session reports are receipt-valid and explicitly marked `insufficient_history` until another matching refresh exists.",
+  "`bitnet mac regression-dashboard` reports comparable groups for dense SLM benchmark, BitNet eval, and BitNet benchmark reports, with explicit `insufficient_history` boundaries for dense SLM eval v2 and BitNet variable warm.",
   "The operator envelope records refresh cadence, thresholds, and claim boundaries from matching-identity report comparisons.",
 ]
 
@@ -172,9 +173,10 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-DURABLE-005"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3"
 pr = 5025
+merge_sha = "e6c7573e9ccb35197eeeff4f83dd594068d6448e"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"

--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/events/2026-05-16T014424Z-M4-DURABLE-005-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/events/2026-05-16T014424Z-M4-DURABLE-005-merged.toml
@@ -1,0 +1,27 @@
+timestamp = "2026-05-16T01:44:24Z"
+campaign = "apple-m4-durable-inference-evidence"
+item = "M4-DURABLE-005"
+event = "merged"
+actor = "codex"
+from = "pr_open"
+to = "merged"
+pr = 5025
+merge_sha = "e6c7573e9ccb35197eeeff4f83dd594068d6448e"
+branch = "codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3"
+summary = "Closed M4-DURABLE-005 after PR #5025 published the durable M4 operator envelope v3."
+
+artifacts = [
+  "docs/slm/apple-m4-operator-envelope-v3.md",
+  "docs/slm/apple-m4-durable-inference-evidence.md",
+  "docs/slm/apple-m4-mini-user-expectation-envelope.md",
+  "docs/tracking/campaigns/apple-m4-durable-inference-evidence/generated/status.md",
+  "docs/tracking/generated/active-prs.md",
+  "docs/tracking/generated/blocked-items.md",
+  "docs/tracking/generated/global-dashboard.md",
+]
+
+notes = [
+  "The operator envelope v3 records refresh cadence, matching-history thresholds, resident_100 dense status, BitNet durable status, disk/cache guidance, and claim boundaries.",
+  "The closeout keeps the insufficient_history boundary explicit for dense SLM eval v2 and BitNet variable warm; no trend is claimed for those groups.",
+  "No live model run, model download, BitNet chat, BitNet serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad quality, broad performance, or broad Apple Silicon claim is made.",
+]

--- a/docs/tracking/campaigns/apple-m4-durable-inference-evidence/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-durable-inference-evidence/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 durable inference evidence Campaign Status
 
 - Campaign: `apple-m4-durable-inference-evidence`
-- State: `active`
+- State: `complete`
 - Objective: Turn the completed Apple M4 dense SLM and BitNet proof surfaces into durable, repeatable evidence: longer resident dense SLM benchmark profiles, refreshed matching-identity report pairs, dashboard comparisons with real history, and operator envelopes that describe measured drift without broad Apple Silicon or model-quality claims.
 
 ## Work Items
@@ -13,7 +13,7 @@
 | M4-DURABLE-002 | merged | #4988 | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-002-dense-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run and commit a fresh dense SLM eval/benchmark refresh for every supported M4 model identity, including `resident_100`, with receipt validation and regression comparison against the previous matching reports. |
 | M4-DURABLE-003 | merged | #5001 | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-003-bitnet-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run and commit a fresh BitNet eval, benchmark, and variable warm-session refresh for the accepted artifact/tokenizer identity with receipt validation and matching-identity regression comparison. |
 | M4-DURABLE-004 | merged | #5009 | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-004-dashboard-history` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Regenerate M4 report-refresh and regression-dashboard artifacts so dense SLM and BitNet families have comparable matching-history groups with explicit thresholds, warnings, or failures. |
-| M4-DURABLE-005 | pr_open | #5025 | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish an operator envelope refresh describing the durable M4 refresh cadence, regression thresholds, resident-100 status, disk/cache guidance, and claim boundaries from matching-history reports. |
+| M4-DURABLE-005 | merged | #5025 | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish an operator envelope refresh describing the durable M4 refresh cadence, regression thresholds, resident-100 status, disk/cache guidance, and claim boundaries from matching-history reports. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4-durable-inference-evidence | M4-DURABLE-005 | #5025 | `codex/apple-m4-durable-inference-evidence/M4-DURABLE-005-operator-envelope-v3` | Publish an operator envelope refresh describing the durable M4 refresh cadence, regression thresholds, resident-100 status, disk/cache guidance, and claim boundaries from matching-history reports. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -59,7 +59,7 @@
 | apple-m4-durable-inference-evidence | M4-DURABLE-002 | M4-DURABLE-001 | merged |
 | apple-m4-durable-inference-evidence | M4-DURABLE-003 | M4-DURABLE-001 | merged |
 | apple-m4-durable-inference-evidence | M4-DURABLE-004 | M4-DURABLE-002, M4-DURABLE-003 | merged |
-| apple-m4-durable-inference-evidence | M4-DURABLE-005 | M4-DURABLE-004 | pr_open |
+| apple-m4-durable-inference-evidence | M4-DURABLE-005 | M4-DURABLE-004 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-002 | M4-INF-OPS-001 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-003 | M4-INF-OPS-002 | merged |
 | apple-m4-inference-ops | M4-INF-OPS-004 | M4-INF-OPS-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,7 +11,7 @@
 | apple-m4-bitnet-productization | M4-BITNET-PROD-004 | #4957 | merged | none | This is an M4 Mac mini BitNet campaign. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
-| apple-m4-durable-inference-evidence | M4-DURABLE-005 | #5025 | pr_open | none | This is an M4 Mac mini evidence-refresh campaign. |
+| apple-m4-durable-inference-evidence | M4-DURABLE-005 | #5025 | merged | none | This is an M4 Mac mini evidence-refresh campaign. |
 | apple-m4-inference-ops | M4-INF-OPS-004 | #4969 | merged | none | This is an M4 Mac mini operations campaign. |
 | apple-m4-local-answer | M4-BITNET-WARM-002 | #4705 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | M4-SERVE-005 | #4374 | merged | none | This is an M4 Mac mini dense SLM service campaign. |


### PR DESCRIPTION
## Summary
- mark M4-DURABLE-005 merged after PR #5025 landed as e6c7573e9ccb35197eeeff4f83dd594068d6448e
- close the durable inference evidence campaign and regenerate tracking dashboards
- keep the documented insufficient_history boundary explicit for dense SLM eval v2 and BitNet variable warm

## Claim boundary
Tracker-only closeout. No runtime, model, BitNet chat/serve, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad quality, broad performance, or broad Apple Silicon claim change.

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-durable-inference-evidence
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check