### PR TITLE
docs(cuda): add receipt triage guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
 - [CUDA Configuration Guide](cuda-configuration-guide.md)
 - [RTX 5070 Ti BitNet CUDA Guide](tutorials/rtx5070ti-bitnet-cuda.md)
 - [RTX 5070 Ti Dense Qwen CUDA Guide](tutorials/rtx5070ti-dense-qwen-cuda.md)
+- [CUDA Receipt Triage](tutorials/cuda-receipt-triage.md)
 - [Intel Arc GPU Setup](INTEL_GPU_SETUP.md)
 
 ## Miscellaneous

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -25,6 +25,7 @@ bitnet receipts explain --latest
 | User quickstart | `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md` |
 | BitNet CUDA guide | `docs/tutorials/rtx5070ti-bitnet-cuda.md` |
 | Dense Qwen CUDA guide | `docs/tutorials/rtx5070ti-dense-qwen-cuda.md` |
+| Receipt triage guide | `docs/tutorials/cuda-receipt-triage.md` |
 
 ## Current CUDA Rows
 

--- a/docs/tutorials/cuda-receipt-triage.md
+++ b/docs/tutorials/cuda-receipt-triage.md
@@ -1,0 +1,216 @@
+# CUDA Receipt Triage
+
+Use this guide when a 9950X3D + RTX 5070 Ti CUDA run produces a surprising
+answer, a rejected claim, or a support issue. The goal is to turn a receipt into
+an actionable diagnosis without broadening the claim beyond what the receipt
+proves.
+
+Start from:
+
+```powershell
+bitnet model status --device nvidia-rtx-5070-ti-cuda
+bitnet receipts explain --latest
+```
+
+Or explain a specific receipt:
+
+```powershell
+bitnet receipts explain <path-to-receipt.json>
+```
+
+The model status command tells you what the repo currently allows each model
+row to claim. The receipt tells you what the last command actually did.
+
+## What To Paste In An Issue
+
+Paste the `receipts explain` summary plus:
+
+```text
+model coverage row
+model id or artifact SHA
+requested backend
+selected backend
+runtime API
+route
+fallback_used
+quality gate result
+speedup_claim
+server_ready
+receipt path
+claim boundary / not allowed claims
+```
+
+Do not paste private paths, tokens, credentials, or model files.
+
+## If `fallback_used=true`
+
+The run is not strict RTX 5070 Ti CUDA proof. Treat it as a rejected or
+diagnostic receipt until the fallback reason is fixed.
+
+Check:
+
+- whether the command requested `nvidia-rtx-5070-ti-cuda`;
+- whether strict CUDA mode was enabled for the path;
+- which operation or route caused fallback;
+- whether unsupported strict ops were nonzero;
+- whether CPU fallback counts were recorded.
+
+Allowed claim: diagnostic failure evidence.
+Not allowed: CUDA answer readiness, CUDA speed, BitNet QK256 proof, or dense
+CUDA proof for that run.
+
+## If The Selected Backend Is Generic `cuda`
+
+Generic `cuda` is not enough for selected-device proof. A strict CUDA claim must
+resolve to:
+
+```text
+selected_backend = nvidia-rtx-5070-ti-cuda
+runtime_api = cuda
+```
+
+If the receipt keeps only a generic CUDA label, file the issue as backend
+identity ambiguity. Include the requested backend, selected backend, device
+probe details, and receipt path.
+
+## If Tokenizer Authority Is Missing
+
+Artifact loading is not answer readiness. A receipt that lacks tokenizer or
+pre-tokenizer authority cannot support a coherent answer claim.
+
+Check:
+
+- the model coverage row;
+- tokenizer authority field;
+- prompt-template authority field;
+- answer artifact gate status;
+- whether an external tokenizer was supplied and recorded.
+
+Allowed claim: structural or diagnostic evidence.
+Not allowed: coherent BitNet answer, dense SLM answer, benchmark speed based on
+generated text, or server readiness.
+
+## If The Prompt Template Is Wrong
+
+A valid model and tokenizer can still fail answer quality when the prompt
+template or stop policy is wrong.
+
+Check:
+
+- prompt authority in the model coverage row;
+- rendered prompt or template family when recorded;
+- stop-token policy;
+- prompt suite or corpus case that failed;
+- first generated token or first divergence.
+
+Do not promote model quality from a receipt that used an unapproved prompt
+template.
+
+## If The Quality Gate Failed
+
+Quality-gate failure is useful proof, but it is failure proof. Keep the claim
+diagnostic until a passing artifact or backend receipt exists.
+
+Check:
+
+- failed prompt id;
+- expected answer class;
+- generated text and token ids;
+- first divergence if recorded;
+- whether CPU and CUDA both failed or only one backend failed;
+- whether the artifact is answer-ready for this model family.
+
+If CPU passes and CUDA fails, route the issue to backend/kernel/parity triage. If
+both fail, route it to artifact, tokenizer, prompt, or model-quality triage.
+
+## If `speedup_claim=false`
+
+This is usually the correct state. CUDA execution proof and answer quality do
+not imply speedup.
+
+Speed can be claimed only when a governed benchmark qualification receipt
+accepts the exact model/profile. Check:
+
+- profile name;
+- CPU and CUDA p50/p95/mean;
+- first-token latency;
+- steady decode timing;
+- kernel time;
+- H2D and D2H timing sources;
+- VRAM high-water mark;
+- power and thermal context when available;
+- accepted or rejected speedup decision and reason.
+
+Do not turn a benchmark baseline, one fast run, or a report-only receipt read
+into a global CUDA speed claim.
+
+## If `server_ready=false`
+
+CLI readiness is not server readiness. A bounded server-smoke receipt is useful,
+but it does not automatically promote broad server support.
+
+Check:
+
+- server route;
+- selected backend;
+- fallback status;
+- model coverage row;
+- response quality;
+- receipt emission path;
+- whether the row was explicitly promoted by an exact-profile readiness gate.
+
+Allowed claim: bounded server-smoke evidence when a receipt exists.
+Not allowed: production server readiness, global dense server readiness, or
+BitNet server readiness unless the exact route has its own receipt and row.
+
+## If Dense Proof Is Mistaken For BitNet Proof
+
+Keep route families separate:
+
+```text
+bitnet_qk256_cuda       -> official BitNet packed I2_S/QK256 only
+dense_regular_llm_cuda  -> dense SLM / small dense LLM only
+```
+
+Dense Qwen2.5, Qwen3, SmolLM2, Llama, Gemma, and Phi receipts never prove
+BitNet packed I2_S/QK256 behavior. Official BitNet QK256 receipts never prove
+dense SLM behavior.
+
+If the issue mixes these claims, paste the route and model coverage row first.
+The route usually determines whether the issue belongs to BitNet QK256 CUDA,
+dense regular-LLM CUDA, CPU reference, server, or benchmark triage.
+
+## If The Receipt Is Missing
+
+Re-run with an explicit receipt output path when the command supports it:
+
+```powershell
+bitnet receipts explain --latest
+```
+
+If `--latest` cannot find the expected file, include:
+
+- command run;
+- working directory;
+- expected receipt directory;
+- whether the command failed before receipt creation;
+- console summary if available.
+
+No receipt means no durable proof. Keep the issue about reproducibility or
+receipt emission until a receipt exists.
+
+## Stop Lines
+
+Do not use a receipt to claim:
+
+- generic `cuda` as strict RTX 5070 Ti proof;
+- CPU fallback as CUDA proof;
+- WGPU, Vulkan, or D3D12 as CUDA proof;
+- dense SLM proof as BitNet QK256 proof;
+- BitNet QK256 proof as dense SLM proof;
+- answer quality as speedup;
+- CLI readiness as server readiness;
+- one bounded server smoke as production readiness;
+- crates.io or docs.rs publication.
+
+When in doubt, demote the claim and keep the receipt as diagnostic evidence.


### PR DESCRIPTION
## Summary

- Add a CUDA receipt triage guide for 9950X3D + RTX 5070 Ti support issues.
- Document how to interpret fallback, selected backend, tokenizer/prompt authority, quality gates, speedup, server readiness, and BitNet-vs-dense route confusion.
- Link the guide from the CUDA capability matrix and docs summary.

## Claim boundary

Docs-only support guide. This PR does not change runtime behavior, CUDA kernels, receipts, model coverage rows, campaign state, generated dashboards, speed claims, server readiness, README badges, crates.io, or docs.rs claims.

The guide explicitly treats missing or failing receipts as diagnostic evidence and preserves the stop lines around generic cuda, CPU fallback, WGPU/Vulkan, dense-vs-BitNet proof, answer quality vs speed, and CLI vs server readiness.

## Validation

- cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir C:\bntarget\cuda-triage-guide-reports --fail-on-error
- git diff --cached --check

Note: local xtask validation used the existing binary at C:\bntarget\cuda-ux-010-closeout\debug\xtask.exe to avoid the known local Windows sentencepiece/native build blocker. Campaign doctor passed with only unrelated pre-existing CPU event metadata warnings.

## Rollback

Revert this docs-only commit to remove the triage guide and its two navigation links. No receipts, model coverage rows, campaign files, or generated dashboards need manual edits.