### PR TITLE
diag(bitnet): compare value-mix head history

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,1123 @@ struct llama_context {
+@@ -3441,6 +3444,1201 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -867,6 +867,84 @@ index 666fcc4d..23ee29ff 100644
 +                bitnet_rs_reference_layer_trace_json_number(out, values[(size_t) head_offset + i]);
 +            }
 +            out << "]}";
++            if (strcmp(value_mix_stage, "kqv") == 0) {
++                const int64_t token_count = std::min<int64_t>((int64_t) n_tokens, tensor->ne[1]);
++                const int64_t history_nelements = tensor->ne[0] * token_count;
++                std::vector<float> history_values;
++                history_values.reserve((size_t) history_nelements);
++                double history_sum = 0.0;
++                double history_sq_sum = 0.0;
++                double history_min = std::numeric_limits<double>::infinity();
++                double history_max = -std::numeric_limits<double>::infinity();
++                for (int64_t dim = 0; dim < tensor->ne[0]; ++dim) {
++                    for (int64_t token = 0; token < token_count; ++token) {
++                        const int64_t history_index = dim + tensor->ne[0] * token + tensor->ne[0] * tensor->ne[1] * head;
++                        if (history_index < 0 || history_index >= nelements) {
++                            continue;
++                        }
++                        const float value_f32 = values[(size_t) history_index];
++                        const double value = value_f32;
++                        history_values.push_back(value_f32);
++                        history_sum += value;
++                        history_sq_sum += value * value;
++                        history_min = value < history_min ? value : history_min;
++                        history_max = value > history_max ? value : history_max;
++                    }
++                }
++                if ((int64_t) history_values.size() == history_nelements) {
++                    const uint64_t history_hash = bitnet_rs_reference_layer_trace_hash(history_values);
++                    const double history_mean = history_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : history_sum / (double) history_nelements;
++                    const double history_rms = history_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : std::sqrt(history_sq_sum / (double) history_nelements);
++                    std::ostringstream history_name;
++                    history_name << "kqv_head" << head << "_history_ref_layout-" << bitnet_rs_reference_layer_trace_layer(name);
++                    std::ostringstream history_stage;
++                    history_stage << "kqv_head" << head << "_history_ref_layout";
++                    out << ",{";
++                    out << "\"graph_index\":" << graph_index;
++                    out << ",\"name\":";
++                    bitnet_rs_reference_layer_trace_json_string(out, history_name.str().c_str());
++                    out << ",\"stage\":";
++                    bitnet_rs_reference_layer_trace_json_string(out, history_stage.str().c_str());
++                    out << ",\"layer\":" << bitnet_rs_reference_layer_trace_layer(name);
++                    out << ",\"graph_op\":";
++                    bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++                    out << ",\"graph_sources\":[]";
++                    out << ",\"view_source\":null";
++                    out << ",\"view_offset\":0";
++                    out << ",\"dtype\":";
++                    bitnet_rs_reference_layer_trace_json_string(out, ggml_type_name(tensor->type));
++                    out << ",\"shape\":[" << tensor->ne[0] << "," << token_count << ",1,1]";
++                    out << ",\"nelements\":" << history_nelements;
++                    out << ",\"full_shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++                    out << ",\"full_nelements\":" << nelements;
++                    out << ",\"token_axis\":-1";
++                    out << ",\"sample_offset\":0";
++                    out << ",\"head_index\":" << head;
++                    out << ",\"layout\":\"dim_major_token_minor\"";
++                    out << ",\"nbytes\":" << nbytes;
++                    out << ",\"contiguous\":" << (ggml_is_contiguous(tensor) ? "true" : "false");
++                    out << ",\"values_available\":true";
++                    out << ",\"values_unavailable_reason\":null";
++                    out << ",\"stats\":{\"mean\":";
++                    bitnet_rs_reference_layer_trace_json_number(out, history_mean);
++                    out << ",\"rms\":";
++                    bitnet_rs_reference_layer_trace_json_number(out, history_rms);
++                    out << ",\"min\":";
++                    bitnet_rs_reference_layer_trace_json_number(out, history_min);
++                    out << ",\"max\":";
++                    bitnet_rs_reference_layer_trace_json_number(out, history_max);
++                    out << ",\"fnv1a64\":\"" << std::hex << history_hash << std::dec << "\"}";
++                    out << ",\"first_values\":[";
++                    const size_t history_sample_count = bitnet_rs_reference_layer_trace_first_values_limit((size_t) history_nelements);
++                    for (size_t i = 0; i < history_sample_count; ++i) {
++                        if (i > 0) {
++                            out << ",";
++                        }
++                        bitnet_rs_reference_layer_trace_json_number(out, history_values[i]);
++                    }
++                    out << "]}";
++                }
++            }
 +        }
 +    }
 +    const char * kv_cache_stage = bitnet_rs_reference_layer_trace_stage(name);

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1132,6 +1132,24 @@ impl MultiHeadAttention {
         if self.layer_idx == trace_target_layer() {
             for head_idx in 0..self.n_heads {
                 let head = attn_value_mix.narrow(1, head_idx, 1)?;
+                let history = head
+                    .reshape(&[seq_len, self.head_dim])?
+                    .transpose(0, 1)?
+                    .to_dtype(DType::F32)?;
+                let trace_seq = trace_target_seq().unwrap_or(_trace_base_seq);
+                let trace_name = format!(
+                    "t{trace_seq}/blk{}/attention_value_mix_head{head_idx}_history_ref_layout",
+                    self.layer_idx
+                );
+                let history_stage =
+                    format!("attention_value_mix_head{head_idx}_history_ref_layout");
+                trace_tensor_record(
+                    &trace_name,
+                    &history,
+                    trace_seq,
+                    Some(self.layer_idx as isize),
+                    &history_stage,
+                )?;
                 let suffix = format!("blk{}/attention_value_mix_head{head_idx}", self.layer_idx);
                 let stage = format!("attention_value_mix_head{head_idx}");
                 trace_tensor_token_axis_record(

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -5128,6 +5128,8 @@ fn compare_reference_to_rust_with_records(
         layer_history_boundary_delta(reference_records, rust_record_list, 0);
     report["layer_0_attention_output_history_boundary_delta"] =
         layer_attention_output_history_boundary_delta(reference_records, rust_record_list, 0);
+    report["attention_value_mix_head_history_delta"] =
+        attention_value_mix_head_history_delta(reference_records, rust_records);
     report["attention_norm_input_history_delta"] =
         attention_norm_input_history_delta(reference_records, rust_records);
     report
@@ -5616,6 +5618,87 @@ fn attention_value_mix_f16_cache_head_lane_best_matches(
         "attention_value_mix_f16_cache_head",
         "F16-cache value-mix head-lane best matches are diagnostic alternate-path evidence only; they do not promote reference parity, A770 semantic quality, value mix residency, resident KV, selected attention, or any support claim",
     )
+}
+
+fn attention_value_mix_head_history_delta(
+    reference_records: &[ReferenceTraceRecord],
+    rust_records: &BTreeMap<String, RustTraceRecord>,
+) -> Value {
+    let reference_heads = reference_records
+        .iter()
+        .filter_map(|record| parse_stage_head(&record.stage, "kqv_head").map(|head| (head, record)))
+        .filter(|(_, record)| {
+            record.stage.ends_with("_history_ref_layout")
+                && record.values_available
+                && !record.first_values.is_empty()
+        })
+        .collect::<BTreeMap<_, _>>();
+    let rust_heads = rust_records
+        .iter()
+        .filter_map(|(stage, record)| {
+            parse_stage_head(stage, "attention_value_mix_head").map(|head| (head, record))
+        })
+        .filter(|(head, record)| {
+            record.stage.as_deref().unwrap_or("")
+                == format!("attention_value_mix_head{head}_history_ref_layout")
+                && !record.first_values.is_empty()
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut rows = Vec::<Value>::new();
+    let mut compared_head_count = 0usize;
+    let mut missing_rust_head_count = 0usize;
+    let mut material_mismatch_count = 0usize;
+    let mut first_material_head = Value::Null;
+
+    for (&head, reference) in &reference_heads {
+        let rust = rust_heads.get(&head).copied();
+        if rust.is_none() {
+            missing_rust_head_count += 1;
+        }
+
+        let mut status = if rust.is_some() { "summary_match" } else { "missing_rust_head" };
+        let mut delta = Value::Null;
+        let mut material_mismatch = false;
+        if let Some(rust) = rust {
+            compared_head_count += 1;
+            delta = dim_major_history_record_delta(reference, rust);
+            material_mismatch = delta_has_material_numeric_delta(&delta);
+            if material_mismatch {
+                status = "material_mismatch";
+                material_mismatch_count += 1;
+            }
+        }
+
+        let row = json!({
+            "head": head,
+            "status": status,
+            "reference_stage": reference.stage,
+            "rust_stage": format!("attention_value_mix_head{head}_history_ref_layout"),
+            "reference": reference_record_summary(reference),
+            "rust": rust.map(rust_record_summary).unwrap_or(Value::Null),
+            "delta": delta,
+            "material_mismatch": material_mismatch,
+        });
+        if material_mismatch && first_material_head.is_null() {
+            first_material_head = row.clone();
+        }
+        rows.push(row);
+    }
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "Per-head value-mix full-history deltas are diagnostic-only evidence for locating which head introduces merged value-mix history drift; they do not promote reference parity, A770 semantic quality, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full residency, performance, or completion",
+        "layout": "dim_major_token_minor",
+        "reference_head_count": reference_heads.len(),
+        "rust_head_count": rust_heads.len(),
+        "compared_head_count": compared_head_count,
+        "missing_rust_head_count": missing_rust_head_count,
+        "material_mismatch_count": material_mismatch_count,
+        "first_material_head": first_material_head,
+        "rows": rows,
+    })
 }
 
 fn attention_value_mix_reference_scalar_recompute(
@@ -11323,6 +11406,13 @@ fn build_plan(args: &LayerTracePlanArgs) -> Result<Value> {
             "scope": format!("layer0 value-mix sampled token head{head}"),
         }));
     }
+    for head in 0..20 {
+        stage_mapping.push(json!({
+            "reference": format!("kqv_head{head}_history_ref_layout"),
+            "rust": format!("attention_value_mix_head{head}_history_ref_layout"),
+            "scope": format!("layer0 full-prefix value-mix history head{head}"),
+        }));
+    }
     stage_mapping.extend([
         json!({"reference": "kqv_merged", "rust": "attention_value_mix_merged", "scope": "layer0 non-contiguous all-token value-mix merge view"}),
         json!({"reference": "attn_value_mix", "rust": "attention_value_mix_merged", "scope": "layer0 contiguous merged value-mix before subnorm"}),
@@ -13680,6 +13770,66 @@ mod tests {
         assert_eq!(f16_matches.pointer("/identity_best_count"), Some(&json!(1)));
         assert_eq!(f16_matches.pointer("/non_identity_best_count"), Some(&json!(1)));
         assert_eq!(f16_matches.pointer("/rows/1/best_rust_head"), Some(&json!(2)));
+    }
+
+    #[test]
+    fn compare_reports_attention_value_mix_head_history_delta() {
+        let mut reference_head0 =
+            test_reference_trace_record("kqv_head0_history_ref_layout", vec![1.0, 1.1, 2.0, 2.1]);
+        reference_head0.shape = vec![2, 2, 1, 1];
+        reference_head0.nelements = 4;
+        reference_head0.layer = Some(0);
+        let mut reference_head1 =
+            test_reference_trace_record("kqv_head1_history_ref_layout", vec![3.0, 3.1, 4.0, 4.1]);
+        reference_head1.shape = vec![2, 2, 1, 1];
+        reference_head1.nelements = 4;
+        reference_head1.layer = Some(0);
+        let reference_records = vec![reference_head0, reference_head1];
+
+        let mut rust_records = BTreeMap::new();
+        rust_records.insert(
+            "attention_value_mix_head0_history_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 2],
+                num_elements: 4,
+                first_values: vec![1.0, 1.1, 2.0, 2.1],
+                ..test_rust_trace_record(
+                    "attention_value_mix_head0_history_ref_layout",
+                    vec![1.0, 1.1, 2.0, 2.1],
+                )
+            },
+        );
+        rust_records.insert(
+            "attention_value_mix_head1_history_ref_layout".to_string(),
+            RustTraceRecord {
+                shape: vec![2, 2],
+                num_elements: 4,
+                first_values: vec![3.0, 3.1, 4.0, 4.6],
+                ..test_rust_trace_record(
+                    "attention_value_mix_head1_history_ref_layout",
+                    vec![3.0, 3.1, 4.0, 4.6],
+                )
+            },
+        );
+
+        let report = compare_reference_to_rust(&reference_records, &rust_records, &[]);
+        let history = report.pointer("/attention_value_mix_head_history_delta").unwrap();
+
+        assert_eq!(history.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(history.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(history.pointer("/reference_head_count"), Some(&json!(2)));
+        assert_eq!(history.pointer("/rust_head_count"), Some(&json!(2)));
+        assert_eq!(history.pointer("/compared_head_count"), Some(&json!(2)));
+        assert_eq!(history.pointer("/material_mismatch_count"), Some(&json!(1)));
+        assert_eq!(history.pointer("/first_material_head/head"), Some(&json!(1)));
+        assert_eq!(
+            history.pointer("/first_material_head/delta/first_mismatch_layout/dim"),
+            Some(&json!(1))
+        );
+        assert_eq!(
+            history.pointer("/first_material_head/delta/first_mismatch_layout/token"),
+            Some(&json!(1))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add trace-only per-head full-prefix value-mix history records for reference and Rust
- add `attention_value_mix_head_history_delta` to identify which value-mix heads contribute to merged history drift
- keep all output diagnostic-only with `claim_allowed=false`

## Diagnostic result
Layer-0 value-mix head history run:
- 20/20 reference heads compared against 20/20 Rust heads
- material mismatch count: 20
- first material head: head `0`, max delta `0.003266572952270508`, RMS `0.00019992830945421156`, first mismatch dim `0`, token `1`
- largest max deltas:
  - head `15`: max `0.015621185302734375`, RMS `0.0005001483423485207`, first mismatch dim `0`, token `4`
  - head `14`: max `0.0155792236328125`, RMS `0.0005852288251045619`, first mismatch dim `0`, token `4`
  - head `13`: max `0.015531539916992188`, RMS `0.00039498430510915547`, first mismatch dim `0`, token `4`
  - head `12`: max `0.008580207824707031`, RMS `0.0002568620542028546`, first mismatch dim `0`, token `4`

Artifacts:
- `target/a770-diagnostic/bitnet-reference-layer-trace-run-layer0-value-mix-head-history.json`
- `target/a770-diagnostic/reference-layer-trace-rust-cpu-layer0-value-mix-head-history/`
- `target/a770-diagnostic/bitnet-reference-layer-trace-compare-layer0-value-mix-head-history.json`

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `cargo check --locked -p bitnet-transformer --features trace`
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `rustfmt --edition 2024 --check crates/bitnet-transformer/src/lib.rs xtask/src/bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claims
No support claim is promoted. A770 semantic quality, selected attention, resident KV, attention/softmax/value residency, full residency, performance, and completion remain unclaimed.