### PR TITLE
Make RIPR review fallback contract-valid

### DIFF
--- a/.github/workflows/ripr-pr-evidence.yml
+++ b/.github/workflows/ripr-pr-evidence.yml
@@ -64,6 +64,14 @@ jobs:
             mkdir -p target/ripr/review
             printf '%s\n' \
               '{' \
+              '  "schema_version": 1,' \
+              '  "tool": "ripr",' \
+              '  "mode": "review-comments-fallback",' \
+              '  "summary": {' \
+              '    "status": "timed_out",' \
+              '    "warnings": ["ripr review-comments timed out; see EffortlessMetrics/ripr#876"]' \
+              '  },' \
+              '  "findings": [],' \
               '  "comments": [],' \
               '  "summary_only": true,' \
               '  "suppressed": [],' \


### PR DESCRIPTION
## Summary
- add the required review contract keys to the RIPR review-guidance fallback JSON
- keep the existing timeout fallback path and markdown artifact
- preserve the advisory-only behavior for review guidance timeouts

## Validation
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- lint-workflows`
- local fallback fixture: `target/debug/xtask ripr-review-comments --check`

## Context
PR #5339 now reaches the review fallback path, but the fallback JSON failed `ripr-review-comments --check` because it lacked `schema_version`, `tool`, `mode`, `summary`, and `findings`.

## Claim Boundary
CI workflow hardening only. No runtime, model, Apple M4, BitNet, Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad quality, or broad performance change.