### PR TITLE
fix: improve sampling probability accuracy

### DIFF
--- a/crates/bitnet-logits/src/lib.rs
+++ b/crates/bitnet-logits/src/lib.rs
@@ -92,7 +92,7 @@ pub fn softmax_in_place(logits: &mut [f32]) {
         return;
     }
     let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    let mut sum = 0.0f32;
+    let mut sum = 0.0f64;
     for l in logits.iter_mut() {
         let v = *l;
         // Optimization: skip exp() for NEG_INFINITY which always yields 0.0.
@@ -102,11 +102,11 @@ pub fn softmax_in_place(logits: &mut [f32]) {
         } else {
             let exp = (v - max).exp();
             *l = exp;
-            sum += exp;
+            sum += f64::from(exp);
         }
     }
-    if sum > 0.0 {
-        let inv_sum = 1.0 / sum;
+    if sum > 0.0 && sum.is_finite() {
+        let inv_sum = (1.0 / sum) as f32;
         for l in logits.iter_mut() {
             *l *= inv_sum;
         }
@@ -232,6 +232,16 @@ mod tests {
         softmax_in_place(&mut logits);
         assert!(logits[1] > logits[2]);
         assert!(logits[2] > logits[0]);
+    }
+
+    #[test]
+    fn softmax_large_uniform_distribution_stays_normalized() {
+        let mut logits = vec![0.0_f32; 100_000];
+        softmax_in_place(&mut logits);
+
+        let sum: f64 = logits.iter().map(|&p| f64::from(p)).sum();
+        assert!((sum - 1.0).abs() < 1e-6, "softmax sum was {sum}");
+        assert!(logits.iter().all(|p| p.is_finite() && *p > 0.0));
     }
 
     #[test]

--- a/crates/bitnet-probability/src/lib.rs
+++ b/crates/bitnet-probability/src/lib.rs
@@ -12,12 +12,12 @@ pub fn renormalize_in_place(probs: &mut [f32]) -> bool {
         return false;
     }
 
-    let sum: f32 = probs.iter().sum();
+    let sum: f64 = probs.iter().map(|&prob| f64::from(prob)).sum();
     if sum <= 0.0 || !sum.is_finite() {
         return false;
     }
 
-    let inv_sum = 1.0 / sum;
+    let inv_sum = (1.0 / sum) as f32;
     for p in probs.iter_mut() {
         *p *= inv_sum;
     }
@@ -38,9 +38,10 @@ pub fn sample_categorical(probabilities: &[f32], random_value: f32) -> Option<us
 
     let rv = random_value.clamp(0.0, 1.0 - f32::EPSILON);
 
-    let mut cumulative = 0.0_f32;
+    let rv = f64::from(rv);
+    let mut cumulative = 0.0_f64;
     for (i, &prob) in probabilities.iter().enumerate() {
-        cumulative += prob;
+        cumulative += f64::from(prob);
         if rv <= cumulative {
             return Some(i);
         }
@@ -76,6 +77,21 @@ mod tests {
     fn categorical_returns_last_on_rounding_tail() {
         let probs = vec![0.1_f32, 0.2, 0.3, 0.4];
         assert_eq!(sample_categorical(&probs, 0.999_999_94), Some(3));
+    }
+
+    #[test]
+    fn renormalize_large_uniform_vector_stays_close_to_one() {
+        let mut probs = vec![1.0_f32; 100_000];
+        assert!(renormalize_in_place(&mut probs));
+
+        let sum: f64 = probs.iter().map(|&p| f64::from(p)).sum();
+        assert!((sum - 1.0).abs() < 1e-6, "renormalized sum was {sum}");
+    }
+
+    #[test]
+    fn categorical_uses_precise_tail_accumulation() {
+        let probs = vec![0.000_01_f32; 100_000];
+        assert_eq!(sample_categorical(&probs, 0.999_99), Some(99_999));
     }
 
     proptest! {


### PR DESCRIPTION
### Motivation

- Reduce rounding drift and improve numerical stability in softmax/renormalization for very large vocabularies and long probability vectors. 
- Make categorical sampling more robust to accumulated floating-point error in the CDF tail.

### Description

- Accumulate softmax exponent sum in `f64` inside `crates/bitnet-logits/src/lib.rs` and convert back to `f32` when normalizing, and guard against non-finite sums.  
- Accumulate renormalization sums and categorical CDF in `f64` inside `crates/bitnet-probability/src/lib.rs` and cast back to `f32` for in-place updates.  
- Add regression tests for large uniform vectors and tail-precision sampling: `softmax_large_uniform_distribution_stays_normalized`, `renormalize_large_uniform_vector_stays_close_to_one`, and `categorical_uses_precise_tail_accumulation`.

### Testing

- Ran unit and integration tests for the affected crates with `cargo test -p bitnet-logits -p bitnet-probability --locked`, and all tests passed.  
- Ran `cargo test -p bitnet-sampling --locked` to ensure sampling integration remained green, and all tests passed.  
- Ran linting with `cargo clippy --locked -p bitnet-logits -p bitnet-probability -p bitnet-sampling --all-targets -- -D warnings` and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1a1845c8333a6b1391c389a171b)