### PR TITLE
diag(bitnet): report selected post-rope raw key epsilon

### DIFF
--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -7497,6 +7497,11 @@ fn compare_reference_to_rust_with_records_with_model(
             &report["attention_rust_score_input_operand_drift"],
             &report["attention_selected_historical_rope_epsilon_materiality"],
         );
+    report["attention_selected_score_key_f16_policy"] = attention_selected_score_key_f16_policy(
+        &report["attention_reference_score_input_operand_policy"],
+        &report["attention_rust_score_input_operand_drift"],
+        &report["attention_selected_key_score_input_capture_source"],
+    );
     report["attention_query_score_input_f16_policy_effect"] =
         attention_query_score_input_f16_policy_effect(
             reference_records,
@@ -23674,6 +23679,198 @@ fn attention_selected_key_score_input_capture_source(
     })
 }
 
+fn attention_selected_score_key_f16_policy(
+    operand_policy: &Value,
+    operand_drift: &Value,
+    capture_source: &Value,
+) -> Value {
+    let operand_rows = operand_policy.pointer("/rows").and_then(Value::as_array);
+    let drift_rows = operand_drift.pointer("/rows").and_then(Value::as_array);
+    let source_rows = capture_source.pointer("/rows").and_then(Value::as_array);
+    let mut rows = Vec::<Value>::new();
+    let mut compared_count = 0usize;
+    let mut missing_context_count = 0usize;
+    let mut aligned_f16_view_count = 0usize;
+    let mut bucket_sensitive_count = 0usize;
+    let mut unpinned_count = 0usize;
+
+    if let Some(source_rows) = source_rows {
+        for source_row in source_rows {
+            let source_classification =
+                source_row.pointer("/classification").and_then(Value::as_str);
+            if !matches!(
+                source_classification,
+                Some("selected_key_score_input_capture_source_post_rope_f16_view")
+                    | Some("selected_key_score_input_capture_source_post_rope_f16_value")
+            ) {
+                continue;
+            }
+            let head = source_row.pointer("/head").and_then(Value::as_u64);
+            let key_slot = source_row.pointer("/key_slot").and_then(Value::as_u64);
+            let query_token = source_row.pointer("/query_token").and_then(Value::as_u64);
+            let operand_row = find_qk_recompute_row(operand_rows, head, key_slot, query_token);
+            let drift_row = find_qk_recompute_row(drift_rows, head, key_slot, query_token);
+            let mut blocked_reasons = Vec::<String>::new();
+            if operand_row.is_none() {
+                blocked_reasons.push("reference_operand_policy_row_missing".to_string());
+            }
+            if drift_row.is_none() {
+                blocked_reasons.push("rust_operand_drift_row_missing".to_string());
+            }
+
+            let reference_operand_classification =
+                operand_row.and_then(|row| row.pointer("/classification").and_then(Value::as_str));
+            let rust_operand_drift_classification =
+                drift_row.and_then(|row| row.pointer("/classification").and_then(Value::as_str));
+            let reference_score_candidate = operand_row
+                .and_then(|row| row.pointer("/reference_score_input_candidate"))
+                .and_then(Value::as_bool)
+                == Some(true);
+            let reference_exact_operand =
+                operand_row.and_then(|row| row.pointer("/exact_operand")).and_then(Value::as_bool)
+                    == Some(true);
+            let reference_tolerance_operand = operand_row
+                .and_then(|row| row.pointer("/tolerance_operand"))
+                .and_then(Value::as_bool)
+                == Some(true);
+            let reference_abs_delta = operand_row
+                .and_then(|row| row.pointer("/reference_abs_delta").and_then(Value::as_f64));
+            let score_key_stage_is_f16 =
+                source_row.pointer("/score_key_stage_is_f16").and_then(Value::as_bool)
+                    == Some(true);
+            let reference_matches_f16 = source_row
+                .pointer("/reference_product_matches_post_rope_f16")
+                .and_then(Value::as_bool)
+                == Some(true);
+            let rust_matches_f16 =
+                source_row.pointer("/rust_product_matches_post_rope_f16").and_then(Value::as_bool)
+                    == Some(true);
+            let reference_matches_raw = source_row
+                .pointer("/reference_product_matches_raw_post_rope")
+                .and_then(Value::as_bool)
+                == Some(true);
+            let rust_matches_raw =
+                source_row.pointer("/rust_product_matches_raw_post_rope").and_then(Value::as_bool)
+                    == Some(true);
+            let f16_bucket_crossing =
+                source_row.pointer("/f16_bucket_crossing").and_then(Value::as_bool) == Some(true);
+            let reference_feeds_f16_view =
+                reference_score_candidate && score_key_stage_is_f16 && reference_matches_f16;
+            let rust_feeds_f16_view = rust_matches_f16;
+            let policy_aligned = reference_feeds_f16_view && rust_feeds_f16_view;
+            let raw_policy_rejected = !reference_matches_raw && !rust_matches_raw;
+
+            if !reference_score_candidate {
+                blocked_reasons.push("reference_score_input_candidate_missing".to_string());
+            }
+            if !score_key_stage_is_f16 {
+                blocked_reasons.push("reference_score_key_stage_not_f16".to_string());
+            }
+            if !reference_matches_f16 || !rust_matches_f16 {
+                blocked_reasons
+                    .push("score_key_product_not_post_rope_f16_on_both_sides".to_string());
+            }
+
+            let row_classification = if !blocked_reasons.is_empty() {
+                "selected_score_key_f16_policy_unpinned"
+            } else if policy_aligned && f16_bucket_crossing && raw_policy_rejected {
+                "selected_score_key_f16_policy_aligned_bucket_sensitive"
+            } else if policy_aligned {
+                "selected_score_key_f16_policy_aligned"
+            } else {
+                "selected_score_key_f16_policy_unpinned"
+            };
+
+            compared_count += 1;
+            match row_classification {
+                "selected_score_key_f16_policy_unpinned" => unpinned_count += 1,
+                "selected_score_key_f16_policy_aligned_bucket_sensitive" => {
+                    aligned_f16_view_count += 1;
+                    bucket_sensitive_count += 1;
+                }
+                "selected_score_key_f16_policy_aligned" => aligned_f16_view_count += 1,
+                _ => {}
+            }
+            if !blocked_reasons.is_empty() {
+                missing_context_count += 1;
+            }
+
+            rows.push(json!({
+                "classification": row_classification,
+                "head": head,
+                "kv_head": source_row.pointer("/kv_head").cloned().unwrap_or(Value::Null),
+                "key_slot": key_slot,
+                "query_token": query_token,
+                "contributor_dim": source_row.pointer("/contributor_dim").cloned().unwrap_or(Value::Null),
+                "blocked_reasons": blocked_reasons,
+                "capture_source_classification": source_classification,
+                "reference_operand_classification": reference_operand_classification,
+                "rust_operand_drift_classification": rust_operand_drift_classification,
+                "reference_score_input_candidate": reference_score_candidate,
+                "reference_exact_operand": reference_exact_operand,
+                "reference_tolerance_operand": reference_tolerance_operand,
+                "reference_abs_delta": reference_abs_delta,
+                "score_key_stage_is_f16": score_key_stage_is_f16,
+                "reference_feeds_post_rope_f16_view": reference_feeds_f16_view,
+                "rust_feeds_post_rope_f16_view": rust_feeds_f16_view,
+                "policy_aligned": policy_aligned,
+                "f16_bucket_crossing": f16_bucket_crossing,
+                "raw_policy_rejected": raw_policy_rejected,
+                "reference_product_matches_raw_post_rope": reference_matches_raw,
+                "rust_product_matches_raw_post_rope": rust_matches_raw,
+                "reference_product_matches_post_rope_f16": reference_matches_f16,
+                "rust_product_matches_post_rope_f16": rust_matches_f16,
+                "runtime_change_candidate": if policy_aligned {
+                    "none_from_score_key_f16_policy"
+                } else {
+                    "score_key_f16_policy_unpinned"
+                },
+            }));
+        }
+    }
+
+    let classification = if compared_count == 0 {
+        "no_selected_key_score_input_capture_source_rows"
+    } else if unpinned_count == compared_count {
+        "selected_score_key_f16_policy_unpinned"
+    } else if aligned_f16_view_count == compared_count && bucket_sensitive_count > 0 {
+        "selected_score_key_f16_policy_aligned_bucket_sensitive"
+    } else if aligned_f16_view_count == compared_count {
+        "selected_score_key_f16_policy_aligned"
+    } else {
+        "selected_score_key_f16_policy_mixed"
+    };
+    let next_diagnostic = match classification {
+        "selected_score_key_f16_policy_aligned_bucket_sensitive" => {
+            "localize the selected post-RoPE raw key epsilon that crosses the F16 bucket boundary; do not change score-input F16 policy"
+        }
+        "selected_score_key_f16_policy_aligned" => {
+            "move downstream from score-key F16 policy because both sides feed post-RoPE F16 key views"
+        }
+        "selected_score_key_f16_policy_unpinned" => {
+            "pin selected score-key F16 policy before changing runtime math"
+        }
+        "no_selected_key_score_input_capture_source_rows" => {
+            "capture selected key score-input source rows before deciding F16 score-key policy"
+        }
+        _ => "keep selected score-key F16 policy diagnostic-only",
+    };
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "Selected score-key F16 policy is diagnostic-only evidence for whether the selected reference and Rust score products are both fed by post-RoPE F16 key views; it does not change runtime math or promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, full residency, performance, or completion",
+        "classification": classification,
+        "compared_count": compared_count,
+        "missing_context_count": missing_context_count,
+        "aligned_f16_view_count": aligned_f16_view_count,
+        "bucket_sensitive_count": bucket_sensitive_count,
+        "unpinned_count": unpinned_count,
+        "rows": rows,
+        "next_diagnostic": next_diagnostic,
+    })
+}
+
 fn find_qk_recompute_row<'a>(
     rows: Option<&'a Vec<Value>>,
     head: Option<u64>,
@@ -36575,6 +36772,88 @@ mod tests {
             report.pointer("/next_diagnostic"),
             Some(&json!(
                 "pin whether Rust and reference should both feed score products from post-RoPE F16 key views before changing runtime math"
+            ))
+        );
+    }
+
+    #[test]
+    fn selected_score_key_f16_policy_reports_aligned_bucket_sensitive() {
+        let operand_policy = json!({
+            "rows": [
+                {
+                    "classification": "reference_score_input_capture_tolerance_pinned_operand",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                    "reference_score_input_candidate": true,
+                    "exact_operand": false,
+                    "tolerance_operand": true,
+                    "reference_abs_delta": 0.000030517578125_f64,
+                }
+            ]
+        });
+        let operand_drift = json!({
+            "rows": [
+                {
+                    "classification": "selected_score_input_operand_drift_key_bucket_crossing",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                }
+            ]
+        });
+        let capture_source = json!({
+            "rows": [
+                {
+                    "classification": "selected_key_score_input_capture_source_post_rope_f16_view",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                    "score_key_stage_is_f16": true,
+                    "f16_bucket_crossing": true,
+                    "reference_product_matches_raw_post_rope": false,
+                    "rust_product_matches_raw_post_rope": false,
+                    "reference_product_matches_post_rope_f16": true,
+                    "rust_product_matches_post_rope_f16": true,
+                }
+            ]
+        });
+
+        let report = attention_selected_score_key_f16_policy(
+            &operand_policy,
+            &operand_drift,
+            &capture_source,
+        );
+
+        assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(
+            report.pointer("/classification"),
+            Some(&json!("selected_score_key_f16_policy_aligned_bucket_sensitive"))
+        );
+        assert_eq!(report.pointer("/compared_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/aligned_f16_view_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/bucket_sensitive_count"), Some(&json!(1)));
+        assert_eq!(
+            report.pointer("/rows/0/reference_feeds_post_rope_f16_view"),
+            Some(&json!(true))
+        );
+        assert_eq!(report.pointer("/rows/0/rust_feeds_post_rope_f16_view"), Some(&json!(true)));
+        assert_eq!(report.pointer("/rows/0/policy_aligned"), Some(&json!(true)));
+        assert_eq!(
+            report.pointer("/rows/0/runtime_change_candidate"),
+            Some(&json!("none_from_score_key_f16_policy"))
+        );
+        assert_eq!(
+            report.pointer("/next_diagnostic"),
+            Some(&json!(
+                "localize the selected post-RoPE raw key epsilon that crosses the F16 bucket boundary; do not change score-input F16 policy"
             ))
         );
     }

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -7491,6 +7491,12 @@ fn compare_reference_to_rust_with_records_with_model(
         &report["attention_reference_score_input_operand_policy"],
         &report["attention_selected_historical_rope_epsilon_materiality"],
     );
+    report["attention_selected_key_score_input_capture_source"] =
+        attention_selected_key_score_input_capture_source(
+            &report["attention_reference_score_input_operand_policy"],
+            &report["attention_rust_score_input_operand_drift"],
+            &report["attention_selected_historical_rope_epsilon_materiality"],
+        );
     report["attention_query_score_input_f16_policy_effect"] =
         attention_query_score_input_f16_policy_effect(
             reference_records,
@@ -23472,6 +23478,202 @@ fn attention_rust_score_input_operand_drift(operand_policy: &Value, materiality:
     })
 }
 
+fn attention_selected_key_score_input_capture_source(
+    operand_policy: &Value,
+    operand_drift: &Value,
+    materiality: &Value,
+) -> Value {
+    let operand_rows = operand_policy.pointer("/rows").and_then(Value::as_array);
+    let drift_rows = operand_drift.pointer("/rows").and_then(Value::as_array);
+    let materiality_rows = materiality.pointer("/rows").and_then(Value::as_array);
+    let mut rows = Vec::<Value>::new();
+    let mut compared_count = 0usize;
+    let mut missing_context_count = 0usize;
+    let mut raw_capture_count = 0usize;
+    let mut post_rope_f16_view_count = 0usize;
+    let mut f16_bucket_crossing_count = 0usize;
+    let mut score_key_stage_f16_count = 0usize;
+
+    if let Some(drift_rows) = drift_rows {
+        for drift_row in drift_rows {
+            if drift_row.pointer("/classification").and_then(Value::as_str)
+                != Some("selected_score_input_operand_drift_key_bucket_crossing")
+            {
+                continue;
+            }
+            let head = drift_row.pointer("/head").and_then(Value::as_u64);
+            let key_slot = drift_row.pointer("/key_slot").and_then(Value::as_u64);
+            let query_token = drift_row.pointer("/query_token").and_then(Value::as_u64);
+            let operand_row = find_qk_recompute_row(operand_rows, head, key_slot, query_token);
+            let materiality_row =
+                find_qk_recompute_row(materiality_rows, head, key_slot, query_token);
+            let product_source = materiality_row
+                .and_then(|row| row.pointer("/materiality/product_bucket_source"))
+                .unwrap_or(&Value::Null);
+            let source_policy = materiality_row
+                .and_then(|row| row.pointer("/materiality/score_product_source_policy"))
+                .unwrap_or(&Value::Null);
+            let epsilon_probe = materiality_row
+                .and_then(|row| row.pointer("/epsilon_probe"))
+                .unwrap_or(&Value::Null);
+            let key_stage = operand_row
+                .and_then(|row| row.pointer("/reference_stage_provenance/key_stage"))
+                .unwrap_or(&Value::Null);
+            let product_reference_key =
+                product_source.pointer("/product_reference_key").and_then(Value::as_f64);
+            let product_rust_key =
+                product_source.pointer("/product_rust_key").and_then(Value::as_f64);
+            let reference_post_rope_raw =
+                epsilon_probe.pointer("/post_rope/reference_capture").and_then(Value::as_f64);
+            let rust_post_rope_raw =
+                epsilon_probe.pointer("/post_rope/rust_capture").and_then(Value::as_f64);
+            let reference_post_rope_f16 =
+                epsilon_probe.pointer("/post_rope_bucket/left_f16_value").and_then(Value::as_f64);
+            let rust_post_rope_f16 =
+                epsilon_probe.pointer("/post_rope_bucket/right_f16_value").and_then(Value::as_f64);
+            let bucket_crossing = epsilon_probe
+                .pointer("/post_rope_bucket/f16_bucket_match")
+                .and_then(Value::as_bool)
+                == Some(false);
+            let reference_matches_raw = product_reference_key
+                .zip(reference_post_rope_raw)
+                .is_some_and(|(product, raw)| (product - raw).abs() <= 1.0e-9);
+            let rust_matches_raw = product_rust_key
+                .zip(rust_post_rope_raw)
+                .is_some_and(|(product, raw)| (product - raw).abs() <= 1.0e-9);
+            let reference_matches_f16 = product_reference_key
+                .zip(reference_post_rope_f16)
+                .is_some_and(|(product, bucket)| (product - bucket).abs() <= 1.0e-9);
+            let rust_matches_f16 = product_rust_key
+                .zip(rust_post_rope_f16)
+                .is_some_and(|(product, bucket)| (product - bucket).abs() <= 1.0e-9);
+            let score_key_stage_is_f16 =
+                key_stage.pointer("/dtype").and_then(Value::as_str) == Some("f16");
+            let mut blocked_reasons = Vec::<String>::new();
+            if operand_row.is_none() {
+                blocked_reasons.push("reference_operand_policy_row_missing".to_string());
+            }
+            if materiality_row.is_none() {
+                blocked_reasons.push("selected_materiality_row_missing".to_string());
+            }
+            if product_reference_key.is_none() || product_rust_key.is_none() {
+                blocked_reasons.push("selected_product_key_values_missing".to_string());
+            }
+            if reference_post_rope_raw.is_none() || rust_post_rope_raw.is_none() {
+                blocked_reasons.push("selected_post_rope_raw_capture_missing".to_string());
+            }
+            if reference_post_rope_f16.is_none() || rust_post_rope_f16.is_none() {
+                blocked_reasons.push("selected_post_rope_f16_bucket_missing".to_string());
+            }
+
+            let row_classification = if !blocked_reasons.is_empty() {
+                "selected_key_score_input_capture_source_missing"
+            } else if reference_matches_raw && rust_matches_raw {
+                "selected_key_score_input_capture_source_raw_post_rope"
+            } else if reference_matches_f16 && rust_matches_f16 && score_key_stage_is_f16 {
+                "selected_key_score_input_capture_source_post_rope_f16_view"
+            } else if reference_matches_f16 && rust_matches_f16 {
+                "selected_key_score_input_capture_source_post_rope_f16_value"
+            } else {
+                "selected_key_score_input_capture_source_unpinned"
+            };
+
+            compared_count += 1;
+            match row_classification {
+                "selected_key_score_input_capture_source_missing" => missing_context_count += 1,
+                "selected_key_score_input_capture_source_raw_post_rope" => raw_capture_count += 1,
+                "selected_key_score_input_capture_source_post_rope_f16_view"
+                | "selected_key_score_input_capture_source_post_rope_f16_value" => {
+                    post_rope_f16_view_count += 1;
+                }
+                _ => {}
+            }
+            if bucket_crossing {
+                f16_bucket_crossing_count += 1;
+            }
+            if score_key_stage_is_f16 {
+                score_key_stage_f16_count += 1;
+            }
+
+            rows.push(json!({
+                "classification": row_classification,
+                "head": head,
+                "kv_head": drift_row.pointer("/kv_head").cloned().unwrap_or(Value::Null),
+                "key_slot": key_slot,
+                "query_token": query_token,
+                "contributor_dim": drift_row.pointer("/contributor_dim").cloned().unwrap_or(Value::Null),
+                "blocked_reasons": blocked_reasons,
+                "operand_row_present": operand_row.is_some(),
+                "materiality_row_present": materiality_row.is_some(),
+                "score_key_stage_is_f16": score_key_stage_is_f16,
+                "score_key_stage": key_stage.clone(),
+                "f16_bucket_crossing": bucket_crossing,
+                "product_reference_key": product_reference_key,
+                "product_rust_key": product_rust_key,
+                "reference_post_rope_raw": reference_post_rope_raw,
+                "rust_post_rope_raw": rust_post_rope_raw,
+                "reference_post_rope_f16": reference_post_rope_f16,
+                "rust_post_rope_f16": rust_post_rope_f16,
+                "reference_product_matches_raw_post_rope": reference_matches_raw,
+                "rust_product_matches_raw_post_rope": rust_matches_raw,
+                "reference_product_matches_post_rope_f16": reference_matches_f16,
+                "rust_product_matches_post_rope_f16": rust_matches_f16,
+                "product_bucket_source": product_source.clone(),
+                "score_product_source_policy": source_policy.clone(),
+            }));
+        }
+    }
+
+    let classification = if compared_count == 0 {
+        "no_selected_key_bucket_crossing_operand_rows"
+    } else if missing_context_count == compared_count {
+        "selected_key_score_input_capture_source_missing"
+    } else if raw_capture_count == compared_count {
+        "selected_key_score_input_capture_source_raw_post_rope"
+    } else if post_rope_f16_view_count == compared_count
+        && score_key_stage_f16_count == compared_count
+    {
+        "selected_key_score_input_capture_source_post_rope_f16_view"
+    } else if post_rope_f16_view_count == compared_count {
+        "selected_key_score_input_capture_source_post_rope_f16_value"
+    } else {
+        "selected_key_score_input_capture_source_unpinned"
+    };
+    let next_diagnostic = match classification {
+        "selected_key_score_input_capture_source_post_rope_f16_view" => {
+            "pin whether Rust and reference should both feed score products from post-RoPE F16 key views before changing runtime math"
+        }
+        "selected_key_score_input_capture_source_post_rope_f16_value" => {
+            "pin score key capture dtype/provenance before changing runtime math"
+        }
+        "selected_key_score_input_capture_source_raw_post_rope" => {
+            "move upstream from score-input capture to post-RoPE raw key generation before changing runtime math"
+        }
+        "selected_key_score_input_capture_source_missing" => {
+            "capture selected key score-input and post-RoPE source values before changing runtime math"
+        }
+        "no_selected_key_bucket_crossing_operand_rows" => {
+            "classify selected Rust/reference score-input operand drift before inspecting key capture source"
+        }
+        _ => "keep selected key score-input capture source diagnostic-only",
+    };
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "Selected key score-input capture source is diagnostic-only evidence for whether the score product consumes raw post-RoPE key values or an F16 score-input view around the selected bucket crossing; it does not change runtime math or promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, full residency, performance, or completion",
+        "classification": classification,
+        "compared_count": compared_count,
+        "missing_context_count": missing_context_count,
+        "raw_capture_count": raw_capture_count,
+        "post_rope_f16_view_count": post_rope_f16_view_count,
+        "f16_bucket_crossing_count": f16_bucket_crossing_count,
+        "score_key_stage_f16_count": score_key_stage_f16_count,
+        "rows": rows,
+        "next_diagnostic": next_diagnostic,
+    })
+}
+
 fn find_qk_recompute_row<'a>(
     rows: Option<&'a Vec<Value>>,
     head: Option<u64>,
@@ -36276,6 +36478,103 @@ mod tests {
             report.pointer("/next_diagnostic"),
             Some(&json!(
                 "inspect selected key score-input capture source around the post-RoPE F16 bucket boundary before changing runtime math"
+            ))
+        );
+    }
+
+    #[test]
+    fn selected_key_score_input_capture_source_reports_post_rope_f16_view() {
+        let operand_policy = json!({
+            "rows": [
+                {
+                    "classification": "reference_score_input_capture_tolerance_pinned_operand",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                    "reference_stage_provenance": {
+                        "key_stage": {
+                            "present": true,
+                            "stage": "k_score_input_head0_history_ref_layout",
+                            "dtype": "f16",
+                        }
+                    }
+                }
+            ]
+        });
+        let operand_drift = json!({
+            "rows": [
+                {
+                    "classification": "selected_score_input_operand_drift_key_bucket_crossing",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                }
+            ]
+        });
+        let materiality = json!({
+            "rows": [
+                {
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                    "epsilon_probe": {
+                        "post_rope": {
+                            "reference_capture": 1.4809578657150269_f64,
+                            "rust_capture": 1.4809563159942627_f64,
+                        },
+                        "post_rope_bucket": {
+                            "f16_bucket_match": false,
+                            "left_f16_value": 1.4814453125_f64,
+                            "right_f16_value": 1.48046875_f64,
+                        }
+                    },
+                    "materiality": {
+                        "product_bucket_source": {
+                            "product_reference_key": 1.4814453125_f64,
+                            "product_rust_key": 1.48046875_f64,
+                        },
+                        "score_product_source_policy": {
+                            "score_input_capture_uses_post_rope_f16_bucket_values": true,
+                        }
+                    }
+                }
+            ]
+        });
+
+        let report = attention_selected_key_score_input_capture_source(
+            &operand_policy,
+            &operand_drift,
+            &materiality,
+        );
+
+        assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(
+            report.pointer("/classification"),
+            Some(&json!("selected_key_score_input_capture_source_post_rope_f16_view"))
+        );
+        assert_eq!(report.pointer("/compared_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/post_rope_f16_view_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/f16_bucket_crossing_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/score_key_stage_f16_count"), Some(&json!(1)));
+        assert_eq!(
+            report.pointer("/rows/0/reference_product_matches_raw_post_rope"),
+            Some(&json!(false))
+        );
+        assert_eq!(
+            report.pointer("/rows/0/reference_product_matches_post_rope_f16"),
+            Some(&json!(true))
+        );
+        assert_eq!(
+            report.pointer("/next_diagnostic"),
+            Some(&json!(
+                "pin whether Rust and reference should both feed score products from post-RoPE F16 key views before changing runtime math"
             ))
         );
     }

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -7502,6 +7502,11 @@ fn compare_reference_to_rust_with_records_with_model(
         &report["attention_rust_score_input_operand_drift"],
         &report["attention_selected_key_score_input_capture_source"],
     );
+    report["attention_selected_post_rope_raw_key_epsilon"] =
+        attention_selected_post_rope_raw_key_epsilon(
+            &report["attention_selected_score_key_f16_policy"],
+            &report["attention_selected_key_historical_projection_rope_source"],
+        );
     report["attention_query_score_input_f16_policy_effect"] =
         attention_query_score_input_f16_policy_effect(
             reference_records,
@@ -23871,6 +23876,250 @@ fn attention_selected_score_key_f16_policy(
     })
 }
 
+fn attention_selected_post_rope_raw_key_epsilon(
+    score_key_policy: &Value,
+    historical_rope_source: &Value,
+) -> Value {
+    let policy_rows = score_key_policy.pointer("/rows").and_then(Value::as_array);
+    let historical_rows = historical_rope_source.pointer("/rows").and_then(Value::as_array);
+    let mut rows = Vec::<Value>::new();
+    let mut selected_count = 0usize;
+    let mut compared_count = 0usize;
+    let mut missing_probe_count = 0usize;
+    let mut projection_bucket_crossing_count = 0usize;
+    let mut capture_replay_mismatch_count = 0usize;
+    let mut linearized_replay_mismatch_count = 0usize;
+    let mut projection_subbucket_midpoint_crossing_count = 0usize;
+    let mut unpinned_count = 0usize;
+    let mut projection_buckets_stable_count = 0usize;
+    let mut midpoint_straddled_count = 0usize;
+    let mut replay_capture_match_count = 0usize;
+    let mut linearized_replay_match_count = 0usize;
+    let mut replay_bucket_crossing_count = 0usize;
+
+    if let Some(policy_rows) = policy_rows {
+        for policy_row in policy_rows {
+            if policy_row.pointer("/classification").and_then(Value::as_str)
+                != Some("selected_score_key_f16_policy_aligned_bucket_sensitive")
+            {
+                continue;
+            }
+            selected_count += 1;
+            let head = policy_row.pointer("/head").and_then(Value::as_u64);
+            let key_slot = policy_row.pointer("/key_slot").and_then(Value::as_u64);
+            let query_token = policy_row.pointer("/query_token").and_then(Value::as_u64);
+            let historical_row =
+                find_qk_recompute_row(historical_rows, head, key_slot, query_token);
+            let probe = historical_row
+                .and_then(|row| row.pointer("/post_rope_epsilon_probe"))
+                .unwrap_or(&Value::Null);
+            let mut blocked_reasons = Vec::<String>::new();
+            if historical_row.is_none() {
+                blocked_reasons.push("historical_projection_rope_source_row_missing".to_string());
+            }
+            if probe.is_null() {
+                blocked_reasons.push("post_rope_epsilon_probe_missing".to_string());
+            }
+
+            let projection_bucket_match =
+                probe.pointer("/projection_bucket/f16_bucket_match").and_then(Value::as_bool);
+            let paired_projection_bucket_match = probe
+                .pointer("/paired_projection_bucket/f16_bucket_match")
+                .and_then(Value::as_bool);
+            let post_rope_bucket_match =
+                probe.pointer("/post_rope_bucket/f16_bucket_match").and_then(Value::as_bool);
+            let replay_bucket_match =
+                probe.pointer("/replay_bucket/f16_bucket_match").and_then(Value::as_bool);
+            let reference_replay_minus_capture =
+                probe.pointer("/post_rope/reference_replay_minus_capture").and_then(Value::as_f64);
+            let rust_replay_minus_capture =
+                probe.pointer("/post_rope/rust_replay_minus_capture").and_then(Value::as_f64);
+            let linearized_delta_minus_runtime_replay_delta = probe
+                .pointer("/post_rope/linearized_delta_minus_runtime_replay_delta")
+                .and_then(Value::as_f64);
+            let left_minus_midpoint =
+                probe.pointer("/post_rope_bucket/left_minus_midpoint").and_then(Value::as_f64);
+            let right_minus_midpoint =
+                probe.pointer("/post_rope_bucket/right_minus_midpoint").and_then(Value::as_f64);
+            let capture_delta = probe.pointer("/post_rope/capture_delta").and_then(Value::as_f64);
+            let runtime_replay_delta =
+                probe.pointer("/post_rope/runtime_replay_delta").and_then(Value::as_f64);
+            let linearized_delta =
+                probe.pointer("/input_pair/linearized_delta_for_probe_dim").and_then(Value::as_f64);
+            let post_rope_bucket_crossing = post_rope_bucket_match == Some(false);
+            let projection_buckets_stable = projection_bucket_match == Some(true)
+                && paired_projection_bucket_match == Some(true);
+            let replay_bucket_crossing = replay_bucket_match == Some(false);
+            let replay_matches_capture =
+                reference_replay_minus_capture.zip(rust_replay_minus_capture).is_some_and(
+                    |(reference, rust)| reference.abs() <= 1.0e-12 && rust.abs() <= 1.0e-12,
+                );
+            let linearized_matches_replay = linearized_delta_minus_runtime_replay_delta
+                .is_some_and(|delta| delta.abs() <= 1.0e-6);
+            let midpoint_straddled =
+                left_minus_midpoint.zip(right_minus_midpoint).is_some_and(|(left, right)| {
+                    (left > 0.0 && right < 0.0) || (left < 0.0 && right > 0.0)
+                });
+
+            if probe.is_null() {
+                missing_probe_count += 1;
+            } else {
+                compared_count += 1;
+            }
+            if projection_bucket_match == Some(false)
+                || paired_projection_bucket_match == Some(false)
+            {
+                projection_bucket_crossing_count += 1;
+            }
+            if projection_buckets_stable {
+                projection_buckets_stable_count += 1;
+            }
+            if replay_bucket_crossing {
+                replay_bucket_crossing_count += 1;
+            }
+            if replay_matches_capture {
+                replay_capture_match_count += 1;
+            }
+            if linearized_matches_replay {
+                linearized_replay_match_count += 1;
+            }
+            if midpoint_straddled {
+                midpoint_straddled_count += 1;
+            }
+
+            let row_classification = if probe.is_null() {
+                "selected_post_rope_raw_key_epsilon_missing"
+            } else if !projection_buckets_stable {
+                "selected_post_rope_raw_key_epsilon_projection_bucket_crossing"
+            } else if !replay_matches_capture {
+                capture_replay_mismatch_count += 1;
+                "selected_post_rope_raw_key_epsilon_capture_replay_mismatch"
+            } else if !linearized_matches_replay {
+                linearized_replay_mismatch_count += 1;
+                "selected_post_rope_raw_key_epsilon_rope_linearization_unpinned"
+            } else if post_rope_bucket_crossing && replay_bucket_crossing && midpoint_straddled {
+                projection_subbucket_midpoint_crossing_count += 1;
+                "selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing"
+            } else {
+                unpinned_count += 1;
+                "selected_post_rope_raw_key_epsilon_unpinned"
+            };
+
+            rows.push(json!({
+                "classification": row_classification,
+                "head": head,
+                "kv_head": policy_row.pointer("/kv_head").cloned().unwrap_or(Value::Null),
+                "key_slot": key_slot,
+                "query_token": query_token,
+                "contributor_dim": policy_row.pointer("/contributor_dim").cloned().unwrap_or(Value::Null),
+                "blocked_reasons": blocked_reasons,
+                "historical_row_present": historical_row.is_some(),
+                "post_rope_epsilon_probe_present": !probe.is_null(),
+                "variant_id": probe.pointer("/variant_id").cloned().unwrap_or(Value::Null),
+                "probe_dim": probe.pointer("/probe_dim").cloned().unwrap_or(Value::Null),
+                "paired_dim": probe.pointer("/paired_dim").cloned().unwrap_or(Value::Null),
+                "lane": probe.pointer("/lane").cloned().unwrap_or(Value::Null),
+                "output_component": probe.pointer("/output_component").cloned().unwrap_or(Value::Null),
+                "capture_delta": capture_delta,
+                "runtime_replay_delta": runtime_replay_delta,
+                "linearized_delta_for_probe_dim": linearized_delta,
+                "linearized_delta_minus_runtime_replay_delta": linearized_delta_minus_runtime_replay_delta,
+                "reference_replay_minus_capture": reference_replay_minus_capture,
+                "rust_replay_minus_capture": rust_replay_minus_capture,
+                "post_rope_bucket_crossing": post_rope_bucket_crossing,
+                "projection_buckets_stable": projection_buckets_stable,
+                "replay_bucket_crossing": replay_bucket_crossing,
+                "replay_matches_capture": replay_matches_capture,
+                "linearized_matches_replay": linearized_matches_replay,
+                "midpoint_straddled": midpoint_straddled,
+                "projection_bucket_match": projection_bucket_match,
+                "paired_projection_bucket_match": paired_projection_bucket_match,
+                "post_rope_bucket_match": post_rope_bucket_match,
+                "replay_bucket_match": replay_bucket_match,
+                "post_rope_bucket": probe.pointer("/post_rope_bucket").cloned().unwrap_or(Value::Null),
+                "projection_bucket": probe.pointer("/projection_bucket").cloned().unwrap_or(Value::Null),
+                "paired_projection_bucket": probe.pointer("/paired_projection_bucket").cloned().unwrap_or(Value::Null),
+                "replay_bucket": probe.pointer("/replay_bucket").cloned().unwrap_or(Value::Null),
+                "input_pair": probe.pointer("/input_pair").cloned().unwrap_or(Value::Null),
+                "runtime_change_candidate": match row_classification {
+                    "selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing" => {
+                        "none_from_score_input_or_rope_replay_capture"
+                    }
+                    "selected_post_rope_raw_key_epsilon_projection_bucket_crossing" => {
+                        "localize_projection_input_bucket_crossing"
+                    }
+                    "selected_post_rope_raw_key_epsilon_capture_replay_mismatch" => {
+                        "pin_post_rope_capture_replay_mismatch"
+                    }
+                    "selected_post_rope_raw_key_epsilon_rope_linearization_unpinned" => {
+                        "pin_rope_linearization"
+                    }
+                    _ => "post_rope_raw_key_epsilon_unpinned",
+                },
+            }));
+        }
+    }
+
+    let classification = if selected_count == 0 {
+        "no_selected_score_key_f16_policy_bucket_sensitive_rows"
+    } else if missing_probe_count == selected_count {
+        "selected_post_rope_raw_key_epsilon_missing"
+    } else if projection_bucket_crossing_count > 0 {
+        "selected_post_rope_raw_key_epsilon_projection_bucket_crossing"
+    } else if capture_replay_mismatch_count > 0 {
+        "selected_post_rope_raw_key_epsilon_capture_replay_mismatch"
+    } else if linearized_replay_mismatch_count > 0 {
+        "selected_post_rope_raw_key_epsilon_rope_linearization_unpinned"
+    } else if projection_subbucket_midpoint_crossing_count > 0 && unpinned_count == 0 {
+        "selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing"
+    } else {
+        "selected_post_rope_raw_key_epsilon_unpinned"
+    };
+    let next_diagnostic = match classification {
+        "selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing" => {
+            "localize selected historical K projection subbucket epsilon source before changing RoPE or score-input runtime math"
+        }
+        "selected_post_rope_raw_key_epsilon_projection_bucket_crossing" => {
+            "localize selected historical K projection bucket crossing before changing RoPE or score-input runtime math"
+        }
+        "selected_post_rope_raw_key_epsilon_capture_replay_mismatch" => {
+            "pin selected post-RoPE capture versus replay mismatch before changing runtime math"
+        }
+        "selected_post_rope_raw_key_epsilon_rope_linearization_unpinned" => {
+            "pin selected RoPE linearized delta versus replay delta before changing runtime math"
+        }
+        "selected_post_rope_raw_key_epsilon_missing" => {
+            "capture selected post-RoPE raw key epsilon probe before changing runtime math"
+        }
+        "no_selected_score_key_f16_policy_bucket_sensitive_rows" => {
+            "pin selected score-key F16 policy before post-RoPE raw key epsilon attribution"
+        }
+        _ => "keep selected post-RoPE raw key epsilon diagnostic-only",
+    };
+
+    json!({
+        "diagnostic_only": true,
+        "claim_allowed": false,
+        "policy": "Selected post-RoPE raw key epsilon is diagnostic-only evidence for whether a selected score-key F16 bucket crossing is explained by sub-bucket projection input drift transformed through RoPE and straddling the post-RoPE F16 midpoint; it does not change runtime math or promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, full residency, performance, or completion",
+        "classification": classification,
+        "selected_count": selected_count,
+        "compared_count": compared_count,
+        "missing_probe_count": missing_probe_count,
+        "projection_bucket_crossing_count": projection_bucket_crossing_count,
+        "capture_replay_mismatch_count": capture_replay_mismatch_count,
+        "linearized_replay_mismatch_count": linearized_replay_mismatch_count,
+        "projection_subbucket_midpoint_crossing_count": projection_subbucket_midpoint_crossing_count,
+        "unpinned_count": unpinned_count,
+        "projection_buckets_stable_count": projection_buckets_stable_count,
+        "midpoint_straddled_count": midpoint_straddled_count,
+        "replay_capture_match_count": replay_capture_match_count,
+        "linearized_replay_match_count": linearized_replay_match_count,
+        "replay_bucket_crossing_count": replay_bucket_crossing_count,
+        "rows": rows,
+        "next_diagnostic": next_diagnostic,
+    })
+}
+
 fn find_qk_recompute_row<'a>(
     rows: Option<&'a Vec<Value>>,
     head: Option<u64>,
@@ -36854,6 +37103,114 @@ mod tests {
             report.pointer("/next_diagnostic"),
             Some(&json!(
                 "localize the selected post-RoPE raw key epsilon that crosses the F16 bucket boundary; do not change score-input F16 policy"
+            ))
+        );
+    }
+
+    #[test]
+    fn selected_post_rope_raw_key_epsilon_reports_projection_subbucket_midpoint_crossing() {
+        let score_key_policy = json!({
+            "rows": [
+                {
+                    "classification": "selected_score_key_f16_policy_aligned_bucket_sensitive",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                }
+            ]
+        });
+        let historical_source = json!({
+            "rows": [
+                {
+                    "classification": "selected_key_historical_post_rope_f16_bucket_sensitivity",
+                    "head": 0,
+                    "kv_head": 0,
+                    "key_slot": 13,
+                    "query_token": 3,
+                    "contributor_dim": 77,
+                    "post_rope_epsilon_probe": {
+                        "variant_id": "bitnet_500000_ggml_f32_iterative_theta_f32_arithmetic",
+                        "probe_dim": 77,
+                        "paired_dim": 13,
+                        "lane": 13,
+                        "output_component": "upper_x0_sin_plus_x1_cos",
+                        "input_pair": {
+                            "delta_x0": -3.5762786865234375e-6_f64,
+                            "delta_x1": 2.1457672119140625e-6_f64,
+                            "linearized_delta_for_probe_dim": -1.4845603999447121e-6_f64,
+                        },
+                        "post_rope": {
+                            "capture_delta": -1.5497207641601562e-6_f64,
+                            "runtime_replay_delta": -1.5497207641601562e-6_f64,
+                            "linearized_delta_minus_runtime_replay_delta": 6.516036421544413e-8_f64,
+                            "reference_replay_minus_capture": 0.0_f64,
+                            "rust_replay_minus_capture": 0.0_f64,
+                        },
+                        "post_rope_bucket": {
+                            "f16_bucket_match": false,
+                            "left_minus_midpoint": 8.344650268554688e-7_f64,
+                            "right_minus_midpoint": -7.152557373046875e-7_f64,
+                            "bucket_value_delta": -0.0009765625_f64,
+                            "abs_delta": 1.5497207641601562e-6_f64,
+                            "f16_bucket_midpoint": 1.48095703125_f64,
+                        },
+                        "projection_bucket": {
+                            "f16_bucket_match": true,
+                            "abs_delta": 2.1457672119140625e-6_f64,
+                            "bucket_value_delta": 0.0_f64,
+                        },
+                        "paired_projection_bucket": {
+                            "f16_bucket_match": true,
+                            "abs_delta": 3.5762786865234375e-6_f64,
+                            "bucket_value_delta": 0.0_f64,
+                        },
+                        "replay_bucket": {
+                            "f16_bucket_match": false,
+                            "bucket_value_delta": -0.0009765625_f64,
+                        }
+                    }
+                }
+            ]
+        });
+
+        let report =
+            attention_selected_post_rope_raw_key_epsilon(&score_key_policy, &historical_source);
+
+        assert_eq!(report.pointer("/diagnostic_only"), Some(&json!(true)));
+        assert_eq!(report.pointer("/claim_allowed"), Some(&json!(false)));
+        assert_eq!(
+            report.pointer("/classification"),
+            Some(&json!(
+                "selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing"
+            ))
+        );
+        assert_eq!(report.pointer("/selected_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/compared_count"), Some(&json!(1)));
+        assert_eq!(
+            report.pointer("/projection_subbucket_midpoint_crossing_count"),
+            Some(&json!(1))
+        );
+        assert_eq!(report.pointer("/projection_buckets_stable_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/midpoint_straddled_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/replay_capture_match_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/linearized_replay_match_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/replay_bucket_crossing_count"), Some(&json!(1)));
+        assert_eq!(
+            report.pointer("/rows/0/classification"),
+            Some(&json!(
+                "selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing"
+            ))
+        );
+        assert_eq!(
+            report.pointer("/rows/0/runtime_change_candidate"),
+            Some(&json!("none_from_score_input_or_rope_replay_capture"))
+        );
+        assert_eq!(
+            report.pointer("/next_diagnostic"),
+            Some(&json!(
+                "localize selected historical K projection subbucket epsilon source before changing RoPE or score-input runtime math"
             ))
         );
     }


### PR DESCRIPTION
## Summary

- add a diagnostic-only `attention_selected_post_rope_raw_key_epsilon` section after the selected score-key F16 policy report
- classify the selected score-key bucket crossing as a projection sub-bucket raw epsilon that straddles the post-RoPE F16 midpoint when replay/capture and linearized RoPE deltas agree
- keep `claim_allowed=false` and preserve all A770/reference parity/residency/performance non-claims

## Live diagnostic

The refreshed compare receipt reports:

```text
attention_selected_post_rope_raw_key_epsilon.classification = selected_post_rope_raw_key_epsilon_projection_subbucket_midpoint_crossing
compared_count = 1
projection_buckets_stable_count = 1
midpoint_straddled_count = 1
replay_capture_match_count = 1
linearized_replay_match_count = 1
claim_allowed = false
```

This points the next diagnostic at the historical K projection sub-bucket epsilon source before changing RoPE or score-input runtime math.

## Validation

```text
cargo test --locked -p xtask --no-default-features --bin xtask selected_post_rope_raw_key_epsilon -- --nocapture
cargo test --locked -p xtask --no-default-features --bin xtask selected_score_key_f16_policy -- --nocapture
cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture
cargo check --locked -p xtask --no-default-features
rustfmt --edition 2024 --check xtask/src/bitnet_reference_layer_trace.rs
git diff --check
```

Live receipt regenerated with:

```text
cargo run --locked -p xtask --no-default-features -- bitnet-reference-layer-trace-compare --reference target/a770-diagnostic/reference-first-token-layer-trace-reference-historical-key-projection.json --cpu-trace-dir target/a770-diagnostic/reference-layer-trace-rust-cpu-historical-key-projection --output target/a770-diagnostic/bitnet-reference-layer-trace-compare-selected-post-rope-raw-key-epsilon.json --format json
```

## Claim boundary

Diagnostic-only. This does not promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, full residency, performance, or completion.