### PR TITLE
docs(cuda): define server readiness boundary

### DIFF
--- a/docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md
+++ b/docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md
@@ -1,0 +1,215 @@
+# BITNET-SPEC-0010: Server Readiness Proof Boundary
+
+Status: proposed
+Linked proposal:
+[BITNET-PROP-0002](../proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
+Linked specs:
+[BITNET-SPEC-0001](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md),
+[BITNET-SPEC-0007](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+Linked ADRs:
+[BITNET-ADR-0004](../adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
+Applies to: RTX 5070 Ti CUDA server smoke, exact-profile server readiness
+promotion, model coverage `server_ready` claims, receipt explanation, CUDA
+status docs
+
+## Purpose
+
+Server execution is a separate product surface from CLI `ask`, `chat`,
+warm-session, and benchmark receipts. A fallback-free CLI receipt can prove a
+model route, backend, quality gate, or benchmark profile without proving that
+the server path is ready for users.
+
+This spec defines the boundary for promoting `server_ready=true` in
+`ci/model-artifacts/model-coverage-matrix.toml`. It keeps bounded server smoke
+useful while preventing one smoke receipt from becoming a broad production
+serving claim.
+
+## Source-Of-Truth Authorities
+
+Server readiness promotion must use these authorities instead of copying their
+full tables into this spec:
+
+- [CUDA product contract](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- [CUDA capability matrix](../status/CUDA_CAPABILITY_MATRIX.md)
+- [CUDA receipt triage guide](../tutorials/cuda-receipt-triage.md)
+- [NVIDIA 5070 Ti campaign](../tracking/campaigns/nvidia-5070ti/CAMPAIGN.md)
+- `ci/model-artifacts/model-coverage-matrix.toml`
+- `ci/hardware/windows-9950x3d-rtx5070ti/**`
+
+The model coverage matrix owns the final `server_ready` boolean. Server
+receipts prove what happened. Status docs and tutorials summarize the current
+state, but they do not promote server readiness by themselves.
+
+## Requirements
+
+### 1. Server Readiness Is Exact-Profile Only
+
+`server_ready=true` may apply only to the exact model, artifact, route,
+backend, endpoint shape, prompt policy, generation policy, and profile proven
+by receipts.
+
+A server-ready row for one model does not imply:
+
+- server readiness for another model in the same family;
+- server readiness for another quantization of the same model;
+- server readiness for another backend;
+- server readiness for another endpoint or serving mode;
+- production serving capacity, concurrency, uptime, or deployment hardening.
+
+### 2. Bounded Server Smoke Is Not Promotion
+
+A bounded server smoke receipt can prove that one server path answered one
+scoped request with the recorded route and backend. It does not promote
+`server_ready=true` unless a separate promotion PR checks this spec, updates the
+model coverage row, and explains the exact profile being promoted.
+
+The dense Qwen2.5 strict server-smoke receipt is useful evidence. Until a
+promotion PR explicitly accepts it, the correct product status remains
+`server_ready=false`.
+
+### 3. Server Receipt Invariants
+
+Every receipt used to promote RTX 5070 Ti CUDA server readiness must preserve:
+
+```text
+model_id
+artifact identity and checksum
+model coverage row
+server endpoint or internal server path
+request schema or endpoint profile
+requested_backend = nvidia-rtx-5070-ti-cuda
+selected_backend = nvidia-rtx-5070-ti-cuda
+runtime_api = cuda
+route = bitnet_qk256_cuda | dense_regular_llm_cuda
+fallback_used = false
+tokenizer authority present
+prompt template authority present
+generation policy present
+quality gate result present
+response non-empty and valid UTF-8 for answer claims
+receipt id or durable receipt path
+speedup_claim = false unless separately benchmark-qualified
+full_residency_claim = false unless separately proven
+server_ready_claimed = true only for the exact promoted profile
+```
+
+BitNet server receipts must also preserve BitNet route evidence:
+
+```text
+bitnet_packed_i2s_qk256_proof = true
+dense_regular_llm_cuda_proof = false
+qk256 kernel invocation evidence present
+BitNet linear CPU fallback count = 0
+```
+
+Dense SLM or small dense LLM server receipts must preserve dense route evidence:
+
+```text
+dense_regular_llm_cuda_proof = true only for the exact artifact
+bitnet_packed_i2s_qk256_proof = false
+```
+
+### 4. Fallback Must Fail Closed
+
+Strict server readiness cannot allow hidden fallback. A promotion is blocked if
+the receipt records:
+
+- selected backend different from `nvidia-rtx-5070-ti-cuda`;
+- generic `cuda` without strict selected backend identity;
+- CPU fallback;
+- unsupported route fallback;
+- missing tokenizer or prompt authority;
+- missing model artifact identity;
+- missing quality gate result for answer claims.
+
+### 5. CLI Proof Does Not Substitute For Server Proof
+
+CLI `ask`, `chat`, warm-session, and benchmark receipts may be prerequisites
+for server promotion. They are not server proof by themselves.
+
+A server promotion PR must identify whether the server path uses the same engine
+as the CLI path or a distinct serving adapter. If there is an engine or adapter
+delta, the receipt or promotion notes must say which part is shared and which
+part is server-specific.
+
+### 6. Status And Receipt Explanation Must Agree
+
+When a row is promoted to `server_ready=true`, the user-facing surfaces must
+agree:
+
+- `ci/model-artifacts/model-coverage-matrix.toml`
+- `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md` when updated
+- `docs/status/CUDA_CAPABILITY_MATRIX.md`
+- `bitnet model status --device nvidia-rtx-5070-ti-cuda`
+- `bitnet receipts explain <server-receipt>` when the receipt is available
+
+If these surfaces disagree, keep the narrower claim until the mismatch is
+repaired.
+
+## Promotion Rule
+
+A promotion PR may set `server_ready=true` only when it includes:
+
+1. exact server receipt path or receipt id;
+2. exact model coverage row;
+3. exact model artifact identity;
+4. exact route and selected backend;
+5. fallback-free server request proof;
+6. quality gate result;
+7. statement of endpoint/profile scope;
+8. explicit non-claims for speed, full residency, broad server readiness, and
+   cross-family proof;
+9. status or model coverage updates that match the receipt.
+
+If any required field is unavailable, keep `server_ready=false` and record the
+next missing proof instead.
+
+## Claim Boundary
+
+| Evidence | May claim | Must not claim |
+| --- | --- | --- |
+| CLI ask/chat receipt | scoped CLI answer path | server readiness |
+| Warm-session receipt | scoped reusable CLI/session behavior | server endpoint readiness |
+| Bounded server smoke | one scoped server path answered with recorded backend and route | broad production serving readiness |
+| Exact-profile server promotion | `server_ready=true` for that model/profile only | global dense GGUF, BitNet, speed, concurrency, or deployment readiness |
+| Dense server receipt | dense regular-LLM server route for the exact artifact | BitNet QK256 server proof |
+| BitNet server receipt | BitNet QK256 server route for the exact artifact | dense SLM server proof |
+
+## Proof Commands
+
+This spec is documentation-only. Its validation is:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+```
+
+Runtime PRs that promote server readiness must add the exact server command or
+internal test path they use, plus receipt validation. For example:
+
+```bash
+cargo run --locked -p bitnet-server --no-default-features --features cpu,cuda -- --device nvidia-rtx-5070-ti-cuda --model <verified-model>
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- receipts explain <server-receipt>
+```
+
+## Non-Goals
+
+- Do not implement server runtime behavior in this spec.
+- Do not modify receipts in this spec.
+- Do not promote any model coverage row in this spec.
+- Do not claim dense Qwen server readiness from server smoke alone.
+- Do not claim official BitNet server readiness from dense Qwen server proof.
+- Do not claim speedup, full residency, concurrency, deployment readiness, or
+  production service reliability.
+- Do not make GPU, model, Windows, macOS, Docker, or server lanes default PR CI.
+
+## Related Policy Or Manifest Sources
+
+- `ci/model-artifacts/model-coverage-matrix.toml`
+- `docs/status/CUDA_CAPABILITY_MATRIX.md`
+- `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+- `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json`
+- `policy/ci-lanes.toml`
+- `policy/ci-budget.toml`
+- `policy/ci-risk-packs.toml`

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -22,6 +22,7 @@ bitnet receipts explain --latest
 | Human-readable model coverage | `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md` |
 | RTX 5070 Ti campaign state | `docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md` |
 | Strict CUDA product contract | `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md` |
+| Server readiness boundary | `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` |
 | User quickstart | `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md` |
 | BitNet CUDA guide | `docs/tutorials/rtx5070ti-bitnet-cuda.md` |
 | Dense Qwen CUDA guide | `docs/tutorials/rtx5070ti-dense-qwen-cuda.md` |
@@ -61,7 +62,7 @@ bitnet receipts explain --latest
 | Row | Next proof |
 | --- | --- |
 | `bitnet_official_2b_i2s_qk256` | Profile-specific speedup qualification and deeper residency/transfer timing. |
-| `dense_qwen25_05b_q8_cuda` | Exact-profile server readiness promotion spec before any `server_ready=true` row; the current bounded server smoke is not broad readiness. |
+| `dense_qwen25_05b_q8_cuda` | Exact-profile server readiness promotion under `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` before any `server_ready=true` row; the current bounded server smoke is not broad readiness. |
 | `dense_qwen3_06b_q8_candidate` | User-facing ask/chat product UX or repeated same-artifact comparator evidence before product CLI promotion. |
 | `dense_smollm2_360m_candidate` | Same-prompt SmolLM2 first-token/top-k or checkpoint comparator capture using the SLM-CPU-022 contract. |
 | Later dense SLM / small-LLM candidates | Artifact contract, tokenizer/prompt authority, CPU answer sanity, all-layer plan, boundary fixtures, strict CUDA proof, warm session, and benchmark review. |

--- a/plans/cuda-5070ti-productization/README.md
+++ b/plans/cuda-5070ti-productization/README.md
@@ -18,6 +18,8 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
   [`BITNET-PROP-0002`](../../docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
 - Contract spec:
   [`BITNET-SPEC-0007`](../../docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- Server readiness spec:
+  [`BITNET-SPEC-0010`](../../docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md)
 - Bench ADR:
   [`BITNET-ADR-0004`](../../docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
 - CUDA campaign:
@@ -39,6 +41,8 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
   onboarding ladder.
 - [`benchmark-qualification.md`](benchmark-qualification.md) owns
   profile-specific speed decisions.
+- [`server-readiness.md`](server-readiness.md) owns exact-profile server
+  readiness promotion rules.
 
 ## Claim Boundary
 

--- a/plans/cuda-5070ti-productization/implementation-plan.md
+++ b/plans/cuda-5070ti-productization/implementation-plan.md
@@ -31,6 +31,9 @@ promotion tied to receipts.
 | 21 | CUDA-SERVER-002 | `server(cuda): commit dense Qwen strict smoke receipt` | server receipt path |
 | 22 | CUDA-MODEL-SMOLLM2-001 | `model(cuda): add SmolLM2 360M artifact contract` | model artifact docs |
 | 23 | CUDA-MODEL-SMOLLM2-002 | `docs(cuda): sync SmolLM2 CPU blocker state` | model coverage and plan docs |
+| 24 | CUDA-SERVER-003 | `docs(cuda): define server readiness promotion boundary` | server readiness spec |
+| 25 | CUDA-SERVER-004 | `docs(cuda): promote dense Qwen exact-profile server readiness` | model coverage and status |
+| 26 | CUDA-SERVER-005 | `server(cuda): official BitNet strict server smoke` | server receipt path |
 
 ## Shared Links
 
@@ -40,6 +43,8 @@ All work items link to:
   `docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md`
 - Spec:
   `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md`
+- Server readiness spec:
+  `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md`
 - ADR:
   `docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md`
 - Campaign:
@@ -54,7 +59,7 @@ All work items link to:
 | Lane | Current state | Last real receipt | Next missing proof |
 | --- | --- | --- | --- |
 | BitNet official 2B I2_S CUDA | product CLI ready, speed false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-003-warm-session-benchmark.json` | profile-specific benchmark qualification |
-| Dense Qwen2.5 0.5B Q8_0 CUDA | product CLI ready in model coverage; real strict runtime receipts, benchmark qualification reviews, and bounded server-smoke receipts exist; speed and broad server readiness stay false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json` | exact-profile server readiness promotion spec before any `server_ready=true` row |
+| Dense Qwen2.5 0.5B Q8_0 CUDA | product CLI ready in model coverage; real strict runtime receipts, benchmark qualification reviews, and bounded server-smoke receipts exist; speed and broad server readiness stay false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json` | exact-profile server readiness promotion under `BITNET-SPEC-0010` before any `server_ready=true` row |
 | Qwen3 0.6B | accelerator-ready dense SLM candidate; one-token, short-decode, warm-session, and benchmark-review evidence exists; product CLI, speed, server, full residency, broad dense GGUF, and BitNet proof stay false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/qwen3-0_6b-benchmark-qualification.json` | user-facing ask/chat product UX or repeated same-artifact comparator evidence before any product CLI or speed profile promotion |
 | SmolLM2 360M | structurally valid artifact contract; strict CPU preflight blocked before tokenizer/prompt/generation; governed normalization-policy audit recorded | `ci/slm-cpu/windows-9950x3d-rtx5070ti/2026-05-16/smollm2-360m-normalization-policy-audit.json` | implement exact metadata-scoped SmolLM2 normalization validation and retry CPU sanity before all-layer planning or CUDA |
 | Llama 3.2 1B | registered candidate | none | artifact contract, tokenizer/prompt authority, CPU sanity |
@@ -525,3 +530,58 @@ Status and docs summarize proof. They do not create new proof.
 ### Rollback
 
 Revert the status/docs/server-smoke PR and demote the server row if needed.
+
+## Work items: CUDA-SERVER-003 through CUDA-SERVER-005
+
+Status: ready through proposed
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
+Linked ADRs: BITNET-ADR-0004
+Campaign items: `CUDA-SERVER-003` through `CUDA-SERVER-005`
+Blocked by: CUDA-SERVER-002
+Blocks: exact-profile server readiness status promotion
+
+### Goal
+
+Define and then apply exact-profile server readiness promotion without turning
+bounded smoke evidence into broad server support.
+
+### Production delta
+
+See [`server-readiness.md`](server-readiness.md).
+
+### Non-goals
+
+No global server readiness, no speedup, no full-residency claim, and no
+cross-family proof inheritance.
+
+### Acceptance
+
+`CUDA-SERVER-003` defines the readiness boundary. Later promotion PRs can set
+`server_ready=true` only for the exact model/profile whose receipt satisfies the
+server readiness spec.
+
+### Proof commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+```
+
+### Receipt paths
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/server-strict-bitnet-i2s-qk256-smoke.json
+```
+
+### Claim boundary
+
+Server readiness is exact-profile only and cannot imply BitNet/dense
+cross-family proof, speedup, full residency, concurrency, or production
+deployment readiness.
+
+### Rollback
+
+Revert the docs or promotion row introduced by the PR. Do not edit historical
+server receipts by hand.

--- a/plans/cuda-5070ti-productization/server-readiness.md
+++ b/plans/cuda-5070ti-productization/server-readiness.md
@@ -1,0 +1,126 @@
+# CUDA Server Readiness
+
+This plan page sequences server readiness work for the 9950X3D + RTX 5070 Ti
+CUDA product lane. It implements the boundary in
+[BITNET-SPEC-0010](../../docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md)
+without promoting any model by itself.
+
+## Source-Of-Truth Links
+
+- Proposal:
+  [`BITNET-PROP-0002`](../../docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
+- CUDA product contract:
+  [`BITNET-SPEC-0007`](../../docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- Server readiness boundary:
+  [`BITNET-SPEC-0010`](../../docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md)
+- CUDA campaign:
+  [`docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md`](../../docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md)
+- Model coverage:
+  `ci/model-artifacts/model-coverage-matrix.toml`
+- Receipt root:
+  `ci/hardware/windows-9950x3d-rtx5070ti/**`
+
+## Current State
+
+Dense Qwen2.5 0.5B Q8_0 has a bounded strict CUDA server-smoke receipt:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json
+```
+
+That receipt is evidence for the bounded smoke path. It is not, by itself, a
+`server_ready=true` promotion. The model coverage row remains false until a
+later promotion PR applies the exact-profile requirements in BITNET-SPEC-0010.
+
+Official BitNet I2_S/QK256 does not have a server-readiness claim from the dense
+Qwen server smoke. It needs its own exact-profile server receipt before any
+server row can promote.
+
+## Work Item: CUDA-SERVER-003
+
+Status: ready
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-SERVER-003`
+Blocked by: CUDA-SERVER-002
+Blocks: exact-profile server readiness promotions
+
+### Goal
+
+Define or apply the server readiness promotion checklist for the bounded dense
+Qwen2.5 server-smoke evidence before changing any model coverage boolean.
+
+### Production Delta
+
+Docs and status alignment only unless the PR explicitly includes a model
+coverage promotion under BITNET-SPEC-0010.
+
+### Non-Goals
+
+No broad production serving claim, no BitNet server claim from dense Qwen, no
+speedup, no full-residency claim, and no default PR CI expansion.
+
+### Acceptance
+
+- The exact model coverage row is identified.
+- The exact server receipt path is identified.
+- The endpoint/profile scope is stated.
+- `server_ready=true` remains false unless all BITNET-SPEC-0010 promotion
+  requirements are met in the same PR.
+- `speedup_claim=false` and `full_residency_claim=false` remain unchanged.
+
+### Proof Commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+```
+
+### Rollback
+
+Revert the docs or model coverage promotion from the PR. Historical server
+smoke receipts stay immutable evidence for what happened.
+
+## Work Item: CUDA-SERVER-004
+
+Status: proposed
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-SERVER-004`
+Blocked by: CUDA-SERVER-003
+Blocks: dense Qwen server status UX
+
+### Goal
+
+Promote dense Qwen2.5 server readiness only for the exact bounded profile, if
+the committed receipt and status surfaces satisfy BITNET-SPEC-0010.
+
+### Claim Boundary
+
+This cannot claim global dense GGUF server readiness, BitNet QK256 server
+readiness, speedup, full CUDA residency, concurrency, or production deployment
+readiness.
+
+## Work Item: CUDA-SERVER-005
+
+Status: proposed
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-SERVER-005`
+Blocked by: CUDA-SERVER-003
+Blocks: official BitNet server status UX
+
+### Goal
+
+Add or promote official BitNet I2_S/QK256 strict server smoke separately from
+dense Qwen.
+
+### Claim Boundary
+
+Official BitNet server proof must use `route = bitnet_qk256_cuda`, preserve
+QK256 invocation evidence, keep dense regular-LLM proof false, and keep speed
+false unless a separate benchmark qualification accepts an exact profile.


### PR DESCRIPTION
## Summary

- Add BITNET-SPEC-0010 to define exact-profile server readiness promotion rules for the RTX 5070 Ti CUDA lane.
- Add a server-readiness plan page for CUDA-SERVER-003 through CUDA-SERVER-005.
- Link the new boundary from the CUDA capability matrix and productization plan.

## Claim Boundary

This PR is docs-only. It does not promote server_ready, speedup, full residency, CUDA execution, model answer readiness, or BitNet/dense cross-family proof. Dense Qwen server smoke remains bounded evidence, not broad server readiness.

## Validation

- git diff --check
- cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir C:\bntarget\server-readiness-spec-reports --fail-on-error

## Rollback

Revert the docs-only commit. Historical server-smoke receipts and model coverage claim booleans remain unchanged.