### PR TITLE
test(tokenizer-discovery-core): cover explicit-path validation and error paths

### DIFF
--- a/crates/bitnet-tokenizer-discovery-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-discovery-core/src/lib.rs
@@ -211,4 +211,141 @@ mod tests {
         assert_eq!(called, 1);
         Ok(())
     }
+
+    #[test]
+    fn explicit_path_missing_returns_error() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        fs::write(&model_path, b"GGUF")?;
+        let missing = temp_dir.path().join("does_not_exist.json");
+
+        let result = resolve_tokenizer_with(&model_path, Some(missing.clone()), always_valid);
+        let message = match result {
+            Err(err) => format!("{err:#}"),
+            Ok(path) => format!("unexpected success: {}", path.display()),
+        };
+        assert!(message.contains("does not exist"), "got: {message}");
+        assert!(message.contains("does_not_exist.json"), "got: {message}");
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_path_directory_returns_error() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        fs::write(&model_path, b"GGUF")?;
+        let dir_as_tokenizer = temp_dir.path().join("subdir");
+        fs::create_dir(&dir_as_tokenizer)?;
+
+        let result = resolve_tokenizer_with(&model_path, Some(dir_as_tokenizer), always_valid);
+        let message = match result {
+            Err(err) => format!("{err:#}"),
+            Ok(path) => format!("unexpected success: {}", path.display()),
+        };
+        assert!(message.contains("not a file"), "got: {message}");
+        Ok(())
+    }
+
+    #[test]
+    fn verifier_error_propagates_through_discovery() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let sibling = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"{}")?;
+
+        let result =
+            resolve_tokenizer_with(&model_path, None, |_| Err(anyhow::anyhow!("verifier blew up")));
+        let message = match result {
+            Err(err) => format!("{err:#}"),
+            Ok(path) => format!("unexpected success: {}", path.display()),
+        };
+        assert!(message.contains("verifier blew up"));
+        Ok(())
+    }
+
+    #[test]
+    fn falls_back_to_parent_when_sibling_rejected() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_dir = temp_dir.path().join("models");
+        fs::create_dir(&model_dir)?;
+
+        let model_path = model_dir.join("model.gguf");
+        let sibling = model_dir.join("tokenizer.json");
+        let parent = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"sibling")?;
+        fs::write(&parent, b"parent")?;
+
+        let mut seen: Vec<PathBuf> = Vec::new();
+        let resolved = resolve_tokenizer_with(&model_path, None, |path| {
+            seen.push(path.to_path_buf());
+            // Reject the sibling; accept the parent.
+            Ok(path != sibling)
+        })?;
+
+        assert_eq!(resolved, parent.canonicalize()?);
+        assert_eq!(seen.len(), 2, "verifier should be called for sibling then parent");
+        assert_eq!(seen[0], sibling);
+        assert_eq!(seen[1], parent);
+        Ok(())
+    }
+
+    #[test]
+    fn discovery_error_message_includes_attempted_paths_and_solutions() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_dir = temp_dir.path().join("models");
+        fs::create_dir(&model_dir)?;
+        let model_path = model_dir.join("model.gguf");
+        fs::write(&model_path, b"GGUF")?;
+
+        let result = resolve_tokenizer_with(&model_path, None, always_valid);
+        let message = match result {
+            Err(err) => format!("{err:#}"),
+            Ok(path) => format!("unexpected success: {}", path.display()),
+        };
+        assert!(message.contains("model.gguf"));
+        assert!(message.contains("Sibling tokenizer.json"));
+        assert!(message.contains("Parent directory"));
+        assert!(message.contains("cargo run -p xtask -- tokenizer --into"));
+        assert!(message.contains("--tokenizer /path/to/tokenizer.json"));
+        Ok(())
+    }
+
+    #[test]
+    fn discovery_struct_usable_directly() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let sibling = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"{}")?;
+
+        let discovery = TokenizerDiscovery::new(model_path);
+        let resolved = discovery.discover_with(&mut always_valid)?;
+        assert_eq!(resolved, sibling.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn sibling_not_found_skips_to_parent() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_dir = temp_dir.path().join("models");
+        fs::create_dir(&model_dir)?;
+        let model_path = model_dir.join("model.gguf");
+        let parent = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&parent, b"{}")?;
+        // Note: no sibling tokenizer.json file.
+
+        let mut verifier_call_count = 0usize;
+        let resolved = resolve_tokenizer_with(&model_path, None, |_| {
+            verifier_call_count += 1;
+            Ok(true)
+        })?;
+
+        assert_eq!(resolved, parent.canonicalize()?);
+        // Sibling does not exist, so verifier is only called once (for parent).
+        assert_eq!(verifier_call_count, 1);
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Expands `bitnet-tokenizer-discovery-core` tests from 4 to 11, covering previously-untested branches in `validate_explicit_path`, `discovery_failed_error`, and call-ordering through the verifier callback.

**Added coverage:**
- `explicit_path_missing_returns_error`: `validate_explicit_path` bails when the path does not exist; asserts user-facing message
- `explicit_path_directory_returns_error`: bails when path is a directory
- `verifier_error_propagates_through_discovery`: verifier `Err` is bubbled
- `falls_back_to_parent_when_sibling_rejected`: sibling fails verifier, parent passes; asserts verifier was called for sibling then parent in order
- `discovery_error_message_includes_attempted_paths_and_solutions`: covers `discovery_failed_error` message content (xtask hint, `--tokenizer` hint)
- `discovery_struct_usable_directly`: `TokenizerDiscovery::new` + `discover_with` direct usage
- `sibling_not_found_skips_to_parent`: when sibling file is absent, verifier is only called once (for parent), not twice

Tests-only; no production code changes.

## Test plan

- [x] `cargo test -p bitnet-tokenizer-discovery-core` — 11 passed
- [x] `cargo clippy -p bitnet-tokenizer-discovery-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MR3vkfUCDw6oPg3VzZQ9om)_