### PR TITLE
refactor: move greedy argmax check into Rust core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ name = "bitnet-task"
 version = "0.2.1-dev"
 dependencies = [
  "anyhow",
+ "bitnet-generation-events-core",
  "clap",
  "fs2",
  "serde_json",

--- a/crates/bitnet-generation-events-core/src/lib.rs
+++ b/crates/bitnet-generation-events-core/src/lib.rs
@@ -3,6 +3,121 @@
 use bitnet_generation_stop_core::StopReason;
 use serde::{Deserialize, Serialize};
 
+/// Top-k logit evidence for a candidate token at one decode step.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TopLogit {
+    /// Vocabulary index of the candidate token.
+    pub token_id: u32,
+    /// Raw logit value for the candidate token.
+    pub logit: f32,
+}
+
+/// Logit evidence captured for a single generation step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GreedyLogitStep {
+    /// Zero-based generation step index.
+    pub step: usize,
+    /// Top-k candidate logits captured for this step.
+    pub top_logits: Vec<TopLogit>,
+    /// Token selected by the sampler for this step.
+    pub chosen_id: Option<u32>,
+}
+
+/// A single greedy argmax invariant violation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GreedyArgmaxViolation {
+    /// Zero-based generation step index.
+    pub step: usize,
+    /// Token with the maximum finite logit among captured candidates.
+    pub argmax_token_id: u32,
+    /// Maximum finite logit among captured candidates.
+    pub argmax_logit: f32,
+    /// Token selected by the sampler.
+    pub chosen_id: u32,
+}
+
+/// Missing or unusable evidence for a generation step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GreedyArgmaxMissingEvidence {
+    /// Zero-based generation step index.
+    pub step: usize,
+    /// Human-readable reason the step could not be checked.
+    pub reason: String,
+}
+
+/// Result of checking greedy argmax evidence.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct GreedyArgmaxReport {
+    /// Number of logit-dump steps inspected.
+    pub checked_steps: usize,
+    /// Steps where the selected token did not match the captured argmax.
+    pub violations: Vec<GreedyArgmaxViolation>,
+    /// Steps that lacked sufficient finite top-logit or chosen-token evidence.
+    pub missing_evidence: Vec<GreedyArgmaxMissingEvidence>,
+}
+
+impl GreedyArgmaxReport {
+    /// Returns true when every inspected step had enough evidence and no mismatch.
+    pub fn is_valid(&self) -> bool {
+        self.checked_steps > 0 && self.violations.is_empty() && self.missing_evidence.is_empty()
+    }
+}
+
+/// Check that every captured greedy decode step selected the maximum finite logit.
+///
+/// The check intentionally ignores non-finite and implausibly huge sentinel values
+/// so JSON receipts containing `NaN`/`inf`-like placeholders do not produce a false
+/// argmax. Ties are resolved in favor of the first maximum in the captured top-k
+/// order, matching the historical maintenance script this core helper replaces.
+pub fn check_greedy_argmax(steps: &[GreedyLogitStep]) -> GreedyArgmaxReport {
+    let mut report = GreedyArgmaxReport { checked_steps: steps.len(), ..Default::default() };
+
+    for (fallback_step, step) in steps.iter().enumerate() {
+        let step_idx = step.step;
+        let Some(chosen_id) = step.chosen_id else {
+            report.missing_evidence.push(GreedyArgmaxMissingEvidence {
+                step: step_idx,
+                reason: "missing chosen_id".to_string(),
+            });
+            continue;
+        };
+
+        let mut best: Option<TopLogit> = None;
+        for candidate in &step.top_logits {
+            if !is_checkable_logit(candidate.logit) {
+                continue;
+            }
+            if best.is_none_or(|current| candidate.logit > current.logit) {
+                best = Some(*candidate);
+            }
+        }
+
+        let Some(best) = best else {
+            report.missing_evidence.push(GreedyArgmaxMissingEvidence {
+                step: step_idx,
+                reason: format!("no finite top_logits for step {fallback_step}"),
+            });
+            continue;
+        };
+
+        if best.token_id != chosen_id {
+            report.violations.push(GreedyArgmaxViolation {
+                step: step_idx,
+                argmax_token_id: best.token_id,
+                argmax_logit: best.logit,
+                chosen_id,
+            });
+        }
+    }
+
+    report
+}
+
+#[inline]
+fn is_checkable_logit(value: f32) -> bool {
+    value.is_finite() && (-1.0e10..1.0e10).contains(&value)
+}
+
 /// A token produced during streaming generation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenEvent {
@@ -52,5 +167,46 @@ mod tests {
             }
             StreamEvent::Token { .. } => panic!("expected Done event"),
         }
+    }
+
+    #[test]
+    fn greedy_argmax_report_accepts_matching_steps() {
+        let report = check_greedy_argmax(&[GreedyLogitStep {
+            step: 0,
+            top_logits: vec![
+                TopLogit { token_id: 7, logit: 1.5 },
+                TopLogit { token_id: 9, logit: 3.25 },
+            ],
+            chosen_id: Some(9),
+        }]);
+
+        assert!(report.is_valid());
+        assert_eq!(report.checked_steps, 1);
+    }
+
+    #[test]
+    fn greedy_argmax_report_records_mismatch_and_missing_evidence() {
+        let report = check_greedy_argmax(&[
+            GreedyLogitStep {
+                step: 2,
+                top_logits: vec![
+                    TopLogit { token_id: 4, logit: 2.0 },
+                    TopLogit { token_id: 5, logit: 1.0 },
+                ],
+                chosen_id: Some(5),
+            },
+            GreedyLogitStep { step: 3, top_logits: vec![], chosen_id: Some(6) },
+            GreedyLogitStep {
+                step: 4,
+                top_logits: vec![TopLogit { token_id: 8, logit: 9.0 }],
+                chosen_id: None,
+            },
+        ]);
+
+        assert!(!report.is_valid());
+        assert_eq!(report.violations[0].step, 2);
+        assert_eq!(report.violations[0].argmax_token_id, 4);
+        assert_eq!(report.violations[0].chosen_id, 5);
+        assert_eq!(report.missing_evidence.len(), 2);
     }
 }

--- a/scripts/check_greedy_argmax.py
+++ b/scripts/check_greedy_argmax.py
@@ -1,80 +1,45 @@
 #!/usr/bin/env python3
-"""
-Check greedy argmax invariant from CLI JSON output.
-Ensures that when --greedy is used, the chosen token at each step
-matches the argmax of the logits.
-"""
+"""Compatibility wrapper for the Rust greedy-argmax invariant checker."""
 
-import sys
-import json
+from __future__ import annotations
+
 import argparse
-from typing import Dict, List, Any
+import subprocess
+import sys
+from pathlib import Path
 
-def check_greedy_invariant(json_path: str) -> bool:
-    """
-    Check that all steps satisfy greedy argmax invariant.
-    Returns True if valid, False otherwise.
-    """
-    with open(json_path, 'r') as f:
-        data = json.load(f)
 
-    # Extract logits dump
-    logits_dump = data.get('logits_dump', [])
-    if not logits_dump:
-        print("No logits dump found in JSON", file=sys.stderr)
-        return False
-
-    all_valid = True
-    for step_idx, step in enumerate(logits_dump):
-        top_logits = step.get('top_logits', [])
-        chosen_id = step.get('chosen_id')
-
-        if not top_logits or chosen_id is None:
-            print(f"Step {step_idx}: Missing data", file=sys.stderr)
-            continue
-
-        # Find the argmax token
-        argmax_token = None
-        max_logit = float('-inf')
-
-        # Check all top logits
-        for entry in top_logits:
-            token_id = entry['token_id']
-            logit_val = entry['logit']
-
-            # Handle NaN/inf
-            if not isinstance(logit_val, (int, float)) or not (-1e10 < logit_val < 1e10):
-                continue
-
-            if logit_val > max_logit:
-                max_logit = logit_val
-                argmax_token = token_id
-
-        # Verify chosen matches argmax
-        if argmax_token != chosen_id:
-            print(f"Step {step_idx}: Greedy violation! argmax={argmax_token} (logit={max_logit:.4f}) but chosen={chosen_id}", file=sys.stderr)
-
-            # Show top-5 for debugging
-            print(f"  Top logits at step {step_idx}:", file=sys.stderr)
-            for i, entry in enumerate(top_logits[:5]):
-                marker = " <-- CHOSEN" if entry['token_id'] == chosen_id else ""
-                print(f"    {i+1}. token={entry['token_id']} logit={entry['logit']:.4f}{marker}", file=sys.stderr)
-
-            all_valid = False
-
-    if all_valid:
-        print(f"✓ Greedy invariant holds for all {len(logits_dump)} steps")
-
-    return all_valid
-
-def main():
-    parser = argparse.ArgumentParser(description='Check greedy argmax invariant')
-    parser.add_argument('json_file', help='Path to CLI JSON output')
-    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check greedy argmax invariant")
+    parser.add_argument("json_file", help="Path to CLI JSON output")
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Accepted for compatibility; Rust checker prints diagnostics on failure.",
+    )
     args = parser.parse_args()
 
-    if not check_greedy_invariant(args.json_file):
-        sys.exit(7)  # EXIT_ARGMAX_MISMATCH
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--locked",
+            "--manifest-path",
+            str(root / "Cargo.toml"),
+            "-p",
+            "bitnet-task",
+            "--",
+            "check-greedy-argmax",
+            args.json_file,
+        ],
+        cwd=root,
+        check=False,
+    )
+    return 7 if result.returncode != 0 else 0
 
-if __name__ == '__main__':
-    main()
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_all.sh
+++ b/scripts/validate_all.sh
@@ -48,7 +48,7 @@ TMP_JSON="$(mktemp)"
   --prompt "Greedy invariant smoke." --max-new-tokens 16 \
   --greedy --deterministic --threads 1 \
   --dump-logit-steps 8 --logits-topk 10 --json-out "$TMP_JSON" >/dev/null
-python3 scripts/check_greedy_argmax.py "$TMP_JSON" || { echo "Greedy invariant failed"; exit 7; }
+cargo run --quiet --locked -p bitnet-task -- check-greedy-argmax "$TMP_JSON" || { echo "Greedy invariant failed"; exit 7; }
 rm -f "$TMP_JSON"
 
 # ---- Logit parity (teacher-forced shared path; τ-b) -------------------------

--- a/tools/bitnet-task/Cargo.toml
+++ b/tools/bitnet-task/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bitnet-generation-events-core = { path = "../../crates/bitnet-generation-events-core", version = "0.2.1-dev" }
 clap = { workspace = true, features = ["derive"] }
 fs2 = "0.4.3"
 serde_json.workspace = true

--- a/tools/bitnet-task/src/main.rs
+++ b/tools/bitnet-task/src/main.rs
@@ -42,8 +42,8 @@ use self::{
     },
     validation::{
         cmd_check_codeowners_teams, cmd_check_coverage, cmd_check_envlock, cmd_check_feature_gates,
-        cmd_check_ignore_annotations, cmd_check_serial_annotations, cmd_check_units,
-        cmd_check_units_imports, cmd_json_schema_gate, cmd_validate_fixtures,
+        cmd_check_greedy_argmax, cmd_check_ignore_annotations, cmd_check_serial_annotations,
+        cmd_check_units, cmd_check_units_imports, cmd_json_schema_gate, cmd_validate_fixtures,
         cmd_validate_iq2s_build, cmd_validate_strict,
     },
 };
@@ -93,6 +93,11 @@ enum Task {
     CheckSerialAnnotations,
     /// Equivalent of scripts/check-codeowners-teams.sh
     CheckCodeownersTeams,
+    /// Equivalent of scripts/check_greedy_argmax.py
+    CheckGreedyArgmax {
+        /// Path to CLI JSON output.
+        json_file: PathBuf,
+    },
     /// Equivalent of scripts/check_coverage.sh
     CheckCoverage {
         /// Coverage report file (JSON).
@@ -291,6 +296,7 @@ fn main() -> Result<()> {
         Task::TestTokenGeneration { model } => cmd_test_token_generation(&root, model),
         Task::CheckSerialAnnotations => cmd_check_serial_annotations(&root),
         Task::CheckCodeownersTeams => cmd_check_codeowners_teams(&root),
+        Task::CheckGreedyArgmax { json_file } => cmd_check_greedy_argmax(&json_file),
         Task::CheckCoverage { coverage_file, threshold } => {
             cmd_check_coverage(&coverage_file, threshold)
         }

--- a/tools/bitnet-task/src/validation.rs
+++ b/tools/bitnet-task/src/validation.rs
@@ -117,6 +117,118 @@ fn coverage_percentage(coverage_data: &Value) -> Result<f64> {
     }
 }
 
+pub(crate) fn cmd_check_greedy_argmax(json_file: &Path) -> Result<()> {
+    use bitnet_generation_events_core::check_greedy_argmax;
+
+    let content = fs::read_to_string(json_file)
+        .with_context(|| format!("failed to read {}", json_file.display()))?;
+    let data: Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse JSON from {}", json_file.display()))?;
+    let logits_dump = data
+        .get("logits_dump")
+        .and_then(Value::as_array)
+        .context("No logits dump found in JSON")?;
+
+    let steps = logits_dump
+        .iter()
+        .enumerate()
+        .map(|(idx, step)| parse_greedy_logit_step(idx, step))
+        .collect::<Result<Vec<_>>>()?;
+    let report = check_greedy_argmax(&steps);
+
+    for missing in &report.missing_evidence {
+        eprintln!("Step {}: Missing data ({})", missing.step, missing.reason);
+    }
+
+    for violation in &report.violations {
+        eprintln!(
+            "Step {}: Greedy violation! argmax={} (logit={:.4}) but chosen={}",
+            violation.step, violation.argmax_token_id, violation.argmax_logit, violation.chosen_id
+        );
+        if let Some(step) = steps.iter().find(|step| step.step == violation.step) {
+            eprintln!("  Top logits at step {}:", violation.step);
+            for (rank, entry) in step.top_logits.iter().take(5).enumerate() {
+                let marker = if entry.token_id == violation.chosen_id { " <-- CHOSEN" } else { "" };
+                eprintln!(
+                    "    {}. token={} logit={:.4}{}",
+                    rank + 1,
+                    entry.token_id,
+                    entry.logit,
+                    marker
+                );
+            }
+        }
+    }
+
+    if report.is_valid() {
+        println!("✓ Greedy invariant holds for all {} steps", report.checked_steps);
+        Ok(())
+    } else {
+        bail!(
+            "greedy argmax invariant failed: {} violation(s), {} missing-evidence step(s)",
+            report.violations.len(),
+            report.missing_evidence.len()
+        )
+    }
+}
+
+fn parse_greedy_logit_step(
+    idx: usize,
+    step: &Value,
+) -> Result<bitnet_generation_events_core::GreedyLogitStep> {
+    let step_no = step.get("step").and_then(Value::as_u64).map_or(idx, |value| value as usize);
+    let chosen_id = step.get("chosen_id").and_then(Value::as_u64).map(|value| value as u32);
+    let top_logits_value = step.get("top_logits").or_else(|| step.get("topk"));
+    let top_logits = top_logits_value
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .enumerate()
+                .map(|(entry_idx, entry)| parse_top_logit(step_no, entry_idx, entry))
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    Ok(bitnet_generation_events_core::GreedyLogitStep { step: step_no, top_logits, chosen_id })
+}
+
+fn parse_top_logit(
+    step: usize,
+    entry_idx: usize,
+    entry: &Value,
+) -> Result<bitnet_generation_events_core::TopLogit> {
+    if let Some(object) = entry.as_object() {
+        let token_id = object
+            .get("token_id")
+            .and_then(Value::as_u64)
+            .with_context(|| format!("step {step} top_logits[{entry_idx}] missing token_id"))?;
+        let logit = object
+            .get("logit")
+            .and_then(Value::as_f64)
+            .with_context(|| format!("step {step} top_logits[{entry_idx}] missing logit"))?;
+        return Ok(bitnet_generation_events_core::TopLogit {
+            token_id: token_id as u32,
+            logit: logit as f32,
+        });
+    }
+
+    let pair = entry.as_array().with_context(|| {
+        format!("step {step} top_logits[{entry_idx}] must be object or [token_id, logit]")
+    })?;
+    if pair.len() != 2 {
+        bail!("step {step} top_logits[{entry_idx}] pair must contain exactly 2 values");
+    }
+    let token_id = pair[0]
+        .as_u64()
+        .with_context(|| format!("step {step} top_logits[{entry_idx}][0] must be token id"))?;
+    let logit = pair[1]
+        .as_f64()
+        .with_context(|| format!("step {step} top_logits[{entry_idx}][1] must be logit"))?;
+    Ok(bitnet_generation_events_core::TopLogit { token_id: token_id as u32, logit: logit as f32 })
+}
+
 pub(crate) fn cmd_check_units_imports(root: &Path) -> Result<()> {
     let mut violations = Vec::new();
     for path in collect_rust_files(root.join("tests"))? {

--- a/tools/bitnet-task/tests/cli_smoke.rs
+++ b/tools/bitnet-task/tests/cli_smoke.rs
@@ -409,3 +409,56 @@ fn vendor_wrapper_injects_master_default() {
         ]
     );
 }
+
+#[test]
+fn check_greedy_argmax_accepts_matching_logit_dump() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let json_path = temp.path().join("greedy.json");
+    fs::write(
+        &json_path,
+        r#"{
+            "logits_dump": [
+                {
+                    "step": 0,
+                    "chosen_id": 9,
+                    "top_logits": [
+                        {"token_id": 7, "logit": 1.5},
+                        {"token_id": 9, "logit": 3.25}
+                    ]
+                }
+            ]
+        }"#,
+    )
+    .expect("write json");
+
+    let output = run_bitnet_task(&["check-greedy-argmax", json_path.to_str().unwrap()]);
+    let stdout = assert_success(&output);
+    assert!(stdout.contains("Greedy invariant holds for all 1 steps"));
+}
+
+#[test]
+fn check_greedy_argmax_rejects_mismatched_logit_dump() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let json_path = temp.path().join("greedy.json");
+    fs::write(
+        &json_path,
+        r#"{
+            "logits_dump": [
+                {
+                    "step": 0,
+                    "chosen_id": 7,
+                    "top_logits": [
+                        {"token_id": 7, "logit": 1.5},
+                        {"token_id": 9, "logit": 3.25}
+                    ]
+                }
+            ]
+        }"#,
+    )
+    .expect("write json");
+
+    let output = run_bitnet_task(&["check-greedy-argmax", json_path.to_str().unwrap()]);
+    let stderr = assert_failure(&output);
+    assert!(stderr.contains("Greedy violation"));
+    assert!(stderr.contains("argmax=9"));
+}


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc Python greedy-argmax checker with a reusable, typed Rust implementation so other tools can call the invariant check from core code instead of duplicating logic.
- Provide a stable `bitnet-task` maintenance command that parses CLI JSON receipts and emits precise diagnostics for greedy/argmax mismatches that were previously detected by scripts.
- Keep backward compatibility for existing CI scripts by converting the legacy Python script into a thin wrapper that delegations to the new Rust command.

### Description
- Added typed evidence and reporting API to `crates/bitnet-generation-events-core` including `TopLogit`, `GreedyLogitStep`, `GreedyArgmaxViolation`, `GreedyArgmaxMissingEvidence`, `GreedyArgmaxReport`, and `check_greedy_argmax(…)` that inspects captured top-k logits and reports violations.
- Implemented `bitnet-task` command `check-greedy-argmax` by adding `cmd_check_greedy_argmax` plus JSON parsing helpers in `tools/bitnet-task/src/validation.rs` and added the `CheckGreedyArgmax` CLI variant in `tools/bitnet-task/src/main.rs` to dispatch it.
- Made `tools/bitnet-task` depend on `bitnet-generation-events-core` via `tools/bitnet-task/Cargo.toml` so the CLI reuses the core implementation.
- Replaced the original `scripts/check_greedy_argmax.py` with a compatibility wrapper that invokes `cargo run -p bitnet-task -- check-greedy-argmax <json>` and updated `scripts/validate_all.sh` to call the Rust-based checker.
- Added smoke/unit tests exercising the new `check-greedy-argmax` command in `tools/bitnet-task/tests/cli_smoke.rs` and included small library tests for the new core helpers; ran `cargo fmt` on touched files.

### Testing
- Ran `cargo test -p bitnet-generation-events-core -p bitnet-task` and all tests passed (new unit tests and smoke tests included). 
- Ran formatting and lints: `cargo fmt --all --check` passed and `cargo clippy --locked -p bitnet-generation-events-core -p bitnet-task --bins -- -D warnings` passed for the changed crates. 
- Executed the new command end-to-end with `cargo run --quiet --locked -p bitnet-task -- check-greedy-argmax <sample-json>` and the compatibility wrapper `python3 scripts/check_greedy_argmax.py <sample-json>`, both succeeded and printed expected diagnostics. 
- Attempted `cargo clippy --locked -p bitnet-generation-events-core -p bitnet-task --all-targets -- -D warnings` which failed due to an existing `clippy::items-after-test-module` lint in `tools/bitnet-task/src/ci.rs` outside of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d19c1fac83338b2cf9d4568cbf0f)