### PR TITLE
docs(cuda): record dense Qwen server readiness blockers

### DIFF
--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -245,7 +245,7 @@ forbidden_claims = [
   "global_speedup",
   "server_ready",
 ]
-next_proof = "bounded dense Qwen strict CUDA server-smoke receipt exists; keep server_ready false until a later readiness gate promotes an exact profile, and keep speedup false unless a later governed benchmark review accepts a profile."
+next_proof = "bounded dense Qwen strict CUDA server-smoke receipt exists, but CUDA-SERVER-003 records that it is missing artifact checksum identity, endpoint/request-profile scope, and generation-policy fields required by BITNET-SPEC-0010. Refresh or supplement the receipt before any exact-profile server_ready=true promotion; keep speedup false unless a later governed benchmark review accepts a profile."
 claim_boundary = "Qwen2.5 0.5B Q8_0 is the first dense CUDA SLM answer lane. Its receipts do not satisfy BitNet packed I2_S/QK256 proof."
 
   [entry.claims]

--- a/docs/model-artifacts/MODEL_COVERAGE_MATRIX.md
+++ b/docs/model-artifacts/MODEL_COVERAGE_MATRIX.md
@@ -62,7 +62,7 @@ CUDA proof.
 
 | Entry | Artifact lane | Current tier | Boundary |
 |---|---|---|---|
-| `dense_qwen25_05b_q8_cuda` | Qwen2.5 0.5B Q8_0 GGUF | `product_cli_ready` | Current dense CUDA SLM answer lane, not globally speed-qualified. |
+| `dense_qwen25_05b_q8_cuda` | Qwen2.5 0.5B Q8_0 GGUF | `product_cli_ready` | Current dense CUDA SLM answer lane. Bounded server-smoke evidence exists, but `server_ready=false` remains correct until a refreshed or supplemental exact-profile receipt includes artifact checksum identity, endpoint/profile scope, and generation policy under BITNET-SPEC-0010. |
 | `dense_qwen3_06b_q8_candidate` | Qwen3 0.6B Q8_0 GGUF candidate | `accelerator_answer_ready` | Accelerator-ready dense SLM candidate with its own artifact, CPU sanity, all-layer plan, one-token, short-decode, warm-session, and benchmark-review receipts; product CLI, speedup, server, full-residency, broad dense GGUF, and BitNet QK256 claims remain false. |
 | `dense_smollm2_360m_candidate` | SmolLM2 360M GGUF candidate | `structurally_valid` | Exact artifact contract plus strict CPU preflight blocker, normalization-policy audit, exact metadata-scoped validation, strict CPU retry evidence, wrong-first-token diagnosis, and comparator contract. The retry reaches one-token generation but fails the math quality gate; a same-prompt reference-compatible first-token/top-k or checkpoint comparator capture is required before CPU answer readiness or CUDA planning. |
 | `dense_smollm2_17b_candidate` | SmolLM2 1.7B GGUF candidate | `registered` | Larger low-footprint pressure row; no answer or CUDA claim. |

--- a/docs/reports/CUDA_SERVER_003_DENSE_QWEN_READINESS_AUDIT.md
+++ b/docs/reports/CUDA_SERVER_003_DENSE_QWEN_READINESS_AUDIT.md
@@ -1,0 +1,116 @@
+# CUDA-SERVER-003 Dense Qwen Server Readiness Audit
+
+Date: 2026-05-16
+Campaign item: CUDA-SERVER-003
+Platform: Windows 9950X3D + RTX 5070 Ti
+Model: qwen2.5-0.5b-instruct-q8_0
+Coverage row: `dense_qwen25_05b_q8_cuda`
+
+## Summary
+
+The committed dense Qwen2.5 server-smoke receipt is valid bounded evidence, but
+it is not sufficient to promote `server_ready=true` under
+[BITNET-SPEC-0010](../specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md).
+
+The receipt proves a strict RTX 5070 Ti CUDA server smoke with the dense route,
+fallback disabled, a non-empty UTF-8 response, and no speed, residency, or
+BitNet proof claim. It does not carry enough exact-profile identity for server
+readiness promotion: the receipt is missing durable artifact checksum identity,
+endpoint or request-profile scope, and generation-policy fields. It also
+correctly records `server_ready_claimed=false`.
+
+Therefore the correct model coverage state remains:
+
+```text
+server_ready = false
+speedup_claim = false
+full_residency_claim = false
+bitnet_packed_i2s_qk256_proof = false
+```
+
+## Receipt Audited
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json
+```
+
+## Field Audit
+
+| BITNET-SPEC-0010 field | Receipt state | Promotion impact |
+| --- | --- | --- |
+| model coverage row | `dense_qwen25_05b_q8_cuda` | present |
+| model identity | `requested_model = qwen2.5-0.5b-instruct-q8_0` | partial |
+| artifact checksum | missing `sha256`, `model_sha256`, or `checksum` field | blocks exact-profile promotion |
+| server endpoint/profile | no endpoint, request profile, or endpoint profile field | blocks exact-profile promotion |
+| generation policy | no max tokens, temperature, top-p, seed, or policy object | blocks exact-profile promotion |
+| requested backend | `nvidia-rtx-5070-ti-cuda` | present |
+| selected backend | `nvidia-rtx-5070-ti-cuda` | present |
+| runtime API | `cuda` | present |
+| route | `dense_regular_llm_cuda` | present as `selected_route` |
+| fallback status | `fallback_used = false` | present |
+| tokenizer authority | `active_model_tokenizer` | present |
+| prompt authority | `server_chat_template` | present |
+| quality gate | `server_non_empty_utf8_response`, passed | present |
+| speedup claim | `speedup_claim = false` | correct |
+| full residency claim | `full_cuda_residency_claimed = false` | correct |
+| dense proof | `dense_regular_llm_cuda_inference_claimed = true` | bounded by missing checksum |
+| BitNet proof | `bitnet_packed_i2s_qk256_proof = false` | correct |
+| server readiness | `server_ready_claimed = false` | correct for smoke, not promotion |
+
+## Decision
+
+Do not promote dense Qwen2.5 server readiness from the current smoke receipt.
+
+The current receipt may support:
+
+- bounded strict CUDA server-smoke evidence for Qwen2.5 0.5B Q8_0;
+- selected backend `nvidia-rtx-5070-ti-cuda`;
+- route `dense_regular_llm_cuda`;
+- fallback-free server response smoke;
+- non-empty UTF-8 response quality gate;
+- explicit non-claims for speed, full residency, and BitNet QK256 proof.
+
+The current receipt must not support:
+
+- `server_ready=true`;
+- broad dense GGUF server readiness;
+- official BitNet server readiness;
+- speedup;
+- full CUDA residency;
+- production service readiness;
+- concurrency, uptime, or deployment hardening.
+
+## Next Required Proof
+
+A future promotion PR needs either a refreshed receipt or an additional
+promotion receipt/report that includes:
+
+- stable model id and artifact checksum;
+- endpoint or internal server request profile;
+- generation policy, including token limit and sampling settings;
+- exact scope for the server-ready profile;
+- `server_ready_claimed=true` only for that exact profile;
+- unchanged `speedup_claim=false` unless separately benchmark-qualified;
+- unchanged `full_residency_claim=false` unless separately proven;
+- unchanged `bitnet_packed_i2s_qk256_proof=false`.
+
+If those fields land, the promotion PR should update the model coverage row,
+the human-readable model coverage page, the CUDA capability matrix, and the
+model-status fixtures together.
+
+## Commands Run
+
+```powershell
+rtk python -m json.tool ci\hardware\windows-9950x3d-rtx5070ti\2026-05-15\server-strict-dense-qwen25-q8-smoke.json
+rtk powershell -NoProfile -Command '$j = Get-Content ci\hardware\windows-9950x3d-rtx5070ti\2026-05-15\server-strict-dense-qwen25-q8-smoke.json -Raw | ConvertFrom-Json; $j.PSObject.Properties.Name | Sort-Object'
+```
+
+Both commands completed successfully during the audit. The second command
+showed that checksum, endpoint/profile, and generation-policy fields are absent
+from the receipt.
+
+## Claim Boundary
+
+This audit records a blocker. It does not change runtime behavior, server
+behavior, receipts, model artifacts, model coverage booleans, CUDA kernels,
+speed claims, server claims, or BitNet proof claims.

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -62,7 +62,7 @@ bitnet receipts explain --latest
 | Row | Next proof |
 | --- | --- |
 | `bitnet_official_2b_i2s_qk256` | Profile-specific speedup qualification and deeper residency/transfer timing. |
-| `dense_qwen25_05b_q8_cuda` | Exact-profile server readiness promotion under `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` before any `server_ready=true` row; the current bounded server smoke is not broad readiness. |
+| `dense_qwen25_05b_q8_cuda` | Refresh or supplement the bounded server-smoke receipt with artifact checksum identity, endpoint/profile scope, and generation policy before any exact-profile `server_ready=true` promotion under `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md`. |
 | `dense_qwen3_06b_q8_candidate` | User-facing ask/chat product UX or repeated same-artifact comparator evidence before product CLI promotion. |
 | `dense_smollm2_360m_candidate` | Same-prompt SmolLM2 first-token/top-k or checkpoint comparator capture using the SLM-CPU-022 contract. |
 | Later dense SLM / small-LLM candidates | Artifact contract, tokenizer/prompt authority, CPU answer sanity, all-layer plan, boundary fixtures, strict CUDA proof, warm session, and benchmark review. |

--- a/plans/cuda-5070ti-productization/implementation-plan.md
+++ b/plans/cuda-5070ti-productization/implementation-plan.md
@@ -59,7 +59,7 @@ All work items link to:
 | Lane | Current state | Last real receipt | Next missing proof |
 | --- | --- | --- | --- |
 | BitNet official 2B I2_S CUDA | product CLI ready, speed false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-003-warm-session-benchmark.json` | profile-specific benchmark qualification |
-| Dense Qwen2.5 0.5B Q8_0 CUDA | product CLI ready in model coverage; real strict runtime receipts, benchmark qualification reviews, and bounded server-smoke receipts exist; speed and broad server readiness stay false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-smoke.json` | exact-profile server readiness promotion under `BITNET-SPEC-0010` before any `server_ready=true` row |
+| Dense Qwen2.5 0.5B Q8_0 CUDA | product CLI ready in model coverage; real strict runtime receipts, benchmark qualification reviews, and bounded server-smoke receipts exist; speed and broad server readiness stay false | `docs/reports/CUDA_SERVER_003_DENSE_QWEN_READINESS_AUDIT.md` | refresh or supplement server-smoke evidence with artifact checksum identity, endpoint/profile scope, and generation policy before any exact-profile `server_ready=true` row |
 | Qwen3 0.6B | accelerator-ready dense SLM candidate; one-token, short-decode, warm-session, and benchmark-review evidence exists; product CLI, speed, server, full residency, broad dense GGUF, and BitNet proof stay false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/qwen3-0_6b-benchmark-qualification.json` | user-facing ask/chat product UX or repeated same-artifact comparator evidence before any product CLI or speed profile promotion |
 | SmolLM2 360M | structurally valid artifact contract; strict CPU preflight blocked before tokenizer/prompt/generation; governed normalization-policy audit recorded | `ci/slm-cpu/windows-9950x3d-rtx5070ti/2026-05-16/smollm2-360m-normalization-policy-audit.json` | implement exact metadata-scoped SmolLM2 normalization validation and retry CPU sanity before all-layer planning or CUDA |
 | Llama 3.2 1B | registered candidate | none | artifact contract, tokenizer/prompt authority, CPU sanity |
@@ -533,7 +533,7 @@ Revert the status/docs/server-smoke PR and demote the server row if needed.
 
 ## Work items: CUDA-SERVER-003 through CUDA-SERVER-005
 
-Status: ready through proposed
+Status: CUDA-SERVER-003 blocked; CUDA-SERVER-004 and CUDA-SERVER-005 proposed
 Linked proposal: BITNET-PROP-0002
 Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
 Linked ADRs: BITNET-ADR-0004
@@ -557,9 +557,10 @@ cross-family proof inheritance.
 
 ### Acceptance
 
-`CUDA-SERVER-003` defines the readiness boundary. Later promotion PRs can set
-`server_ready=true` only for the exact model/profile whose receipt satisfies the
-server readiness spec.
+`CUDA-SERVER-003` audits the bounded dense Qwen server-smoke receipt against the
+readiness boundary and records that it is not promotable as-is. Later promotion
+PRs can set `server_ready=true` only for the exact model/profile whose refreshed
+or supplemental receipt satisfies the server readiness spec.
 
 ### Proof commands
 

--- a/plans/cuda-5070ti-productization/server-readiness.md
+++ b/plans/cuda-5070ti-productization/server-readiness.md
@@ -29,8 +29,11 @@ ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/server-strict-dense-qwen25-q8-s
 ```
 
 That receipt is evidence for the bounded smoke path. It is not, by itself, a
-`server_ready=true` promotion. The model coverage row remains false until a
-later promotion PR applies the exact-profile requirements in BITNET-SPEC-0010.
+`server_ready=true` promotion. CUDA-SERVER-003 audited it against
+BITNET-SPEC-0010 and found the receipt is missing artifact checksum identity,
+endpoint or request-profile scope, and generation-policy fields. The model
+coverage row remains false until a later promotion PR supplies those fields and
+applies the exact-profile requirements in BITNET-SPEC-0010.
 
 Official BitNet I2_S/QK256 does not have a server-readiness claim from the dense
 Qwen server smoke. It needs its own exact-profile server receipt before any
@@ -38,7 +41,7 @@ server row can promote.
 
 ## Work Item: CUDA-SERVER-003
 
-Status: ready
+Status: blocked
 Linked proposal: BITNET-PROP-0002
 Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
 Linked ADRs: BITNET-ADR-0004
@@ -48,13 +51,13 @@ Blocks: exact-profile server readiness promotions
 
 ### Goal
 
-Define or apply the server readiness promotion checklist for the bounded dense
-Qwen2.5 server-smoke evidence before changing any model coverage boolean.
+Apply the server readiness promotion checklist to the bounded dense Qwen2.5
+server-smoke evidence before changing any model coverage boolean.
 
 ### Production Delta
 
-Docs and status alignment only unless the PR explicitly includes a model
-coverage promotion under BITNET-SPEC-0010.
+Docs and status alignment only. CUDA-SERVER-003 records that the current server
+smoke is not promotable as-is.
 
 ### Non-Goals
 
@@ -65,9 +68,9 @@ speedup, no full-residency claim, and no default PR CI expansion.
 
 - The exact model coverage row is identified.
 - The exact server receipt path is identified.
-- The endpoint/profile scope is stated.
-- `server_ready=true` remains false unless all BITNET-SPEC-0010 promotion
-  requirements are met in the same PR.
+- Missing artifact checksum, endpoint/profile scope, and generation-policy
+  fields are recorded as blockers.
+- `server_ready=true` remains false.
 - `speedup_claim=false` and `full_residency_claim=false` remain unchanged.
 
 ### Proof Commands
@@ -90,13 +93,14 @@ Linked proposal: BITNET-PROP-0002
 Linked specs: BITNET-SPEC-0007, BITNET-SPEC-0010
 Linked ADRs: BITNET-ADR-0004
 Campaign item: `CUDA-SERVER-004`
-Blocked by: CUDA-SERVER-003
+Blocked by: CUDA-SERVER-003 missing receipt fields
 Blocks: dense Qwen server status UX
 
 ### Goal
 
-Promote dense Qwen2.5 server readiness only for the exact bounded profile, if
-the committed receipt and status surfaces satisfy BITNET-SPEC-0010.
+Promote dense Qwen2.5 server readiness only for the exact bounded profile after
+a refreshed or supplemental receipt carries the artifact checksum, endpoint or
+request-profile scope, and generation policy required by BITNET-SPEC-0010.
 
 ### Claim Boundary
 


### PR DESCRIPTION
## Summary

- Add CUDA-SERVER-003 dense Qwen server-readiness audit report.
- Record that the bounded dense Qwen server-smoke receipt is useful evidence but not promotable to server_ready=true under BITNET-SPEC-0010.
- Update model coverage/status/plan wording with the exact missing fields: artifact checksum identity, endpoint/profile scope, and generation policy.

## Claim Boundary

This PR does not promote server_ready, speedup, full residency, model answer readiness, CUDA execution, or BitNet proof. The dense Qwen server-smoke receipt remains bounded evidence only.

## Validation

- python -m json.tool ci\\hardware\\windows-9950x3d-rtx5070ti\\2026-05-15\\server-strict-dense-qwen25-q8-smoke.json
- git diff --check
- cargo run --locked -p xtask --no-default-features -- check-model-coverage
- cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir C:\\bntarget\\server-readiness-audit-reports --fail-on-error

## Rollback

Revert the docs/model-coverage wording and audit report. The committed server-smoke receipt and existing false claim booleans remain unchanged.