### PR TITLE
fix(sampling): harden greedy sampling and add edge-case tests

### DIFF
--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -417,21 +417,23 @@ mod tests {
     }
 
     #[test]
-    fn greedy_sampling_ignores_nan_logits() {
+    fn greedy_sampling_ignores_nan_logits() -> Result<()> {
         let logits = vec![f32::NAN, 1.0, 0.5];
-        let token = greedy_sample(&logits).unwrap();
+        let token = greedy_sample(&logits)?;
         assert_eq!(token, 1);
+        Ok(())
     }
 
     #[test]
-    fn greedy_sampling_all_nan_falls_back_to_lowest_token_id() {
+    fn greedy_sampling_all_nan_falls_back_to_lowest_token_id() -> Result<()> {
         let logits = vec![f32::NAN, f32::NAN, f32::NAN];
-        let token = greedy_sample(&logits).unwrap();
+        let token = greedy_sample(&logits)?;
         assert_eq!(token, 0);
+        Ok(())
     }
 
     #[test]
-    fn invalid_repetition_penalty_is_ignored_before_greedy_sampling() {
+    fn invalid_repetition_penalty_is_ignored_before_greedy_sampling() -> Result<()> {
         let config = SamplingConfig {
             temperature: 0.0,
             repetition_penalty: f32::NAN,
@@ -439,16 +441,18 @@ mod tests {
             ..Default::default()
         };
         let mut strategy = SamplingStrategy::new(config);
-        let token = strategy.sample(&[10.0, 9.0], &[0]).unwrap();
+        let token = strategy.sample(&[10.0, 9.0], &[0])?;
         assert_eq!(token, 0);
+        Ok(())
     }
 
     #[test]
-    fn non_finite_temperature_uses_greedy_fallback() {
+    fn non_finite_temperature_uses_greedy_fallback() -> Result<()> {
         let config = SamplingConfig { temperature: f32::NAN, seed: Some(0), ..Default::default() };
         let mut strategy = SamplingStrategy::new(config);
-        let token = strategy.sample(&[1.0, 2.0, 3.0], &[]).unwrap();
+        let token = strategy.sample(&[1.0, 2.0, 3.0], &[])?;
         assert_eq!(token, 2);
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -16,7 +16,7 @@ pub use strategies::{
     SamplerStage, TypicalSampler,
 };
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use bitnet_probability::{renormalize_in_place, sample_categorical};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -160,7 +160,7 @@ impl SamplingStrategy {
             return Err(anyhow::anyhow!("Empty logits slice"));
         }
 
-        if self.config.temperature == 0.0
+        if (self.config.temperature <= 0.0 || !self.config.temperature.is_finite())
             && (self.config.repetition_penalty == 1.0 || context_tokens.is_empty())
         {
             return greedy_sample(logits);
@@ -199,9 +199,9 @@ impl SamplingStrategy {
         // the flat single-occurrence version in bitnet-logits).
         self.penalize_repeated_tokens(logits, context_tokens);
 
-        // Greedy path: temperature == 0.0 → greedy_sample (handles empty input
+        // Greedy path: temperature <= 0.0 or non-finite -> greedy_sample (handles empty input
         // as Err and breaks ties by lowest token ID for llama.cpp compatibility).
-        if self.config.temperature == 0.0 {
+        if self.config.temperature <= 0.0 || !self.config.temperature.is_finite() {
             return greedy_sample(logits);
         }
 
@@ -236,8 +236,9 @@ impl SamplingStrategy {
     /// [`bitnet_logits::apply_repetition_penalty`], which applies a flat single-
     /// occurrence penalty.
     fn penalize_repeated_tokens(&self, logits: &mut [f32], context_tokens: &[u32]) {
+        let penalty = self.config.repetition_penalty;
         #[allow(clippy::float_cmp)]
-        if self.config.repetition_penalty == 1.0 || context_tokens.is_empty() {
+        if penalty <= 0.0 || !penalty.is_finite() || penalty == 1.0 || context_tokens.is_empty() {
             return;
         }
 
@@ -245,7 +246,6 @@ impl SamplingStrategy {
         // to `logit /= penalty^count` because `logit / penalty / penalty` == `logit / (penalty^2)`.
         // This avoids allocating a HashMap to count token occurrences.
         // Also pre-calculate 1.0 / penalty to replace division with multiplication.
-        let penalty = self.config.repetition_penalty;
         let inv_penalty = 1.0 / penalty;
 
         for &token in context_tokens {
@@ -351,26 +351,30 @@ impl SamplingStrategy {
 /// assert_eq!(greedy_sample(&tied).unwrap(), 0);
 /// ```
 pub fn greedy_sample(logits: &[f32]) -> Result<u32> {
-    logits
-        .iter()
-        .enumerate()
-        .max_by(|(idx_a, a), (idx_b, b)| {
-            // First compare logits
-            match a.partial_cmp(b).unwrap() {
-                std::cmp::Ordering::Equal => {
-                    // On tie, prefer lower token ID
-                    idx_b.cmp(idx_a) // Reverse: lower idx is "greater" priority
-                }
-                other => other,
-            }
-        })
-        .map(|(idx, _)| idx as u32)
-        .context("Empty logits for greedy sampling")
+    if logits.is_empty() {
+        return Err(anyhow::anyhow!("Empty logits for greedy sampling"));
+    }
+
+    let mut best_idx = 0usize;
+    let mut best_value: Option<f32> = None;
+
+    for (idx, &logit) in logits.iter().enumerate() {
+        if logit.is_nan() {
+            continue;
+        }
+
+        if best_value.is_none_or(|best| logit > best) {
+            best_idx = idx;
+            best_value = Some(logit);
+        }
+    }
+
+    Ok(best_idx as u32)
 }
 
 /// Convenience wrapper: multinomial sampling with temperature.
 ///
-/// Delegates to [`greedy_sample`] when `temperature <= 0.0`, otherwise
+/// Delegates to [`greedy_sample`] when `temperature <= 0.0` or non-finite, otherwise
 /// creates a one-shot [`SamplingStrategy`] with top-k and top-p disabled.
 ///
 /// `_rng` is accepted for API compatibility but the strategy manages its own
@@ -380,7 +384,7 @@ pub fn greedy_sample(logits: &[f32]) -> Result<u32> {
 ///
 /// Returns an error if `logits` is empty.
 pub fn temperature_sample(logits: &[f32], temperature: f32, _rng: &mut impl Rng) -> Result<u32> {
-    if temperature <= 0.0 {
+    if temperature <= 0.0 || !temperature.is_finite() {
         return greedy_sample(logits);
     }
 
@@ -410,6 +414,41 @@ mod tests {
         let logits = vec![0.1, 0.8, 0.1];
         let token = greedy_sample(&logits).unwrap();
         assert_eq!(token, 1); // Index of highest logit
+    }
+
+    #[test]
+    fn greedy_sampling_ignores_nan_logits() {
+        let logits = vec![f32::NAN, 1.0, 0.5];
+        let token = greedy_sample(&logits).unwrap();
+        assert_eq!(token, 1);
+    }
+
+    #[test]
+    fn greedy_sampling_all_nan_falls_back_to_lowest_token_id() {
+        let logits = vec![f32::NAN, f32::NAN, f32::NAN];
+        let token = greedy_sample(&logits).unwrap();
+        assert_eq!(token, 0);
+    }
+
+    #[test]
+    fn invalid_repetition_penalty_is_ignored_before_greedy_sampling() {
+        let config = SamplingConfig {
+            temperature: 0.0,
+            repetition_penalty: f32::NAN,
+            seed: Some(0),
+            ..Default::default()
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&[10.0, 9.0], &[0]).unwrap();
+        assert_eq!(token, 0);
+    }
+
+    #[test]
+    fn non_finite_temperature_uses_greedy_fallback() {
+        let config = SamplingConfig { temperature: f32::NAN, seed: Some(0), ..Default::default() };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&[1.0, 2.0, 3.0], &[]).unwrap();
+        assert_eq!(token, 2);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent panics and undefined behaviour when sampling sees degenerate logits (NaN-only entries) or non-finite configuration values. 
- Cover red/green test cases for NaN logits, all-NaN fallback, invalid repetition-penalty values, and non-finite temperatures to lock the behaviour in tests. 

### Description

- Harden `greedy_sample` to skip `NaN` logits and deterministically fall back to the lowest token id when all entries are non-finite, returning an error only for an empty slice. 
- Treat non-positive or non-finite `temperature` as the greedy/deterministic path in `SamplingStrategy::sample` and `temperature_sample`. 
- Validate `repetition_penalty` in `penalize_repeated_tokens` to ignore non-positive, non-finite, or identity penalty values before mutating logits, and precompute the penalty for clarity. 
- Add unit tests exercising: ignoring `NaN` logits, all-`NaN` fallback, ignored invalid repetition penalty, and non-finite temperature greedy fallback, and remove an unused import. 

### Testing

- Ran the crate unit test suite with `cargo test -p bitnet-sampling --no-default-features`, which completed successfully (all tests passed). 
- Ran linting with `cargo clippy -p bitnet-sampling --all-targets --no-default-features -- -D warnings`, which returned clean (no warnings/error failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ef15748333a11be3edaf1cd43e)