### PR TITLE
test(session-config-core): cover validation ordering, display, and trait impls

### DIFF
--- a/crates/bitnet-session-config-core/src/lib.rs
+++ b/crates/bitnet-session-config-core/src/lib.rs
@@ -187,14 +187,8 @@ mod tests {
 
     #[test]
     fn config_error_display_messages() {
-        assert_eq!(
-            ConfigError::EmptyModelPath.to_string(),
-            "model_path must not be empty"
-        );
-        assert_eq!(
-            ConfigError::EmptyTokenizerPath.to_string(),
-            "tokenizer_path must not be empty"
-        );
+        assert_eq!(ConfigError::EmptyModelPath.to_string(), "model_path must not be empty");
+        assert_eq!(ConfigError::EmptyTokenizerPath.to_string(), "tokenizer_path must not be empty");
         assert_eq!(
             ConfigError::UnsupportedBackend("foo".into()).to_string(),
             "unsupported backend: \"foo\""

--- a/crates/bitnet-session-config-core/src/lib.rs
+++ b/crates/bitnet-session-config-core/src/lib.rs
@@ -85,6 +85,16 @@ impl SessionConfig {
 mod tests {
     use super::*;
 
+    fn valid_cfg() -> SessionConfig {
+        SessionConfig {
+            model_path: "m.gguf".into(),
+            tokenizer_path: "t.json".into(),
+            backend: "cpu".into(),
+            max_context: 2048,
+            seed: None,
+        }
+    }
+
     #[test]
     fn defaults_match_engine_expectations() {
         let cfg = SessionConfig::default();
@@ -92,6 +102,7 @@ mod tests {
         assert_eq!(cfg.max_context, 2048);
         assert!(cfg.model_path.is_empty());
         assert!(cfg.tokenizer_path.is_empty());
+        assert_eq!(cfg.seed, None);
     }
 
     #[test]
@@ -109,5 +120,103 @@ mod tests {
         cfg.backend = "cpu".into();
         cfg.max_context = 0;
         assert_eq!(cfg.validate(), Err(ConfigError::ZeroContextWindow));
+    }
+
+    #[test]
+    fn validate_accepts_minimal_valid_config() {
+        assert_eq!(valid_cfg().validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_all_known_backends() {
+        for backend in VALID_BACKENDS {
+            let mut cfg = valid_cfg();
+            cfg.backend = (*backend).to_string();
+            assert_eq!(cfg.validate(), Ok(()), "backend {backend} should validate");
+        }
+    }
+
+    #[test]
+    fn validate_accepts_minimum_context_window() {
+        let mut cfg = valid_cfg();
+        cfg.max_context = 1;
+        assert_eq!(cfg.validate(), Ok(()));
+    }
+
+    #[test]
+    fn validate_reports_model_path_before_other_errors() {
+        // All fields invalid: model_path is reported first.
+        let cfg = SessionConfig {
+            model_path: String::new(),
+            tokenizer_path: String::new(),
+            backend: "bogus".into(),
+            max_context: 0,
+            seed: None,
+        };
+        assert_eq!(cfg.validate(), Err(ConfigError::EmptyModelPath));
+    }
+
+    #[test]
+    fn validate_reports_tokenizer_path_before_backend_or_context() {
+        let cfg = SessionConfig {
+            model_path: "m.gguf".into(),
+            tokenizer_path: String::new(),
+            backend: "bogus".into(),
+            max_context: 0,
+            seed: None,
+        };
+        assert_eq!(cfg.validate(), Err(ConfigError::EmptyTokenizerPath));
+    }
+
+    #[test]
+    fn validate_reports_backend_before_context() {
+        let cfg = SessionConfig {
+            model_path: "m.gguf".into(),
+            tokenizer_path: "t.json".into(),
+            backend: "bogus".into(),
+            max_context: 0,
+            seed: None,
+        };
+        assert_eq!(cfg.validate(), Err(ConfigError::UnsupportedBackend("bogus".into())));
+    }
+
+    #[test]
+    fn valid_backends_constant_matches_documented_set() {
+        assert_eq!(VALID_BACKENDS, &["cpu", "cuda", "gpu", "ffi"]);
+    }
+
+    #[test]
+    fn config_error_display_messages() {
+        assert_eq!(
+            ConfigError::EmptyModelPath.to_string(),
+            "model_path must not be empty"
+        );
+        assert_eq!(
+            ConfigError::EmptyTokenizerPath.to_string(),
+            "tokenizer_path must not be empty"
+        );
+        assert_eq!(
+            ConfigError::UnsupportedBackend("foo".into()).to_string(),
+            "unsupported backend: \"foo\""
+        );
+        assert_eq!(
+            ConfigError::ZeroContextWindow.to_string(),
+            "max_context must be greater than zero"
+        );
+    }
+
+    #[test]
+    fn config_error_is_std_error() {
+        let err: Box<dyn std::error::Error> = Box::new(ConfigError::EmptyModelPath);
+        assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn config_error_eq_and_clone() {
+        let a = ConfigError::UnsupportedBackend("x".into());
+        let b = a.clone();
+        assert_eq!(a, b);
+        assert_ne!(a, ConfigError::UnsupportedBackend("y".into()));
+        assert_ne!(ConfigError::EmptyModelPath, ConfigError::EmptyTokenizerPath);
     }
 }


### PR DESCRIPTION
## Summary

Adds 10 unit tests to `bitnet-session-config-core` (previously 2), targeting coverage gaps in validation ordering, error Display, and derived trait behavior.

- **Positive validation** (previously absent): minimal valid config, all `VALID_BACKENDS` variants, `max_context = 1` boundary
- **Field-precedence ordering**: `model_path` → `tokenizer_path` → `backend` → `context` (separate test per layer)
- **Default `seed = None`** coverage
- **`ConfigError::Display`**: all four variants asserted against exact strings
- **`std::error::Error` blanket impl**: `source()` returns `None`
- **`Clone` / `PartialEq` round-trips** on `ConfigError`
- **`VALID_BACKENDS` constant** content assertion

No production code changes; tests-only addition. `cargo test -p bitnet-session-config-core` → 12 passed, 0 failed.

## Test plan

- [x] `cargo test -p bitnet-session-config-core` — 12 passed
- [x] `cargo clippy -p bitnet-session-config-core --all-targets -- -D warnings` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR3vkfUCDw6oPg3VzZQ9om)_