### PR TITLE
feat: port performance comparison into Rust core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,8 @@ name = "bitnet-bench-regression-core"
 version = "0.1.0"
 dependencies = [
  "bitnet-bench-receipts",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10037,6 +10039,7 @@ dependencies = [
  "assert_cmd",
  "bitnet",
  "bitnet-bdd-grid",
+ "bitnet-bench-regression-core",
  "bitnet-common",
  "bitnet-crossval",
  "bitnet-download",

--- a/crates/bitnet-bench-regression-core/Cargo.toml
+++ b/crates/bitnet-bench-regression-core/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitnet-bench-receipts = { path = "../bitnet-bench-receipts" }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bitnet-bench-regression-core/src/lib.rs
+++ b/crates/bitnet-bench-regression-core/src/lib.rs
@@ -1,6 +1,10 @@
+#![allow(clippy::module_name_repetitions)]
 //! Regression detection by comparing baseline vs current benchmark receipts.
 
 use bitnet_bench_receipts::BenchReceipt;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 /// The outcome of comparing a single kernel's performance against its baseline.
 #[derive(Debug, Clone)]
@@ -27,8 +31,6 @@ impl RegressionDetector {
         current: &[BenchReceipt],
         threshold_pct: f64,
     ) -> Vec<RegressionResult> {
-        use std::collections::HashMap;
-
         let baseline_map: HashMap<&str, u64> =
             baseline.iter().map(|r| (r.kernel_name.as_str(), r.elapsed_us)).collect();
 
@@ -61,9 +63,277 @@ impl RegressionDetector {
     }
 }
 
+/// One normalized timing-style benchmark metric extracted from JSON.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerformanceMetric {
+    pub name: String,
+    pub value: f64,
+}
+
+/// Classification for one benchmark metric comparison.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PerformanceStatus {
+    New,
+    Removed,
+    Maintained,
+    Regression,
+    Improvement,
+}
+
+/// Comparison details for a single metric.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerformanceSummaryEntry {
+    pub status: PerformanceStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ratio: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_percent: Option<f64>,
+}
+
+/// A metric that regressed beyond the allowed ratio threshold.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerformanceRegression {
+    pub benchmark: String,
+    pub baseline: f64,
+    pub current: f64,
+    pub ratio: f64,
+    pub change_percent: f64,
+}
+
+/// A metric that improved beyond the configured improvement ratio.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerformanceImprovement {
+    pub benchmark: String,
+    pub baseline: f64,
+    pub current: f64,
+    pub ratio: f64,
+    pub change_percent: f64,
+}
+
+/// Full performance comparison result used by release-validation tooling.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerformanceComparison {
+    pub passed: bool,
+    pub regressions: Vec<PerformanceRegression>,
+    pub improvements: Vec<PerformanceImprovement>,
+    pub summary: BTreeMap<String, PerformanceSummaryEntry>,
+}
+
+impl PerformanceComparison {
+    /// Render a deterministic Markdown report.
+    #[must_use]
+    pub fn to_markdown(&self) -> String {
+        let mut report = Vec::new();
+        report.push("# Performance Comparison Report".to_string());
+        report.push(String::new());
+        report.push(if self.passed {
+            "✅ **Performance validation PASSED**".to_string()
+        } else {
+            "❌ **Performance validation FAILED**".to_string()
+        });
+        report.push(String::new());
+        report.push("## Summary".to_string());
+        report.push(format!("- Total benchmarks: {}", self.summary.len()));
+        report.push(format!("- Regressions: {}", self.regressions.len()));
+        report.push(format!("- Improvements: {}", self.improvements.len()));
+        report.push(String::new());
+
+        if !self.regressions.is_empty() {
+            report.push("## ❌ Performance Regressions".to_string());
+            for regression in &self.regressions {
+                report.push(format!(
+                    "- **{}**: {:+.2}% ({:.3}s → {:.3}s)",
+                    regression.benchmark,
+                    regression.change_percent,
+                    regression.baseline,
+                    regression.current
+                ));
+            }
+            report.push(String::new());
+        }
+
+        if !self.improvements.is_empty() {
+            report.push("## ✅ Performance Improvements".to_string());
+            for improvement in &self.improvements {
+                report.push(format!(
+                    "- **{}**: {:+.2}% ({:.3}s → {:.3}s)",
+                    improvement.benchmark,
+                    improvement.change_percent,
+                    improvement.baseline,
+                    improvement.current
+                ));
+            }
+            report.push(String::new());
+        }
+
+        report.push("## Detailed Results".to_string());
+        for (benchmark, data) in &self.summary {
+            let status_icon = match data.status {
+                PerformanceStatus::Regression => "❌",
+                PerformanceStatus::Improvement => "✅",
+                PerformanceStatus::Maintained => "➖",
+                PerformanceStatus::New => "🆕",
+                PerformanceStatus::Removed => "🗑️",
+            };
+            if let Some(change_percent) = data.change_percent {
+                report.push(format!("- {status_icon} **{benchmark}**: {change_percent:+.2}%"));
+            } else {
+                report.push(format!("- {status_icon} **{benchmark}**: {:?}", data.status));
+            }
+        }
+
+        report.join("\n")
+    }
+}
+
+/// Extract legacy benchmark metrics from the release-validation JSON shape.
+///
+/// Accepted entries are objects inside a top-level `benchmarks` array. The
+/// metric value is selected in the same priority order as the historical Python
+/// helper: `value`, then `mean`, then `median`.
+#[must_use]
+pub fn extract_legacy_benchmark_metrics(results: &Value) -> BTreeMap<String, f64> {
+    let mut metrics = BTreeMap::new();
+    let Some(benchmarks) = results.get("benchmarks").and_then(Value::as_array) else {
+        return metrics;
+    };
+
+    for benchmark in benchmarks {
+        let Some(name) = benchmark.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let value = benchmark
+            .get("value")
+            .or_else(|| benchmark.get("mean"))
+            .or_else(|| benchmark.get("median"))
+            .and_then(Value::as_f64);
+        if let Some(value) = value {
+            metrics.insert(name.to_string(), value);
+        }
+    }
+
+    metrics
+}
+
+/// Merge metrics from inference and kernel benchmark result files.
+#[must_use]
+pub fn merge_benchmark_metrics(
+    inference: BTreeMap<String, f64>,
+    kernels: BTreeMap<String, f64>,
+) -> BTreeMap<String, f64> {
+    inference.into_iter().chain(kernels).collect()
+}
+
+/// Compare timing metrics with the historical ratio threshold semantics.
+///
+/// Lower values are better. A `threshold_ratio` of `0.95` allows a regression
+/// up to `1 / 0.95` (about 5.26%) and records improvements below `0.95`.
+#[must_use]
+pub fn compare_performance_metrics(
+    baseline_metrics: &BTreeMap<String, f64>,
+    current_metrics: &BTreeMap<String, f64>,
+    threshold_ratio: f64,
+) -> PerformanceComparison {
+    let mut comparison = PerformanceComparison {
+        passed: true,
+        regressions: Vec::new(),
+        improvements: Vec::new(),
+        summary: BTreeMap::new(),
+    };
+
+    let all_benchmarks: BTreeSet<String> =
+        baseline_metrics.keys().chain(current_metrics.keys()).cloned().collect();
+
+    for benchmark in all_benchmarks {
+        match (baseline_metrics.get(&benchmark), current_metrics.get(&benchmark)) {
+            (None, Some(&current)) => {
+                comparison.summary.insert(
+                    benchmark,
+                    PerformanceSummaryEntry {
+                        status: PerformanceStatus::New,
+                        baseline: None,
+                        current: Some(current),
+                        ratio: None,
+                        change_percent: None,
+                    },
+                );
+            }
+            (Some(&baseline), None) => {
+                comparison.summary.insert(
+                    benchmark,
+                    PerformanceSummaryEntry {
+                        status: PerformanceStatus::Removed,
+                        baseline: Some(baseline),
+                        current: None,
+                        ratio: None,
+                        change_percent: None,
+                    },
+                );
+            }
+            (Some(&baseline), Some(&current)) if baseline > 0.0 => {
+                let ratio = current / baseline;
+                let change_percent = (ratio - 1.0) * 100.0;
+                let status = if ratio > (1.0 / threshold_ratio) {
+                    comparison.passed = false;
+                    comparison.regressions.push(PerformanceRegression {
+                        benchmark: benchmark.clone(),
+                        baseline,
+                        current,
+                        ratio,
+                        change_percent,
+                    });
+                    PerformanceStatus::Regression
+                } else if ratio < threshold_ratio {
+                    comparison.improvements.push(PerformanceImprovement {
+                        benchmark: benchmark.clone(),
+                        baseline,
+                        current,
+                        ratio,
+                        change_percent,
+                    });
+                    PerformanceStatus::Improvement
+                } else {
+                    PerformanceStatus::Maintained
+                };
+                comparison.summary.insert(
+                    benchmark,
+                    PerformanceSummaryEntry {
+                        status,
+                        baseline: Some(baseline),
+                        current: Some(current),
+                        ratio: Some(ratio),
+                        change_percent: Some(change_percent),
+                    },
+                );
+            }
+            (Some(&baseline), Some(&current)) => {
+                comparison.summary.insert(
+                    benchmark,
+                    PerformanceSummaryEntry {
+                        status: PerformanceStatus::Maintained,
+                        baseline: Some(baseline),
+                        current: Some(current),
+                        ratio: None,
+                        change_percent: None,
+                    },
+                );
+            }
+            (None, None) => unreachable!("benchmark set is built from existing keys"),
+        }
+    }
+
+    comparison
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn receipt(name: &str, elapsed_us: u64) -> BenchReceipt {
         BenchReceipt::new(name, [256, 1, 1], [1, 1, 1], elapsed_us, 0.0, 0, "", "")
@@ -145,5 +415,58 @@ mod tests {
         let results = RegressionDetector::check(&baseline, &current, 10.0);
         assert!(!results[0].is_regression);
         assert_eq!(results[0].baseline_us, 0);
+    }
+
+    #[test]
+    fn extracts_legacy_benchmark_array_values_by_priority() {
+        let input = json!({
+            "benchmarks": [
+                {"name": "value_case", "value": 1.0, "mean": 2.0},
+                {"name": "mean_case", "mean": 3.0, "median": 4.0},
+                {"name": "median_case", "median": 5.0},
+                {"name": "ignored_without_value"}
+            ]
+        });
+
+        let metrics = extract_legacy_benchmark_metrics(&input);
+        assert_eq!(metrics.get("value_case"), Some(&1.0));
+        assert_eq!(metrics.get("mean_case"), Some(&3.0));
+        assert_eq!(metrics.get("median_case"), Some(&5.0));
+        assert!(!metrics.contains_key("ignored_without_value"));
+    }
+
+    #[test]
+    fn compares_legacy_metrics_with_deterministic_statuses() {
+        let baseline = BTreeMap::from([
+            ("faster".to_string(), 100.0),
+            ("stable".to_string(), 100.0),
+            ("slower".to_string(), 100.0),
+            ("removed".to_string(), 100.0),
+        ]);
+        let current = BTreeMap::from([
+            ("faster".to_string(), 90.0),
+            ("stable".to_string(), 102.0),
+            ("slower".to_string(), 110.0),
+            ("new".to_string(), 50.0),
+        ]);
+
+        let comparison = compare_performance_metrics(&baseline, &current, 0.95);
+
+        assert!(!comparison.passed);
+        assert_eq!(comparison.regressions[0].benchmark, "slower");
+        assert_eq!(comparison.improvements[0].benchmark, "faster");
+        assert_eq!(comparison.summary["new"].status, PerformanceStatus::New);
+        assert_eq!(comparison.summary["removed"].status, PerformanceStatus::Removed);
+        assert_eq!(comparison.summary["stable"].status, PerformanceStatus::Maintained);
+    }
+
+    #[test]
+    fn markdown_rendering_does_not_require_missing_change_field() {
+        let baseline = BTreeMap::from([("new_only".to_string(), 1.0)]);
+        let current = BTreeMap::new();
+        let comparison = compare_performance_metrics(&baseline, &current, 0.95);
+        let report = comparison.to_markdown();
+        assert!(report.contains("Performance Comparison Report"));
+        assert!(report.contains("🗑️ **new_only**"));
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -41,6 +41,7 @@ xtask-build-helper = { path = "../xtask-build-helper", version = "0.2.1-dev" }
 bitnet-crossval = { path = "../crossval", version = "0.2.1-dev", default-features = false, optional = true }
 bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.1-dev", default-features = false, optional = true }
 bitnet-bdd-grid = { path = "../crates/bitnet-bdd-grid", version = "0.2.1-dev" }
+bitnet-bench-regression-core = { path = "../crates/bitnet-bench-regression-core" }
 scopeguard = "1.2.0"
 thiserror = "2.0.17"
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,7 @@
 use anyhow::{Context, Result, anyhow, bail};
+use bitnet_bench_regression_core::{
+    compare_performance_metrics, extract_legacy_benchmark_metrics, merge_benchmark_metrics,
+};
 use bitnet_common::Device;
 use bitnet_download::{
     atomic_write, exp_backoff_ms, offline_enabled as bitnet_offline_enabled,
@@ -976,6 +979,28 @@ enum Cmd {
         /// Output format (human, json)
         #[arg(long, default_value = "human")]
         format: String,
+    },
+
+    /// Compare legacy release-validation performance JSON files.
+    ///
+    /// Rust replacement for scripts/compare_performance.py. Accepts the same
+    /// four-file benchmark layout and optional JSON output.
+    #[command(name = "compare-performance")]
+    ComparePerformance {
+        /// Baseline inference benchmark results
+        baseline_inference: PathBuf,
+        /// Current inference benchmark results
+        current_inference: PathBuf,
+        /// Baseline kernels benchmark results
+        baseline_kernels: PathBuf,
+        /// Current kernels benchmark results
+        current_kernels: PathBuf,
+        /// Output comparison results to JSON file
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Performance threshold ratio (0.95 = allow about 5% regression)
+        #[arg(long, default_value_t = 0.95)]
+        threshold: f64,
     },
 
     /// Compare benchmark results against baseline with regression thresholds
@@ -2011,6 +2036,21 @@ fn real_main() -> Result<()> {
             auto_download,
             deterministic,
             &format,
+        ),
+        Cmd::ComparePerformance {
+            baseline_inference,
+            current_inference,
+            baseline_kernels,
+            current_kernels,
+            output,
+            threshold,
+        } => compare_performance_cmd(
+            &baseline_inference,
+            &current_inference,
+            &baseline_kernels,
+            &current_kernels,
+            output.as_deref(),
+            threshold,
         ),
         Cmd::BenchCompare {
             current,
@@ -3719,6 +3759,57 @@ fn auto_detect_baseline(device: &str, category: &str) -> Result<PathBuf> {
 }
 
 /// Load benchmark results from JSON file
+fn compare_performance_cmd(
+    baseline_inference: &Path,
+    current_inference: &Path,
+    baseline_kernels: &Path,
+    current_kernels: &Path,
+    output: Option<&Path>,
+    threshold: f64,
+) -> Result<()> {
+    if !(0.0..=1.0).contains(&threshold) || threshold == 0.0 {
+        bail!("threshold must be greater than 0 and less than or equal to 1");
+    }
+
+    let baseline_inference = load_benchmark_results(baseline_inference)?;
+    let current_inference = load_benchmark_results(current_inference)?;
+    let baseline_kernels = load_benchmark_results(baseline_kernels)?;
+    let current_kernels = load_benchmark_results(current_kernels)?;
+
+    let baseline_metrics = merge_benchmark_metrics(
+        extract_legacy_benchmark_metrics(&baseline_inference),
+        extract_legacy_benchmark_metrics(&baseline_kernels),
+    );
+    let current_metrics = merge_benchmark_metrics(
+        extract_legacy_benchmark_metrics(&current_inference),
+        extract_legacy_benchmark_metrics(&current_kernels),
+    );
+
+    let comparison = compare_performance_metrics(&baseline_metrics, &current_metrics, threshold);
+    let report = comparison.to_markdown();
+    println!("{report}");
+
+    if let Some(path) = output {
+        let mut value = serde_json::to_value(&comparison)?;
+        if let Value::Object(ref mut object) = value {
+            object.insert("report".to_string(), Value::String(report));
+        }
+        fs::write(path, serde_json::to_string_pretty(&value)?)
+            .with_context(|| format!("Failed to write comparison results to {}", path.display()))?;
+        println!("\nComparison results saved to: {}", path.display());
+    }
+
+    if !comparison.passed {
+        bail!(
+            "Performance validation failed: {} regressions detected",
+            comparison.regressions.len()
+        );
+    }
+
+    println!("\n✅ Performance validation passed");
+    Ok(())
+}
+
 fn load_benchmark_results(path: &Path) -> Result<Value> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read benchmark file: {}", path.display()))?;


### PR DESCRIPTION
### Motivation
- Replace the legacy Python `compare_performance.py` helper with a native Rust implementation so performance comparison logic lives in the workspace core and can be reused by CI and xtask without a Python dependency.
- Provide deterministic, serialisable comparison results (Markdown + optional JSON) for release-validation and CI regression gates.

### Description
- Ported legacy benchmark comparison semantics into `crates/bitnet-bench-regression-core` by adding metric extraction from legacy `benchmarks[]` JSON, merging inference+kernel metrics, and ratio-threshold regression/improvement classification, plus deterministic Markdown rendering and serialisable result types; see `crates/bitnet-bench-regression-core/src/lib.rs`.
- Added `serde`/`serde_json` usage to the new core comparison code and updated `crates/bitnet-bench-regression-core/Cargo.toml` to expose serialization for CI artifacts.
- Added an `xtask compare-performance` subcommand that wires the new core APIs into the xtask CLI, accepts the historical four JSON inputs plus `--output` and `--threshold`, writes optional JSON artifacts, prints a Markdown report, and exits non-zero on regressions; see `xtask/src/main.rs` and `xtask/Cargo.toml`.
- Updated workspace metadata / lockfile to include the new crate dependency and ensure the xtask binary can call into the new core module (`Cargo.lock` updated).

### Testing
- Ran `cargo test -p bitnet-bench-regression-core --locked` and all unit tests passed (12 passed, 0 failed).
- Ran `cargo check -p xtask --no-default-features` which completed successfully to validate xtask integration.
- Performed a smoke run of the new command with synthetic JSON inputs using `cargo run -p xtask --no-default-features -- compare-performance <base_inf> <cur_inf> <base_kern> <cur_kern> --output out.json --threshold 0.95` and verified output Markdown and written JSON; the run returned success (no regressions) as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d19c1fac83338b2cf9d4568cbf0f)