### PR TITLE
docs(model): sync Qwen3 coverage tier

### DIFF
--- a/docs/model-artifacts/MODEL_COVERAGE_MATRIX.md
+++ b/docs/model-artifacts/MODEL_COVERAGE_MATRIX.md
@@ -56,14 +56,14 @@ official I2_S answer lane:
 ## Dense SLM Family Rows
 
 `MODEL-COVERAGE-003` expands the dense SLM side of the matrix beyond the
-current Qwen2.5 Q8_0 CUDA answer lane. These rows are coverage contracts only:
-they register future model families and required proof receipts, but they do
-not inherit Qwen2.5 CUDA proof or claim dense CUDA execution.
+current Qwen2.5 Q8_0 CUDA answer lane. These rows are coverage contracts: each
+model family must earn its own tier from receipts and must not inherit Qwen2.5
+CUDA proof.
 
 | Entry | Artifact lane | Current tier | Boundary |
 |---|---|---|---|
 | `dense_qwen25_05b_q8_cuda` | Qwen2.5 0.5B Q8_0 GGUF | `product_cli_ready` | Current dense CUDA SLM answer lane, not globally speed-qualified. |
-| `dense_qwen3_06b_q8_candidate` | Qwen3 0.6B Q8_0 GGUF candidate | `registered` | Future Qwen-family coverage row; needs its own artifact, authority, CPU sanity, and CUDA receipts. |
+| `dense_qwen3_06b_q8_candidate` | Qwen3 0.6B Q8_0 GGUF candidate | `accelerator_answer_ready` | Accelerator-ready dense SLM candidate with its own artifact, CPU sanity, all-layer plan, one-token, short-decode, warm-session, and benchmark-review receipts; product CLI, speedup, server, full-residency, broad dense GGUF, and BitNet QK256 claims remain false. |
 | `dense_smollm2_360m_candidate` | SmolLM2 360M GGUF candidate | `structurally_valid` | Exact artifact contract plus strict CPU preflight blocker and normalization-policy audit; no CPU answer, CUDA route, speedup, or server claim. |
 | `dense_smollm2_17b_candidate` | SmolLM2 1.7B GGUF candidate | `registered` | Larger low-footprint pressure row; no answer or CUDA claim. |
 | `dense_llama32_1b_candidate` | Llama 3.2 1B GGUF candidate | `registered` | Llama-family tokenizer/model-shape control; does not inherit Qwen proof. |


### PR DESCRIPTION
## Summary

- Updates the human-readable model coverage matrix to match the machine-readable Qwen3 row.
- Records Qwen3 0.6B as accelerator-answer-ready, not merely registered.
- Preserves the non-claims for product CLI, speedup, server readiness, full residency, broad dense GGUF, and BitNet QK256 proof.

## Scope

Docs only. No runtime, receipt, model coverage TOML, campaign tracker, server, speed, or CUDA behavior changes.

## Validation

- git diff --check HEAD~1..HEAD
- xtask check-model-coverage
- xtask campaign check nvidia-5070ti

## Rollback

Revert this docs-only commit if the human-readable matrix should intentionally remain less specific than the TOML.