### PR TITLE
Bound RIPR PR evidence step

### DIFF
--- a/.github/workflows/ripr-pr-evidence.yml
+++ b/.github/workflows/ripr-pr-evidence.yml
@@ -39,14 +39,28 @@ jobs:
         if: github.base_ref != ''
         run: git fetch origin ${{ github.base_ref }}
 
+      - name: Build xtask
+        run: cargo build --locked -p xtask --no-default-features
+
       - name: RIPR PR evidence
         env:
           RIPR_BASE: origin/${{ github.base_ref }}
-        run: cargo xtask ripr-pr
+        run: |
+          if ! timeout 50s target/debug/xtask ripr-pr; then
+            mkdir -p target/ripr/pr
+            printf '%s\n' \
+              '{' \
+              '  "findings": [],' \
+              '  "warnings": ["ripr-pr timed out; JSON and markdown fallback written for advisory contract"]' \
+              '}' > target/ripr/pr/repo-exposure.json
+            printf '%s\n' \
+              'RIPR PR evidence timed out; JSON and markdown fallback written for advisory contract.' \
+              > target/ripr/pr/repo-exposure.md
+          fi
 
       - name: RIPR review guidance
         run: |
-          if ! timeout 120s cargo xtask ripr-review-comments --base origin/${{ github.base_ref }} --head HEAD; then
+          if ! timeout 120s target/debug/xtask ripr-review-comments --base origin/${{ github.base_ref }} --head HEAD; then
             mkdir -p target/ripr/review
             printf '%s\n' \
               '{' \
@@ -62,11 +76,11 @@ jobs:
 
       - name: RIPR PR contract
         if: always()
-        run: cargo xtask ripr-pr --check
+        run: target/debug/xtask ripr-pr --check
 
       - name: RIPR review contract
         if: always()
-        run: cargo xtask ripr-review-comments --check
+        run: target/debug/xtask ripr-review-comments --check
 
       - name: RIPR summary
         if: always()
@@ -83,7 +97,7 @@ jobs:
 
       - name: RIPR annotations
         if: always()
-        run: cargo xtask ripr-annotations
+        run: target/debug/xtask ripr-annotations
 
       - name: Upload RIPR PR evidence
         if: always()


### PR DESCRIPTION
## Summary
- build `xtask` once before RIPR PR evidence runs
- run `target/debug/xtask ripr-pr` behind a bounded timeout
- write valid fallback JSON/Markdown artifacts so the advisory contract can complete instead of canceling the workflow
- reuse the built `xtask` binary for review guidance, contract checks, and annotations

## Validation
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- lint-workflows`

## Context
PR #5339 repeatedly reached the RIPR PR evidence executable and was then canceled after the compile step. This keeps the advisory evidence surface bounded and still produces explicit fallback artifacts when the advisory scan times out.

## Claim Boundary
CI workflow hardening only. No runtime, model, Apple M4, BitNet, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad quality, or broad performance change.