### PR TITLE
test(stop,repl,tokenizer): cover stop-priority, REPL helpers, GPU threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ version = "0.2.1-dev"
 dependencies = [
  "proptest",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/bitnet-generation-stop-core/Cargo.toml
+++ b/crates/bitnet-generation-stop-core/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/crates/bitnet-generation-stop-core/src/lib.rs
+++ b/crates/bitnet-generation-stop-core/src/lib.rs
@@ -111,6 +111,69 @@ mod tests {
         );
     }
 
+    #[test]
+    fn stop_on_eos_token_when_no_explicit_stop_ids() {
+        let criteria = make_criteria(&[], &[], 100, Some(2));
+        assert_eq!(check_stop(&criteria, 2, &[], ""), Some(StopReason::EosToken));
+    }
+
+    #[test]
+    fn max_tokens_takes_priority_over_stop_string() {
+        let criteria = make_criteria(&[], &["END"], 3, None);
+        // generated.len() >= max_tokens, but decoded tail also contains "END".
+        assert_eq!(
+            check_stop(&criteria, 99, &[1, 2, 3], "this has END inside"),
+            Some(StopReason::MaxTokens),
+        );
+    }
+
+    #[test]
+    fn max_tokens_zero_means_no_token_budget() {
+        // max_tokens == 0 is documented as "no limit": must not trigger
+        // regardless of how many tokens have been generated.
+        let criteria = make_criteria(&[], &[], 0, None);
+        let generated: Vec<u32> = (0..50).collect();
+        assert!(check_stop(&criteria, 7, &generated, "").is_none());
+    }
+
+    #[test]
+    fn stop_string_only_matches_when_present_in_tail() {
+        let criteria = make_criteria(&[], &["END"], 100, None);
+        assert!(check_stop(&criteria, 5, &[], "harmless text").is_none());
+    }
+
+    #[test]
+    fn stop_string_returns_first_matching_in_order() {
+        let criteria = make_criteria(&[], &["alpha", "beta"], 100, None);
+        // Both candidates appear; the first registered one must win.
+        assert_eq!(
+            check_stop(&criteria, 1, &[], "contains alpha and beta"),
+            Some(StopReason::StopString("alpha".to_string())),
+        );
+    }
+
+    #[test]
+    fn no_stop_when_all_criteria_empty() {
+        let criteria = StopCriteria::default();
+        assert!(check_stop(&criteria, 0, &[], "").is_none());
+    }
+
+    #[test]
+    fn stop_reason_serde_round_trip() {
+        let reasons = [
+            StopReason::MaxTokens,
+            StopReason::EosToken,
+            StopReason::StopTokenId(42),
+            StopReason::StopString("END".to_string()),
+        ];
+        for r in &reasons {
+            let json = serde_json::to_string(r).expect("serialize stop reason");
+            let restored: StopReason =
+                serde_json::from_str(&json).expect("deserialize stop reason");
+            assert_eq!(*r, restored);
+        }
+    }
+
     proptest::proptest! {
         #[test]
         fn no_stop_without_triggers(id in 1000u32..2000, generated_len in 1usize..50) {

--- a/crates/bitnet-repl-core/src/lib.rs
+++ b/crates/bitnet-repl-core/src/lib.rs
@@ -164,4 +164,85 @@ mod tests {
 
         assert!(copied.exists());
     }
+
+    #[test]
+    fn parse_repl_input_recognises_clear_metrics_and_exit_aliases() {
+        assert_eq!(parse_repl_input("/clear"), Some(ReplInput::Clear));
+        assert_eq!(parse_repl_input("/metrics"), Some(ReplInput::Metrics));
+        assert_eq!(parse_repl_input("/exit"), Some(ReplInput::Exit));
+    }
+
+    #[test]
+    fn parse_repl_input_trims_whitespace_around_messages_and_commands() {
+        assert_eq!(parse_repl_input("\n"), None);
+        assert_eq!(parse_repl_input("   /help   "), Some(ReplInput::Help));
+        assert_eq!(parse_repl_input("  hi  "), Some(ReplInput::Message("hi".into())));
+    }
+
+    #[test]
+    fn parse_repl_input_unknown_slash_command_falls_through_to_message() {
+        // We deliberately do not invent commands; an unknown "/foo" is a plain message.
+        assert_eq!(parse_repl_input("/foo"), Some(ReplInput::Message("/foo".into())));
+    }
+
+    #[test]
+    fn chat_metrics_average_tps_with_positive_time() {
+        let mut metrics = ChatMetrics::default();
+        metrics.add_exchange(100, 1000); // 100 tokens in 1s -> 100 tps
+        metrics.add_exchange(50, 1000); //  50 tokens in 1s -> averaged into 75 tps
+        assert_eq!(metrics.num_exchanges, 2);
+        assert_eq!(metrics.total_tokens_generated, 150);
+        assert_eq!(metrics.total_time_ms, 2000);
+        assert!((metrics.average_tps() - 75.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bounded_history_unbounded_accepts_arbitrary_pushes() {
+        let mut history = BoundedHistory::new(None);
+        for i in 0..10 {
+            history.push(i);
+        }
+        assert_eq!(history.len(), 10);
+        assert_eq!(history.to_vec(), (0..10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn bounded_history_clear_and_is_empty() {
+        let mut history = BoundedHistory::new(Some(3));
+        assert!(history.is_empty());
+        history.push(1);
+        history.push(2);
+        assert!(!history.is_empty());
+        history.clear();
+        assert!(history.is_empty());
+        assert_eq!(history.len(), 0);
+    }
+
+    #[test]
+    fn bounded_history_to_vec_matches_iter() {
+        let mut history = BoundedHistory::new(Some(5));
+        for i in 0..3 {
+            history.push(i);
+        }
+        let iter_vec: Vec<i32> = history.iter().copied().collect();
+        assert_eq!(iter_vec, history.to_vec());
+    }
+
+    #[test]
+    fn bounded_history_zero_limit_drops_every_push() {
+        // limit == 0 means we always over-fill by 1, then trim back to 0.
+        let mut history = BoundedHistory::new(Some(0));
+        history.push(1);
+        history.push(2);
+        assert!(history.is_empty());
+    }
+
+    #[test]
+    fn copy_receipt_returns_none_when_source_missing() {
+        let dst_dir = tempdir().expect("temp dir should be created");
+        let missing = PathBuf::from("/this/path/does/not/exist/receipt.json");
+        let result = copy_receipt_if_present(&missing, dst_dir.path())
+            .expect("missing source should not be an error");
+        assert!(result.is_none());
+    }
 }

--- a/crates/bitnet-tokenizer-model-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-model-core/src/lib.rs
@@ -112,4 +112,69 @@ mod tests {
         assert!(ModelTypeDetector::validate_vocab_size(0).is_err());
         assert!(ModelTypeDetector::validate_vocab_size(2_000_001).is_err());
     }
+
+    #[test]
+    fn requires_gpu_acceleration_threshold_is_inclusive_below() {
+        // 65536 is the boundary documented as "> 65536"; anything at or below must not trigger.
+        assert!(!ModelTypeDetector::requires_gpu_acceleration(0));
+        assert!(!ModelTypeDetector::requires_gpu_acceleration(32000));
+        assert!(!ModelTypeDetector::requires_gpu_acceleration(65536));
+    }
+
+    #[test]
+    fn requires_gpu_acceleration_triggers_above_threshold() {
+        assert!(ModelTypeDetector::requires_gpu_acceleration(65537));
+        assert!(ModelTypeDetector::requires_gpu_acceleration(128256));
+        assert!(ModelTypeDetector::requires_gpu_acceleration(256000));
+    }
+
+    #[test]
+    fn expected_vocab_size_unknown_family() {
+        assert_eq!(ModelTypeDetector::expected_vocab_size(""), None);
+        assert_eq!(ModelTypeDetector::expected_vocab_size("LLAMA2"), None);
+        assert_eq!(ModelTypeDetector::expected_vocab_size("phi"), None);
+    }
+
+    #[test]
+    fn expected_vocab_size_handles_mistral_aliases() {
+        // "mistral" without a version maps to 32000 (the original llama-derived vocab).
+        assert_eq!(ModelTypeDetector::expected_vocab_size("mistral"), Some(32000));
+    }
+
+    #[test]
+    fn validate_vocab_error_messages_carry_size_context() {
+        let too_large = ModelTypeDetector::validate_vocab_size(5_000_000).unwrap_err();
+        let rendered = format!("{too_large}");
+        assert!(
+            rendered.contains("5000000"),
+            "error should mention the offending size: {rendered}"
+        );
+    }
+
+    #[test]
+    fn detection_and_expected_size_are_round_trip_for_known_families() {
+        for family in [
+            "llama2",
+            "llama3",
+            "codellama",
+            "gpt2",
+            "phi4",
+            "phi3",
+            "phi2",
+            "qwen2.5",
+            "qwen2",
+            "gemma",
+            "mistral-v03",
+            "mistral-nemo",
+            "smollm",
+        ] {
+            let vocab = ModelTypeDetector::expected_vocab_size(family)
+                .expect("known family should have an expected vocab size");
+            assert_eq!(
+                ModelTypeDetector::detect_from_vocab_size(vocab),
+                family,
+                "detection of {family} should round-trip through its expected vocab size",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Tests-only PR closing coverage gaps in three SRP microcrates.

- **`bitnet-generation-stop-core`** — adds tests for: EOS-only termination, the `max_tokens > stop_string` priority ordering, the documented `max_tokens == 0` "no limit" semantics, the no-match path for stop strings, first-match ordering across multiple stop strings, the empty-criteria no-op, and a serde round-trip for every `StopReason` variant. Gains a `serde_json` dev-dependency (already in the lockfile).
- **`bitnet-repl-core`** — adds tests for: `/clear`, `/metrics`, and `/exit` aliases; whitespace trimming around commands and messages; the fallthrough of unknown slash-commands to plain messages; `ChatMetrics::average_tps` in the non-zero-time path; `BoundedHistory::{clear, is_empty, to_vec}`, the unbounded-`None`-limit mode, the zero-limit-drops-everything case; and `copy_receipt_if_present` returning `Ok(None)` when the source is absent.
- **`bitnet-tokenizer-model-core`** — adds tests for: `requires_gpu_acceleration` on both sides of the 65 536 boundary (no test existed for this function before), `expected_vocab_size` returning `None` for empty / uppercase / partial names, the `"mistral"` alias, the error-message format from `validate_vocab_size`, and a round-trip between `expected_vocab_size` and `detect_from_vocab_size` across every known family.

No production code changes; only `#[cfg(test)]` additions and one dev-dependency.

## Test plan
- [x] `cargo test -p bitnet-generation-stop-core -p bitnet-tokenizer-model-core -p bitnet-repl-core` — 34 passed (12 + 9 + 13; was 5 + 3 + 4)
- [x] `cargo clippy --locked -p bitnet-generation-stop-core -p bitnet-tokenizer-model-core -p bitnet-repl-core --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkMjeAM2QmwNDg1Sm82ksb)_