### PR TITLE
test(policy): remove panic-family calls from core tests

### DIFF
--- a/crates/bitnet-atomic-file-core/src/lib.rs
+++ b/crates/bitnet-atomic-file-core/src/lib.rs
@@ -34,67 +34,75 @@ mod tests {
     use super::atomic_write;
 
     #[test]
-    fn writes_and_replaces() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn writes_and_replaces() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("data.json");
 
-        atomic_write(&path, b"v1").expect("first write");
-        assert_eq!(std::fs::read(&path).expect("read v1"), b"v1");
+        atomic_write(&path, b"v1")?;
+        assert_eq!(std::fs::read(&path)?, b"v1");
 
-        atomic_write(&path, b"v2").expect("second write");
-        assert_eq!(std::fs::read(&path).expect("read v2"), b"v2");
+        atomic_write(&path, b"v2")?;
+        assert_eq!(std::fs::read(&path)?, b"v2");
+        Ok(())
     }
 
     #[test]
-    fn writes_empty_bytes() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn writes_empty_bytes() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("empty.bin");
 
-        atomic_write(&path, b"").expect("write empty");
-        let data = std::fs::read(&path).expect("read");
+        atomic_write(&path, b"")?;
+        let data = std::fs::read(&path)?;
         assert!(data.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn writes_binary_payload_byte_for_byte() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn writes_binary_payload_byte_for_byte() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("payload.bin");
         let payload: Vec<u8> = (0..=255_u8).collect();
 
-        atomic_write(&path, &payload).expect("write");
-        let read_back = std::fs::read(&path).expect("read");
+        atomic_write(&path, &payload)?;
+        let read_back = std::fs::read(&path)?;
         assert_eq!(read_back, payload);
+        Ok(())
     }
 
     #[test]
-    fn rename_replaces_existing_target() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn rename_replaces_existing_target() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("file.txt");
 
-        std::fs::write(&path, b"old").expect("seed");
-        atomic_write(&path, b"new").expect("overwrite");
-        assert_eq!(std::fs::read(&path).expect("read"), b"new");
+        std::fs::write(&path, b"old")?;
+        atomic_write(&path, b"new")?;
+        assert_eq!(std::fs::read(&path)?, b"new");
+        Ok(())
     }
 
     #[test]
-    fn does_not_leave_temp_sibling_on_success() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn does_not_leave_temp_sibling_on_success() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("output.json");
 
-        atomic_write(&path, b"{}").expect("write");
+        atomic_write(&path, b"{}")?;
 
         // The implementation writes to "<path>.tmp" then renames into place.
         let tmp = path.with_extension("tmp");
         assert!(!tmp.exists(), "atomic_write must not leave behind the tmp sibling");
         assert!(path.exists(), "final path must exist");
+        Ok(())
     }
 
     #[test]
-    fn fails_when_parent_directory_missing() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn fails_when_parent_directory_missing() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("missing").join("file.txt");
 
-        let err = atomic_write(&path, b"data").expect_err("parent dir does not exist");
+        let Err(err) = atomic_write(&path, b"data") else {
+            return Err(std::io::Error::other("parent dir should not exist"));
+        };
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+        Ok(())
     }
 }

--- a/crates/bitnet-build-info-core/src/lib.rs
+++ b/crates/bitnet-build-info-core/src/lib.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn serde_serializes_all_fields() {
+    fn serde_serializes_all_fields() -> Result<(), Box<dyn std::error::Error>> {
         let metadata = BuildMetadata::from_env(
             Some("deadbeef"),
             Some("feature/x"),
@@ -126,8 +126,10 @@ mod tests {
             Some("aarch64-apple-darwin"),
             Some("0"),
         );
-        let json: serde_json::Value = serde_json::to_value(&metadata).expect("serialize");
-        let obj = json.as_object().expect("object");
+        let json: serde_json::Value = serde_json::to_value(&metadata)?;
+        let obj = json
+            .as_object()
+            .ok_or_else(|| std::io::Error::other("serialized metadata should be a JSON object"))?;
         assert_eq!(obj.get("git_sha").and_then(|v| v.as_str()), Some("deadbeef"));
         assert_eq!(obj.get("git_branch").and_then(|v| v.as_str()), Some("feature/x"));
         assert_eq!(
@@ -140,5 +142,6 @@ mod tests {
             Some("aarch64-apple-darwin")
         );
         assert_eq!(obj.get("cargo_opt_level").and_then(|v| v.as_str()), Some("0"));
+        Ok(())
     }
 }

--- a/crates/bitnet-cli-config-core/src/lib.rs
+++ b/crates/bitnet-cli-config-core/src/lib.rs
@@ -318,23 +318,25 @@ mod tests {
     };
 
     #[test]
-    fn supported_device_labels_constant_matches_validation() {
+    fn supported_device_labels_constant_matches_validation() -> anyhow::Result<()> {
         for device in SUPPORTED_DEVICE_LABELS {
             if device.contains("<index>") {
                 continue;
             }
             let config =
                 CliConfig { default_device: (*device).to_string(), ..CliConfig::default() };
-            config.validate().unwrap_or_else(|err| panic!("{device} should validate: {err}"));
+            config.validate()?;
         }
+        Ok(())
     }
 
     #[test]
-    fn validates_intel_npu_labels_without_aliasing() {
+    fn validates_intel_npu_labels_without_aliasing() -> anyhow::Result<()> {
         for device in ["npu", "intel-npu", "intel-npu:1", "openvino-npu", "intel-npu-openvino"] {
             let config = CliConfig { default_device: device.to_string(), ..CliConfig::default() };
-            config.validate().unwrap();
+            config.validate()?;
         }
+        Ok(())
     }
 
     #[test]
@@ -346,17 +348,19 @@ mod tests {
     }
 
     #[test]
-    fn builder_preserves_intel_npu_device_label() {
-        let config = ConfigBuilder::new().device(Some("intel-npu:2".to_string())).build().unwrap();
+    fn builder_preserves_intel_npu_device_label() -> anyhow::Result<()> {
+        let config = ConfigBuilder::new().device(Some("intel-npu:2".to_string())).build()?;
         assert_eq!(config.default_device, "intel-npu:2");
+        Ok(())
     }
 
     #[test]
-    fn validates_apple_m4_labels_without_aliasing() {
+    fn validates_apple_m4_labels_without_aliasing() -> anyhow::Result<()> {
         for device in ["apple-m4-metal", "apple-m4-mpsgraph", "apple-m4-cpu-neon"] {
             let config = CliConfig { default_device: device.to_string(), ..CliConfig::default() };
-            config.validate().unwrap();
+            config.validate()?;
         }
+        Ok(())
     }
 
     #[test]
@@ -403,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn defaults_validate_cleanly() {
+    fn defaults_validate_cleanly() -> anyhow::Result<()> {
         let config = CliConfig::default();
         assert_eq!(config.default_device, "auto");
         assert_eq!(config.logging.level, "info");
@@ -412,7 +416,8 @@ mod tests {
         assert_eq!(config.performance.batch_size, 1);
         assert!(config.performance.memory_optimization);
         assert!(config.performance.cpu_threads.is_none());
-        config.validate().expect("default config validates");
+        config.validate()?;
+        Ok(())
     }
 
     #[test]
@@ -426,14 +431,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_each_log_level() {
+    fn validate_accepts_each_log_level() -> anyhow::Result<()> {
         for level in ["trace", "debug", "info", "warn", "error"] {
             let config = CliConfig {
                 logging: LoggingConfig { level: level.to_string(), ..LoggingConfig::default() },
                 ..CliConfig::default()
             };
-            config.validate().unwrap_or_else(|e| panic!("{level} should validate: {e}"));
+            config.validate()?;
         }
+        Ok(())
     }
 
     #[test]
@@ -447,14 +453,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_each_log_format() {
+    fn validate_accepts_each_log_format() -> anyhow::Result<()> {
         for fmt in ["pretty", "json", "compact"] {
             let config = CliConfig {
                 logging: LoggingConfig { format: fmt.to_string(), ..LoggingConfig::default() },
                 ..CliConfig::default()
             };
-            config.validate().unwrap_or_else(|e| panic!("{fmt} should validate: {e}"));
+            config.validate()?;
         }
+        Ok(())
     }
 
     #[test]
@@ -468,18 +475,19 @@ mod tests {
     }
 
     #[test]
-    fn load_from_file_returns_defaults_when_missing() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn load_from_file_returns_defaults_when_missing() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("does-not-exist.toml");
-        let config = CliConfig::load_from_file(&path).expect("missing file is non-fatal");
+        let config = CliConfig::load_from_file(&path)?;
         // Compare to default by checking a few representative fields.
         assert_eq!(config.default_device, CliConfig::default().default_device);
         assert_eq!(config.logging.level, CliConfig::default().logging.level);
+        Ok(())
     }
 
     #[test]
-    fn save_and_load_round_trip() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn save_and_load_round_trip() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("nested").join("config.toml");
         let original = CliConfig {
             default_device: "cpu".to_string(),
@@ -495,10 +503,10 @@ mod tests {
             },
             ..CliConfig::default()
         };
-        original.save_to_file(&path).expect("save");
+        original.save_to_file(&path)?;
         assert!(path.exists(), "save_to_file must create the file (and any parents)");
 
-        let loaded = CliConfig::load_from_file(&path).expect("load");
+        let loaded = CliConfig::load_from_file(&path)?;
         assert_eq!(loaded.default_device, "cpu");
         assert_eq!(loaded.logging.level, "debug");
         assert_eq!(loaded.logging.format, "json");
@@ -506,22 +514,27 @@ mod tests {
         assert_eq!(loaded.performance.cpu_threads, Some(8));
         assert_eq!(loaded.performance.batch_size, 4);
         assert!(!loaded.performance.memory_optimization);
+        Ok(())
     }
 
     #[test]
-    fn load_from_file_rejects_malformed_toml() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn load_from_file_rejects_malformed_toml() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("bad.toml");
-        std::fs::write(&path, "this is = not = toml").expect("write");
-        let err = CliConfig::load_from_file(&path).expect_err("malformed toml must fail");
+        std::fs::write(&path, "this is = not = toml")?;
+        let Err(err) = CliConfig::load_from_file(&path) else {
+            anyhow::bail!("malformed TOML should fail");
+        };
         let message = format!("{err:#}");
         assert!(message.contains("parse"), "expected parse error, got: {message}");
+        Ok(())
     }
 
     #[test]
-    fn default_config_path_ends_in_bitnet_config_toml() {
-        let path = CliConfig::default_config_path().expect("config dir");
+    fn default_config_path_ends_in_bitnet_config_toml() -> anyhow::Result<()> {
+        let path = CliConfig::default_config_path()?;
         assert!(path.ends_with("bitnet/config.toml"), "got: {}", path.display());
+        Ok(())
     }
 
     #[test]
@@ -588,54 +601,54 @@ mod tests {
     }
 
     #[test]
-    fn builder_log_level_cpu_threads_batch_size_propagate() {
-        temp_env::with_vars(
+    fn builder_log_level_cpu_threads_batch_size_propagate() -> anyhow::Result<()> {
+        let config = temp_env::with_vars(
             vec![
                 ("BITNET_DEVICE", Option::<&str>::None),
                 ("BITNET_BACKEND", Option::<&str>::None),
                 ("BITNET_LOG_LEVEL", Option::<&str>::None),
                 ("BITNET_CPU_THREADS", Option::<&str>::None),
             ],
-            || {
-                let config = ConfigBuilder::new()
+            || -> anyhow::Result<CliConfig> {
+                ConfigBuilder::new()
                     .device(Some("cpu".to_string()))
                     .log_level(Some("debug".to_string()))
                     .cpu_threads(Some(2))
                     .batch_size(Some(8))
                     .build()
-                    .expect("build");
-                assert_eq!(config.default_device, "cpu");
-                assert_eq!(config.logging.level, "debug");
-                assert_eq!(config.performance.cpu_threads, Some(2));
-                assert_eq!(config.performance.batch_size, 8);
             },
-        );
+        )?;
+        assert_eq!(config.default_device, "cpu");
+        assert_eq!(config.logging.level, "debug");
+        assert_eq!(config.performance.cpu_threads, Some(2));
+        assert_eq!(config.performance.batch_size, 8);
+        Ok(())
     }
 
     #[test]
-    fn builder_none_options_leave_defaults_intact() {
-        temp_env::with_vars(
+    fn builder_none_options_leave_defaults_intact() -> anyhow::Result<()> {
+        let config = temp_env::with_vars(
             vec![
                 ("BITNET_DEVICE", Option::<&str>::None),
                 ("BITNET_BACKEND", Option::<&str>::None),
                 ("BITNET_LOG_LEVEL", Option::<&str>::None),
                 ("BITNET_CPU_THREADS", Option::<&str>::None),
             ],
-            || {
-                let defaults = CliConfig::default();
-                let config = ConfigBuilder::new()
+            || -> anyhow::Result<CliConfig> {
+                ConfigBuilder::new()
                     .device(None)
                     .log_level(None)
                     .cpu_threads(None)
                     .batch_size(None)
                     .build()
-                    .expect("build");
-                assert_eq!(config.default_device, defaults.default_device);
-                assert_eq!(config.logging.level, defaults.logging.level);
-                assert_eq!(config.performance.cpu_threads, defaults.performance.cpu_threads);
-                assert_eq!(config.performance.batch_size, defaults.performance.batch_size);
             },
-        );
+        )?;
+        let defaults = CliConfig::default();
+        assert_eq!(config.default_device, defaults.default_device);
+        assert_eq!(config.logging.level, defaults.logging.level);
+        assert_eq!(config.performance.cpu_threads, defaults.performance.cpu_threads);
+        assert_eq!(config.performance.batch_size, defaults.performance.batch_size);
+        Ok(())
     }
 
     #[test]
@@ -648,23 +661,21 @@ mod tests {
     }
 
     #[test]
-    fn builder_from_file_loads_existing_config() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn builder_from_file_loads_existing_config() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
         let path = dir.path().join("cfg.toml");
         let written = CliConfig { default_device: "cpu".to_string(), ..CliConfig::default() };
-        written.save_to_file(&path).expect("save");
-        temp_env::with_vars(
+        written.save_to_file(&path)?;
+        let config = temp_env::with_vars(
             vec![
                 ("BITNET_DEVICE", Option::<&str>::None),
                 ("BITNET_BACKEND", Option::<&str>::None),
                 ("BITNET_LOG_LEVEL", Option::<&str>::None),
                 ("BITNET_CPU_THREADS", Option::<&str>::None),
             ],
-            || {
-                let config =
-                    ConfigBuilder::from_file(&path).expect("from_file").build().expect("build");
-                assert_eq!(config.default_device, "cpu");
-            },
-        );
+            || -> anyhow::Result<CliConfig> { ConfigBuilder::from_file(&path)?.build() },
+        )?;
+        assert_eq!(config.default_device, "cpu");
+        Ok(())
     }
 }

--- a/crates/bitnet-generation-events-core/src/lib.rs
+++ b/crates/bitnet-generation-events-core/src/lib.rs
@@ -40,30 +40,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stream_event_done_carries_reason() {
+    fn stream_event_done_carries_reason() -> Result<(), Box<dyn std::error::Error>> {
         let ev = StreamEvent::Done {
             reason: StopReason::EosToken,
             stats: GenerationStats { tokens_generated: 10, tokens_per_second: 5.0 },
         };
-        match ev {
-            StreamEvent::Done { reason, stats } => {
-                assert_eq!(reason, StopReason::EosToken);
-                assert_eq!(stats.tokens_generated, 10);
-            }
-            StreamEvent::Token { .. } => panic!("expected Done event"),
-        }
+        let StreamEvent::Done { reason, stats } = ev else {
+            return Err(std::io::Error::other("expected Done event").into());
+        };
+        assert_eq!(reason, StopReason::EosToken);
+        assert_eq!(stats.tokens_generated, 10);
+        Ok(())
     }
 
     #[test]
-    fn stream_event_token_carries_payload() {
+    fn stream_event_token_carries_payload() -> Result<(), Box<dyn std::error::Error>> {
         let ev = StreamEvent::Token(TokenEvent { id: 7, text: "hi".to_string() });
-        match ev {
-            StreamEvent::Token(t) => {
-                assert_eq!(t.id, 7);
-                assert_eq!(t.text, "hi");
-            }
-            StreamEvent::Done { .. } => panic!("expected Token event"),
-        }
+        let StreamEvent::Token(t) = ev else {
+            return Err(std::io::Error::other("expected Token event").into());
+        };
+        assert_eq!(t.id, 7);
+        assert_eq!(t.text, "hi");
+        Ok(())
     }
 
     #[test]
@@ -74,43 +72,42 @@ mod tests {
     }
 
     #[test]
-    fn token_event_serde_round_trip() {
+    fn token_event_serde_round_trip() -> Result<(), Box<dyn std::error::Error>> {
         let original = TokenEvent { id: 42, text: "fox".to_string() };
-        let json = serde_json::to_string(&original).expect("serialize");
-        let parsed: TokenEvent = serde_json::from_str(&json).expect("deserialize");
+        let json = serde_json::to_string(&original)?;
+        let parsed: TokenEvent = serde_json::from_str(&json)?;
         assert_eq!(parsed.id, original.id);
         assert_eq!(parsed.text, original.text);
+        Ok(())
     }
 
     #[test]
-    fn stream_event_serde_round_trip_for_done_variant() {
+    fn stream_event_serde_round_trip_for_done_variant() -> Result<(), Box<dyn std::error::Error>> {
         let original = StreamEvent::Done {
             reason: StopReason::MaxTokens,
             stats: GenerationStats { tokens_generated: 4, tokens_per_second: 12.5 },
         };
-        let json = serde_json::to_string(&original).expect("serialize");
-        let parsed: StreamEvent = serde_json::from_str(&json).expect("deserialize");
-        match parsed {
-            StreamEvent::Done { reason, stats } => {
-                assert_eq!(reason, StopReason::MaxTokens);
-                assert_eq!(stats.tokens_generated, 4);
-                assert!((stats.tokens_per_second - 12.5).abs() < 1e-9);
-            }
-            StreamEvent::Token { .. } => panic!("expected Done after round-trip"),
-        }
+        let json = serde_json::to_string(&original)?;
+        let parsed: StreamEvent = serde_json::from_str(&json)?;
+        let StreamEvent::Done { reason, stats } = parsed else {
+            return Err(std::io::Error::other("expected Done after round-trip").into());
+        };
+        assert_eq!(reason, StopReason::MaxTokens);
+        assert_eq!(stats.tokens_generated, 4);
+        assert!((stats.tokens_per_second - 12.5).abs() < 1e-9);
+        Ok(())
     }
 
     #[test]
-    fn stream_event_serde_round_trip_for_token_variant() {
+    fn stream_event_serde_round_trip_for_token_variant() -> Result<(), Box<dyn std::error::Error>> {
         let original = StreamEvent::Token(TokenEvent { id: 99, text: "tok".to_string() });
-        let json = serde_json::to_string(&original).expect("serialize");
-        let parsed: StreamEvent = serde_json::from_str(&json).expect("deserialize");
-        match parsed {
-            StreamEvent::Token(t) => {
-                assert_eq!(t.id, 99);
-                assert_eq!(t.text, "tok");
-            }
-            StreamEvent::Done { .. } => panic!("expected Token after round-trip"),
-        }
+        let json = serde_json::to_string(&original)?;
+        let parsed: StreamEvent = serde_json::from_str(&json)?;
+        let StreamEvent::Token(t) = parsed else {
+            return Err(std::io::Error::other("expected Token after round-trip").into());
+        };
+        assert_eq!(t.id, 99);
+        assert_eq!(t.text, "tok");
+        Ok(())
     }
 }

--- a/crates/bitnet-generation-stop-core/src/lib.rs
+++ b/crates/bitnet-generation-stop-core/src/lib.rs
@@ -159,7 +159,7 @@ mod tests {
     }
 
     #[test]
-    fn stop_reason_serde_round_trip() {
+    fn stop_reason_serde_round_trip() -> serde_json::Result<()> {
         let reasons = [
             StopReason::MaxTokens,
             StopReason::EosToken,
@@ -167,18 +167,18 @@ mod tests {
             StopReason::StopString("END".to_string()),
         ];
         for r in &reasons {
-            let json = serde_json::to_string(r).expect("serialize stop reason");
-            let restored: StopReason =
-                serde_json::from_str(&json).expect("deserialize stop reason");
+            let json = serde_json::to_string(r)?;
+            let restored: StopReason = serde_json::from_str(&json)?;
             assert_eq!(*r, restored);
         }
+        Ok(())
     }
 
     proptest::proptest! {
         #[test]
         fn no_stop_without_triggers(id in 1000u32..2000, generated_len in 1usize..50) {
             let criteria = make_criteria(&[9999], &[], 100, Some(9998));
-            let generated: Vec<u32> = (0..u32::try_from(generated_len).unwrap()).collect();
+            let generated: Vec<u32> = (0..generated_len).map(|idx| idx as u32).collect();
             let result = check_stop(&criteria, id, &generated, "no-stop-string-here");
             proptest::prop_assert!(result.is_none());
         }
@@ -243,16 +243,17 @@ mod tests {
     }
 
     #[test]
-    fn stop_reason_serde_round_trip() {
+    fn stop_reason_serde_round_trip_declared_variants() -> serde_json::Result<()> {
         for reason in [
             StopReason::MaxTokens,
             StopReason::EosToken,
             StopReason::StopTokenId(42),
             StopReason::StopString("end".to_string()),
         ] {
-            let json = serde_json::to_string(&reason).expect("serialize");
-            let parsed: StopReason = serde_json::from_str(&json).expect("deserialize");
+            let json = serde_json::to_string(&reason)?;
+            let parsed: StopReason = serde_json::from_str(&json)?;
             assert_eq!(parsed, reason);
         }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- converts current no-panic policy failures in core test modules from `expect`/`panic!` shapes to fallible tests
- keeps behavior coverage the same for atomic writes, build metadata serde, CLI config, generation events, and generation stop serde
- does not change runtime behavior or policy ledgers

## Validation

- `rustfmt --edition 2024 --check crates/bitnet-atomic-file-core/src/lib.rs crates/bitnet-build-info-core/src/lib.rs crates/bitnet-cli-config-core/src/lib.rs crates/bitnet-generation-events-core/src/lib.rs crates/bitnet-generation-stop-core/src/lib.rs`
- `cargo test --locked -p bitnet-atomic-file-core -p bitnet-cli-config-core -p bitnet-generation-events-core -p bitnet-generation-stop-core --no-default-features --lib`
- `cargo test --locked -p bitnet-build-info-core --no-default-features --features serde --lib`
- `xtask check-no-panic-family --report-dir C:\bntarget\no-panic-current-policy\reports` using the existing local xtask binary
- `git diff --check`

## Rollback

Revert this PR to restore the previous test assertion style. Runtime behavior is unchanged.