### PR TITLE
docs(cuda): add dense Qwen RTX 5070 Ti guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,6 +31,8 @@
 - [CPU Kernel Architecture](cpu-kernel-architecture.md)
 - [GPU Kernel Architecture](gpu-kernel-architecture.md)
 - [CUDA Configuration Guide](cuda-configuration-guide.md)
+- [RTX 5070 Ti BitNet CUDA Guide](tutorials/rtx5070ti-bitnet-cuda.md)
+- [RTX 5070 Ti Dense Qwen CUDA Guide](tutorials/rtx5070ti-dense-qwen-cuda.md)
 - [Intel Arc GPU Setup](INTEL_GPU_SETUP.md)
 
 ## Miscellaneous

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -24,6 +24,7 @@ bitnet receipts explain --latest
 | Strict CUDA product contract | `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md` |
 | User quickstart | `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md` |
 | BitNet CUDA guide | `docs/tutorials/rtx5070ti-bitnet-cuda.md` |
+| Dense Qwen CUDA guide | `docs/tutorials/rtx5070ti-dense-qwen-cuda.md` |
 
 ## Current CUDA Rows
 

--- a/docs/tutorials/rtx5070ti-dense-qwen-cuda.md
+++ b/docs/tutorials/rtx5070ti-dense-qwen-cuda.md
@@ -1,0 +1,194 @@
+# RTX 5070 Ti Dense Qwen CUDA Guide
+
+This guide is for the Qwen2.5 0.5B Q8_0 dense SLM lane on the 9950X3D + RTX
+5070 Ti bench. It shows the normal commands for checking support, verifying the
+model artifact, running dense CUDA ask and chat-style commands, reading the
+committed receipts, and understanding what the lane does not prove.
+
+The claim is intentionally narrow:
+
+- model family: dense SLM, Qwen2.5 0.5B Q8_0
+- required selected backend for strict proof: `nvidia-rtx-5070-ti-cuda`
+- route: `dense_regular_llm_cuda`
+- fallback: rejected in strict CUDA receipts
+- speed: reviewed, not accepted
+- server readiness: not broadly ready
+- BitNet proof: false
+
+Official BitNet I2_S/QK256 receipts do not prove this dense lane. This dense
+lane also does not prove BitNet packed I2_S/QK256 behavior, QK256 kernels,
+global dense GGUF support, full CUDA residency, accepted speedup, or production
+server readiness.
+
+## Prerequisites
+
+Use a local checkout or installed `bitnet` binary built with CUDA support. From a
+checkout, the equivalent prefix is:
+
+```powershell
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli --
+```
+
+The examples below use `bitnet` for readability.
+
+The dense Qwen row is identified by the model coverage matrix as:
+
+```text
+row: dense_qwen25_05b_q8_cuda
+model: qwen2.5-0.5b-instruct-q8_0
+route: dense_regular_llm_cuda
+```
+
+## Check Current Model Status
+
+Start with the model status command. It reads the model coverage matrix and does
+not require CUDA hardware:
+
+```powershell
+bitnet model status --device nvidia-rtx-5070-ti-cuda
+```
+
+For automation:
+
+```powershell
+bitnet model status --device nvidia-rtx-5070-ti-cuda --format json
+```
+
+The dense Qwen row should show `product_cli_ready`, route
+`dense_regular_llm_cuda`, `speedup_claim=false`, and `server_ready=false`.
+
+## Verify The Model Artifact
+
+Verify the registered dense artifact before running answer paths:
+
+```powershell
+bitnet model verify qwen2.5-0.5b-instruct-q8_0
+```
+
+Artifact verification is necessary, but it is not enough by itself. Dense CUDA
+answer claims also need tokenizer authority, prompt authority, CPU reference,
+strict CUDA route receipts, answer-quality evidence, and claim booleans.
+
+## Run Dense Ask
+
+Use the exact RTX 5070 Ti device label when you need a strict selected-device
+claim:
+
+```powershell
+bitnet ask `
+  --device nvidia-rtx-5070-ti-cuda `
+  --model qwen2.5-0.5b-instruct-q8_0 `
+  --max-new-tokens 8 `
+  "What is 2+2?"
+```
+
+If a convenience command uses `--device cuda`, the receipt must still resolve to
+`selected_backend = nvidia-rtx-5070-ti-cuda` before it can support this lane's
+strict CUDA claim.
+
+The receipt must preserve:
+
+- `route = dense_regular_llm_cuda`
+- `selected_backend = nvidia-rtx-5070-ti-cuda`
+- `runtime_api = cuda`
+- `fallback_used = false`
+- tokenizer and prompt authority
+- quality-gate status
+- `speedup_claim = false`
+- `bitnet_packed_i2s_qk256_proof = false`
+
+## Run A Chat-Style Session
+
+For a bounded chat-style session:
+
+```powershell
+@("What is 2+2?", "Name the previous answer in words.") | bitnet chat `
+  --device nvidia-rtx-5070-ti-cuda `
+  --model qwen2.5-0.5b-instruct-q8_0 `
+  --max-tokens 8
+```
+
+The committed warm-session proof is a bounded CLI/session proof. It records
+model, tokenizer, and CUDA context reuse for the proof run, but it does not
+claim full CUDA residency, broad chat quality, server readiness, or speedup.
+
+## Explain Dense Receipts
+
+Explain the latest receipt:
+
+```powershell
+bitnet receipts explain --latest
+```
+
+Or inspect the committed dense receipts directly:
+
+```powershell
+bitnet receipts explain ci\hardware\windows-9950x3d-rtx5070ti\2026-05-13\dense-qwen25-q8-one-token-cuda.json
+
+bitnet receipts explain ci\hardware\windows-9950x3d-rtx5070ti\2026-05-14\dense-qwen25-q8-short-decode-current-source.json
+
+bitnet receipts explain ci\hardware\windows-9950x3d-rtx5070ti\2026-05-14\dense-qwen25-q8-warm-session-current-source.json
+```
+
+The useful fields to paste into an issue are:
+
+- model coverage row
+- model id and artifact identity
+- route
+- requested and selected backend
+- fallback status
+- generated-token equality or first divergence
+- quality gate
+- kernel and transfer fields
+- speed qualification state
+- server readiness state
+- claim boundary
+
+## Read The Governed Benchmark Receipt
+
+The current dense Qwen benchmark qualification review is committed as:
+
+```powershell
+bitnet bench --device cuda `
+  --cuda-benchmark-receipt ci\hardware\windows-9950x3d-rtx5070ti\2026-05-14\dense-qwen25-q8-benchmark-qualification-current-source.json
+```
+
+This is report-only receipt inspection. It is not a fresh live CUDA benchmark
+run. The current review keeps:
+
+```text
+speedup_claim = false
+benchmark_qualified_speedup = false
+accepted_profiles = []
+```
+
+Speed remains unqualified until a later governed review accepts an exact
+same-artifact, fallback-free profile.
+
+## Server Smoke Is Not Broad Readiness
+
+The bounded server-smoke receipt exists for the exact dense Qwen profile:
+
+```powershell
+bitnet receipts explain ci\hardware\windows-9950x3d-rtx5070ti\2026-05-15\server-strict-dense-qwen25-q8-smoke.json
+```
+
+That receipt is useful server evidence, but the model coverage row still keeps
+`server_ready=false`. Do not turn one bounded server smoke into broad dense
+server readiness or production-serving readiness.
+
+## What This Guide Does Not Claim
+
+This guide does not claim:
+
+- BitNet I2_S, QK256, 1-bit, or packed-kernel proof
+- Qwen3, SmolLM2, Llama, Gemma, or Phi support
+- accepted CUDA speedup
+- broad server readiness
+- full CUDA residency
+- global dense GGUF support
+- generic `cuda`, WGPU, Vulkan, or CPU fallback as strict RTX 5070 Ti proof
+- crates.io or docs.rs publication
+
+The source-of-truth status remains the model coverage matrix, NVIDIA 5070 Ti
+campaign tracker, committed receipts, and governed benchmark reports.


### PR DESCRIPTION
## Summary

- Add a dedicated RTX 5070 Ti dense Qwen CUDA guide for the Qwen2.5 0.5B Q8_0 lane.
- Link the guide from the CUDA capability matrix and docs summary.
- Keep the guide scoped to existing one-token, short-decode, warm-session, benchmark-review, and bounded server-smoke receipts.

## Claim boundary

Docs-only guide. This PR does not change runtime behavior, CUDA kernels, receipts, model coverage rows, campaign state, generated dashboards, speed claims, server readiness, README badges, crates.io, or docs.rs claims.

The guide explicitly does not claim BitNet I2_S/QK256 proof, accepted speedup, broad server readiness, full CUDA residency, global dense GGUF support, or Qwen3/SmolLM/Llama/Gemma/Phi support.

## Validation

- cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir C:\bntarget\dense-qwen-guide-reports --fail-on-error
- git diff --cached --check

Note: local xtask validation used the existing binary at C:\bntarget\cuda-ux-010-closeout\debug\xtask.exe to avoid the known local Windows sentencepiece/native build blocker. Campaign doctor passed with only unrelated pre-existing CPU event metadata warnings.

## Rollback

Revert this docs-only commit to remove the dense Qwen guide and its two navigation links. No receipts, model coverage rows, campaign files, or generated dashboards need manual edits.