### PR TITLE
fix(bitnet): use f16 keys for attention scores

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -115,7 +115,7 @@ fn attention_f16_dot_input(tensor: &Tensor) -> Result<Tensor> {
 }
 
 fn attention_score_key_input(tensor: &Tensor) -> Result<Tensor> {
-    Ok(tensor.to_dtype(DType::F32)?)
+    attention_f16_dot_input(tensor)
 }
 
 #[cfg(any(feature = "trace", test))]
@@ -2383,7 +2383,7 @@ mod tests {
     }
 
     #[test]
-    fn attention_score_key_input_preserves_f32_values() -> Result<()> {
+    fn attention_score_key_input_uses_f16_roundtrip_values() -> Result<()> {
         let device = Device::Cpu;
         let input =
             Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
@@ -2391,7 +2391,7 @@ mod tests {
         let output = attention_score_key_input(&input)?;
         let values = output.flatten_all()?.to_vec1::<f32>()?;
 
-        assert_eq!(values, vec![1.0003, -2.0007, 3.1259, -4.2509]);
+        assert_eq!(values, vec![1.0, -2.0, 3.125, -4.25]);
         Ok(())
     }
 
@@ -2409,7 +2409,7 @@ mod tests {
     }
 
     #[test]
-    fn attention_score_key_precision_variants_distinguish_runtime_and_probe() -> Result<()> {
+    fn attention_score_key_runtime_matches_f16_probe_contract() -> Result<()> {
         let device = Device::Cpu;
         let query =
             Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
@@ -2424,9 +2424,9 @@ mod tests {
         let probe_score =
             q_values.iter().zip(probe_k_values.iter()).fold(0.0f32, |sum, (q, k)| sum + q * k);
 
-        assert_eq!(runtime_k_values, vec![5.0003, 6.0007, -7.1259, 8.2509]);
+        assert_eq!(runtime_k_values, vec![5.0, 6.0, -7.125, 8.25]);
         assert_eq!(probe_k_values, vec![5.0, 6.0, -7.125, 8.25]);
-        assert_eq!(runtime_score, -64.33586);
+        assert_eq!(runtime_score, -64.328125);
         assert_eq!(probe_score, -64.328125);
         Ok(())
     }
@@ -2443,8 +2443,8 @@ mod tests {
         let score = q_values.iter().zip(k_values.iter()).fold(0.0f32, |sum, (q, k)| sum + q * k);
 
         assert_eq!(q_values, vec![1.0, -2.0, 3.125, -4.25]);
-        assert_eq!(k_values, vec![5.0003, 6.0007, -7.1259, 8.2509]);
-        assert_eq!(score, -64.33586);
+        assert_eq!(k_values, vec![5.0, 6.0, -7.125, 8.25]);
+        assert_eq!(score, -64.328125);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- switch the live attention score key input to the same F16-roundtrip precision used by Q and the diagnostic probe
- update the transformer precision-contract tests so runtime score keys match the probe path

## Evidence
- local f64 RMSNorm diagnostic capture after this change moved the first material mismatch from kqv_head7 / attention_value_mix_head7 to ffn_out / post_swiglu
- value projection/cache bucket drift stayed at zero in the diagnostic compare

## Claim boundary
- correctness/runtime math fix only
- no A770 semantic quality, performance, selected attention, resident KV, attention score residency, value mix residency, full residency, or completion promotion

## Validation
- cargo test --locked -p bitnet-transformer --features trace -- --nocapture
- cargo check --locked -p bitnet-transformer --features trace
- rustfmt --edition 2024 --check crates/bitnet-transformer/src/lib.rs
- git diff --check

## Diagnostic rerun
- BITNET_TRACE_FIRST_VALUES_LIMIT=46080 cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-capture-rust --plan target/a770-diagnostic/bitnet-reference-plan.json --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu-rmsnorm-f64-score-key-runtime-f16 --a770-trace-dir target/a770-diagnostic/reference-layer-trace-rust-a770-rmsnorm-f64-score-key-runtime-f16 --skip-a770 --overwrite --diag-rmsnorm-f64-accum --output target/a770-diagnostic/bitnet-reference-layer-trace-rust-capture-rmsnorm-f64-score-key-runtime-f16.json --format human
- cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-compare --reference target/a770-diagnostic/bitnet-reference-layer-trace-run-fullhist46080.json --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu-rmsnorm-f64-score-key-runtime-f16 --output target/a770-diagnostic/bitnet-reference-layer-trace-compare-fullhist46080-rmsnorm-f64-score-key-runtime-f16.json --format human