### PR TITLE
refactor: dry up simple config scenarios

### DIFF
--- a/tests/common/config_scenarios_simple.rs
+++ b/tests/common/config_scenarios_simple.rs
@@ -4,90 +4,61 @@ use super::config::FixtureConfig;
 use super::config::{CrossValidationConfig, ReportFormat, ReportingConfig, TestConfig};
 use std::time::Duration;
 
-/// Create a simple test config without FastConfigBuilder
-pub fn create_unit_config() -> TestConfig {
+fn scenario_config(
+    max_parallel_tests: usize,
+    timeout_secs: u64,
+    log_level: &str,
+    coverage_threshold: f64,
+    formats: Vec<ReportFormat>,
+) -> TestConfig {
     TestConfig {
-        max_parallel_tests: 8,
-        test_timeout: Duration::from_secs(30),
-        log_level: "warn".to_string(),
-        coverage_threshold: 0.8,
+        max_parallel_tests,
+        test_timeout: Duration::from_secs(timeout_secs),
+        log_level: log_level.to_string(),
+        coverage_threshold,
         #[cfg(feature = "fixtures")]
         fixtures: FixtureConfig::default(),
         crossval: CrossValidationConfig::default(),
-        reporting: ReportingConfig {
-            formats: vec![ReportFormat::Json, ReportFormat::Html],
-            ..Default::default()
-        },
+        reporting: ReportingConfig { formats, ..Default::default() },
         ..Default::default()
     }
+}
+
+/// Create a simple test config without FastConfigBuilder
+pub fn create_unit_config() -> TestConfig {
+    scenario_config(8, 30, "warn", 0.8, vec![ReportFormat::Json, ReportFormat::Html])
 }
 
 pub fn create_integration_config() -> TestConfig {
-    TestConfig {
-        max_parallel_tests: 4,
-        test_timeout: Duration::from_secs(120),
-        log_level: "info".to_string(),
-        coverage_threshold: 0.8,
-        #[cfg(feature = "fixtures")]
-        fixtures: FixtureConfig::default(),
-        crossval: CrossValidationConfig::default(),
-        reporting: ReportingConfig {
-            formats: vec![ReportFormat::Html, ReportFormat::Json, ReportFormat::Junit],
-            ..Default::default()
-        },
-        ..Default::default()
-    }
+    scenario_config(
+        4,
+        120,
+        "info",
+        0.8,
+        vec![ReportFormat::Html, ReportFormat::Json, ReportFormat::Junit],
+    )
 }
 
 pub fn create_e2e_config() -> TestConfig {
-    TestConfig {
-        max_parallel_tests: 2,
-        test_timeout: Duration::from_secs(300),
-        log_level: "info".to_string(),
-        coverage_threshold: 0.8,
-        #[cfg(feature = "fixtures")]
-        fixtures: FixtureConfig::default(),
-        crossval: CrossValidationConfig::default(),
-        reporting: ReportingConfig {
-            formats: vec![
-                ReportFormat::Html,
-                ReportFormat::Json,
-                ReportFormat::Junit,
-                ReportFormat::Markdown,
-            ],
-            ..Default::default()
-        },
-        ..Default::default()
-    }
+    scenario_config(
+        2,
+        300,
+        "info",
+        0.8,
+        vec![ReportFormat::Html, ReportFormat::Json, ReportFormat::Junit, ReportFormat::Markdown],
+    )
 }
 
 pub fn create_smoke_config() -> TestConfig {
-    TestConfig {
-        max_parallel_tests: 1,
-        test_timeout: Duration::from_secs(10),
-        log_level: "error".to_string(),
-        coverage_threshold: 0.0,
-        #[cfg(feature = "fixtures")]
-        fixtures: FixtureConfig::default(),
-        crossval: CrossValidationConfig::default(),
-        reporting: ReportingConfig { formats: vec![ReportFormat::Json], ..Default::default() },
-        ..Default::default()
-    }
+    scenario_config(1, 10, "error", 0.0, vec![ReportFormat::Json])
 }
 
 pub fn create_perf_config() -> TestConfig {
-    TestConfig {
-        max_parallel_tests: 1,
-        test_timeout: Duration::from_secs(600),
-        log_level: "info".to_string(),
-        coverage_threshold: 0.0,
-        #[cfg(feature = "fixtures")]
-        fixtures: FixtureConfig::default(),
-        crossval: CrossValidationConfig::default(),
-        reporting: ReportingConfig {
-            formats: vec![ReportFormat::Html, ReportFormat::Json, ReportFormat::Markdown],
-            ..Default::default()
-        },
-        ..Default::default()
-    }
+    scenario_config(
+        1,
+        600,
+        "info",
+        0.0,
+        vec![ReportFormat::Html, ReportFormat::Json, ReportFormat::Markdown],
+    )
 }


### PR DESCRIPTION
### Motivation
- Remove repeated `TestConfig` struct literals in the simple scenario presets to make the code DRY and easier to maintain.
- Centralize the common construction logic so future changes to defaults only need one update.

### Description
- Add a `scenario_config(...) -> TestConfig` helper that encapsulates the common `TestConfig` construction used by the simple presets in `tests/common/config_scenarios_simple.rs`.
- Replace the previous verbose `TestConfig` literals for `create_unit_config`, `create_integration_config`, `create_e2e_config`, `create_smoke_config`, and `create_perf_config` with concise calls to `scenario_config` using the same parameter values.
- Keep `#[cfg(feature = "fixtures")]` and `ReportingConfig` defaults intact while reducing boilerplate and improving readability.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test --locked -p bitnet-tests --lib config_scenarios_simple` which completed and returned ok (no failing tests in the test-only target).
- Ran `cargo clippy --locked -p bitnet-tests --lib --no-default-features --features fixtures -- -D warnings` which completed without warnings.
- An attempted run of `cargo test --locked --test test_configuration_scenarios --no-default-features --features cpu` failed early because the specified test target `test_configuration_scenarios` is not available in the current test targets; this does not affect the simple-config change and the targeted package tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b87c744c8333be63eddb3396339e)