### PR TITLE
diag(bitnet): trace key cache boundary

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -617,6 +617,20 @@ impl MultiHeadAttention {
         #[cfg(feature = "trace")]
         if self.layer_idx == 0 {
             for kv_head_idx in 0..self.n_kv_heads {
+                let before_store = k
+                    .narrow(1, kv_head_idx, 1)?
+                    .reshape(&[seq_len, self.head_dim])?
+                    .transpose(0, 1)?
+                    .to_dtype(DType::F32)?;
+                let trace_seq = trace_target_seq().unwrap_or(_trace_base_seq);
+                let trace_name = format!(
+                    "t{trace_seq}/blk0/attention_k_before_cache_store_kv_head{kv_head_idx}_ref_layout"
+                );
+                let stage =
+                    format!("attention_k_before_cache_store_kv_head{kv_head_idx}_ref_layout");
+                trace_tensor_record(&trace_name, &before_store, trace_seq, Some(0), &stage)?;
+            }
+            for kv_head_idx in 0..self.n_kv_heads {
                 let before_store = v
                     .narrow(1, kv_head_idx, 1)?
                     .reshape(&[seq_len, self.head_dim])?

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -3831,6 +3831,7 @@ fn compare_reference_to_rust(
         "attention_score_reference_numeric_variants": attention_score_reference_numeric_variants(reference_records),
         "attention_score_input_attribution": attention_score_input_attribution(reference_records, rust_records),
         "attention_key_score_input_delta": attention_key_score_input_delta(reference_records, rust_records),
+        "attention_key_cache_store_readback_boundary": attention_key_cache_store_readback_boundary(reference_records, rust_records),
         "attention_score_rust_scalar_recompute": attention_score_rust_scalar_recompute(rust_records),
         "attention_score_raw_head_lane_best_matches": attention_score_raw_head_lane_best_matches(reference_records, rust_records),
         "attention_probability_reference_softmax_variants": attention_probability_reference_softmax_variants(reference_records),
@@ -7046,6 +7047,206 @@ fn attention_key_score_input_delta(
         "all_compared": !rust_heads.is_empty() && missing_head_count == 0,
         "rows": rows,
     })
+}
+
+fn attention_key_cache_store_readback_boundary(
+    reference_records: &[ReferenceTraceRecord],
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    let reference_cache_heads = reference_records
+        .iter()
+        .filter_map(|record| {
+            parse_stage_head(&record.stage, "k_kv_head").map(|head| (head, record))
+        })
+        .filter(|(_, record)| record.values_available && !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "key-cache store/readback boundary comparison is diagnostic-only evidence for where live key score-input drift enters; it does not promote reference parity, A770 semantic quality, attention score residency, resident KV, selected attention, or any support claim",
+        "reference_stage_prefix": "k_kv_head",
+        "reference_reinterpretation": "token_major_to_dim_major",
+        "reference_head_count": reference_cache_heads.len(),
+        "before_cache_store": key_cache_boundary_kv_section(
+            &reference_cache_heads,
+            rust_records,
+            "attention_k_before_cache_store_kv_head",
+            "before_cache_store",
+        ),
+        "cache_readback": key_cache_boundary_kv_section(
+            &reference_cache_heads,
+            rust_records,
+            "attention_k_cache_kv_head",
+            "cache_readback",
+        ),
+        "cache_f16_roundtrip": key_cache_boundary_kv_section(
+            &reference_cache_heads,
+            rust_records,
+            "attention_k_cache_f16_roundtrip_kv_head",
+            "cache_f16_roundtrip",
+        ),
+        "score_input": key_cache_boundary_expanded_section(&reference_cache_heads, rust_records),
+    })
+}
+
+fn key_cache_boundary_kv_section(
+    reference_cache_heads: &BTreeMap<usize, &ReferenceTraceRecord>,
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+    rust_stage_prefix: &str,
+    boundary: &str,
+) -> Value {
+    let rust_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, rust_stage_prefix).map(|head| (head, record))
+        })
+        .filter(|(_, record)| !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+
+    let mut rows = Vec::new();
+    let mut compared_head_count = 0usize;
+    let mut missing_head_count = 0usize;
+    let mut total_bucket_mismatch_count = 0usize;
+    let mut max_bucket_mismatch_count = 0usize;
+    let mut max_abs_delta = 0.0f64;
+    let mut max_rms_delta = 0.0f64;
+
+    for (&head, reference) in reference_cache_heads {
+        if let Some(rust) = rust_heads.get(&head) {
+            let delta = key_cache_dim_major_delta(reference, rust);
+            let bucket_mismatch_count =
+                delta.pointer("/f16_bucket_mismatch_count").and_then(Value::as_u64).unwrap_or(0)
+                    as usize;
+            total_bucket_mismatch_count += bucket_mismatch_count;
+            max_bucket_mismatch_count = max_bucket_mismatch_count.max(bucket_mismatch_count);
+            max_abs_delta = max_abs_delta.max(delta_metric(&delta, "/max_abs_delta"));
+            max_rms_delta = max_rms_delta.max(delta_metric(&delta, "/rms_abs_delta"));
+            compared_head_count += 1;
+            rows.push(json!({
+                "head": head,
+                "status": "compared",
+                "delta": delta,
+            }));
+        } else {
+            missing_head_count += 1;
+            rows.push(json!({
+                "head": head,
+                "status": "missing_rust_boundary_stage",
+            }));
+        }
+    }
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "boundary": boundary,
+        "rust_stage_prefix": rust_stage_prefix,
+        "reference_head_count": reference_cache_heads.len(),
+        "rust_head_count": rust_heads.len(),
+        "compared_head_count": compared_head_count,
+        "missing_head_count": missing_head_count,
+        "total_f16_bucket_mismatch_count": total_bucket_mismatch_count,
+        "max_head_f16_bucket_mismatch_count": max_bucket_mismatch_count,
+        "max_abs_delta": max_abs_delta,
+        "max_rms_delta": max_rms_delta,
+        "all_compared": !reference_cache_heads.is_empty() && missing_head_count == 0,
+        "rows": rows,
+    })
+}
+
+fn key_cache_boundary_expanded_section(
+    reference_cache_heads: &BTreeMap<usize, &ReferenceTraceRecord>,
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    let rust_stage_prefix = "attention_k_score_input_head";
+    let rust_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, rust_stage_prefix).map(|head| (head, record))
+        })
+        .filter(|(_, record)| !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+    let group_size = if reference_cache_heads.is_empty()
+        || rust_heads.is_empty()
+        || !rust_heads.len().is_multiple_of(reference_cache_heads.len())
+    {
+        None
+    } else {
+        Some(rust_heads.len() / reference_cache_heads.len())
+    };
+
+    let mut rows = Vec::new();
+    let mut compared_head_count = 0usize;
+    let mut missing_head_count = 0usize;
+    let mut total_bucket_mismatch_count = 0usize;
+    let mut max_bucket_mismatch_count = 0usize;
+    let mut max_abs_delta = 0.0f64;
+    let mut max_rms_delta = 0.0f64;
+
+    for (&head, rust) in &rust_heads {
+        let kv_head = group_size.map(|group_size| head / group_size);
+        if let Some(reference) = kv_head.and_then(|kv_head| reference_cache_heads.get(&kv_head)) {
+            let delta = key_cache_dim_major_delta(reference, rust);
+            let bucket_mismatch_count =
+                delta.pointer("/f16_bucket_mismatch_count").and_then(Value::as_u64).unwrap_or(0)
+                    as usize;
+            total_bucket_mismatch_count += bucket_mismatch_count;
+            max_bucket_mismatch_count = max_bucket_mismatch_count.max(bucket_mismatch_count);
+            max_abs_delta = max_abs_delta.max(delta_metric(&delta, "/max_abs_delta"));
+            max_rms_delta = max_rms_delta.max(delta_metric(&delta, "/rms_abs_delta"));
+            compared_head_count += 1;
+            rows.push(json!({
+                "head": head,
+                "kv_head": kv_head,
+                "status": "compared",
+                "delta": delta,
+            }));
+        } else {
+            missing_head_count += 1;
+            rows.push(json!({
+                "head": head,
+                "kv_head": kv_head,
+                "status": "missing_reference_key_cache",
+            }));
+        }
+    }
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "boundary": "score_input",
+        "rust_stage_prefix": rust_stage_prefix,
+        "reference_head_count": reference_cache_heads.len(),
+        "rust_head_count": rust_heads.len(),
+        "group_size": group_size,
+        "compared_head_count": compared_head_count,
+        "missing_head_count": missing_head_count,
+        "total_f16_bucket_mismatch_count": total_bucket_mismatch_count,
+        "max_head_f16_bucket_mismatch_count": max_bucket_mismatch_count,
+        "max_abs_delta": max_abs_delta,
+        "max_rms_delta": max_rms_delta,
+        "all_compared": !rust_heads.is_empty() && missing_head_count == 0,
+        "rows": rows,
+    })
+}
+
+fn key_cache_dim_major_delta(reference: &ReferenceTraceRecord, rust: &RustTraceRecord) -> Value {
+    let dim_count = reference.shape.first().and_then(|dim| usize::try_from(*dim).ok());
+    let token_count = reference.shape.get(1).and_then(|dim| usize::try_from(*dim).ok());
+    match (dim_count, token_count, key_cache_dim_major_first_values(reference)) {
+        (Some(dim_count), Some(token_count), Some(reference_dim_major))
+            if dim_count > 0 && token_count > 0 =>
+        {
+            f16_bucket_delta_dim_major(
+                &reference_dim_major,
+                &rust.first_values,
+                dim_count,
+                token_count,
+            )
+        }
+        _ => f16_bucket_delta(&reference.first_values, &rust.first_values),
+    }
 }
 
 fn attention_value_cache_kv_head_best_matches(
@@ -10871,6 +11072,120 @@ mod tests {
             |reasons| reasons.contains(&json!("reference_k_kv_head_sample_incomplete"))
                 && reasons.contains(&json!("rust_attention_k_score_input_sample_incomplete"))
         ));
+    }
+
+    #[test]
+    fn compare_reports_key_cache_store_readback_boundary() {
+        let reference_records = vec![ReferenceTraceRecord {
+            shape: vec![2, 3, 1, 1],
+            nelements: 6,
+            // Reference k_kv_head records are token-major.
+            first_values: vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0],
+            ..test_reference_trace_record("k_kv_head0_live", vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0])
+        }];
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_k_before_cache_store_kv_head0_live_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 3],
+                num_elements: 6,
+                first_values: vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+                ..test_rust_trace_record(
+                    "attention_k_before_cache_store_kv_head0_live_ref_layout",
+                    vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+                )
+            },
+        );
+        rust_records.insert(
+            "attention_k_cache_kv_head0_live_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 3],
+                num_elements: 6,
+                first_values: vec![1.0, 2.25, 3.0, 10.0, 20.0, 30.0],
+                ..test_rust_trace_record(
+                    "attention_k_cache_kv_head0_live_ref_layout",
+                    vec![1.0, 2.25, 3.0, 10.0, 20.0, 30.0],
+                )
+            },
+        );
+        rust_records.insert(
+            "attention_k_cache_f16_roundtrip_kv_head0_live_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 3],
+                num_elements: 6,
+                first_values: vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+                ..test_rust_trace_record(
+                    "attention_k_cache_f16_roundtrip_kv_head0_live_ref_layout",
+                    vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+                )
+            },
+        );
+        rust_records.insert(
+            "attention_k_score_input_head0_live_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 3],
+                num_elements: 6,
+                first_values: vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+                ..test_rust_trace_record(
+                    "attention_k_score_input_head0_live_ref_layout",
+                    vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+                )
+            },
+        );
+        rust_records.insert(
+            "attention_k_score_input_head1_live_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 3],
+                num_elements: 6,
+                first_values: vec![1.0, 2.0, 3.0, 10.0, 20.5, 30.0],
+                ..test_rust_trace_record(
+                    "attention_k_score_input_head1_live_ref_layout",
+                    vec![1.0, 2.0, 3.0, 10.0, 20.5, 30.0],
+                )
+            },
+        );
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let boundary = report.pointer("/attention_key_cache_store_readback_boundary").unwrap();
+
+        assert_eq!(boundary.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(boundary.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(boundary.pointer("/reference_stage_prefix"), Some(&json!("k_kv_head")));
+        assert_eq!(
+            boundary.pointer("/reference_reinterpretation"),
+            Some(&json!("token_major_to_dim_major"))
+        );
+        assert_eq!(boundary.pointer("/before_cache_store/compared_head_count"), Some(&json!(1)));
+        assert_eq!(boundary.pointer("/before_cache_store/max_abs_delta"), Some(&json!(0.0)));
+        assert_eq!(boundary.pointer("/cache_readback/max_abs_delta"), Some(&json!(0.25)));
+        assert_eq!(boundary.pointer("/cache_f16_roundtrip/max_abs_delta"), Some(&json!(0.0)));
+        assert_eq!(boundary.pointer("/score_input/group_size"), Some(&json!(2)));
+        assert_eq!(boundary.pointer("/score_input/compared_head_count"), Some(&json!(2)));
+        assert_eq!(boundary.pointer("/score_input/rows/1/delta/max_abs_delta"), Some(&json!(0.5)));
+    }
+
+    #[test]
+    fn compare_reports_key_cache_store_readback_missing_stages_as_diagnostic() {
+        let reference_records = vec![ReferenceTraceRecord {
+            shape: vec![2, 3, 1, 1],
+            nelements: 6,
+            first_values: vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0],
+            ..test_reference_trace_record("k_kv_head0_live", vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0])
+        }];
+
+        let report = compare_reference_to_rust(&reference_records, &BTreeMap::new(), &[]);
+        let boundary = report.pointer("/attention_key_cache_store_readback_boundary").unwrap();
+
+        assert_eq!(boundary.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(boundary.pointer("/before_cache_store/missing_head_count"), Some(&json!(1)));
+        assert_eq!(boundary.pointer("/cache_readback/missing_head_count"), Some(&json!(1)));
+        assert_eq!(boundary.pointer("/cache_f16_roundtrip/missing_head_count"), Some(&json!(1)));
+        assert_eq!(boundary.pointer("/score_input/missing_head_count"), Some(&json!(0)));
+        assert_eq!(boundary.pointer("/score_input/all_compared"), Some(&json!(false)));
+        assert_eq!(
+            boundary.pointer("/before_cache_store/rows/0/status"),
+            Some(&json!("missing_rust_boundary_stage"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- trace layer-0 post-RoPE K before cache store as `attention_k_before_cache_store_kv_head*`
- add diagnostic `attention_key_cache_store_readback_boundary` to compare reference K live-cache rows against Rust before-store, cache readback, F16 roundtrip, and score-input stages
- keep all output diagnostic-only with `claim_allowed=false`

## Target-local evidence
With `BITNET_DIAG_RMSNORM_F64_ACCUM=1` and full trace prefix:
- first material mismatch remains `kqv_head7`
- `before_cache_store.max_abs_delta = 0.003902435302734375`
- `cache_readback.max_abs_delta = 0.003902435302734375`
- `score_input.max_abs_delta = 0.003902435302734375`
- head 7 maps to KV head 1; the same delta is already present before cache store

This moves the next frontier earlier than key cache storage/readback/score expansion: K projection/RoPE semantics are the next suspect.

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `cargo check --locked -p xtask --no-default-features`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-capture-rust --plan target/a770-diagnostic/bitnet-reference-plan.json --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu-rmsnorm-f64-key-boundary --a770-trace-dir target/a770-diagnostic/reference-layer-trace-rust-a770-rmsnorm-f64-key-boundary --skip-a770 --overwrite --output target/a770-diagnostic/bitnet-reference-layer-trace-rust-capture-rmsnorm-f64-key-boundary.json --format human`
- `cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-compare --reference target/a770-diagnostic/bitnet-reference-layer-trace-run-input-history.json --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu-rmsnorm-f64-key-boundary --output target/a770-diagnostic/bitnet-reference-layer-trace-compare-rmsnorm-f64-key-boundary.json --format human`
- `rustfmt --edition 2024 --check crates/bitnet-transformer/src/lib.rs xtask/src/bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claim boundary
No promotion of A770 semantic quality, selected attention, resident KV, attention scores, softmax, value mix residency, full residency, performance, or completion.