### PR TITLE
refactor(xtask): port trace-diff to native Rust

### DIFF
--- a/xtask/src/trace_diff.rs
+++ b/xtask/src/trace_diff.rs
@@ -277,15 +277,15 @@ mod tests {
     use std::{fs, path::PathBuf};
     use tempfile::tempdir;
 
-    fn write_trace(dir: &Path, name: &str, hash: &str) {
+    fn write_trace(dir: &Path, name: &str, hash: &str) -> Result<()> {
         fs::write(
             dir.join(name),
             format!(
                 r#"{{"seq":0,"layer":1,"stage":"attn","shape":[1,2],"dtype":"f32","blake3":"{hash}","rms":1.25,"num_elements":2}}
 "#
             ),
-        )
-        .unwrap();
+        )?;
+        Ok(())
     }
 
     #[test]
@@ -299,37 +299,41 @@ mod tests {
     }
 
     #[test]
-    fn test_load_traces_skips_records_without_keys() {
-        let dir = tempdir().unwrap();
+    fn test_load_traces_skips_records_without_keys() -> Result<()> {
+        let dir = tempdir()?;
         fs::write(
             dir.path().join("sample.trace"),
             "{\"event\":\"legacy\"}\n{\"seq\":1,\"layer\":2,\"stage\":\"mlp\",\"blake3\":\"abc\"}\n",
-        )
-        .unwrap();
+        )?;
 
-        let traces = load_traces(dir.path()).unwrap();
+        let traces = load_traces(dir.path())?;
         assert_eq!(traces.len(), 1);
         assert!(traces.contains_key(&TraceKey { seq: 1, layer: 2, stage: "mlp".to_owned() }));
+        Ok(())
     }
 
     #[test]
-    fn test_compare_matching_traces() {
-        let rs_dir = tempdir().unwrap();
-        let cpp_dir = tempdir().unwrap();
-        write_trace(rs_dir.path(), "a.trace", "abcdef0123456789");
-        write_trace(cpp_dir.path(), "a.jsonl", "abcdef0123456789");
+    fn test_compare_matching_traces() -> Result<()> {
+        let rs_dir = tempdir()?;
+        let cpp_dir = tempdir()?;
+        write_trace(rs_dir.path(), "a.trace", "abcdef0123456789")?;
+        write_trace(cpp_dir.path(), "a.jsonl", "abcdef0123456789")?;
 
-        run(rs_dir.path(), cpp_dir.path()).unwrap();
+        run(rs_dir.path(), cpp_dir.path())?;
+        Ok(())
     }
 
     #[test]
-    fn test_compare_detects_hash_divergence() {
-        let rs_dir = tempdir().unwrap();
-        let cpp_dir = tempdir().unwrap();
-        write_trace(rs_dir.path(), "a.trace", "abcdef0123456789");
-        write_trace(cpp_dir.path(), "a.trace", "fedcba9876543210");
+    fn test_compare_detects_hash_divergence() -> Result<()> {
+        let rs_dir = tempdir()?;
+        let cpp_dir = tempdir()?;
+        write_trace(rs_dir.path(), "a.trace", "abcdef0123456789")?;
+        write_trace(cpp_dir.path(), "a.trace", "fedcba9876543210")?;
 
-        let err = run(rs_dir.path(), cpp_dir.path()).unwrap_err();
-        assert!(err.to_string().contains("trace divergence detected"));
+        match run(rs_dir.path(), cpp_dir.path()) {
+            Ok(()) => bail!("expected trace divergence"),
+            Err(err) => assert!(err.to_string().contains("trace divergence detected")),
+        }
+        Ok(())
     }
 }

--- a/xtask/src/trace_diff.rs
+++ b/xtask/src/trace_diff.rs
@@ -1,8 +1,9 @@
-//! Trace diff wrapper for cross-validation debugging.
+//! Native trace diff support for cross-validation debugging.
 //!
-//! This module provides a Rust wrapper for the Python `scripts/trace_diff.py`
-//! script, which performs Blake3 hash comparison of trace files captured during
-//! Rust vs C++ cross-validation runs.
+//! This module compares trace files captured during Rust vs C++ cross-validation
+//! runs.  It intentionally lives in `xtask` instead of a Python helper so the
+//! workflow uses the repository's Rust developer-tooling path and works in
+//! minimal environments without a Python interpreter.
 //!
 //! # Usage
 //!
@@ -22,38 +23,178 @@
 //! The tool prints:
 //! - First divergence point: `(seq, layer, stage)` where traces differ
 //! - "All tracepoints match" if traces are identical
-//! - Error diagnostics if trace files are missing or Python is unavailable
+//! - Error diagnostics if trace files are missing or malformed
 
 use anyhow::{Context, Result, bail};
-use std::{fs, path::Path, process::Command};
+use serde_json::Value;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::{self, File},
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
 
-/// Find available Python interpreter
-///
-/// Tries interpreters in order: python3, python, py
-fn find_python() -> Result<String> {
-    for interp in ["python3", "python", "py"] {
-        if Command::new(interp)
-            .arg("--version")
-            .output()
-            .ok()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-        {
-            return Ok(interp.to_string());
-        }
-    }
-    bail!(
-        "Python interpreter not found (tried python3, python, py).\n\
-         Install Python 3.7+ to use trace comparison."
-    )
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct TraceKey {
+    seq: i64,
+    layer: i64,
+    stage: String,
 }
 
-/// Check if a directory has trace files
+type TraceMap = BTreeMap<TraceKey, Value>;
+
+/// Check if a directory has any entries.
 fn has_trace_files(dir: &Path) -> bool {
     fs::read_dir(dir).ok().map(|entries| entries.count() > 0).unwrap_or(false)
 }
 
-/// Compare Rust vs C++ traces and report first divergence
+fn is_trace_path(path: &Path) -> bool {
+    matches!(path.extension().and_then(|ext| ext.to_str()), Some("trace" | "jsonl"))
+}
+
+fn trace_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = fs::read_dir(dir)
+        .with_context(|| format!("failed to read trace directory {}", dir.display()))?
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path()),
+            Err(err) => {
+                eprintln!("Warning: Failed to read trace directory entry: {err}");
+                None
+            }
+        })
+        .filter(|path| path.is_file() && is_trace_path(path))
+        .collect::<Vec<_>>();
+    files.sort();
+    Ok(files)
+}
+
+fn integer_field(record: &Value, name: &str) -> Option<i64> {
+    let value = record.get(name)?;
+    value.as_i64().or_else(|| value.as_u64().and_then(|v| i64::try_from(v).ok()))
+}
+
+fn key_from_record(record: &Value) -> Option<TraceKey> {
+    Some(TraceKey {
+        seq: integer_field(record, "seq")?,
+        layer: integer_field(record, "layer")?,
+        stage: record.get("stage")?.as_str()?.to_owned(),
+    })
+}
+
+fn load_traces(directory: &Path) -> Result<TraceMap> {
+    let mut traces = TraceMap::new();
+
+    for path in trace_files(directory)? {
+        let file =
+            File::open(&path).with_context(|| format!("failed to open {}", path.display()))?;
+        let reader = BufReader::new(file);
+
+        for (line_no, line) in reader.lines().enumerate() {
+            let line =
+                line.with_context(|| format!("failed to read {}:{}", path.display(), line_no + 1))?;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let record: Value = match serde_json::from_str(line) {
+                Ok(record) => record,
+                Err(err) => {
+                    eprintln!("Warning: Failed to parse {}:{}: {err}", path.display(), line_no + 1);
+                    continue;
+                }
+            };
+
+            // Skip records without seq/layer/stage for backward compatibility.
+            if let Some(key) = key_from_record(&record) {
+                traces.insert(key, record);
+            }
+        }
+    }
+
+    Ok(traces)
+}
+
+fn shape(record: &Value) -> Option<&Value> {
+    record.get("shape")
+}
+
+fn dtype(record: &Value) -> Option<&str> {
+    record.get("dtype").and_then(Value::as_str)
+}
+
+fn blake3(record: &Value) -> &str {
+    record.get("blake3").and_then(Value::as_str).unwrap_or("")
+}
+
+fn f64_field(record: &Value, name: &str) -> f64 {
+    record.get(name).and_then(Value::as_f64).unwrap_or(0.0)
+}
+
+fn u64_field(record: &Value, name: &str) -> u64 {
+    record.get(name).and_then(Value::as_u64).unwrap_or(0)
+}
+
+fn print_key(prefix: &str, key: &TraceKey) {
+    println!("{prefix}: seq={}, layer={}, stage={}", key.seq, key.layer, key.stage);
+}
+
+fn compare_trace_maps(rust_traces: &TraceMap, cpp_traces: &TraceMap) -> Result<()> {
+    let all_keys = rust_traces.keys().chain(cpp_traces.keys()).cloned().collect::<BTreeSet<_>>();
+
+    for key in all_keys {
+        let Some(rust_rec) = rust_traces.get(&key) else {
+            print_key("✗ Missing in Rust", &key);
+            bail!("trace divergence detected");
+        };
+        let Some(cpp_rec) = cpp_traces.get(&key) else {
+            print_key("✗ Missing in C++", &key);
+            bail!("trace divergence detected");
+        };
+
+        if shape(rust_rec) != shape(cpp_rec) {
+            print_key("✗ Shape mismatch at", &key);
+            println!("  Rust shape: {}", shape(rust_rec).unwrap_or(&Value::Null));
+            println!("  C++ shape:  {}", shape(cpp_rec).unwrap_or(&Value::Null));
+            bail!("trace divergence detected");
+        }
+
+        if dtype(rust_rec) != dtype(cpp_rec) {
+            print_key("✗ Dtype mismatch at", &key);
+            println!("  Rust dtype: {}", dtype(rust_rec).unwrap_or(""));
+            println!("  C++ dtype:  {}", dtype(cpp_rec).unwrap_or(""));
+            bail!("trace divergence detected");
+        }
+
+        let rust_hash = blake3(rust_rec);
+        let cpp_hash = blake3(cpp_rec);
+        if rust_hash != cpp_hash {
+            print_key("✗ First divergence at", &key);
+            println!("  Rust blake3: {}...", hash_prefix(rust_hash));
+            println!("  C++ blake3:  {}...", hash_prefix(cpp_hash));
+            println!(
+                "  Rust stats:  rms={:.6}, num_elements={}",
+                f64_field(rust_rec, "rms"),
+                u64_field(rust_rec, "num_elements")
+            );
+            println!(
+                "  C++ stats:   rms={:.6}, num_elements={}",
+                f64_field(cpp_rec, "rms"),
+                u64_field(cpp_rec, "num_elements")
+            );
+            bail!("trace divergence detected");
+        }
+    }
+
+    println!("✓ All tracepoints match");
+    Ok(())
+}
+
+fn hash_prefix(hash: &str) -> &str {
+    hash.get(..16).unwrap_or(hash)
+}
+
+/// Compare Rust vs C++ traces and report first divergence.
 ///
 /// # Arguments
 ///
@@ -63,31 +204,20 @@ fn has_trace_files(dir: &Path) -> bool {
 /// # Workflow
 ///
 /// 1. Validates both trace directories exist
-/// 2. Checks `scripts/trace_diff.py` is available in repo
-/// 3. Executes Python script via `python3` subprocess
-/// 4. Propagates exit code from Python script
-///
-/// # Returns
-///
-/// - `Ok(())` if comparison succeeds (traces match or divergence found)
-/// - `Err(_)` if:
-///   - Trace directories don't exist
-///   - `trace_diff.py` script not found
-///   - `python3` not available
-///   - Script execution fails
+/// 2. Reads `.trace` and `.jsonl` newline-delimited JSON trace records
+/// 3. Compares sorted `(seq, layer, stage)` records for shape, dtype, and Blake3 hash
+/// 4. Returns an error when the first divergence is found
 pub fn run(rs_dir: &Path, cpp_dir: &Path) -> Result<()> {
     // 1) Validate trace directories exist
     if !rs_dir.exists() {
         eprintln!("❌ Rust trace directory not found: {}", rs_dir.display());
         eprintln!();
         eprintln!("How to capture Rust traces:");
-        eprintln!(
-            "  BITNET_TRACE_DIR=/tmp/rs RUST_LOG=warn BITNET_DETERMINISTIC=1 BITNET_SEED=42 \\"
-        );
+        eprintln!("  BITNET_TRACE_DIR=/tmp/rs RUST_LOG=warn BITNET_DETERMINISTIC=1 BITNET_SEED=42");
         eprintln!("    cargo run -p bitnet-cli --features cpu,trace -- run \\");
         eprintln!("    --model <model.gguf> --tokenizer <tokenizer.json> \\");
         eprintln!("    --prompt \"What is 2+2?\" --max-tokens 4 --greedy");
-        anyhow::bail!("Rust trace directory not found: {}", rs_dir.display());
+        bail!("Rust trace directory not found: {}", rs_dir.display());
     }
 
     if !cpp_dir.exists() {
@@ -95,7 +225,7 @@ pub fn run(rs_dir: &Path, cpp_dir: &Path) -> Result<()> {
         eprintln!();
         eprintln!("How to capture C++ traces:");
         eprintln!("  See docs/howto/cpp-setup.md for C++ instrumentation and trace capture");
-        anyhow::bail!("C++ trace directory not found: {}", cpp_dir.display());
+        bail!("C++ trace directory not found: {}", cpp_dir.display());
     }
 
     // 2) Check if directories are empty
@@ -103,13 +233,11 @@ pub fn run(rs_dir: &Path, cpp_dir: &Path) -> Result<()> {
         eprintln!("❌ Rust trace directory is empty: {}", rs_dir.display());
         eprintln!();
         eprintln!("How to capture Rust traces:");
-        eprintln!(
-            "  BITNET_TRACE_DIR=/tmp/rs RUST_LOG=warn BITNET_DETERMINISTIC=1 BITNET_SEED=42 \\"
-        );
+        eprintln!("  BITNET_TRACE_DIR=/tmp/rs RUST_LOG=warn BITNET_DETERMINISTIC=1 BITNET_SEED=42");
         eprintln!("    cargo run -p bitnet-cli --features cpu,trace -- run \\");
         eprintln!("    --model <model.gguf> --tokenizer <tokenizer.json> \\");
         eprintln!("    --prompt \"What is 2+2?\" --max-tokens 4 --greedy");
-        anyhow::bail!("Rust trace directory is empty: {}", rs_dir.display());
+        bail!("Rust trace directory is empty: {}", rs_dir.display());
     }
 
     if !has_trace_files(cpp_dir) {
@@ -117,47 +245,48 @@ pub fn run(rs_dir: &Path, cpp_dir: &Path) -> Result<()> {
         eprintln!();
         eprintln!("How to capture C++ traces:");
         eprintln!("  See docs/howto/cpp-setup.md for C++ instrumentation and trace capture");
-        anyhow::bail!("C++ trace directory is empty: {}", cpp_dir.display());
+        bail!("C++ trace directory is empty: {}", cpp_dir.display());
     }
 
-    // 3) Verify trace_diff.py script exists
-    let script = Path::new("scripts/trace_diff.py");
-    if !script.exists() {
-        bail!(
-            "scripts/trace_diff.py not found at {}\n\
-             Are you running from the repository root?",
-            script.display()
-        );
-    }
-
-    // 4) Find Python interpreter
-    let python = find_python()?;
-
-    // 5) Execute Python script
     eprintln!("[bitnet] Comparing traces:");
     eprintln!("  Rust:  {}", rs_dir.display());
     eprintln!("  C++:   {}", cpp_dir.display());
     eprintln!();
 
-    let status = Command::new(&python)
-        .arg(script)
-        .arg(rs_dir)
-        .arg(cpp_dir)
-        .status()
-        .context(format!("failed to spawn {} for trace_diff.py", python))?;
+    println!("Loading Rust traces from {}...", rs_dir.display());
+    let rust_traces = load_traces(rs_dir)?;
+    println!("  Loaded {} Rust tracepoints", rust_traces.len());
 
-    // 6) Propagate exit code
-    if !status.success() {
-        bail!("trace_diff.py failed with exit code: {:?}", status.code().unwrap_or(-1));
+    println!("Loading C++ traces from {}...", cpp_dir.display());
+    let cpp_traces = load_traces(cpp_dir)?;
+    println!("  Loaded {} C++ tracepoints", cpp_traces.len());
+    println!();
+
+    if rust_traces.is_empty() || cpp_traces.is_empty() {
+        bail!(
+            "no comparable trace records found; expected newline-delimited JSON with seq, layer, and stage fields"
+        );
     }
 
-    Ok(())
+    compare_trace_maps(&rust_traces, &cpp_traces)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::{fs, path::PathBuf};
+    use tempfile::tempdir;
+
+    fn write_trace(dir: &Path, name: &str, hash: &str) {
+        fs::write(
+            dir.join(name),
+            format!(
+                r#"{{"seq":0,"layer":1,"stage":"attn","shape":[1,2],"dtype":"f32","blake3":"{hash}","rms":1.25,"num_elements":2}}
+"#
+            ),
+        )
+        .unwrap();
+    }
 
     #[test]
     fn test_run_missing_dirs() {
@@ -167,5 +296,40 @@ mod tests {
         let result = run(&rs_dir, &cpp_dir);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("trace directory not found"));
+    }
+
+    #[test]
+    fn test_load_traces_skips_records_without_keys() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("sample.trace"),
+            "{\"event\":\"legacy\"}\n{\"seq\":1,\"layer\":2,\"stage\":\"mlp\",\"blake3\":\"abc\"}\n",
+        )
+        .unwrap();
+
+        let traces = load_traces(dir.path()).unwrap();
+        assert_eq!(traces.len(), 1);
+        assert!(traces.contains_key(&TraceKey { seq: 1, layer: 2, stage: "mlp".to_owned() }));
+    }
+
+    #[test]
+    fn test_compare_matching_traces() {
+        let rs_dir = tempdir().unwrap();
+        let cpp_dir = tempdir().unwrap();
+        write_trace(rs_dir.path(), "a.trace", "abcdef0123456789");
+        write_trace(cpp_dir.path(), "a.jsonl", "abcdef0123456789");
+
+        run(rs_dir.path(), cpp_dir.path()).unwrap();
+    }
+
+    #[test]
+    fn test_compare_detects_hash_divergence() {
+        let rs_dir = tempdir().unwrap();
+        let cpp_dir = tempdir().unwrap();
+        write_trace(rs_dir.path(), "a.trace", "abcdef0123456789");
+        write_trace(cpp_dir.path(), "a.trace", "fedcba9876543210");
+
+        let err = run(rs_dir.path(), cpp_dir.path()).unwrap_err();
+        assert!(err.to_string().contains("trace divergence detected"));
     }
 }


### PR DESCRIPTION
### Motivation
- Remove the runtime dependency on a Python helper and keep trace comparison inside the Rust developer-tooling path so the `xtask trace-diff` flow works in minimal environments. 
- Improve maintainability by implementing trace loading and comparison in Rust alongside other `xtask` utilities.

### Description
- Replace the Python-wrapper approach with a native implementation in `xtask/src/trace_diff.rs` that reads `.trace`/`.jsonl` newline-delimited JSON records and extracts keys by `(seq, layer, stage)`.
- Implement `load_traces`, stable trace-file discovery, `TraceKey`/`TraceMap` types, and `compare_trace_maps` to detect missing records, shape mismatches, dtype mismatches, and Blake3 hash divergences with diagnostic output.
- Update `run` to validate directories and directly compare traces without spawning Python, and add helper formatters (`hash_prefix`, `print_key`) and field accessors (`shape`, `dtype`, `f64_field`, `u64_field`).
- Add unit tests covering missing directories, skipping legacy records without keys, matching traces, and detecting hash divergence; wire the new implementation into the `xtask` CLI command handler.

### Testing
- Ran `cargo test --locked -p xtask --no-default-features trace_diff` and all added tests passed (`4 passed`).
- Ran formatting and lints: `cargo fmt --all --check` and `cargo clippy --locked -p xtask --no-default-features -- -D warnings`, both succeeded with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d199cb188333a269887d3781f8e1)