### PR TITLE
fix: improve sampling numerical accuracy

### DIFF
--- a/crates/bitnet-inference/src/layers/quantized_linear.rs
+++ b/crates/bitnet-inference/src/layers/quantized_linear.rs
@@ -1381,17 +1381,17 @@ impl QuantizedLinear {
             .into());
         }
 
-        let n = a.len() as f32;
-        let mean_a = a.iter().sum::<f32>() / n;
-        let mean_b = b.iter().sum::<f32>() / n;
+        let n = a.len() as f64;
+        let mean_a = a.iter().map(|&value| f64::from(value)).sum::<f64>() / n;
+        let mean_b = b.iter().map(|&value| f64::from(value)).sum::<f64>() / n;
 
-        let mut num = 0.0;
-        let mut den_a = 0.0;
-        let mut den_b = 0.0;
+        let mut num = 0.0f64;
+        let mut den_a = 0.0f64;
+        let mut den_b = 0.0f64;
 
         for (&a_val, &b_val) in a.iter().zip(b.iter()) {
-            let da = a_val - mean_a;
-            let db = b_val - mean_b;
+            let da = f64::from(a_val) - mean_a;
+            let db = f64::from(b_val) - mean_b;
             num += da * db;
             den_a += da * da;
             den_b += db * db;
@@ -1399,10 +1399,10 @@ impl QuantizedLinear {
 
         let denominator = (den_a * den_b).sqrt();
         if denominator == 0.0 {
-            return Ok(0.0); // Handle degenerate case
+            return Ok(if a == b { 1.0 } else { 0.0 });
         }
 
-        Ok(num / denominator)
+        Ok((num / denominator).clamp(-1.0, 1.0) as f32)
     }
 }
 

--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -64,11 +64,11 @@ pub fn apply_top_p(probs: &mut [f32], top_p: f32) {
 
     indexed.sort_unstable_by(|a, b| f32_descending(a.1, b.1));
 
-    let mut cumsum = 0.0f32;
+    let mut cumsum = 0.0f64;
     let mut cutoff = indexed.len();
     for (rank, (_, p)) in indexed.iter().enumerate() {
-        cumsum += p;
-        if cumsum >= top_p {
+        cumsum += f64::from(*p);
+        if cumsum >= f64::from(top_p) {
             cutoff = rank + 1;
             break;
         }
@@ -113,12 +113,12 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
 
     // First pass: collect non-zero probabilities, accumulate entropy, and
     // cache surprise (-p.ln()) so we don't re-evaluate ln() per element.
-    let mut entropy = 0.0f32;
+    let mut entropy = 0.0f64;
     let mut deviations: Vec<(usize, f32, f32)> = Vec::with_capacity(probs.len());
     for (i, &p) in probs.iter().enumerate() {
         if p > 0.0 {
             let surprise = -p.ln();
-            entropy += p * surprise;
+            entropy += f64::from(p * surprise);
             deviations.push((i, p, surprise));
         }
     }
@@ -129,16 +129,16 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
 
     // Second pass: turn the cached surprise into the deviation from entropy.
     for entry in &mut deviations {
-        entry.2 = (entry.2 - entropy).abs();
+        entry.2 = (f64::from(entry.2) - entropy).abs() as f32;
     }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 
-    let mut cumsum = 0.0f32;
+    let mut cumsum = 0.0f64;
     let mut cutoff = deviations.len();
     for (rank, &(_, p, _)) in deviations.iter().enumerate() {
-        cumsum += p;
-        if cumsum >= typical_p {
+        cumsum += f64::from(p);
+        if cumsum >= f64::from(typical_p) {
             cutoff = rank + 1;
             break;
         }
@@ -162,6 +162,15 @@ fn f32_ascending(a: f32, b: f32) -> Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn top_p_uses_accurate_cumulative_sum_for_large_vocab() {
+        let mut probs = vec![1.0e-5f32; 100_000];
+        apply_top_p(&mut probs, 0.5);
+
+        let kept = probs.iter().filter(|&&p| p > 0.0).count();
+        assert_eq!(kept, 50_001);
+    }
 
     #[test]
     fn top_k_keeps_k_largest() {

--- a/crates/bitnet-logits/src/lib.rs
+++ b/crates/bitnet-logits/src/lib.rs
@@ -92,7 +92,17 @@ pub fn softmax_in_place(logits: &mut [f32]) {
         return;
     }
     let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    let mut sum = 0.0f32;
+    if max == f32::INFINITY {
+        let positive_infinity_count =
+            logits.iter().filter(|&&value| value == f32::INFINITY).count();
+        let probability = 1.0 / positive_infinity_count as f32;
+        for l in logits.iter_mut() {
+            *l = if *l == f32::INFINITY { probability } else { 0.0 };
+        }
+        return;
+    }
+
+    let mut sum = 0.0f64;
     for l in logits.iter_mut() {
         let v = *l;
         // Optimization: skip exp() for NEG_INFINITY which always yields 0.0.
@@ -100,13 +110,13 @@ pub fn softmax_in_place(logits: &mut [f32]) {
         if v == f32::NEG_INFINITY {
             *l = 0.0;
         } else {
-            let exp = (v - max).exp();
-            *l = exp;
+            let exp = f64::from(v - max).exp();
+            *l = exp as f32;
             sum += exp;
         }
     }
-    if sum > 0.0 {
-        let inv_sum = 1.0 / sum;
+    if sum > 0.0 && sum.is_finite() {
+        let inv_sum = (1.0 / sum) as f32;
         for l in logits.iter_mut() {
             *l *= inv_sum;
         }
@@ -216,6 +226,26 @@ mod tests {
         let mut logits = original.clone();
         apply_temperature(&mut logits, 1.0);
         assert_eq!(logits, original);
+    }
+
+    #[test]
+    fn softmax_handles_large_vocab_with_accurate_normalization() {
+        let mut logits = vec![-12.0f32; 65_536];
+        logits[0] = 0.0;
+        softmax_in_place(&mut logits);
+
+        let sum: f64 = logits.iter().map(|&p| f64::from(p)).sum();
+        assert!((sum - 1.0).abs() < 1e-7, "softmax sum = {sum}");
+        assert!(logits[0] > logits[1]);
+        assert!(logits.iter().all(|p| p.is_finite() && *p >= 0.0));
+    }
+
+    #[test]
+    fn softmax_preserves_positive_infinity_winners() {
+        let mut logits = vec![1.0f32, f32::INFINITY, 2.0, f32::INFINITY];
+        softmax_in_place(&mut logits);
+
+        assert_eq!(logits, vec![0.0, 0.5, 0.0, 0.5]);
     }
 
     #[test]

--- a/crates/bitnet-logits/tests/logits_filter_edge_cases.rs
+++ b/crates/bitnet-logits/tests/logits_filter_edge_cases.rs
@@ -158,12 +158,12 @@ fn softmax_all_neg_infinity_gives_uniform() {
 fn softmax_with_positive_infinity() {
     let mut v = vec![1.0, f32::INFINITY, 3.0];
     softmax_in_place(&mut v);
-    // max = inf, so exp(inf - inf) = exp(NaN) = NaN → sum is NaN,
-    // which fails the `sum > 0.0` check, triggering the uniform fallback.
-    let expected = 1.0 / 3.0;
-    for &p in &v {
-        assert_approx(p, expected, 1e-6);
-    }
+    // Infinite logits dominate finite logits. This avoids the old NaN path
+    // from `inf - inf`, which incorrectly fell back to a uniform distribution
+    // across finite and infinite entries.
+    assert_approx(v[0], 0.0, 1e-6);
+    assert_approx(v[1], 1.0, 1e-6);
+    assert_approx(v[2], 0.0, 1e-6);
 }
 
 #[test]

--- a/crates/bitnet-probability/src/lib.rs
+++ b/crates/bitnet-probability/src/lib.rs
@@ -12,12 +12,12 @@ pub fn renormalize_in_place(probs: &mut [f32]) -> bool {
         return false;
     }
 
-    let sum: f32 = probs.iter().sum();
+    let sum: f64 = probs.iter().map(|&p| f64::from(p)).sum();
     if sum <= 0.0 || !sum.is_finite() {
         return false;
     }
 
-    let inv_sum = 1.0 / sum;
+    let inv_sum = (1.0 / sum) as f32;
     for p in probs.iter_mut() {
         *p *= inv_sum;
     }
@@ -36,11 +36,11 @@ pub fn sample_categorical(probabilities: &[f32], random_value: f32) -> Option<us
         return None;
     }
 
-    let rv = random_value.clamp(0.0, 1.0 - f32::EPSILON);
+    let rv = f64::from(random_value.clamp(0.0, 1.0 - f32::EPSILON));
 
-    let mut cumulative = 0.0_f32;
+    let mut cumulative = 0.0_f64;
     for (i, &prob) in probabilities.iter().enumerate() {
-        cumulative += prob;
+        cumulative += f64::from(prob);
         if rv <= cumulative {
             return Some(i);
         }
@@ -61,6 +61,15 @@ mod tests {
         assert!(renormalize_in_place(&mut probs));
         let sum: f32 = probs.iter().sum();
         assert!((sum - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn renormalize_large_distribution_uses_accurate_sum() {
+        let mut probs = vec![1.0e-5_f32; 100_000];
+        assert!(renormalize_in_place(&mut probs));
+
+        let sum: f64 = probs.iter().map(|&p| f64::from(p)).sum();
+        assert!((sum - 1.0).abs() < 1e-7, "renormalized sum = {sum}");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Reduce large-vocabulary rounding drift and improve numerical robustness in the sampling pipeline and softmax implementation. 
- Avoid NaN/uniform fallbacks when logits contain `+inf` and make quantized-linear accuracy validation more reliable. 

### Description

- Use `f64` accumulation in softmax internals to improve normalization accuracy for large vocabularies and convert back to `f32` for outputs, and special-case `f32::INFINITY` logits so they are treated as dominant winners instead of triggering the uniform fallback (changes in `crates/bitnet-logits/src/lib.rs`).
- Use `f64` for cumulative sums and entropy in nucleus/typical filters to avoid rounding drift in `apply_top_p` and `apply_typical` and add a large-vocab regression test (changes in `crates/bitnet-logits-filters/src/lib.rs`).
- Use `f64` accumulation for renormalization and categorical sampling (`renormalize_in_place` and `sample_categorical`) to ensure correct renormalization and sampling behavior on large distributions, and add a regression test (changes in `crates/bitnet-probability/src/lib.rs`).
- Compute Pearson correlation in `f64` for quantized-linear accuracy validation, clamp the returned correlation to `[-1.0, 1.0]`, and treat identical vectors as perfectly correlated to avoid degenerate-case false negatives (changes in `crates/bitnet-inference/src/layers/quantized_linear.rs`).
- Added/updated unit tests covering large-vocabulary normalization, top-p cumulative behavior, positive-infinity softmax handling, and renormalization correctness.

### Testing

- Ran `cargo test --locked -p bitnet-logits -p bitnet-logits-filters -p bitnet-probability --no-default-features --features cpu` and all tests in those crates passed (unit, edge-case, proptest, and integration suites).
- Ran `cargo check --locked -p bitnet-inference --no-default-features --features cpu` and the check completed successfully.
- Verified the softmax positive-infinity edge-case and the added large-vocab regression tests now pass, resolving the previous NaN/uniform-fallback failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1a1845c8333a6b1391c389a171b)