### PR TITLE
docs(cuda): sync 5070 Ti productization plan state

### DIFF
--- a/plans/cuda-5070ti-productization/bitnet-official-i2s.md
+++ b/plans/cuda-5070ti-productization/bitnet-official-i2s.md
@@ -36,7 +36,11 @@ ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-002-repeated-s
 ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-003-warm-session-benchmark.json
 ```
 
-## Next PRs
+## Completed Productization PRs
+
+These items have landed and should be treated as the current official BitNet
+CUDA productization baseline. Future BitNet work should build on these receipts
+instead of reopening basic CUDA execution proof.
 
 ### CUDA-PROD-008: Reconcile Proof State
 

--- a/plans/cuda-5070ti-productization/dense-qwen.md
+++ b/plans/cuda-5070ti-productization/dense-qwen.md
@@ -16,12 +16,14 @@ speedup_claim = false
 server_ready = false
 ```
 
-The first productization task is to audit which Qwen receipts are real hardware
-user-path receipts versus validators, fixtures, or contracts.
+The productization audit, one-token proof, short-decode proof, warm-session
+proof, benchmark qualification review, and bounded server-smoke receipt have
+landed. The remaining boundary is still conservative: speedup and broad server
+readiness stay false until later profile-specific readiness gates promote them.
 
 ## Work item: CUDA-DENSE-050
 
-Status: PR open (#4713)
+Status: merged (#4589)
 Linked proposal: BITNET-PROP-0002
 Linked specs: BITNET-SPEC-0007
 Linked ADRs: BITNET-ADR-0004
@@ -119,7 +121,7 @@ Remove the new receipt and demote any matrix/status row that depended on it.
 
 ## Work item: CUDA-DENSE-052
 
-Status: pr_open
+Status: merged (#4695)
 Campaign item: `CUDA-DENSE-052`
 Blocked by: none
 

--- a/plans/cuda-5070ti-productization/implementation-plan.md
+++ b/plans/cuda-5070ti-productization/implementation-plan.md
@@ -21,14 +21,16 @@ promotion tied to receipts.
 | 11 | CUDA-MODEL-002 | `model(cuda): add Qwen3 CPU answer sanity` | CPU receipts |
 | 12 | CUDA-MODEL-003 | `model(cuda): add Qwen3 CUDA all-layer plan` | all-layer plan |
 | 13 | CUDA-MODEL-004 | `model(cuda): add Qwen3 one-token CUDA proof` | CUDA receipt path |
-| 14 | CUDA-MODEL-005 | `model(cuda): add Qwen3 short-decode and warm-session proof` | CUDA receipt path |
-| 15 | CUDA-UX-008 | `cli(cuda): model support dashboard` | CLI/status surface |
-| 16 | CUDA-UX-010 | `docs(cuda): 9950X3D+5070Ti CUDA quickstart` | tutorial |
-| 17 | CUDA-SERVER-001 | `server(cuda): strict CUDA server smoke` | server path |
-| 18 | CUDA-SERVER-002 | `server(cuda): commit dense Qwen strict smoke receipt` | server receipt path |
-| 19 | CUDA-MODEL-008 | `model(cuda): sync Qwen3 earned status row` | model coverage and status |
-| 20 | CUDA-MODEL-SMOLLM2-001 | `model(cuda): add SmolLM2 360M artifact contract` | model artifact docs |
-| 21 | CUDA-MODEL-SMOLLM2-002 | `docs(cuda): sync SmolLM2 CPU blocker state` | model coverage and plan docs |
+| 14 | CUDA-MODEL-005 | `model(cuda): add Qwen3 short-decode CUDA proof` | CUDA receipt path |
+| 15 | CUDA-MODEL-006 | `model(cuda): add Qwen3 warm-session CUDA proof` | CUDA receipt path |
+| 16 | CUDA-MODEL-007 | `model(cuda): add Qwen3 benchmark qualification review` | benchmark receipts |
+| 17 | CUDA-MODEL-008 | `model(cuda): sync Qwen3 earned status row` | model coverage and status |
+| 18 | CUDA-UX-008 | `cli(cuda): model support dashboard` | CLI/status surface |
+| 19 | CUDA-UX-010 | `docs(cuda): 9950X3D+5070Ti CUDA quickstart` | tutorial |
+| 20 | CUDA-SERVER-001 | `server(cuda): strict CUDA server smoke` | server path |
+| 21 | CUDA-SERVER-002 | `server(cuda): commit dense Qwen strict smoke receipt` | server receipt path |
+| 22 | CUDA-MODEL-SMOLLM2-001 | `model(cuda): add SmolLM2 360M artifact contract` | model artifact docs |
+| 23 | CUDA-MODEL-SMOLLM2-002 | `docs(cuda): sync SmolLM2 CPU blocker state` | model coverage and plan docs |
 
 ## Shared Links
 

--- a/plans/cuda-5070ti-productization/small-llm-candidates.md
+++ b/plans/cuda-5070ti-productization/small-llm-candidates.md
@@ -27,7 +27,7 @@ Each model uses the same sequence:
 | F. Short decode / warm session | decode and session receipts | scoped answer proof |
 | G. Benchmark qualification | profile-specific decision | exact accepted profiles only |
 
-## Work items: CUDA-MODEL-001 through CUDA-MODEL-005
+## Work items: CUDA-MODEL-001 through CUDA-MODEL-008
 
 Qwen3 0.6B was the first candidate because it is closest to the existing
 Qwen2.5 dense infrastructure. It has now advanced through artifact contract,
@@ -110,16 +110,53 @@ Acceptance:
 
 Rollback: remove the one-token receipt and keep CUDA answer readiness false.
 
-### CUDA-MODEL-005: Short Decode And Warm Session
+### CUDA-MODEL-005: Short Decode
 
 Acceptance:
 
 - deterministic short-decode receipt;
-- warm-session receipt when model/session reuse is claimed;
+- valid UTF-8 decoded text;
+- CPU/CUDA generated-token equality or explicit first-divergence evidence;
 - quality gate result present;
 - speedup false unless benchmark-qualified.
 
-Rollback: remove the decode/session receipt and demote status rows.
+Rollback: remove the short-decode receipt and keep warm-session/product status
+unpromoted.
+
+### CUDA-MODEL-006: Warm Session
+
+Acceptance:
+
+- model, tokenizer, and CUDA context loaded once when claimed;
+- runtime buffers and weights reused where intended;
+- per-turn receipt evidence or a session summary;
+- speedup, server readiness, and full residency remain false unless later
+  receipts prove those exact claims.
+
+Rollback: remove the warm-session receipt and demote status rows that depended
+on it.
+
+### CUDA-MODEL-007: Benchmark Review
+
+Acceptance:
+
+- one-token, short-decode, and warm-session receipts are reviewed together;
+- each reviewed profile accepts or rejects speedup explicitly;
+- global speedup, server readiness, full residency, and BitNet QK256 proof stay
+  false.
+
+Rollback: remove the benchmark review receipt or demote the benchmark status
+row; do not edit execution receipts by hand.
+
+### CUDA-MODEL-008: Earned Status Sync
+
+Acceptance:
+
+- the Qwen3 model coverage and model-status row reflect the exact earned tier;
+- product CLI, speedup, server, full-residency, broad dense GGUF, and BitNet
+  QK256 claims remain false.
+
+Rollback: restore the previous Qwen3 candidate wording and claim booleans.
 
 ## Next Candidate
 


### PR DESCRIPTION
## Summary

- Sync the CUDA productization plan queue with the merged Qwen3 proof ladder, splitting one-token, short-decode, warm-session, benchmark review, and status-sync items into the actual campaign sequence.
- Update dense Qwen plan wording so CUDA-DENSE-050 and CUDA-DENSE-052 are no longer shown as open, and keep speed/server claims conservative.
- Mark the official BitNet I2_S productization plan items as the completed baseline instead of future proof work.

## Claim boundary

Docs-only plan sync. This PR does not change runtime behavior, CUDA kernels, receipts, model coverage rows, campaign state, generated dashboards, speed claims, server readiness, README badges, crates.io, or docs.rs claims.

## Validation

- cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check

Note: local validation used the existing xtask binary at C:\bntarget\cuda-ux-010-closeout\debug\xtask.exe to avoid the known local Windows sentencepiece/native build blocker. Campaign doctor passed with only unrelated pre-existing CPU event metadata warnings.

## Rollback

Revert this docs-only commit to restore the prior productization plan wording. No proof artifacts or generated dashboards need manual edits.