### PR TITLE
fix(cli): cfg full-cli logits scratch test

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -13348,6 +13348,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "full-cli")]
     fn extract_logits_2d_into_reuses_host_scratch() -> Result<()> {
         let logits =
             candle_core::Tensor::new(&[[0.25f32, 1.0, 0.5, 1.5]], &candle_core::Device::Cpu)?;


### PR DESCRIPTION
## Summary
- Gate the xtract_logits_2d_into_reuses_host_scratch test with ull-cli, matching the helper it exercises.
- Restores the no-default-features CPU all-targets MSRV workspace check after #5393.

## Validation
- tk proxy cargo fmt -p bitnet-cli -- --check passed.
- tk git diff --check passed.
- tk proxy cargo check --workspace --all-targets --locked --no-default-features --features cpu attempted locally; blocked by Windows sentencepiece-sys CMake/Visual Studio discovery before completing the Linux MSRV signal.