### PR TITLE
fix(bitnet): match ggml iterative RoPE theta

### DIFF
--- a/crates/bitnet-rope/src/lib.rs
+++ b/crates/bitnet-rope/src/lib.rs
@@ -149,7 +149,12 @@ mod tests {
         let dim = 128usize;
         let pos = 17usize;
         let base = 500_000.0f32;
-        let tables = build_tables(dim, pos + 1, base).expect("tables");
+        let tables_result = build_tables(dim, pos + 1, base);
+        assert!(tables_result.is_ok());
+        let Some(tables) = tables_result.ok() else {
+            return;
+        };
+
         let row = pos * tables.half_dim;
         let theta_scale = base.powf(-2.0 / dim as f32);
         let mut theta = pos as f32;

--- a/crates/bitnet-rope/src/lib.rs
+++ b/crates/bitnet-rope/src/lib.rs
@@ -75,18 +75,17 @@ pub fn build_tables(
     }
 
     let half_dim = dim / 2;
-    let inv_freq =
-        (0..half_dim).map(|i| 1.0 / base.powf((2.0 * i as f32) / dim as f32)).collect::<Vec<_>>();
+    let theta_scale = base.powf(-2.0 / dim as f32);
 
     let mut sin = Vec::with_capacity(max_seq_len * half_dim);
     let mut cos = Vec::with_capacity(max_seq_len * half_dim);
 
     for pos in 0..max_seq_len {
-        let pos = pos as f32;
-        for &freq in &inv_freq {
-            let angle = pos * freq;
-            sin.push(angle.sin());
-            cos.push(angle.cos());
+        let mut theta = pos as f32;
+        for _ in 0..half_dim {
+            sin.push(theta.sin());
+            cos.push(theta.cos());
+            theta *= theta_scale;
         }
     }
 
@@ -143,6 +142,34 @@ mod tests {
 
         approx_eq(tables.sin[row1_offset + 1], 0.01_f32.sin(), 1e-6);
         approx_eq(tables.cos[row1_offset + 1], 0.01_f32.cos(), 1e-6);
+    }
+
+    #[test]
+    fn build_tables_uses_ggml_iterative_f32_theta() {
+        let dim = 128usize;
+        let pos = 17usize;
+        let base = 500_000.0f32;
+        let tables = build_tables(dim, pos + 1, base).expect("tables");
+        let row = pos * tables.half_dim;
+        let theta_scale = base.powf(-2.0 / dim as f32);
+        let mut theta = pos as f32;
+        let mut differs_from_independent_f64_powf = false;
+
+        for lane in 0..tables.half_dim {
+            let index = row + lane;
+            assert_eq!(tables.sin[index].to_bits(), theta.sin().to_bits());
+            assert_eq!(tables.cos[index].to_bits(), theta.cos().to_bits());
+
+            let exponent_f64 = (2.0 * lane as f64) / dim as f64;
+            let angle_f64 = pos as f64 / f64::from(base).powf(exponent_f64);
+            differs_from_independent_f64_powf |= tables.sin[index].to_bits()
+                != (angle_f64.sin() as f32).to_bits()
+                || tables.cos[index].to_bits() != (angle_f64.cos() as f32).to_bits();
+
+            theta *= theta_scale;
+        }
+
+        assert!(differs_from_independent_f64_powf);
     }
 
     #[test]

--- a/crates/bitnet-rope/tests/rope_edge_cases.rs
+++ b/crates/bitnet-rope/tests/rope_edge_cases.rs
@@ -150,7 +150,7 @@ fn build_tables_odd_dim_5() {
 #[test]
 fn build_tables_nan_base() {
     let err = build_tables(4, 10, f32::NAN).unwrap_err();
-    assert_eq!(err, RopeTableError::NonFiniteBase { base: f32::NAN });
+    assert!(matches!(err, RopeTableError::NonFiniteBase { base } if base.is_nan()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- build RoPE tables with ggml-style f32 iterative theta updates instead of independent per-lane frequency tables
- keep table entries as f32 for the existing runtime tensor path
- pin the source-compatible rule with a focused RoPE table test
- keep the NaN edge-case assertion from comparing `NaN == NaN`

## Source Rule

The local reference source computes RoPE cache values with:

```c
const float theta_scale = powf(freq_base, -2.0f/n_dims);
float theta = position;
...
theta *= theta_scale;
```

The runtime table builder now mirrors that f32 iterative theta rule.

## Diagnostic Context

The stacked diagnostic PRs show the source-derived `bitnet_500000_ggml_f32_iterative_theta_f32_arithmetic` variant is the best reference match for all 5 sampled KV heads and clears the remaining reference-side post-RoPE F16 bucket. This replaces the earlier f64 per-lane table direction for this runtime slice.

## Claim Boundary

Runtime correctness slice only. This does not promote A770 semantic quality, A770 performance, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full support/device residency, reference parity, or completion.

## Validation

- `cargo test --locked -p bitnet-rope -- --nocapture`
- `cargo check --locked -p bitnet-transformer --features trace`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --edition 2024 --check crates/bitnet-rope/src/lib.rs crates/bitnet-rope/tests/rope_edge_cases.rs`
- `git diff --check`