### PR TITLE
Bound RIPR review guidance step

### DIFF
--- a/.github/workflows/ripr-pr-evidence.yml
+++ b/.github/workflows/ripr-pr-evidence.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: RIPR review guidance
         run: |
-          if ! timeout 120s target/debug/xtask ripr-review-comments --base origin/${{ github.base_ref }} --head HEAD; then
+          if ! timeout 25s target/debug/xtask ripr-review-comments --base origin/${{ github.base_ref }} --head HEAD; then
             mkdir -p target/ripr/review
             printf '%s\n' \
               '{' \


### PR DESCRIPTION
## Summary
- reduce the advisory `ripr-review-comments` budget to 25s
- keep the existing fallback JSON/Markdown artifacts for review guidance timeouts
- preserve the later contract, summary, annotation, and upload steps

## Validation
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- lint-workflows`

## Context
PR #5339 now gets through the bounded RIPR PR evidence step, but the review-guidance step is canceled before its previous 120s timeout can fire. This gives the advisory fallback path enough runtime margin to finish the workflow cleanly.

## Claim Boundary
CI workflow hardening only. No runtime, model, Apple M4, BitNet, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad quality, or broad performance change.