### PR TITLE
policy: add docs source-of-truth ledger

### DIFF
--- a/policy/docs-source-of-truth.toml
+++ b/policy/docs-source-of-truth.toml
@@ -1,0 +1,116 @@
+schema_version = "1.0"
+policy = "docs-source-of-truth"
+owner = "release/ci"
+status = "active"
+updated = "2026-05-16"
+
+# This ledger names the BitNet-rs source-of-truth surfaces for proof-backed
+# model, hardware, CI, campaign, and product claims. It is descriptive policy:
+# proposals, specs, plans, campaign manifests, model coverage ledgers, hardware
+# receipts, and generated dashboards keep their existing operational roles.
+
+[source.roadmap]
+path = "ROADMAP.md"
+owns = ["release_direction", "current_limitations", "milestone_strategy"]
+hand_editable = true
+
+[source.proposals]
+path = "docs/proposals/"
+owns = ["why", "user_value", "alternatives", "success_criteria"]
+hand_editable = true
+
+[source.specs]
+path = "docs/specs/"
+owns = ["behavior_contract", "acceptance", "proof_requirements", "claim_boundaries"]
+hand_editable = true
+
+[source.adrs]
+path = "docs/adr/"
+owns = ["durable_architecture_decisions", "durable_proof_decisions"]
+hand_editable = true
+
+[source.plans]
+path = "plans/"
+owns = ["pr_sequence", "proof_commands", "rollback"]
+hand_editable = true
+
+[source.status_docs]
+path = "docs/status/"
+owns = ["user_facing_claim_map", "claim_tiers", "proof_commands", "claim_boundaries"]
+hand_editable = true
+
+[source.cuda_capability_matrix]
+path = "docs/status/CUDA_CAPABILITY_MATRIX.md"
+owns = ["cuda_product_claim_summary", "model_family_boundaries", "next_proof_summary"]
+hand_editable = true
+
+[source.answer_artifact_gate]
+path = "docs/model-artifacts/ANSWER_ARTIFACT_GATE.md"
+owns = ["model_answer_readiness", "tokenizer_authority", "prompt_suite_authority"]
+hand_editable = true
+
+[source.model_coverage_matrix]
+path = "ci/model-artifacts/model-coverage-matrix.toml"
+owns = ["model_tiers", "claim_booleans", "next_proof", "forbidden_claims"]
+hand_editable = true
+
+[source.hardware_matrix]
+path = "docs/hardware/HARDWARE_MATRIX.md"
+owns = ["hardware_lane_identity", "runtime_identity", "backend_claim_boundaries"]
+hand_editable = true
+
+[source.hardware_receipts]
+path = "ci/hardware/"
+owns = ["hardware_backend_proof_receipts", "fallback_status", "runtime_identity"]
+hand_editable = false
+
+[source.campaign_tracker_model]
+path = "docs/tracking/TRACKER_MODEL.md"
+owns = ["campaign_manifest_contract", "active_work_item_contract", "generated_dashboard_rules"]
+hand_editable = true
+
+[source.campaigns]
+path = "docs/tracking/campaigns/"
+owns = ["active_work_items", "campaign_events", "campaign_claim_boundaries"]
+hand_editable = true
+
+[source.ci_cost_policy]
+path = "docs/ci/cost-and-verification-policy.md"
+owns = ["ci_economics_doctrine", "default_pr_posture", "expensive_lane_routing"]
+hand_editable = true
+
+[source.ci_lanes]
+path = "policy/ci-lanes.toml"
+owns = ["ci_lane_cost", "ci_lane_intent", "ci_lane_posture"]
+hand_editable = true
+
+[source.ci_budget]
+path = "policy/ci-budget.toml"
+owns = ["lem_bands", "budget_guardrails", "timeout_policy"]
+hand_editable = true
+
+[source.ci_risk_packs]
+path = "policy/ci-risk-packs.toml"
+owns = ["path_to_lane_routing", "label_to_deep_lane_routing"]
+hand_editable = true
+
+[source.file_policy]
+path = "policy/non-rust-allowlist.toml"
+owns = ["non_rust_file_allowlist", "policy_surface_classification"]
+hand_editable = true
+
+[derived.campaign_dashboards]
+paths = [
+  "docs/tracking/generated/",
+  "docs/tracking/campaigns/*/generated/",
+]
+owns = ["derived_campaign_status_views"]
+hand_editable = false
+generated_by = "cargo run --locked -p xtask --no-default-features -- campaign generate"
+
+[rules]
+active_execution_state = "docs/tracking/campaigns/<campaign>/active.toml"
+no_hidden_goal_files = [".adze/goals", ".bitnet/goals"]
+readme_role = "summary_not_final_proof_map"
+receipts_role = "evidence_for_what_happened"
+generated_dashboards_hand_editable = false


### PR DESCRIPTION
## Summary

- Add policy/docs-source-of-truth.toml as the machine-readable ledger for BitNet proposal/spec/ADR/plan/status/campaign/model/hardware/CI source-of-truth surfaces.
- Mark generated tracker dashboards as derived and not hand-editable.
- Preserve the existing campaign tracker, model coverage matrix, hardware receipts, and CI policy TOMLs as the operational authorities; this PR only names those roles.

## Claim boundary

Policy/docs ledger only. This PR does not change runtime behavior, CUDA kernels, receipts, model coverage rows, campaign state, generated dashboards, speed claims, server readiness, README badges, crates.io, or docs.rs claims.

## Validation

- python -c "import tomllib; tomllib.load(open('policy/docs-source-of-truth.toml','rb'))"
- cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir C:\bntarget\doc-source-truth-policy-reports --fail-on-error
- cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --cached --check

Note: local xtask validation used the existing binary at C:\bntarget\cuda-ux-010-closeout\debug\xtask.exe to avoid the known local Windows sentencepiece/native build blocker. Campaign doctor passed with only unrelated pre-existing CPU event metadata warnings.

## Rollback

Revert this policy-only commit to remove the ledger. Existing docs, campaign manifests, receipts, and generated dashboards remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a documentation governance and source-of-truth policy framework defining documentation sources, derived views, and operational rules for maintaining repository documentation standards and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/5168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->