### PR TITLE
refactor(bitnet-cli): extract allocation audit and digest helpers

### DIFF
--- a/crates/bitnet-cli/src/allocation_audit.rs
+++ b/crates/bitnet-cli/src/allocation_audit.rs
@@ -1,0 +1,108 @@
+//! Allocation auditing primitives for CLI profiling receipts.
+//!
+//! This module owns the process-global allocator counters and the small RAII
+//! guard used by command paths that need scoped allocation deltas. Keeping this
+//! separate from `main.rs` keeps the CLI command dispatcher focused on command
+//! parsing and execution rather than allocator instrumentation mechanics.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+static ALLOCATION_AUDIT_ENABLED: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_AUDIT_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_AUDIT_ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_AUDIT_DEALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_AUDIT_DEALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// Global allocator wrapper that records allocation counters when auditing is enabled.
+pub(crate) struct AllocationAuditAllocator;
+
+unsafe impl GlobalAlloc for AllocationAuditAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_dealloc(layout.size());
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_dealloc(layout.size());
+            record_allocation_audit_alloc(new_size);
+        }
+        new_ptr
+    }
+}
+
+fn record_allocation_audit_alloc(size: usize) {
+    ALLOCATION_AUDIT_ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    ALLOCATION_AUDIT_ALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
+}
+
+fn record_allocation_audit_dealloc(size: usize) {
+    ALLOCATION_AUDIT_DEALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    ALLOCATION_AUDIT_DEALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct AllocationAuditSnapshot {
+    pub(crate) alloc_count: u64,
+    pub(crate) alloc_bytes: u64,
+    pub(crate) dealloc_count: u64,
+    pub(crate) dealloc_bytes: u64,
+}
+
+impl AllocationAuditSnapshot {
+    pub(crate) fn current() -> Self {
+        Self {
+            alloc_count: ALLOCATION_AUDIT_ALLOC_COUNT.load(Ordering::Relaxed),
+            alloc_bytes: ALLOCATION_AUDIT_ALLOC_BYTES.load(Ordering::Relaxed),
+            dealloc_count: ALLOCATION_AUDIT_DEALLOC_COUNT.load(Ordering::Relaxed),
+            dealloc_bytes: ALLOCATION_AUDIT_DEALLOC_BYTES.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(crate) fn delta_since(start: Self) -> Self {
+        let current = Self::current();
+        Self {
+            alloc_count: current.alloc_count.saturating_sub(start.alloc_count),
+            alloc_bytes: current.alloc_bytes.saturating_sub(start.alloc_bytes),
+            dealloc_count: current.dealloc_count.saturating_sub(start.dealloc_count),
+            dealloc_bytes: current.dealloc_bytes.saturating_sub(start.dealloc_bytes),
+        }
+    }
+}
+
+pub(crate) struct AllocationAuditGuard {
+    previous: bool,
+}
+
+impl AllocationAuditGuard {
+    pub(crate) fn enable(enabled: bool) -> Self {
+        let previous = ALLOCATION_AUDIT_ENABLED.swap(enabled, Ordering::Relaxed);
+        Self { previous }
+    }
+}
+
+impl Drop for AllocationAuditGuard {
+    fn drop(&mut self) {
+        ALLOCATION_AUDIT_ENABLED.store(self.previous, Ordering::Relaxed);
+    }
+}

--- a/crates/bitnet-cli/src/digest.rs
+++ b/crates/bitnet-cli/src/digest.rs
@@ -1,0 +1,14 @@
+//! Hashing helpers for stable receipt fields.
+
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+
+pub(crate) fn sha256_hex_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+pub(crate) fn sha256_token_ids(tokens: &[u32]) -> Result<String> {
+    Ok(sha256_hex_bytes(&serde_json::to_vec(tokens)?))
+}

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -18,69 +18,19 @@ use candle_core::{DType, IndexOp};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use console::style;
-use std::alloc::{GlobalAlloc, Layout, System};
 use std::io;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tracing::{debug, error, info, warn};
 
 #[global_allocator]
-static ALLOCATION_AUDIT_ALLOCATOR: AllocationAuditAllocator = AllocationAuditAllocator;
+static ALLOCATION_AUDIT_ALLOCATOR: allocation_audit::AllocationAuditAllocator =
+    allocation_audit::AllocationAuditAllocator;
 
-static ALLOCATION_AUDIT_ENABLED: AtomicBool = AtomicBool::new(false);
-static ALLOCATION_AUDIT_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
-static ALLOCATION_AUDIT_ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
-static ALLOCATION_AUDIT_DEALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
-static ALLOCATION_AUDIT_DEALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
-
-struct AllocationAuditAllocator;
-
-unsafe impl GlobalAlloc for AllocationAuditAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc(layout) };
-        if !ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
-            record_allocation_audit_alloc(layout.size());
-        }
-        ptr
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc_zeroed(layout) };
-        if !ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
-            record_allocation_audit_alloc(layout.size());
-        }
-        ptr
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        if ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
-            record_allocation_audit_dealloc(layout.size());
-        }
-        unsafe { System.dealloc(ptr, layout) };
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
-        if !new_ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
-            record_allocation_audit_dealloc(layout.size());
-            record_allocation_audit_alloc(new_size);
-        }
-        new_ptr
-    }
-}
-
-fn record_allocation_audit_alloc(size: usize) {
-    ALLOCATION_AUDIT_ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
-    ALLOCATION_AUDIT_ALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
-}
-
-fn record_allocation_audit_dealloc(size: usize) {
-    ALLOCATION_AUDIT_DEALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
-    ALLOCATION_AUDIT_DEALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
-}
+mod allocation_audit;
 
 #[cfg(feature = "full-cli")]
 mod commands;
 mod config;
+mod digest;
 mod exit;
 mod intel_arc;
 mod intel_npu;
@@ -126,17 +76,6 @@ fn bitnet_version() -> &'static str {
     })
 }
 
-fn sha256_hex_bytes(bytes: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
-}
-
-fn sha256_token_ids(tokens: &[u32]) -> Result<String> {
-    Ok(sha256_hex_bytes(&serde_json::to_vec(tokens)?))
-}
-
 fn critical_not_claims() -> Vec<&'static str> {
     vec![
         "selected_attention_residency",
@@ -150,6 +89,7 @@ fn critical_not_claims() -> Vec<&'static str> {
     ]
 }
 
+use allocation_audit::{AllocationAuditGuard, AllocationAuditSnapshot};
 #[cfg(feature = "cli-bench")]
 use commands::BenchmarkCommand;
 #[cfg(feature = "full-cli")]
@@ -172,6 +112,7 @@ use commands::{
     run_dense_qwen_cuda_ask,
 };
 use config::{CliConfig, ConfigBuilder, DEVICE_HELP};
+use digest::sha256_token_ids;
 #[cfg(feature = "full-cli")]
 use mac::MacCommand;
 use model_cache::ModelCommand;
@@ -11338,52 +11279,6 @@ fn ms_to_us(ms: f64) -> u128 {
 
 fn rounded_ms(ms: f64) -> f64 {
     (ms * 1000.0).round() / 1000.0
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct AllocationAuditSnapshot {
-    alloc_count: u64,
-    alloc_bytes: u64,
-    dealloc_count: u64,
-    dealloc_bytes: u64,
-}
-
-impl AllocationAuditSnapshot {
-    fn current() -> Self {
-        Self {
-            alloc_count: ALLOCATION_AUDIT_ALLOC_COUNT.load(Ordering::Relaxed),
-            alloc_bytes: ALLOCATION_AUDIT_ALLOC_BYTES.load(Ordering::Relaxed),
-            dealloc_count: ALLOCATION_AUDIT_DEALLOC_COUNT.load(Ordering::Relaxed),
-            dealloc_bytes: ALLOCATION_AUDIT_DEALLOC_BYTES.load(Ordering::Relaxed),
-        }
-    }
-
-    fn delta_since(start: Self) -> Self {
-        let current = Self::current();
-        Self {
-            alloc_count: current.alloc_count.saturating_sub(start.alloc_count),
-            alloc_bytes: current.alloc_bytes.saturating_sub(start.alloc_bytes),
-            dealloc_count: current.dealloc_count.saturating_sub(start.dealloc_count),
-            dealloc_bytes: current.dealloc_bytes.saturating_sub(start.dealloc_bytes),
-        }
-    }
-}
-
-struct AllocationAuditGuard {
-    previous: bool,
-}
-
-impl AllocationAuditGuard {
-    fn enable(enabled: bool) -> Self {
-        let previous = ALLOCATION_AUDIT_ENABLED.swap(enabled, Ordering::Relaxed);
-        Self { previous }
-    }
-}
-
-impl Drop for AllocationAuditGuard {
-    fn drop(&mut self) {
-        ALLOCATION_AUDIT_ENABLED.store(self.previous, Ordering::Relaxed);
-    }
 }
 
 fn timing_samples_json(samples: &[f64]) -> serde_json::Value {


### PR DESCRIPTION
### Motivation
- Reduce complexity in `main.rs` by moving allocation-auditing and hashing helpers into focused SRP modules. 
- Improve readability and testability by keeping CLI wiring separate from allocator instrumentation and digest logic.
- Make the allocator counters, snapshot logic, and hashing helpers reusable from other CLI command paths without duplicating code.

### Description
- Added `crates/bitnet-cli/src/allocation_audit.rs` which owns the global allocator wrapper, process-global counters, `AllocationAuditSnapshot`, and `AllocationAuditGuard` used for scoped allocation deltas. 
- Added `crates/bitnet-cli/src/digest.rs` which contains SHA-256 helpers `sha256_hex_bytes` and `sha256_token_ids` for stable receipt fields.
- Updated `crates/bitnet-cli/src/main.rs` to register the global allocator as `allocation_audit::AllocationAuditAllocator`, `mod` the two new modules, and import `AllocationAuditGuard`, `AllocationAuditSnapshot`, and `sha256_token_ids` where needed, removing the previous inlined implementations.
- Kept external behavior unchanged; the CLI still exposes the same profiling and receipt fields while the implementation is reorganized for SRP.

### Testing
- Ran `cargo fmt --all` and formatting succeeded. 
- Ran `cargo check --locked -p bitnet-cli --no-default-features --features cpu` and the check succeeded. 
- Ran `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu -- -D warnings` and lints passed with no warnings. 
- Ran `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bcfa7584833397e2684344dc8ccc)