### PR TITLE
diag(bitnet): trace layer0 attention norm input history

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -29,7 +29,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,1204 @@ struct llama_context {
+@@ -3441,6 +3444,1205 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -605,7 +605,8 @@ index 666fcc4d..23ee29ff 100644
 +    const char * bitnet_rs_history_stage = bitnet_rs_reference_layer_trace_layer_stage(name, &bitnet_rs_history_layer);
 +    const bool bitnet_rs_history_is_requested_layer = bitnet_rs_history_layer == bitnet_rs_requested_history_layer;
 +    const bool bitnet_rs_history_is_attn_norm = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "attn_norm") == 0;
-+    const bool bitnet_rs_history_is_attn_norm_input = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "l_out") == 0 && bitnet_rs_history_layer + 1 == bitnet_rs_requested_history_layer;
++    const bool bitnet_rs_history_is_layer0_attn_norm_input = strcmp(name, "inp_embd") == 0 && bitnet_rs_requested_history_layer == 0;
++    const bool bitnet_rs_history_is_attn_norm_input = bitnet_rs_history_is_layer0_attn_norm_input || (bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "l_out") == 0 && bitnet_rs_history_layer + 1 == bitnet_rs_requested_history_layer);
 +    const bool bitnet_rs_history_is_vcur = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "Vcur") == 0;
 +    const bool bitnet_rs_history_is_attn_value_mix = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "attn_value_mix") == 0;
 +    const bool bitnet_rs_history_is_attn_sub_norm = bitnet_rs_history_stage != nullptr && strcmp(bitnet_rs_history_stage, "attn_sub_norm") == 0;

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -12794,6 +12794,12 @@ mod tests {
         assert!(patch.contains(
             "strcmp(bitnet_rs_history_stage, \"l_out\") == 0 && bitnet_rs_history_layer + 1 == bitnet_rs_requested_history_layer"
         ));
+        assert!(patch.contains("bitnet_rs_history_is_layer0_attn_norm_input"));
+        assert!(
+            patch.contains(
+                "strcmp(name, \"inp_embd\") == 0 && bitnet_rs_requested_history_layer == 0"
+            )
+        );
         assert!(!patch.contains(
             "const bool bitnet_rs_history_is_attn_norm = strcmp(name, \"attn_norm-0\") == 0"
         ));


### PR DESCRIPTION
## Summary
- trace reference layer-0 attention-norm input history by mapping `inp_embd` to `attn_norm_input_history_ref_layout` for `--trace-layer 0`
- keep the existing previous-layer `l_out` mapping for nonzero layer attention-norm input history
- add a guard test so the reference patch keeps the layer-0 input-history contract

## Live diagnostic
Artifacts:
- `target/a770-diagnostic/bitnet-reference-layer-trace-run-layer0-attn-norm-input-history.json`
- `target/a770-diagnostic/bitnet-reference-layer-trace-compare-layer0-attn-norm-input-history.json`

Result:
- `attention_norm_input_history_delta.reference_present=true`
- `attention_norm_input_history_delta.rust_present=true`
- `attention_norm_input_history_delta.max_abs_delta=0.0`
- `attention_norm_input_history_delta.rms_abs_delta=0.0`
- `attention_norm_history_delta.reference_current_vs_rust_current.max_abs_delta=4.470348358154297e-08`
- `attention_norm_history_delta.reference_history_token_vs_rust_history_token_f16.f16_bucket_mismatch_count=1`
- `attention_value_projection_output_history.total_f16_bucket_mismatch_count=10`

Interpretation: layer-0 attention-norm input history is not the source of drift; the first observed delta is introduced by attention RMSNorm numeric output and crosses an F16 bucket boundary downstream in V projection/cache.

## Validation
- `git -C target/external/BitNet-reference/3rdparty/llama.cpp apply --check E:/Code/Rust/BitNet-rs/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch`
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --edition 2024 --check xtask/src/bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claims
Diagnostic only. Does not promote A770 semantic quality, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full residency, performance, or completion.