### PR TITLE
fix: improve softmax edge-case accuracy

### DIFF
--- a/crates/bitnet-logits/src/lib.rs
+++ b/crates/bitnet-logits/src/lib.rs
@@ -69,11 +69,14 @@ pub fn apply_temperature(logits: &mut [f32], temperature: f32) {
 
 /// Convert raw logits to a probability distribution in-place via softmax.
 ///
-/// Uses the numerically-stable "subtract max" form.  `f32::NEG_INFINITY`
-/// entries (from [`apply_top_k`]) become `0.0` after exponentiation.
+/// Uses the numerically-stable "subtract max" form. `f32::NEG_INFINITY`
+/// entries (from [`apply_top_k`]) become `0.0` after exponentiation. The
+/// normalization sum is accumulated in `f64` before rounding probabilities back
+/// to `f32`, which reduces drift for large vocabularies.
 ///
-/// Falls back to a uniform distribution when all exponentiated values underflow
-/// to zero (rare with finite logits).
+/// Degenerate non-finite inputs are handled explicitly: all-masked
+/// (`-∞`-only) inputs remain all zero, while one or more `+∞` logits share the
+/// probability mass uniformly and suppress finite logits.
 ///
 /// # Examples
 ///
@@ -91,8 +94,28 @@ pub fn softmax_in_place(logits: &mut [f32]) {
     if logits.is_empty() {
         return;
     }
+
+    let pos_inf_count = logits.iter().filter(|&&l| l == f32::INFINITY).count();
+    if pos_inf_count > 0 {
+        #[allow(clippy::cast_precision_loss)]
+        let probability = 1.0_f32 / pos_inf_count as f32;
+        for l in logits.iter_mut() {
+            *l = if *l == f32::INFINITY { probability } else { 0.0 };
+        }
+        return;
+    }
+
     let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    let mut sum = 0.0f32;
+    if max == f32::NEG_INFINITY {
+        // Preserve a fully masked distribution instead of reintroducing
+        // probability mass into tokens that upstream filters removed.
+        for l in logits.iter_mut() {
+            *l = 0.0;
+        }
+        return;
+    }
+
+    let mut sum = 0.0f64;
     for l in logits.iter_mut() {
         let v = *l;
         // Optimization: skip exp() for NEG_INFINITY which always yields 0.0.
@@ -102,23 +125,13 @@ pub fn softmax_in_place(logits: &mut [f32]) {
         } else {
             let exp = (v - max).exp();
             *l = exp;
-            sum += exp;
+            sum += f64::from(exp);
         }
     }
-    if sum > 0.0 {
-        let inv_sum = 1.0 / sum;
-        for l in logits.iter_mut() {
-            *l *= inv_sum;
-        }
-    } else {
-        // Degenerate case: all exponentiated values underflowed to 0.
-        // Fall back to a uniform distribution so downstream sampling receives
-        // a valid probability distribution.
-        #[allow(clippy::cast_precision_loss)]
-        let uniform = 1.0_f32 / logits.len() as f32;
-        for l in logits.iter_mut() {
-            *l = uniform;
-        }
+
+    let inv_sum = (1.0 / sum) as f32;
+    for l in logits.iter_mut() {
+        *l *= inv_sum;
     }
 }
 
@@ -232,6 +245,20 @@ mod tests {
         softmax_in_place(&mut logits);
         assert!(logits[1] > logits[2]);
         assert!(logits[2] > logits[0]);
+    }
+
+    #[test]
+    fn softmax_all_masked_stays_zero() {
+        let mut logits = vec![f32::NEG_INFINITY; 4];
+        softmax_in_place(&mut logits);
+        assert_eq!(logits, vec![0.0; 4]);
+    }
+
+    #[test]
+    fn softmax_positive_infinity_takes_all_mass() {
+        let mut logits = vec![1.0f32, f32::INFINITY, 2.0, f32::INFINITY];
+        softmax_in_place(&mut logits);
+        assert_eq!(logits, vec![0.0, 0.5, 0.0, 0.5]);
     }
 
     #[test]

--- a/crates/bitnet-logits/tests/logits_filter_edge_cases.rs
+++ b/crates/bitnet-logits/tests/logits_filter_edge_cases.rs
@@ -142,15 +142,13 @@ fn softmax_with_neg_infinity_entries() {
 }
 
 #[test]
-fn softmax_all_neg_infinity_gives_uniform() {
+fn softmax_all_neg_infinity_stays_zero() {
     let mut v = vec![f32::NEG_INFINITY; 4];
     softmax_in_place(&mut v);
-    // All exp(-inf - (-inf)) = exp(0) for max=-inf? Actually max = -inf,
-    // so v - max = -inf - (-inf) = NaN → exp(NaN) = NaN.
-    // The implementation checks `v == NEG_INFINITY` and sets to 0.0,
-    // then sum==0 triggers uniform fallback.
+    // Fully masked logits should not reintroduce probability mass into
+    // tokens that upstream filters already removed.
     for &p in &v {
-        assert_approx(p, 0.25, 1e-6);
+        assert_approx(p, 0.0, 1e-6);
     }
 }
 
@@ -158,12 +156,10 @@ fn softmax_all_neg_infinity_gives_uniform() {
 fn softmax_with_positive_infinity() {
     let mut v = vec![1.0, f32::INFINITY, 3.0];
     softmax_in_place(&mut v);
-    // max = inf, so exp(inf - inf) = exp(NaN) = NaN → sum is NaN,
-    // which fails the `sum > 0.0` check, triggering the uniform fallback.
-    let expected = 1.0 / 3.0;
-    for &p in &v {
-        assert_approx(p, expected, 1e-6);
-    }
+    // The +∞ logit dominates the finite logits in the softmax limit.
+    assert_approx(v[0], 0.0, 1e-6);
+    assert_approx(v[1], 1.0, 1e-6);
+    assert_approx(v[2], 0.0, 1e-6);
 }
 
 #[test]

--- a/crates/bitnet-logits/tests/logits_pipeline_integration.rs
+++ b/crates/bitnet-logits/tests/logits_pipeline_integration.rs
@@ -212,12 +212,12 @@ fn softmax_handles_neg_infinity() {
 }
 
 #[test]
-fn softmax_all_neg_infinity_uniform() {
+fn softmax_all_neg_infinity_stays_zero() {
     let mut logits = vec![f32::NEG_INFINITY; 5];
     softmax_in_place(&mut logits);
-    // Should fall back to uniform
+    // Fully masked logits should stay masked instead of falling back to uniform.
     for &p in &logits {
-        assert!((p - 0.2).abs() < 1e-5);
+        assert_eq!(p, 0.0);
     }
 }
 

--- a/crates/bitnet-logits/tests/logits_proptests.rs
+++ b/crates/bitnet-logits/tests/logits_proptests.rs
@@ -411,14 +411,14 @@ proptest! {
         );
     }
 
-    /// A single-element NEG_INFINITY input (degenerate): softmax falls back to uniform (= 1.0).
+    /// A single-element NEG_INFINITY input is already fully masked, so it stays zero.
     #[test]
-    fn single_element_neginf_softmax_is_one(_seed in 0u32..=100u32) {
+    fn single_element_neginf_softmax_is_zero(_seed in 0u32..=100u32) {
         let mut logits = vec![f32::NEG_INFINITY];
         softmax_in_place(&mut logits);
         prop_assert!(
-            (logits[0] - 1.0).abs() < 1e-6,
-            "single NEG_INFINITY softmax expected 1.0 (uniform fallback), got {}",
+            logits[0] == 0.0,
+            "single NEG_INFINITY softmax expected 0.0 (fully masked), got {}",
             logits[0]
         );
     }


### PR DESCRIPTION
### Motivation

- Reduce numerical drift in softmax normalization for large vocabularies by avoiding f32 accumulation error. 
- Correct incorrect fallback behavior for degenerate inputs so upstream masking is respected and +∞ logits dominate as mathematically expected.

### Description

- Change `softmax_in_place` to accumulate the normalization sum in `f64` and then round back to `f32` to improve numeric accuracy.
- Add explicit handling for `+∞` logits so tokens with `f32::INFINITY` share probability mass and suppress finite logits. 
- Preserve fully-masked inputs (`-∞`-only) by leaving them as zero instead of falling back to a uniform distribution. 
- Update and add tests covering all-masked and positive-infinity softmax edge cases in `crates/bitnet-logits/src/lib.rs`, `crates/bitnet-logits/tests/logits_filter_edge_cases.rs`, `crates/bitnet-logits/tests/logits_pipeline_integration.rs`, and `crates/bitnet-logits/tests/logits_proptests.rs`.

### Testing

- Ran formatting check with `cargo fmt --all -- --check`, which passed. 
- Ran the crate test suite with `cargo test -p bitnet-logits --locked --no-default-features --features cpu`, and all unit, integration, and property tests passed. 
- Ran lints with `cargo clippy -p bitnet-logits --locked --all-targets --no-default-features --features cpu -- -D warnings`, which produced no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1a1845c8333a6b1391c389a171b)