### PR TITLE
diag(reference): report truncated Qcur score samples

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -115,7 +115,12 @@ fn attention_f16_dot_input(tensor: &Tensor) -> Result<Tensor> {
 }
 
 fn attention_score_key_input(tensor: &Tensor) -> Result<Tensor> {
-    Ok(tensor.to_dtype(DType::F32)?)
+    attention_f16_dot_input(tensor)
+}
+
+#[cfg(any(feature = "trace", test))]
+fn attention_score_key_f16_probe_input(tensor: &Tensor) -> Result<Tensor> {
+    attention_f16_dot_input(tensor)
 }
 
 fn qk256_scale_for(
@@ -811,6 +816,7 @@ impl MultiHeadAttention {
         let k_for_scores = attention_score_key_input(&k_expanded)?;
         #[cfg(feature = "trace")]
         if self.layer_idx == 0 {
+            let k_for_scores_f16_probe = attention_score_key_f16_probe_input(&k_expanded)?;
             trace_layer0_tensor(
                 self.layer_idx,
                 _trace_base_seq,
@@ -830,6 +836,18 @@ impl MultiHeadAttention {
                 );
                 let stage = format!("attention_k_score_input_head{head_idx}_live_ref_layout");
                 trace_tensor_record(&trace_name, &key_head, trace_seq, Some(0), &stage)?;
+
+                let key_head_f16_probe = k_for_scores_f16_probe
+                    .narrow(1, head_idx, 1)?
+                    .reshape(&[t_k, self.head_dim])?
+                    .transpose(0, 1)?
+                    .to_dtype(DType::F32)?;
+                let trace_name = format!(
+                    "t{trace_seq}/blk0/attention_k_score_input_f16_roundtrip_head{head_idx}_live_ref_layout"
+                );
+                let stage =
+                    format!("attention_k_score_input_f16_roundtrip_head{head_idx}_live_ref_layout");
+                trace_tensor_record(&trace_name, &key_head_f16_probe, trace_seq, Some(0), &stage)?;
             }
         }
         let scores = q_for_scores.matmul(&k_for_scores.transpose(2, 3)?)?;
@@ -2365,7 +2383,7 @@ mod tests {
     }
 
     #[test]
-    fn attention_score_key_input_preserves_f32_values() -> Result<()> {
+    fn attention_score_key_input_uses_f16_roundtrip_values() -> Result<()> {
         let device = Device::Cpu;
         let input =
             Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
@@ -2373,7 +2391,43 @@ mod tests {
         let output = attention_score_key_input(&input)?;
         let values = output.flatten_all()?.to_vec1::<f32>()?;
 
-        assert_eq!(values, vec![1.0003, -2.0007, 3.1259, -4.2509]);
+        assert_eq!(values, vec![1.0, -2.0, 3.125, -4.25]);
+        Ok(())
+    }
+
+    #[test]
+    fn attention_score_key_f16_probe_input_uses_f16_roundtrip_values() -> Result<()> {
+        let device = Device::Cpu;
+        let input =
+            Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
+
+        let output = attention_score_key_f16_probe_input(&input)?;
+        let values = output.flatten_all()?.to_vec1::<f32>()?;
+
+        assert_eq!(values, vec![1.0, -2.0, 3.125, -4.25]);
+        Ok(())
+    }
+
+    #[test]
+    fn attention_score_key_runtime_matches_f16_probe_contract() -> Result<()> {
+        let device = Device::Cpu;
+        let query =
+            Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
+        let key = Tensor::from_slice(&[5.0003f32, 6.0007, -7.1259, 8.2509], (1, 1, 1, 4), &device)?;
+
+        let q_values = attention_f16_dot_input(&query)?.flatten_all()?.to_vec1::<f32>()?;
+        let runtime_k_values = attention_score_key_input(&key)?.flatten_all()?.to_vec1::<f32>()?;
+        let probe_k_values =
+            attention_score_key_f16_probe_input(&key)?.flatten_all()?.to_vec1::<f32>()?;
+        let runtime_score =
+            q_values.iter().zip(runtime_k_values.iter()).fold(0.0f32, |sum, (q, k)| sum + q * k);
+        let probe_score =
+            q_values.iter().zip(probe_k_values.iter()).fold(0.0f32, |sum, (q, k)| sum + q * k);
+
+        assert_eq!(runtime_k_values, vec![5.0, 6.0, -7.125, 8.25]);
+        assert_eq!(probe_k_values, vec![5.0, 6.0, -7.125, 8.25]);
+        assert_eq!(runtime_score, -64.328125);
+        assert_eq!(probe_score, -64.328125);
         Ok(())
     }
 
@@ -2389,8 +2443,8 @@ mod tests {
         let score = q_values.iter().zip(k_values.iter()).fold(0.0f32, |sum, (q, k)| sum + q * k);
 
         assert_eq!(q_values, vec![1.0, -2.0, 3.125, -4.25]);
-        assert_eq!(k_values, vec![5.0003, 6.0007, -7.1259, 8.2509]);
-        assert_eq!(score, -64.33586);
+        assert_eq!(k_values, vec![5.0, 6.0, -7.125, 8.25]);
+        assert_eq!(score, -64.328125);
         Ok(())
     }
 

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -152,6 +152,7 @@ struct LayerTraceRustCaptureArgs {
     cpu_trace_dir: PathBuf,
     a770_trace_dir: PathBuf,
     skip_a770: bool,
+    diag_rmsnorm_f64_accum: bool,
     overwrite: bool,
     output: Option<PathBuf>,
     format: String,
@@ -450,7 +451,7 @@ fn print_compare_help() {
 
 fn print_rust_capture_help() {
     println!(
-        "Run the Rust CPU and strict A770 commands from the matched reference plan with BITNET_TRACE_DIR set\n\nUsage: xtask.exe bitnet-reference-layer-trace-capture-rust [OPTIONS]\n\nOptions:\n      --plan <PATH>            Reference plan JSON [default: target/a770-diagnostic/bitnet-reference-plan.json]\n      --cpu-trace-dir <PATH>   Rust CPU BITNET_TRACE_DIR output [default: target/a770-diagnostic/reference-layer-trace-rust-cpu]\n      --a770-trace-dir <PATH>  Strict A770 BITNET_TRACE_DIR output [default: target/a770-diagnostic/reference-layer-trace-rust-a770]\n      --skip-a770              Capture CPU trace only and report strict A770 as skipped\n      --overwrite              Remove existing top-level .trace files from output trace directories before running\n      --output <PATH>          Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-layer-trace-rust-capture.json]\n      --format <FORMAT>        Output format: human or json [default: human]\n  -h, --help                   Print help"
+        "Run the Rust CPU and strict A770 commands from the matched reference plan with BITNET_TRACE_DIR set\n\nUsage: xtask.exe bitnet-reference-layer-trace-capture-rust [OPTIONS]\n\nOptions:\n      --plan <PATH>            Reference plan JSON [default: target/a770-diagnostic/bitnet-reference-plan.json]\n      --cpu-trace-dir <PATH>   Rust CPU BITNET_TRACE_DIR output [default: target/a770-diagnostic/reference-layer-trace-rust-cpu]\n      --a770-trace-dir <PATH>  Strict A770 BITNET_TRACE_DIR output [default: target/a770-diagnostic/reference-layer-trace-rust-a770]\n      --skip-a770              Capture CPU trace only and report strict A770 as skipped\n      --diag-rmsnorm-f64-accum Capture Rust traces with BITNET_DIAG_RMSNORM_F64_ACCUM=1\n      --overwrite              Remove existing top-level .trace files from output trace directories before running\n      --output <PATH>          Output JSON receipt [default: target/a770-diagnostic/bitnet-reference-layer-trace-rust-capture.json]\n      --format <FORMAT>        Output format: human or json [default: human]\n  -h, --help                   Print help"
     );
 }
 
@@ -587,6 +588,7 @@ fn parse_rust_capture_args(args: &[String]) -> Result<LayerTraceRustCaptureArgs>
     let mut cpu_trace_dir = PathBuf::from(DEFAULT_CPU_TRACE_DIR);
     let mut a770_trace_dir = PathBuf::from(DEFAULT_A770_TRACE_DIR);
     let mut skip_a770 = false;
+    let mut diag_rmsnorm_f64_accum = false;
     let mut overwrite = false;
     let mut output = Some(PathBuf::from(DEFAULT_RUST_CAPTURE_OUTPUT));
     let mut format = "human".to_string();
@@ -604,6 +606,7 @@ fn parse_rust_capture_args(args: &[String]) -> Result<LayerTraceRustCaptureArgs>
             "--cpu-trace-dir" => cpu_trace_dir = PathBuf::from(value()?),
             "--a770-trace-dir" => a770_trace_dir = PathBuf::from(value()?),
             "--skip-a770" => skip_a770 = true,
+            "--diag-rmsnorm-f64-accum" => diag_rmsnorm_f64_accum = true,
             "--overwrite" => overwrite = true,
             "--output" => output = Some(PathBuf::from(value()?)),
             "--format" => format = value()?,
@@ -615,6 +618,7 @@ fn parse_rust_capture_args(args: &[String]) -> Result<LayerTraceRustCaptureArgs>
         cpu_trace_dir,
         a770_trace_dir,
         skip_a770,
+        diag_rmsnorm_f64_accum,
         overwrite,
         output,
         format,
@@ -1157,6 +1161,7 @@ fn capture_rust_layer_traces(args: &LayerTraceRustCaptureArgs) -> Result<Value> 
             cpu_argv.as_deref().unwrap_or(&[]),
             &cpu_trace_dir,
             trace_target_seq,
+            args.diag_rmsnorm_f64_accum,
         )?
     } else {
         skipped_rust_trace_capture("cpu", cpu_argv.as_deref(), &cpu_trace_dir)
@@ -1169,6 +1174,7 @@ fn capture_rust_layer_traces(args: &LayerTraceRustCaptureArgs) -> Result<Value> 
             a770_argv.as_deref().unwrap_or(&[]),
             &a770_trace_dir,
             trace_target_seq,
+            args.diag_rmsnorm_f64_accum,
         )?
     } else {
         if args.skip_a770 {
@@ -1204,6 +1210,7 @@ fn capture_rust_layer_traces(args: &LayerTraceRustCaptureArgs) -> Result<Value> 
             "cpu_trace_dir": path_to_string(&cpu_trace_dir),
             "a770_trace_dir": path_to_string(&a770_trace_dir),
             "skip_a770": args.skip_a770,
+            "diag_rmsnorm_f64_accum": args.diag_rmsnorm_f64_accum,
             "overwrite": args.overwrite,
         },
         "model": plan.pointer("/model").cloned().unwrap_or(Value::Null),
@@ -1220,6 +1227,10 @@ fn capture_rust_layer_traces(args: &LayerTraceRustCaptureArgs) -> Result<Value> 
             "trace_target_source": trace_target_seq.map(|_| "prompt_identity.prompt_token_count_minus_one"),
             "cpu_trace_feature_injected": cpu_trace_feature_injected.unwrap_or(false),
             "a770_trace_feature_injected": a770_trace_feature_injected.unwrap_or(false),
+            "diag_rmsnorm_f64_accum": args.diag_rmsnorm_f64_accum,
+            "diag_rmsnorm_f64_accum_env": args
+                .diag_rmsnorm_f64_accum
+                .then_some("BITNET_DIAG_RMSNORM_F64_ACCUM=1"),
             "cpu_trace_dir_prepare": cpu_prepare,
             "a770_trace_dir_prepare": a770_prepare,
             "first_values_limit_env": std::env::var("BITNET_TRACE_FIRST_VALUES_LIMIT").ok(),
@@ -3850,6 +3861,7 @@ fn compare_reference_to_rust(
         "attention_norm_history_delta": attention_norm_history_delta(reference_records, rust_records),
         "attention_value_projection_input_history": attention_value_projection_input_history(reference_records, rust_records),
         "attention_value_projection_output_history": attention_value_projection_output_history(reference_records, rust_records),
+        "attention_value_projection_to_cache_layout_bridge": attention_value_projection_to_cache_layout_bridge(reference_records, rust_records),
         "attention_value_mix_reference_scalar_recompute": attention_value_mix_reference_scalar_recompute(reference_records),
         "attention_value_mix_reference_numeric_variants": attention_value_mix_reference_numeric_variants(reference_records),
         "attention_value_mix_rust_scalar_recompute": attention_value_mix_rust_scalar_recompute(rust_records),
@@ -4330,7 +4342,6 @@ fn attention_value_mix_reference_numeric_variants(
             }));
         }
     }
-
     json!({
         "diagnostic_only": true,
         "claim_allowed": false,
@@ -4851,7 +4862,6 @@ fn attention_value_mix_input_candidate_best_summary(
             }));
         }
     }
-
     json!({
         "diagnostic_only": true,
         "claim_allowed": false,
@@ -5845,6 +5855,14 @@ fn attention_score_input_attribution(
         })
         .filter(|(_, record)| !record.first_values.is_empty())
         .collect::<BTreeMap<_, _>>();
+    let rust_score_key_f16_probe_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, "attention_k_score_input_f16_roundtrip_head")
+                .map(|head| (head, record))
+        })
+        .filter(|(_, record)| !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
     let rust_fallback_key_heads = rust_records
         .iter()
         .filter_map(|(stage, record)| {
@@ -5921,6 +5939,7 @@ fn attention_score_input_attribution(
             ScoreKeyLayout::TokenMajor
         };
         let actual_rust_key = rust_score_key_heads.get(&head).copied();
+        let rust_key_f16_probe = rust_score_key_f16_probe_heads.get(&head).copied();
         let fallback_rust_key =
             kv_head.and_then(|kv_head| rust_fallback_key_heads.get(&kv_head).copied());
         let rust_key = actual_rust_key.or(fallback_rust_key);
@@ -5949,7 +5968,7 @@ fn attention_score_input_attribution(
                 .min(rust_key_token_count(rust_key).unwrap_or(rust_score.first_values.len()))
                 .min(reference_score.first_values.len())
                 .min(rust_score.first_values.len());
-            let candidates = [
+            let mut candidates = vec![
                 ScoreInputAttributionCandidate {
                     id: "reference_q_reference_k_q_f16_k_f32",
                     base_candidate: "reference_q_reference_k",
@@ -6047,6 +6066,32 @@ fn attention_score_input_attribution(
                     key_values: &rust_key.first_values,
                 },
             ];
+            if let Some(rust_key_f16_probe) = rust_key_f16_probe {
+                candidates.push(ScoreInputAttributionCandidate {
+                    id: "reference_q_rust_k_f16_probe_q_f16_k_trace_f16",
+                    base_candidate: "reference_q_rust_k_f16_probe",
+                    score_input_variant: "q_f16_k_trace_f16",
+                    query_source: "reference_Qcur",
+                    key_source: "rust_attention_k_score_input_f16_roundtrip_head",
+                    key_layout: ScoreKeyLayout::DimMajor,
+                    query_f16_roundtrip: true,
+                    key_f16_roundtrip: false,
+                    query_values: &reference_query.first_values,
+                    key_values: &rust_key_f16_probe.first_values,
+                });
+                candidates.push(ScoreInputAttributionCandidate {
+                    id: "rust_q_rust_k_f16_probe_q_f16_k_trace_f16",
+                    base_candidate: "rust_q_rust_k_f16_probe",
+                    score_input_variant: "q_f16_k_trace_f16",
+                    query_source: "rust_attention_q_rope",
+                    key_source: "rust_attention_k_score_input_f16_roundtrip_head",
+                    key_layout: ScoreKeyLayout::DimMajor,
+                    query_f16_roundtrip: true,
+                    key_f16_roundtrip: false,
+                    query_values: &rust_query.first_values,
+                    key_values: &rust_key_f16_probe.first_values,
+                });
+            }
 
             let mut candidate_rows = Vec::new();
             let mut reference_deltas = BTreeMap::<&str, Value>::new();
@@ -6153,6 +6198,7 @@ fn attention_score_input_attribution(
                 "reference_key_source_kind": reference_key_source_kind,
                 "rust_key_source": rust_key_source,
                 "rust_key_source_kind": rust_key_source_kind,
+                "rust_key_f16_probe_present": rust_key_f16_probe.is_some(),
                 "reference_best_candidate": reference_best_info.map(|candidate| candidate.base_candidate),
                 "reference_best_candidate_id": reference_best,
                 "reference_best_score_input_variant": reference_best_info.map(|candidate| candidate.score_input_variant),
@@ -6175,6 +6221,7 @@ fn attention_score_input_attribution(
                 "reference_kcur_history_key_present": reference_kcur_history_key.is_some(),
                 "reference_legacy_key_present": reference_legacy_key.is_some(),
                 "rust_key_present": rust_key.is_some(),
+                "rust_score_key_f16_probe_present": rust_score_key_f16_probe_heads.contains_key(&head),
                 "rust_score_key_present": actual_rust_key.is_some(),
                 "rust_fallback_key_present": fallback_rust_key.is_some(),
                 "reference_score_present": true,
@@ -6208,6 +6255,7 @@ fn attention_score_input_attribution(
             rust_score_key_heads.len()
         },
         "rust_score_key_head_count": rust_score_key_heads.len(),
+        "rust_score_key_f16_probe_head_count": rust_score_key_f16_probe_heads.len(),
         "rust_fallback_key_head_count": rust_fallback_key_heads.len(),
         "rust_key_stage_source": if rust_score_key_heads.is_empty() {
             "attention_k_cache_f16_roundtrip_kv_head_fallback"
@@ -8390,7 +8438,6 @@ fn attention_value_projection_output_history(
             }
         }
     }
-
     json!({
         "diagnostic_only": true,
         "claim_allowed": false,
@@ -8410,6 +8457,219 @@ fn attention_value_projection_output_history(
         "current_blocked_reasons": blocked_reasons,
         "rows": rows,
     })
+}
+
+fn attention_value_projection_to_cache_layout_bridge(
+    reference_records: &[ReferenceTraceRecord],
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    let reference_projection = reference_records
+        .iter()
+        .find(|record| record.stage == "vcur_history_ref_layout")
+        .filter(|record| record.values_available && !record.first_values.is_empty());
+    let reference_cache_heads = reference_records
+        .iter()
+        .filter_map(|record| {
+            parse_stage_head(&record.stage, "v_cache_rust_layout_head").map(|head| (head, record))
+        })
+        .filter(|(_, record)| record.values_available && !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+    let rust_before_store_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, "attention_v_before_cache_store_kv_head")
+                .map(|head| (head, record))
+        })
+        .filter(|(_, record)| !record.first_values.is_empty())
+        .collect::<BTreeMap<_, _>>();
+
+    let mut rows = Vec::new();
+    let mut compared_projection_cache_count = 0usize;
+    let mut compared_projection_rust_count = 0usize;
+    let mut compared_cache_rust_count = 0usize;
+    let mut total_projection_cache_bucket_mismatch_count = 0usize;
+    let mut total_projection_rust_bucket_mismatch_count = 0usize;
+    let mut total_cache_rust_bucket_mismatch_count = 0usize;
+    let mut max_projection_cache_bucket_mismatch_count = 0usize;
+    let mut max_projection_rust_bucket_mismatch_count = 0usize;
+    let mut max_cache_rust_bucket_mismatch_count = 0usize;
+    let mut incomplete_projection_head_count = 0usize;
+    let mut expected_head_count = 0usize;
+    let mut blocked_reasons = Vec::<String>::new();
+
+    if reference_projection.is_none() {
+        blocked_reasons.push("reference_vcur_history_ref_layout_missing".to_string());
+    }
+    if reference_cache_heads.is_empty() {
+        blocked_reasons.push("reference_v_cache_rust_layout_heads_missing".to_string());
+    }
+    if rust_before_store_heads.is_empty() {
+        blocked_reasons.push("rust_attention_v_before_cache_store_heads_missing".to_string());
+    }
+
+    if let Some(reference_projection) = reference_projection {
+        let total_dim_count =
+            reference_projection.shape.first().and_then(|dim| usize::try_from(*dim).ok());
+        let token_count =
+            reference_projection.shape.get(1).and_then(|dim| usize::try_from(*dim).ok());
+        let head_dim = reference_cache_heads
+            .values()
+            .find_map(|record| record.shape.first().and_then(|dim| usize::try_from(*dim).ok()))
+            .or_else(|| {
+                rust_before_store_heads
+                    .values()
+                    .find_map(|record| record.shape.first().copied().filter(|dim| *dim > 0))
+            });
+
+        match (total_dim_count, token_count, head_dim) {
+            (Some(total_dim_count), Some(token_count), Some(head_dim))
+                if total_dim_count > 0 && token_count > 0 && head_dim > 0 =>
+            {
+                if !total_dim_count.is_multiple_of(head_dim) {
+                    blocked_reasons.push(format!(
+                        "reference_vcur_dim_count_not_divisible_by_head_dim:{total_dim_count}:{head_dim}"
+                    ));
+                } else {
+                    expected_head_count = total_dim_count / head_dim;
+                    for head in 0..expected_head_count {
+                        let projection_head = slice_dim_major_head(
+                            &reference_projection.first_values,
+                            head,
+                            head_dim,
+                            token_count,
+                        );
+                        let projection_head_required_count = head_dim.saturating_mul(token_count);
+                        let projection_head_complete =
+                            projection_head.len() == projection_head_required_count;
+                        let reference_cache = reference_cache_heads.get(&head).copied();
+                        let rust_before_store = rust_before_store_heads.get(&head);
+
+                        let projection_history_slice_vs_reference_cache_layout =
+                            projection_head_complete.then_some(reference_cache).flatten().map(
+                                |record| {
+                                    f16_bucket_delta_dim_major(
+                                        &projection_head,
+                                        &record.first_values,
+                                        head_dim,
+                                        token_count,
+                                    )
+                                },
+                            );
+                        let projection_history_slice_vs_rust_before_cache_store =
+                            projection_head_complete.then_some(rust_before_store).flatten().map(
+                                |record| {
+                                    f16_bucket_delta_dim_major(
+                                        &projection_head,
+                                        &record.first_values,
+                                        head_dim,
+                                        token_count,
+                                    )
+                                },
+                            );
+                        let reference_cache_layout_vs_rust_before_cache_store =
+                            reference_cache.zip(rust_before_store).map(|(reference, rust)| {
+                                f16_bucket_delta_dim_major(
+                                    &reference.first_values,
+                                    &rust.first_values,
+                                    head_dim,
+                                    token_count,
+                                )
+                            });
+
+                        if let Some(delta) = &projection_history_slice_vs_reference_cache_layout {
+                            let count = f16_bucket_mismatch_count(delta);
+                            total_projection_cache_bucket_mismatch_count += count;
+                            max_projection_cache_bucket_mismatch_count =
+                                max_projection_cache_bucket_mismatch_count.max(count);
+                            compared_projection_cache_count += 1;
+                        }
+                        if let Some(delta) = &projection_history_slice_vs_rust_before_cache_store {
+                            let count = f16_bucket_mismatch_count(delta);
+                            total_projection_rust_bucket_mismatch_count += count;
+                            max_projection_rust_bucket_mismatch_count =
+                                max_projection_rust_bucket_mismatch_count.max(count);
+                            compared_projection_rust_count += 1;
+                        }
+                        if let Some(delta) = &reference_cache_layout_vs_rust_before_cache_store {
+                            let count = f16_bucket_mismatch_count(delta);
+                            total_cache_rust_bucket_mismatch_count += count;
+                            max_cache_rust_bucket_mismatch_count =
+                                max_cache_rust_bucket_mismatch_count.max(count);
+                            compared_cache_rust_count += 1;
+                        }
+
+                        let mut missing = Vec::<&str>::new();
+                        if !projection_head_complete {
+                            incomplete_projection_head_count += 1;
+                            missing.push("reference_projection_history_head_sample_incomplete");
+                        }
+                        if reference_cache.is_none() {
+                            missing.push("reference_cache_layout_head");
+                        }
+                        if rust_before_store.is_none() {
+                            missing.push("rust_before_cache_store_head");
+                        }
+
+                        rows.push(json!({
+                            "kv_head": head,
+                            "status": if missing.is_empty() { "compared" } else { "missing_input" },
+                            "missing": missing,
+                            "projection_head_first_values_count": projection_head.len(),
+                            "projection_head_required_values_count": projection_head_required_count,
+                            "projection_history_slice_vs_reference_cache_layout":
+                                projection_history_slice_vs_reference_cache_layout.unwrap_or(Value::Null),
+                            "projection_history_slice_vs_rust_before_cache_store":
+                                projection_history_slice_vs_rust_before_cache_store.unwrap_or(Value::Null),
+                            "reference_cache_layout_vs_rust_before_cache_store":
+                                reference_cache_layout_vs_rust_before_cache_store.unwrap_or(Value::Null),
+                        }));
+                    }
+                }
+            }
+            (Some(_), Some(_), None) => {
+                blocked_reasons.push("value_projection_cache_bridge_head_dim_unusable".to_string());
+            }
+            _ => {
+                blocked_reasons.push("reference_vcur_history_shape_unusable".to_string());
+            }
+        }
+    }
+    if incomplete_projection_head_count > 0 {
+        blocked_reasons.push("reference_projection_history_head_samples_incomplete".to_string());
+    }
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "value-projection to cache-layout bridge is diagnostic-only evidence for whether the reference V projection history, reference V cache layout, and Rust before-cache-store history agree in the same head/token/dim scope; it does not promote reference parity, A770 semantic quality, resident KV, value mix residency, selected attention, or any support claim",
+        "reference_projection_stage": "vcur_history_ref_layout",
+        "reference_cache_stage_prefix": "v_cache_rust_layout_head",
+        "rust_before_cache_store_stage_prefix": "attention_v_before_cache_store_kv_head",
+        "reference_projection_present": reference_projection.is_some(),
+        "reference_cache_head_count": reference_cache_heads.len(),
+        "rust_before_cache_store_head_count": rust_before_store_heads.len(),
+        "expected_head_count": expected_head_count,
+        "compared_projection_cache_count": compared_projection_cache_count,
+        "compared_projection_rust_count": compared_projection_rust_count,
+        "compared_cache_rust_count": compared_cache_rust_count,
+        "total_projection_cache_f16_bucket_mismatch_count": total_projection_cache_bucket_mismatch_count,
+        "total_projection_rust_f16_bucket_mismatch_count": total_projection_rust_bucket_mismatch_count,
+        "total_cache_rust_f16_bucket_mismatch_count": total_cache_rust_bucket_mismatch_count,
+        "max_projection_cache_head_f16_bucket_mismatch_count": max_projection_cache_bucket_mismatch_count,
+        "max_projection_rust_head_f16_bucket_mismatch_count": max_projection_rust_bucket_mismatch_count,
+        "max_cache_rust_head_f16_bucket_mismatch_count": max_cache_rust_bucket_mismatch_count,
+        "incomplete_projection_head_count": incomplete_projection_head_count,
+        "all_compared": expected_head_count > 0
+            && compared_projection_cache_count == expected_head_count
+            && compared_projection_rust_count == expected_head_count
+            && compared_cache_rust_count == expected_head_count,
+        "current_blocked_reasons": blocked_reasons,
+        "rows": rows,
+    })
+}
+
+fn f16_bucket_mismatch_count(delta: &Value) -> usize {
+    delta.pointer("/f16_bucket_mismatch_count").and_then(Value::as_u64).unwrap_or(0) as usize
 }
 
 fn slice_dim_major_head(
@@ -9520,6 +9780,7 @@ fn run_rust_trace_capture(
     argv: &[String],
     trace_dir: &Path,
     trace_target_seq: Option<usize>,
+    diag_rmsnorm_f64_accum: bool,
 ) -> Result<Value> {
     let executable = argv.first().context("empty Rust trace command")?;
     let mut command = Command::new(executable);
@@ -9529,6 +9790,9 @@ fn run_rust_trace_capture(
         .env("BITNET_DETERMINISTIC", "1")
         .env("BITNET_SEED", "0")
         .stdin(Stdio::null());
+    if diag_rmsnorm_f64_accum {
+        command.env("BITNET_DIAG_RMSNORM_F64_ACCUM", "1");
+    }
     if let Some(trace_target_seq) = trace_target_seq {
         command.env("BITNET_TRACE_TARGET_SEQ", trace_target_seq.to_string());
     }
@@ -9540,6 +9804,9 @@ fn run_rust_trace_capture(
         "trace_dir": path_to_string(trace_dir),
         "trace_target_seq": trace_target_seq,
         "trace_target_source": trace_target_seq.map(|_| "prompt_identity.prompt_token_count_minus_one"),
+        "diag_rmsnorm_f64_accum": diag_rmsnorm_f64_accum,
+        "diag_rmsnorm_f64_accum_env": diag_rmsnorm_f64_accum
+            .then_some("BITNET_DIAG_RMSNORM_F64_ACCUM=1"),
         "argv": argv,
         "command": capture_json(Some(&capture)),
         "trace": trace,
@@ -10142,6 +10409,7 @@ mod tests {
             cpu_trace_dir: dir.path().join("cpu"),
             a770_trace_dir: dir.path().join("a770"),
             skip_a770: false,
+            diag_rmsnorm_f64_accum: false,
             overwrite: false,
             output: None,
             format: "json".to_string(),
@@ -10152,8 +10420,78 @@ mod tests {
 
         assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
         assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(report.pointer("/inputs/diag_rmsnorm_f64_accum"), Some(&json!(false)));
+        assert_eq!(report.pointer("/preflight/diag_rmsnorm_f64_accum"), Some(&json!(false)));
+        assert_eq!(report.pointer("/preflight/diag_rmsnorm_f64_accum_env"), Some(&Value::Null));
         assert!(reasons.contains(&json!("reference_plan_missing")));
         assert_eq!(report.pointer("/decision/compare_ready"), Some(&json!(false)));
+    }
+
+    #[test]
+    fn rust_capture_args_parse_diag_rmsnorm_f64_accum_flag() {
+        let default_args =
+            vec!["xtask".to_string(), "bitnet-reference-layer-trace-capture-rust".to_string()];
+        let defaults = parse_rust_capture_args(&default_args).unwrap();
+        assert_eq!(defaults.plan, PathBuf::from(DEFAULT_REFERENCE_PLAN));
+        assert_eq!(defaults.cpu_trace_dir, PathBuf::from(DEFAULT_CPU_TRACE_DIR));
+        assert_eq!(defaults.a770_trace_dir, PathBuf::from(DEFAULT_A770_TRACE_DIR));
+        assert!(!defaults.skip_a770);
+        assert!(!defaults.diag_rmsnorm_f64_accum);
+        assert!(!defaults.overwrite);
+        assert_eq!(defaults.output, Some(PathBuf::from(DEFAULT_RUST_CAPTURE_OUTPUT)));
+        assert_eq!(defaults.format, "human");
+
+        let args = vec![
+            "xtask".to_string(),
+            "bitnet-reference-layer-trace-capture-rust".to_string(),
+            "--plan".to_string(),
+            "plan.json".to_string(),
+            "--cpu-trace-dir".to_string(),
+            "cpu".to_string(),
+            "--a770-trace-dir".to_string(),
+            "a770".to_string(),
+            "--skip-a770".to_string(),
+            "--diag-rmsnorm-f64-accum".to_string(),
+            "--overwrite".to_string(),
+            "--output".to_string(),
+            "out.json".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        let parsed = parse_rust_capture_args(&args).unwrap();
+        assert_eq!(parsed.plan, PathBuf::from("plan.json"));
+        assert_eq!(parsed.cpu_trace_dir, PathBuf::from("cpu"));
+        assert_eq!(parsed.a770_trace_dir, PathBuf::from("a770"));
+        assert!(parsed.skip_a770);
+        assert!(parsed.diag_rmsnorm_f64_accum);
+        assert!(parsed.overwrite);
+        assert_eq!(parsed.output, Some(PathBuf::from("out.json")));
+        assert_eq!(parsed.format, "json");
+    }
+
+    #[test]
+    fn rust_capture_report_records_diag_rmsnorm_f64_accum_intent() {
+        let dir = tempdir().unwrap();
+        let report = capture_rust_layer_traces(&LayerTraceRustCaptureArgs {
+            plan: dir.path().join("missing-plan.json"),
+            cpu_trace_dir: dir.path().join("cpu"),
+            a770_trace_dir: dir.path().join("a770"),
+            skip_a770: true,
+            diag_rmsnorm_f64_accum: true,
+            overwrite: false,
+            output: None,
+            format: "json".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(report.pointer("/inputs/diag_rmsnorm_f64_accum"), Some(&json!(true)));
+        assert_eq!(report.pointer("/preflight/diag_rmsnorm_f64_accum"), Some(&json!(true)));
+        assert_eq!(
+            report.pointer("/preflight/diag_rmsnorm_f64_accum_env"),
+            Some(&json!("BITNET_DIAG_RMSNORM_F64_ACCUM=1"))
+        );
     }
 
     #[test]
@@ -10172,6 +10510,7 @@ mod tests {
             cpu_trace_dir: cpu,
             a770_trace_dir: a770,
             skip_a770: false,
+            diag_rmsnorm_f64_accum: false,
             overwrite: false,
             output: None,
             format: "json".to_string(),
@@ -11173,6 +11512,18 @@ mod tests {
             },
         );
         rust_records.insert(
+            "attention_k_score_input_f16_roundtrip_head0_live_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 2],
+                num_elements: 4,
+                first_values: vec![30.0, 50.0, 40.0, 60.0],
+                ..test_rust_trace_record(
+                    "attention_k_score_input_f16_roundtrip_head0_live_ref_layout",
+                    vec![30.0, 50.0, 40.0, 60.0],
+                )
+            },
+        );
+        rust_records.insert(
             "attention_scores_raw_head0".to_string(),
             RustTraceRecord {
                 shape: vec![2],
@@ -11191,6 +11542,7 @@ mod tests {
             Some(&json!("attention_k_score_input_head"))
         );
         assert_eq!(report.pointer("/rust_score_key_head_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/rust_score_key_f16_probe_head_count"), Some(&json!(1)));
         assert_eq!(report.pointer("/rust_fallback_key_head_count"), Some(&json!(1)));
         assert_eq!(
             report.pointer("/rows/0/rust_key_source"),
@@ -11201,6 +11553,7 @@ mod tests {
             Some(&json!("actual_score_input"))
         );
         assert_eq!(report.pointer("/rows/0/rust_best_candidate"), Some(&json!("rust_q_rust_k")));
+        assert_eq!(report.pointer("/rows/0/rust_key_f16_probe_present"), Some(&json!(true)));
         assert_eq!(
             report.pointer("/rows/0/candidates/3/key_source"),
             Some(&json!("reference_k_kv_head"))
@@ -11215,6 +11568,17 @@ mod tests {
                 },
             );
         assert!(has_actual_k_f16_candidate);
+        let has_probe_candidate =
+            report.pointer("/rows/0/candidates").and_then(Value::as_array).unwrap().iter().any(
+                |candidate| {
+                    candidate.pointer("/base_candidate") == Some(&json!("rust_q_rust_k_f16_probe"))
+                        && candidate.pointer("/score_input_variant")
+                            == Some(&json!("q_f16_k_trace_f16"))
+                        && candidate.pointer("/key_source")
+                            == Some(&json!("rust_attention_k_score_input_f16_roundtrip_head"))
+                },
+            );
+        assert!(has_probe_candidate);
     }
 
     #[test]
@@ -12616,6 +12980,201 @@ mod tests {
             boundary.pointer("/expanded_for_value_mix/compared_head_count"),
             Some(&json!(2))
         );
+    }
+
+    #[test]
+    fn compare_reports_value_projection_to_cache_layout_bridge_matches() {
+        let reference_records = vec![
+            ReferenceTraceRecord {
+                shape: vec![2, 2, 1, 1],
+                nelements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_reference_trace_record("vcur_history_ref_layout", vec![1.0, 2.0, 3.0, 4.0])
+            },
+            ReferenceTraceRecord {
+                shape: vec![2, 2, 1, 1],
+                nelements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_reference_trace_record(
+                    "v_cache_rust_layout_head0_live",
+                    vec![1.0, 2.0, 3.0, 4.0],
+                )
+            },
+        ];
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_v_before_cache_store_kv_head0_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 2],
+                num_elements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_rust_trace_record(
+                    "attention_v_before_cache_store_kv_head0_ref_layout",
+                    vec![1.0, 2.0, 3.0, 4.0],
+                )
+            },
+        );
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let bridge = report.pointer("/attention_value_projection_to_cache_layout_bridge").unwrap();
+
+        assert_eq!(bridge.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(bridge.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(bridge.pointer("/all_compared"), Some(&json!(true)));
+        assert_eq!(
+            bridge.pointer("/total_projection_cache_f16_bucket_mismatch_count"),
+            Some(&json!(0))
+        );
+        assert_eq!(
+            bridge.pointer("/total_projection_rust_f16_bucket_mismatch_count"),
+            Some(&json!(0))
+        );
+        assert_eq!(bridge.pointer("/total_cache_rust_f16_bucket_mismatch_count"), Some(&json!(0)));
+    }
+
+    #[test]
+    fn compare_reports_value_projection_to_cache_layout_bridge_localizes_reference_cache_delta() {
+        let reference_records = vec![
+            ReferenceTraceRecord {
+                shape: vec![2, 2, 1, 1],
+                nelements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_reference_trace_record("vcur_history_ref_layout", vec![1.0, 2.0, 3.0, 4.0])
+            },
+            ReferenceTraceRecord {
+                shape: vec![2, 2, 1, 1],
+                nelements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.5],
+                ..test_reference_trace_record(
+                    "v_cache_rust_layout_head0_live",
+                    vec![1.0, 2.0, 3.0, 4.5],
+                )
+            },
+        ];
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_v_before_cache_store_kv_head0_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 2],
+                num_elements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_rust_trace_record(
+                    "attention_v_before_cache_store_kv_head0_ref_layout",
+                    vec![1.0, 2.0, 3.0, 4.0],
+                )
+            },
+        );
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let bridge = report.pointer("/attention_value_projection_to_cache_layout_bridge").unwrap();
+
+        assert_eq!(bridge.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(bridge.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(bridge.pointer("/all_compared"), Some(&json!(true)));
+        assert_eq!(
+            bridge.pointer("/rows/0/projection_history_slice_vs_rust_before_cache_store/f16_bucket_mismatch_count"),
+            Some(&json!(0))
+        );
+        assert_eq!(
+            bridge.pointer("/rows/0/projection_history_slice_vs_reference_cache_layout/f16_bucket_mismatch_count"),
+            Some(&json!(1))
+        );
+        assert_eq!(
+            bridge.pointer("/rows/0/reference_cache_layout_vs_rust_before_cache_store/f16_bucket_mismatch_count"),
+            Some(&json!(1))
+        );
+        assert_eq!(
+            bridge.pointer("/total_projection_cache_f16_bucket_mismatch_count"),
+            Some(&json!(1))
+        );
+        assert_eq!(
+            bridge.pointer("/total_projection_rust_f16_bucket_mismatch_count"),
+            Some(&json!(0))
+        );
+        assert_eq!(bridge.pointer("/total_cache_rust_f16_bucket_mismatch_count"), Some(&json!(1)));
+    }
+
+    #[test]
+    fn compare_reports_value_projection_to_cache_layout_bridge_incomplete_projection_sample() {
+        let reference_records = vec![
+            ReferenceTraceRecord {
+                shape: vec![2, 2, 1, 1],
+                nelements: 4,
+                first_values: vec![1.0, 2.0],
+                ..test_reference_trace_record("vcur_history_ref_layout", vec![1.0, 2.0])
+            },
+            ReferenceTraceRecord {
+                shape: vec![2, 2, 1, 1],
+                nelements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_reference_trace_record(
+                    "v_cache_rust_layout_head0_live",
+                    vec![1.0, 2.0, 3.0, 4.0],
+                )
+            },
+        ];
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_v_before_cache_store_kv_head0_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 2],
+                num_elements: 4,
+                first_values: vec![1.0, 2.0, 3.0, 4.0],
+                ..test_rust_trace_record(
+                    "attention_v_before_cache_store_kv_head0_ref_layout",
+                    vec![1.0, 2.0, 3.0, 4.0],
+                )
+            },
+        );
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let bridge = report.pointer("/attention_value_projection_to_cache_layout_bridge").unwrap();
+        let missing = bridge.pointer("/rows/0/missing").and_then(Value::as_array).unwrap();
+        let reasons = bridge.pointer("/current_blocked_reasons").and_then(Value::as_array).unwrap();
+
+        assert_eq!(bridge.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(bridge.pointer("/all_compared"), Some(&json!(false)));
+        assert_eq!(bridge.pointer("/incomplete_projection_head_count"), Some(&json!(1)));
+        assert!(reasons.contains(&json!("reference_projection_history_head_samples_incomplete")));
+        assert_eq!(bridge.pointer("/rows/0/projection_head_first_values_count"), Some(&json!(2)));
+        assert_eq!(
+            bridge.pointer("/rows/0/projection_head_required_values_count"),
+            Some(&json!(4))
+        );
+        assert!(missing.contains(&json!("reference_projection_history_head_sample_incomplete")));
+        assert_eq!(
+            bridge.pointer("/rows/0/projection_history_slice_vs_reference_cache_layout"),
+            Some(&Value::Null)
+        );
+        assert_eq!(
+            bridge.pointer("/rows/0/projection_history_slice_vs_rust_before_cache_store"),
+            Some(&Value::Null)
+        );
+        assert_eq!(
+            bridge.pointer("/rows/0/reference_cache_layout_vs_rust_before_cache_store/f16_bucket_mismatch_count"),
+            Some(&json!(0))
+        );
+    }
+
+    #[test]
+    fn compare_reports_value_projection_to_cache_layout_bridge_missing_inputs() {
+        let reference_records = vec![ReferenceTraceRecord {
+            shape: vec![2, 2, 1, 1],
+            nelements: 4,
+            first_values: vec![1.0, 2.0, 3.0, 4.0],
+            ..test_reference_trace_record("vcur_history_ref_layout", vec![1.0, 2.0, 3.0, 4.0])
+        }];
+        let rust_records = BTreeMap::new();
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let bridge = report.pointer("/attention_value_projection_to_cache_layout_bridge").unwrap();
+        let reasons = bridge.pointer("/current_blocked_reasons").and_then(Value::as_array).unwrap();
+
+        assert_eq!(bridge.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(bridge.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(bridge.pointer("/all_compared"), Some(&json!(false)));
+        assert!(reasons.contains(&json!("reference_v_cache_rust_layout_heads_missing")));
+        assert!(reasons.contains(&json!("rust_attention_v_before_cache_store_heads_missing")));
     }
 
     #[test]

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -4893,6 +4893,7 @@ fn attention_query_rope_ref_layout_delta(
 
 fn attention_score_reference_scalar_recompute(reference_records: &[ReferenceTraceRecord]) -> Value {
     let query = reference_rope_query_record(reference_records);
+    let query_sample_status = reference_query_sample_status(query);
     let key_heads = reference_records
         .iter()
         .filter_map(|record| {
@@ -4977,6 +4978,11 @@ fn attention_score_reference_scalar_recompute(reference_records: &[ReferenceTrac
         "policy": "reference scalar score recompute is diagnostic arithmetic evidence only; it recomputes sampled raw attention rows from reference Qcur and reference K-cache samples and does not promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, or any support claim",
         "query_stage_present": query.is_some(),
         "query_stage": query.map(|record| record.stage.clone()),
+        "query_first_values_count": query_sample_status.first_values_count,
+        "query_required_values_count": query_sample_status.required_values_count,
+        "query_missing_values_count": query_sample_status.missing_values_count,
+        "query_sample_complete": query_sample_status.sample_complete,
+        "query_sample_blocked_reason": query_sample_status.blocked_reason,
         "key_head_count": key_heads.len(),
         "score_head_count": score_heads.len(),
         "head_dim": if head_dim == 0 { Value::Null } else { json!(head_dim) },
@@ -5150,6 +5156,7 @@ fn attention_score_reference_semantic_variants(
     reference_records: &[ReferenceTraceRecord],
 ) -> Value {
     let query = reference_rope_query_record(reference_records);
+    let query_sample_status = reference_query_sample_status(query);
     let key_heads = reference_records
         .iter()
         .filter_map(|record| {
@@ -5295,6 +5302,11 @@ fn attention_score_reference_semantic_variants(
         "policy": "reference score semantic variants are diagnostic-only scale, mask, live-token, and padded-tail probes for reproducing reference kq_head rows; they do not promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, or any support claim",
         "query_stage_present": query.is_some(),
         "query_stage": query.map(|record| record.stage.clone()),
+        "query_first_values_count": query_sample_status.first_values_count,
+        "query_required_values_count": query_sample_status.required_values_count,
+        "query_missing_values_count": query_sample_status.missing_values_count,
+        "query_sample_complete": query_sample_status.sample_complete,
+        "query_sample_blocked_reason": query_sample_status.blocked_reason,
         "key_head_count": key_heads.len(),
         "score_head_count": score_heads.len(),
         "head_dim": if head_dim == 0 { Value::Null } else { json!(head_dim) },
@@ -5462,6 +5474,7 @@ fn reference_score_row_from_query_key_numeric(
 
 fn attention_score_reference_numeric_variants(reference_records: &[ReferenceTraceRecord]) -> Value {
     let query = reference_rope_query_record(reference_records);
+    let query_sample_status = reference_query_sample_status(query);
     let key_heads = reference_records
         .iter()
         .filter_map(|record| {
@@ -5616,6 +5629,11 @@ fn attention_score_reference_numeric_variants(reference_records: &[ReferenceTrac
         "policy": "reference score numeric variants are diagnostic-only probes for GGML-like score dot numeric behavior; they keep the padded-tail-zeroed row shape fixed and vary Q/K F16 roundtrip plus f32/f64 accumulation without promoting reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, or any support claim",
         "query_stage_present": query.is_some(),
         "query_stage": query.map(|record| record.stage.clone()),
+        "query_first_values_count": query_sample_status.first_values_count,
+        "query_required_values_count": query_sample_status.required_values_count,
+        "query_missing_values_count": query_sample_status.missing_values_count,
+        "query_sample_complete": query_sample_status.sample_complete,
+        "query_sample_blocked_reason": query_sample_status.blocked_reason,
         "key_head_count": key_heads.len(),
         "score_head_count": score_heads.len(),
         "head_dim": if head_dim == 0 { Value::Null } else { json!(head_dim) },
@@ -6849,6 +6867,59 @@ fn rust_query_head_dim_count(record: &RustTraceRecord) -> Option<(usize, usize)>
             }
         }
         _ => None,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReferenceQuerySampleStatus {
+    first_values_count: usize,
+    required_values_count: Value,
+    missing_values_count: Value,
+    sample_complete: bool,
+    blocked_reason: Value,
+}
+
+fn reference_query_sample_status(
+    record: Option<&ReferenceTraceRecord>,
+) -> ReferenceQuerySampleStatus {
+    let Some(record) = record else {
+        return ReferenceQuerySampleStatus {
+            first_values_count: 0,
+            required_values_count: Value::Null,
+            missing_values_count: Value::Null,
+            sample_complete: false,
+            blocked_reason: json!("reference_qcur_missing"),
+        };
+    };
+    let first_values_count = record.first_values.len();
+    let required_values_count = record
+        .shape
+        .first()
+        .and_then(|head_dim| usize::try_from(*head_dim).ok())
+        .zip(record.shape.get(1).and_then(|head_count| usize::try_from(*head_count).ok()))
+        .and_then(|(head_dim, head_count)| head_dim.checked_mul(head_count))
+        .filter(|count| *count > 0);
+    let Some(required_values_count) = required_values_count else {
+        return ReferenceQuerySampleStatus {
+            first_values_count,
+            required_values_count: Value::Null,
+            missing_values_count: Value::Null,
+            sample_complete: false,
+            blocked_reason: json!("reference_qcur_shape_unusable"),
+        };
+    };
+    let missing_values_count = required_values_count.saturating_sub(first_values_count);
+    let sample_complete = missing_values_count == 0;
+    ReferenceQuerySampleStatus {
+        first_values_count,
+        required_values_count: json!(required_values_count),
+        missing_values_count: json!(missing_values_count),
+        sample_complete,
+        blocked_reason: if sample_complete {
+            Value::Null
+        } else {
+            json!("reference_qcur_first_values_truncated")
+        },
     }
 }
 
@@ -12098,6 +12169,52 @@ mod tests {
             variants.pointer("/variants_tested/5"),
             Some(&json!("reference_score_recompute_with_mask_applied"))
         );
+    }
+
+    #[test]
+    fn reference_score_reports_mark_truncated_qcur_sample() {
+        let reference_records = vec![
+            ReferenceTraceRecord {
+                shape: vec![128, 20, 1, 1],
+                full_shape: vec![128, 20, 18, 1],
+                nelements: 2560,
+                first_values: vec![0.0; 16],
+                ..test_reference_trace_record("Qcur", vec![0.0; 16])
+            },
+            ReferenceTraceRecord {
+                shape: vec![128, 2, 1, 1],
+                nelements: 256,
+                first_values: vec![0.0; 256],
+                ..test_reference_trace_record("k_kv_head0_live", vec![0.0; 256])
+            },
+            ReferenceTraceRecord {
+                shape: vec![2, 1, 1, 1],
+                nelements: 2,
+                first_values: vec![0.0, 0.0],
+                ..test_reference_trace_record("kq_head0", vec![0.0, 0.0])
+            },
+        ];
+        let report = compare_reference_to_rust(&reference_records, &BTreeMap::new(), &[]);
+        for section in [
+            "attention_score_reference_scalar_recompute",
+            "attention_score_reference_semantic_variants",
+            "attention_score_reference_numeric_variants",
+        ] {
+            let section = report.pointer(&format!("/{section}")).unwrap();
+            assert_eq!(section.pointer("/claim_allowed"), Some(&json!(false)));
+            assert_eq!(section.pointer("/query_stage_present"), Some(&json!(true)));
+            assert_eq!(section.pointer("/query_first_values_count"), Some(&json!(16)));
+            assert_eq!(section.pointer("/query_required_values_count"), Some(&json!(2560)));
+            assert_eq!(section.pointer("/query_missing_values_count"), Some(&json!(2544)));
+            assert_eq!(section.pointer("/query_sample_complete"), Some(&json!(false)));
+            assert_eq!(
+                section.pointer("/query_sample_blocked_reason"),
+                Some(&json!("reference_qcur_first_values_truncated"))
+            );
+            assert_eq!(section.pointer("/compared_count"), Some(&json!(0)));
+            assert_eq!(section.pointer("/missing_input_count"), Some(&json!(1)));
+            assert_eq!(section.pointer("/rows/0/status"), Some(&json!("missing_input")));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add explicit Qcur sample completeness fields to the scalar, semantic, and numeric reference score reports
- report when the reference Qcur `first_values` sample is too short to recompute all score heads
- cover the truncated-Qcur path with a focused xtask unit test

## Real trace evidence
Using `target/a770-diagnostic/bitnet-reference-layer-trace-run-kcur-history.json` against the Rust CPU trace, all three reference score sections now report:

```text
query_first_values_count = 16
query_required_values_count = 2560
query_missing_values_count = 2544
query_sample_complete = false
query_sample_blocked_reason = reference_qcur_first_values_truncated
claim_allowed = false
```

The compare receipt remains diagnostic-only. This does not promote reference parity, A770 semantic quality, selected attention, resident KV, attention score residency, value-mix residency, performance, full residency, or completion.

## Validation
```text
cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture
rustfmt --edition 2024 --check xtask/src/bitnet_reference_layer_trace.rs
git diff --check
cargo check --locked -p xtask --no-default-features
```