### PR TITLE
test(tokenizer-text): cover pre-tokenize strategies and normalizer flags

### DIFF
--- a/crates/bitnet-tokenizer-text-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-text-core/src/lib.rs
@@ -166,4 +166,160 @@ mod tests {
         });
         assert_eq!(normalizer.normalize("“Café” — déjà vu"), "\"cafe\" - deja vu");
     }
+
+    #[test]
+    fn pre_tokenize_whitespace_splits_on_runs() {
+        let tk = PreTokenizer::new(PreTokenizeStrategy::Whitespace);
+        assert_eq!(tk.pre_tokenize("hello   world"), vec!["hello", "world"]);
+        // Tabs and newlines count as whitespace.
+        assert_eq!(tk.pre_tokenize("a\tb\nc"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn pre_tokenize_whitespace_empty_input() {
+        let tk = PreTokenizer::new(PreTokenizeStrategy::Whitespace);
+        assert!(tk.pre_tokenize("").is_empty());
+        assert!(tk.pre_tokenize("   \t\n").is_empty());
+    }
+
+    #[test]
+    fn pre_tokenize_byte_level_replaces_spaces_with_marker() {
+        let tk = PreTokenizer::new(PreTokenizeStrategy::ByteLevel);
+        let out = tk.pre_tokenize("a b");
+        // Three chars: 'a', U+0120, 'b'.
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], "a");
+        assert_eq!(out[1], "\u{0120}");
+        assert_eq!(out[2], "b");
+    }
+
+    #[test]
+    fn pre_tokenize_byte_level_empty_input_returns_empty() {
+        let tk = PreTokenizer::new(PreTokenizeStrategy::ByteLevel);
+        assert!(tk.pre_tokenize("").is_empty());
+    }
+
+    #[test]
+    fn pre_tokenize_byte_level_single_char() {
+        let tk = PreTokenizer::new(PreTokenizeStrategy::ByteLevel);
+        assert_eq!(tk.pre_tokenize("x"), vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn pre_tokenize_punctuation_delegates_to_split_on_punctuation() {
+        let tk = PreTokenizer::new(PreTokenizeStrategy::Punctuation);
+        assert_eq!(tk.pre_tokenize("hi, bye."), vec!["hi", ",", "bye", "."]);
+    }
+
+    #[test]
+    fn split_on_punctuation_empty_input() {
+        assert!(split_on_punctuation("").is_empty());
+    }
+
+    #[test]
+    fn split_on_punctuation_only_whitespace() {
+        // Whitespace alone produces no tokens and no punctuation tokens.
+        assert!(split_on_punctuation("   \t  ").is_empty());
+    }
+
+    #[test]
+    fn split_on_punctuation_only_punctuation() {
+        assert_eq!(split_on_punctuation("!?."), vec!["!", "?", "."]);
+    }
+
+    #[test]
+    fn split_on_punctuation_leading_and_trailing_punctuation() {
+        assert_eq!(split_on_punctuation("!hi"), vec!["!", "hi"]);
+        assert_eq!(split_on_punctuation("hi!"), vec!["hi", "!"]);
+    }
+
+    #[test]
+    fn split_on_punctuation_internal_whitespace_does_not_emit_token() {
+        // A space ends the current token but does not become its own token.
+        let tokens = split_on_punctuation("ab cd");
+        assert_eq!(tokens, vec!["ab", "cd"]);
+    }
+
+    #[test]
+    fn normalizer_lowercase_constructor_sets_only_lowercase() {
+        let n = TokenNormalizer::lowercase();
+        assert_eq!(n.normalize("ABC Café"), "abc café");
+    }
+
+    #[test]
+    fn normalizer_default_flags_is_identity() {
+        let n = TokenNormalizer::new(NormalizationFlags::default());
+        let s = "Hello — World";
+        assert_eq!(n.normalize(s), s);
+    }
+
+    #[test]
+    fn normalizer_only_nfkc_does_not_change_case_or_accents() {
+        let n = TokenNormalizer::new(NormalizationFlags { nfkc: true, ..Default::default() });
+        // Curly quote folded; case and accent preserved.
+        assert_eq!(n.normalize("“Café”"), "\"Café\"");
+    }
+
+    #[test]
+    fn normalizer_only_strip_accents_keeps_case() {
+        let n = TokenNormalizer::new(NormalizationFlags {
+            strip_accents: true,
+            ..Default::default()
+        });
+        assert_eq!(n.normalize("Café Déjà"), "Cafe Deja");
+    }
+
+    #[test]
+    fn ascii_nfkc_fold_curly_quotes() {
+        assert_eq!(ascii_nfkc_fold("\u{201C}hi\u{201D}"), "\"hi\"");
+        assert_eq!(ascii_nfkc_fold("\u{2018}hi\u{2019}"), "'hi'");
+    }
+
+    #[test]
+    fn ascii_nfkc_fold_em_dash_ellipsis_nbsp() {
+        assert_eq!(ascii_nfkc_fold("a\u{2014}b"), "a-b");
+        assert_eq!(ascii_nfkc_fold("e\u{2026}"), "e.");
+        // Non-breaking space → regular space.
+        assert_eq!(ascii_nfkc_fold("a\u{00A0}b"), "a b");
+    }
+
+    #[test]
+    fn ascii_nfkc_fold_leaves_unaffected_chars_alone() {
+        let s = "abc XYZ 123 !@# αβ漢";
+        assert_eq!(ascii_nfkc_fold(s), s);
+    }
+
+    #[test]
+    fn strip_accents_ascii_covers_each_vowel_family() {
+        assert_eq!(strip_accents_ascii("áàâäã"), "aaaaa");
+        assert_eq!(strip_accents_ascii("éèêë"), "eeee");
+        assert_eq!(strip_accents_ascii("íìîï"), "iiii");
+        assert_eq!(strip_accents_ascii("óòôöõ"), "ooooo");
+        assert_eq!(strip_accents_ascii("úùûü"), "uuuu");
+        assert_eq!(strip_accents_ascii("ñ"), "n");
+        assert_eq!(strip_accents_ascii("ç"), "c");
+    }
+
+    #[test]
+    fn strip_accents_ascii_preserves_unrelated_unicode() {
+        // Upper-case accented letters are not covered by this table.
+        assert_eq!(strip_accents_ascii("ÁÉ漢"), "ÁÉ漢");
+    }
+
+    #[test]
+    fn pre_tokenize_strategy_is_copy_and_eq() {
+        let s = PreTokenizeStrategy::ByteLevel;
+        let copy = s;
+        assert_eq!(s, copy);
+        // Debug should render without panicking.
+        let _ = format!("{s:?}");
+    }
+
+    #[test]
+    fn normalization_flags_default_is_all_false() {
+        let flags = NormalizationFlags::default();
+        assert!(!flags.nfkc);
+        assert!(!flags.lowercase);
+        assert!(!flags.strip_accents);
+    }
 }


### PR DESCRIPTION
## Summary

Expands the unit-test suite for `bitnet-tokenizer-text-core` from 2 to 24 tests, covering pre-tokenize strategies, normalizer flag combinations, and helper function edge cases that previously had no direct coverage.

### New tests

- `PreTokenizer::pre_tokenize` for all three strategies (Whitespace, ByteLevel, Punctuation): empty input, single-char, runs of whitespace, mixed tabs/newlines, ByteLevel space-marker substitution (`U+0120`)
- `split_on_punctuation` edge cases: empty, whitespace-only, punctuation-only, leading/trailing punctuation, internal whitespace
- `TokenNormalizer` flag combinations: default = identity, `nfkc`-only, `strip_accents`-only, `lowercase` constructor
- `ascii_nfkc_fold` for curly quotes, em-dash, ellipsis, NBSP, and unaffected chars
- `strip_accents_ascii` for every vowel family plus `ñ`/`ç`, plus preservation of upper-case accented letters and CJK
- `PreTokenizeStrategy` `Copy`/`Eq`/`Debug` round-trip and `NormalizationFlags::default()` invariants

### Test plan

- [x] `cargo test --locked -p bitnet-tokenizer-text-core --no-default-features` → 24 passed
- [x] `cargo clippy --locked -p bitnet-tokenizer-text-core --all-targets --no-default-features -- -D warnings` → clean

Pure-logic test additions only. No behavior changes; no API changes.

https://claude.ai/code/session_01VdHqrizf9N3md4TYzUarVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdHqrizf9N3md4TYzUarVX)_