### PR TITLE
diag(bitnet): trace target-layer value history

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,1089 @@ struct llama_context {
+@@ -3441,6 +3444,1092 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -600,10 +600,13 @@ index 666fcc4d..23ee29ff 100644
 +        bitnet_rs_reference_layer_trace_json_number(out, values[(size_t) sample_offset + i]);
 +    }
 +    out << "]}";
-+    const bool bitnet_rs_history_is_attn_norm = strcmp(name, "attn_norm-0") == 0;
-+    const bool bitnet_rs_history_is_vcur = strcmp(name, "Vcur-0") == 0;
-+    if ((bitnet_rs_history_is_attn_norm || bitnet_rs_history_is_vcur) && values_available && n_tokens > 0 && tensor->ne[0] > 0 && tensor->ne[1] >= (int64_t) n_tokens) {
-+        const char * history_record_name = bitnet_rs_history_is_attn_norm ? "attn_norm_history_ref_layout-0" : "vcur_history_ref_layout-0";
++    int bitnet_rs_history_layer = -1;
++    const char * bitnet_rs_history_stage = bitnet_rs_reference_layer_trace_layer_stage(name, &bitnet_rs_history_layer);
++    const bool bitnet_rs_history_is_attn_norm = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "attn_norm") == 0;
++    const bool bitnet_rs_history_is_vcur = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "Vcur") == 0;
++    if ((bitnet_rs_history_is_attn_norm || bitnet_rs_history_is_vcur) && bitnet_rs_history_layer == bitnet_rs_reference_layer_trace_requested_layer() && values_available && n_tokens > 0 && tensor->ne[0] > 0 && tensor->ne[1] >= (int64_t) n_tokens) {
++        std::ostringstream history_record_name;
++        history_record_name << (bitnet_rs_history_is_attn_norm ? "attn_norm_history_ref_layout-" : "vcur_history_ref_layout-") << bitnet_rs_history_layer;
 +        const char * history_stage_name = bitnet_rs_history_is_attn_norm ? "attn_norm_history_ref_layout" : "vcur_history_ref_layout";
 +        const int64_t hidden = tensor->ne[0];
 +        const int64_t token_count = (int64_t) n_tokens;
@@ -631,7 +634,7 @@ index 666fcc4d..23ee29ff 100644
 +        out << ",{";
 +        out << "\"graph_index\":" << graph_index;
 +        out << ",\"name\":";
-+        bitnet_rs_reference_layer_trace_json_string(out, history_record_name);
++        bitnet_rs_reference_layer_trace_json_string(out, history_record_name.str().c_str());
 +        out << ",\"stage\":";
 +        bitnet_rs_reference_layer_trace_json_string(out, history_stage_name);
 +        out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -12078,6 +12078,28 @@ mod tests {
     }
 
     #[test]
+    fn reference_patch_history_records_follow_requested_trace_layer() {
+        let patch =
+            include_str!("../../ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch");
+
+        assert!(patch.contains(
+            "bitnet_rs_reference_layer_trace_layer_stage(name, &bitnet_rs_history_layer)"
+        ));
+        assert!(patch.contains(
+            "bitnet_rs_history_layer == bitnet_rs_reference_layer_trace_requested_layer()"
+        ));
+        assert!(patch.contains(
+            "history_record_name << (bitnet_rs_history_is_attn_norm ? \"attn_norm_history_ref_layout-\" : \"vcur_history_ref_layout-\") << bitnet_rs_history_layer"
+        ));
+        assert!(!patch.contains(
+            "const bool bitnet_rs_history_is_attn_norm = strcmp(name, \"attn_norm-0\") == 0"
+        ));
+        assert!(
+            !patch.contains("const bool bitnet_rs_history_is_vcur = strcmp(name, \"Vcur-0\") == 0")
+        );
+    }
+
+    #[test]
     fn final_norm_trace_record_lookup_selects_expected_layer_inputs() {
         let mut reference_layer0 = test_reference_trace_record("l_out", vec![1.0, 2.0]);
         reference_layer0.name = "l_out-0".to_string();


### PR DESCRIPTION
## Summary
- make the target-local reference patch emit `attn_norm_history_ref_layout-N` and `vcur_history_ref_layout-N` for the requested trace layer instead of only layer 0
- add a guard test so value-history capture remains requested-layer aware
- keep this diagnostic-only; no Rust runtime math changes

## Live diagnostic read
Using a layer-1 reference run with a full first-values sample:
- reference emits `attn_norm_history_ref_layout-1` and `vcur_history_ref_layout-1`
- value projection input history is now comparable: max delta 0.000987078528851271, RMS 0.000103160439911456
- value projection output/history is comparable across 5/5 KV heads: max delta 0.186432182788849
- projection/cache bridge is now complete across 5/5 KV heads

This keeps the active frontier at layer-1 V projection/history, not A770 dispatch.

## Validation
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --edition 2024 --check xtask/src/bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claim boundary
No promotion of A770 semantic quality, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full residency, performance, or completion.