### PR TITLE
Improve dense inference numerical accuracy

### DIFF
--- a/crates/bitnet-inference/src/dense_forward.rs
+++ b/crates/bitnet-inference/src/dense_forward.rs
@@ -29,10 +29,10 @@ pub fn rms_norm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
 pub fn rms_norm_into(x: &[f32], weight: &[f32], eps: f32, out: &mut [f32]) {
     assert_eq!(x.len(), weight.len(), "rms_norm: x.len() != weight.len()");
     assert!(out.len() >= x.len(), "rms_norm_into: out buffer too small");
-    let n = x.len() as f32;
-    let sum_sq: f32 = x.iter().map(|v| v * v).sum();
-    let rms = (sum_sq / n + eps).sqrt();
-    let inv_rms = 1.0 / rms;
+    let n = x.len() as f64;
+    let sum_sq: f64 = x.iter().map(|&v| f64::from(v) * f64::from(v)).sum();
+    let rms = (sum_sq / n + f64::from(eps)).sqrt();
+    let inv_rms = (1.0 / rms) as f32;
     for (i, (xi, wi)) in x.iter().zip(weight.iter()).enumerate() {
         out[i] = xi * inv_rms * wi;
     }
@@ -96,14 +96,14 @@ impl DenseLinear {
             let x_row = &x[b * self.in_features..(b + 1) * self.in_features];
             for o in 0..self.out_features {
                 let w_row = &self.weight[o * self.in_features..(o + 1) * self.in_features];
-                let mut acc = 0.0f32;
+                let mut acc = 0.0f64;
                 for (xi, wi) in x_row.iter().zip(w_row.iter()) {
-                    acc += xi * wi;
+                    acc += f64::from(*xi) * f64::from(*wi);
                 }
                 if let Some(ref bias) = self.bias {
-                    acc += bias[o];
+                    acc += f64::from(bias[o]);
                 }
-                out[b * self.out_features + o] = acc;
+                out[b * self.out_features + o] = acc as f32;
             }
         }
     }
@@ -245,13 +245,13 @@ impl DenseAttention {
             for i in 0..seq_len {
                 ws.scores[..seq_len].fill(f32::NEG_INFINITY);
                 for j in 0..=i {
-                    let mut dot = 0.0f32;
+                    let mut dot = 0.0f64;
                     for d in 0..head_dim {
                         let qi = ws.q[i * num_heads * head_dim + h * head_dim + d];
                         let kj = ws.k[j * num_kv_heads * head_dim + kv_h * head_dim + d];
-                        dot += qi * kj;
+                        dot += f64::from(qi) * f64::from(kj);
                     }
-                    ws.scores[j] = dot * scale;
+                    ws.scores[j] = (dot * f64::from(scale)) as f32;
                 }
 
                 let max_score = ws.scores[..=i].iter().copied().fold(f32::NEG_INFINITY, f32::max);
@@ -317,13 +317,13 @@ impl DenseAttention {
                 scores[..seq_len].fill(f32::NEG_INFINITY);
 
                 for j in 0..=i {
-                    let mut dot = 0.0f32;
+                    let mut dot = 0.0f64;
                     for d in 0..head_dim {
                         let qi = q_flat[i * num_heads * head_dim + h * head_dim + d];
                         let kj = k_flat[j * num_kv_heads * head_dim + kv_h * head_dim + d];
-                        dot += qi * kj;
+                        dot += f64::from(qi) * f64::from(kj);
                     }
-                    scores[j] = dot * scale;
+                    scores[j] = (dot * f64::from(scale)) as f32;
                 }
 
                 // Numerically-stable softmax over [0..=i]

--- a/crates/bitnet-inference/tests/dense_model_validation.rs
+++ b/crates/bitnet-inference/tests/dense_model_validation.rs
@@ -143,6 +143,46 @@ fn rmsnorm_with_learned_weights() {
     assert!((output[1] - 0.5).abs() < 0.01);
 }
 
+/// Dense forward RMSNorm should accumulate squares in enough precision to avoid
+/// overflowing on large-but-finite f32 activations.
+#[test]
+fn dense_rms_norm_handles_large_finite_activations() {
+    use bitnet_inference::rms_norm;
+
+    let input = vec![1.0e20f32, -1.0e20f32];
+    let weight = vec![1.0f32, 1.0f32];
+    let output = rms_norm(&input, &weight, 0.0);
+
+    assert!(output.iter().all(|v| v.is_finite()), "RMSNorm output must stay finite: {output:?}");
+    assert!(
+        (output[0] - 1.0).abs() < 1e-6,
+        "positive activation should normalize to 1, got {}",
+        output[0]
+    );
+    assert!(
+        (output[1] + 1.0).abs() < 1e-6,
+        "negative activation should normalize to -1, got {}",
+        output[1]
+    );
+}
+
+/// DenseLinear should not lose small residual terms during cancellation-heavy
+/// dot products, which can change downstream logits and greedy token choices.
+#[test]
+fn dense_linear_preserves_cancellation_residual() {
+    use bitnet_inference::DenseLinear;
+
+    let layer = DenseLinear::new(vec![1.0, 1.0, 1.0], None, 3, 1);
+    let output = layer.forward(&[1.0e8, 1.0, -1.0e8]);
+
+    assert_eq!(output.len(), 1);
+    assert!(
+        (output[0] - 1.0).abs() < 1e-6,
+        "cancellation residual should be preserved, got {}",
+        output[0]
+    );
+}
+
 // ---------------------------------------------------------------------------
 // SiLU + RMSNorm pipeline test
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Reduce numerical instability in dense FP32 inference paths where large activations or cancellation can produce incorrect results or overflow when accumulated in `f32`.
- Preserve small residuals in dense matmuls and attention dot products so downstream logits and greedy selection remain accurate.

### Description
- Accumulate RMSNorm sum-of-squares in `f64` in `rms_norm_into` and cast the reciprocal RMS back to `f32` to avoid overflow on very large-but-finite activations (`crates/bitnet-inference/src/dense_forward.rs`).
- Accumulate dense linear dot-products and bias addition in `f64` in `DenseLinear::forward_into` and cast back to `f32` to preserve cancellation-sensitive residuals.
- Compute Q/K dot-products in the dense attention path using `f64` accumulation in both `DenseAttention::forward_into` and `DenseAttention::forward` and cast scores back to `f32` for subsequent softmax.
- Add regression tests covering large finite RMSNorm activations and cancellation-heavy dense linear outputs (`dense_rms_norm_handles_large_finite_activations` and `dense_linear_preserves_cancellation_residual` in `crates/bitnet-inference/tests/dense_model_validation.rs`).

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test --locked -p bitnet-inference --test dense_model_validation --no-default-features --features cpu` and all tests passed.
- Ran `cargo test --locked -p bitnet-inference --lib dense_forward --no-default-features --features cpu` and all unit tests passed.
- Ran `cargo clippy --locked -p bitnet-inference --tests --no-default-features --features cpu -- -D warnings` and the linter passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1a1845c8333a6b1391c389a171b)