### PR TITLE
fix: harden minimal json edge cases

### DIFF
--- a/crates/bitnet-minimal-json-core/src/lib.rs
+++ b/crates/bitnet-minimal-json-core/src/lib.rs
@@ -23,55 +23,176 @@ impl MinimalJson {
         let inner = &trimmed[1..trimmed.len() - 1];
         let mut fields = HashMap::new();
 
-        for part in Self::split_top_level(inner) {
+        for part in Self::split_top_level(inner)? {
             let part = part.trim();
             if part.is_empty() {
                 continue;
             }
-            if let Some((k, v)) = part.split_once(':') {
-                let key = k.trim().trim_matches('"').to_string();
-                let val = v.trim();
-                let val = if val.starts_with('"') && val.ends_with('"') && val.len() >= 2 {
-                    val[1..val.len() - 1].to_string()
-                } else {
-                    val.to_string()
-                };
-                fields.insert(key, val);
-            }
+            let Some(separator) = Self::top_level_colon(part)? else {
+                return Err("expected ':' after object key".to_string());
+            };
+            let key = Self::parse_key(&part[..separator])?;
+            let val = Self::parse_value(&part[separator + 1..])?;
+            fields.insert(key, val);
         }
         Ok(Self { fields })
     }
 
     /// Split on commas that are not inside braces/brackets/quotes.
-    fn split_top_level(s: &str) -> Vec<String> {
+    fn split_top_level(s: &str) -> Result<Vec<String>, String> {
         let mut parts = Vec::new();
         let mut current = String::new();
         let mut depth = 0_i32;
         let mut in_string = false;
-        let mut prev = '\0';
+        let mut escaped = false;
         for ch in s.chars() {
-            if ch == '"' && prev != '\\' {
-                in_string = !in_string;
-            }
-            if !in_string {
-                match ch {
-                    '{' | '[' => depth += 1,
-                    '}' | ']' => depth -= 1,
-                    ',' if depth == 0 => {
-                        parts.push(std::mem::take(&mut current));
-                        prev = ch;
-                        continue;
-                    }
-                    _ => {}
+            if in_string {
+                current.push(ch);
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '"' {
+                    in_string = false;
                 }
+                continue;
             }
-            current.push(ch);
-            prev = ch;
+
+            match ch {
+                '"' => {
+                    in_string = true;
+                    current.push(ch);
+                }
+                '{' | '[' => {
+                    depth += 1;
+                    current.push(ch);
+                }
+                '}' | ']' => {
+                    depth -= 1;
+                    if depth < 0 {
+                        return Err("unbalanced nested JSON value".to_string());
+                    }
+                    current.push(ch);
+                }
+                ',' if depth == 0 => {
+                    parts.push(std::mem::take(&mut current));
+                }
+                _ => current.push(ch),
+            }
+        }
+        if in_string {
+            return Err("unterminated string".to_string());
+        }
+        if depth != 0 {
+            return Err("unbalanced nested JSON value".to_string());
         }
         if !current.trim().is_empty() {
             parts.push(current);
         }
-        parts
+        Ok(parts)
+    }
+
+    fn top_level_colon(s: &str) -> Result<Option<usize>, String> {
+        let mut depth = 0_i32;
+        let mut in_string = false;
+        let mut escaped = false;
+        for (idx, ch) in s.char_indices() {
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '"' {
+                    in_string = false;
+                }
+                continue;
+            }
+
+            match ch {
+                '"' => in_string = true,
+                '{' | '[' => depth += 1,
+                '}' | ']' => {
+                    depth -= 1;
+                    if depth < 0 {
+                        return Err("unbalanced nested JSON value".to_string());
+                    }
+                }
+                ':' if depth == 0 => return Ok(Some(idx)),
+                _ => {}
+            }
+        }
+        if in_string {
+            return Err("unterminated string".to_string());
+        }
+        if depth != 0 {
+            return Err("unbalanced nested JSON value".to_string());
+        }
+        Ok(None)
+    }
+
+    fn parse_key(raw: &str) -> Result<String, String> {
+        let raw = raw.trim();
+        if !raw.starts_with('"') || !raw.ends_with('"') || raw.len() < 2 {
+            return Err("expected quoted object key".to_string());
+        }
+        Self::parse_json_string(raw)
+    }
+
+    fn parse_value(raw: &str) -> Result<String, String> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err("expected value after ':'".to_string());
+        }
+        if raw.starts_with('"') {
+            if !raw.ends_with('"') || raw.len() < 2 {
+                return Err("unterminated string".to_string());
+            }
+            Self::parse_json_string(raw)
+        } else {
+            Ok(raw.to_string())
+        }
+    }
+
+    fn parse_json_string(raw: &str) -> Result<String, String> {
+        let inner = raw
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .ok_or_else(|| "expected JSON string".to_string())?;
+        let mut decoded = String::new();
+        let mut chars = inner.chars();
+        while let Some(ch) = chars.next() {
+            if ch != '\\' {
+                decoded.push(ch);
+                continue;
+            }
+
+            let escaped = chars.next().ok_or_else(|| "unterminated escape".to_string())?;
+            match escaped {
+                '"' => decoded.push('"'),
+                '\\' => decoded.push('\\'),
+                '/' => decoded.push('/'),
+                'b' => decoded.push('\u{0008}'),
+                'f' => decoded.push('\u{000c}'),
+                'n' => decoded.push('\n'),
+                'r' => decoded.push('\r'),
+                't' => decoded.push('\t'),
+                'u' => {
+                    let mut digits = String::with_capacity(4);
+                    for _ in 0..4 {
+                        digits.push(
+                            chars.next().ok_or_else(|| "incomplete unicode escape".to_string())?,
+                        );
+                    }
+                    let code = u32::from_str_radix(&digits, 16)
+                        .map_err(|_| "invalid unicode escape".to_string())?;
+                    let ch = char::from_u32(code)
+                        .ok_or_else(|| "invalid unicode scalar value".to_string())?;
+                    decoded.push(ch);
+                }
+                _ => return Err("invalid escape".to_string()),
+            }
+        }
+        Ok(decoded)
     }
 
     #[must_use]
@@ -132,6 +253,28 @@ mod tests {
         let j = MinimalJson::parse(r#"{"obj":{"a":1},"arr":[1,2,3]}"#).unwrap();
         assert_eq!(j.get_str("obj"), Some("{\"a\":1}".to_string()));
         assert_eq!(j.get_str("arr"), Some("[1,2,3]".to_string()));
+    }
+
+    #[test]
+    fn parses_colons_and_commas_inside_strings() {
+        let j = MinimalJson::parse(r#"{"message":"time: 12:30, ok","key:with:colon":"value"}"#)
+            .unwrap();
+        assert_eq!(j.get_str("message"), Some("time: 12:30, ok".to_string()));
+        assert_eq!(j.get_str("key:with:colon"), Some("value".to_string()));
+    }
+
+    #[test]
+    fn unescapes_quoted_string_keys_and_values() {
+        let j = MinimalJson::parse(r##"{"quote\"key":"say \"hello\"","path":"C:\\tmp"}"##).unwrap();
+        assert_eq!(j.get_str("quote\"key"), Some("say \"hello\"".to_string()));
+        assert_eq!(j.get_str("path"), Some("C:\\tmp".to_string()));
+    }
+
+    #[test]
+    fn rejects_malformed_object_fields() {
+        assert!(MinimalJson::parse(r#"{"ok":1, "missing_colon"}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"unterminated":"value}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"arr":[1,2}"#).is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The existing minimal JSON field extractor treated top-level separators naively and returned raw escape sequences, which broke on quoted commas/colons and escaped characters.
- The parser also silently accepted malformed flat-object fields (missing colon, unterminated strings, unbalanced nested values) instead of returning errors.

### Description

- Reworked `MinimalJson::parse` to iterate over `split_top_level` which now returns a `Result` and preserves commas inside strings and nested values while tracking depth and escapes.
- Added `top_level_colon`, `parse_key`, `parse_value`, and `parse_json_string` helpers to locate the true key/value separator, enforce quoted keys, and decode JSON string escapes (including `\"`, `\\`, control escapes and `\uXXXX`).
- Introduced validation for unterminated strings and unbalanced nested braces/brackets so malformed object fields return errors instead of producing incorrect output.
- Added edge-case tests for `:`/`,` inside strings, quoted keys/values with escapes, backslash-paths, and malformed fields, and formatted the file to satisfy lints.

### Testing

- Ran `cargo fmt --all --check` which completed successfully.
- Ran `cargo test -p bitnet-minimal-json-core --locked` and all tests passed (`10 passed; 0 failed`).
- Ran `cargo clippy -p bitnet-minimal-json-core --locked --all-targets --no-default-features -- -D warnings` with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ef15748333a11be3edaf1cd43e)