### PR TITLE
Bound ripr SARIF advisory step

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -50,7 +50,42 @@ jobs:
 
       - name: Run ripr check SARIF (advisory)
         run: |
-          ripr check --root . --base "origin/${{ github.base_ref }}" --format sarif > target/ripr/ripr.sarif || true
+          if timeout 25s ripr check --root . --base "origin/${{ github.base_ref }}" --format sarif > target/ripr/ripr.sarif; then
+            echo "ripr SARIF generated"
+          else
+            status=$?
+            echo "ripr SARIF generation timed out or failed with status ${status}; writing advisory fallback."
+            cat > target/ripr/ripr.sarif <<'JSON'
+          {
+            "version": "2.1.0",
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "ripr",
+                    "rules": []
+                  }
+                },
+                "results": [],
+                "invocations": [
+                  {
+                    "executionSuccessful": false,
+                    "toolExecutionNotifications": [
+                      {
+                        "level": "warning",
+                        "message": {
+                          "text": "ripr SARIF generation timed out or failed; JSON and markdown advisory artifacts remain authoritative for this job."
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+          JSON
+          fi
 
       - name: Step summary
         if: always()


### PR DESCRIPTION
## Summary
- wrap the advisory `ripr --format sarif` generation in a 25s timeout
- write a minimal advisory SARIF fallback if SARIF generation times out or fails
- keep JSON and Markdown ripr outputs as the authoritative advisory artifacts

## Validation
- `git diff --check`

## Context
PR #5339 repeatedly passed ripr doctor, JSON, and Markdown summary, then failed because the SARIF step was canceled after roughly 34s. This keeps the advisory job from blocking unrelated PRs when SARIF generation is unhealthy.

## Claim Boundary
CI workflow hardening only. No runtime, model, M4, BitNet, Metal, QK256, Neural Engine, MPSGraph, MacBook, quality, speed, benchmark, or claim-surface behavior change.