### PR TITLE
fix(minimal-json-core): harden minimal JSON edge cases

### DIFF
--- a/crates/bitnet-minimal-json-core/src/lib.rs
+++ b/crates/bitnet-minimal-json-core/src/lib.rs
@@ -23,55 +23,152 @@ impl MinimalJson {
         let inner = &trimmed[1..trimmed.len() - 1];
         let mut fields = HashMap::new();
 
-        for part in Self::split_top_level(inner) {
+        for part in Self::split_top_level(inner)? {
             let part = part.trim();
             if part.is_empty() {
-                continue;
+                return Err("empty field in JSON object".to_string());
             }
-            if let Some((k, v)) = part.split_once(':') {
-                let key = k.trim().trim_matches('"').to_string();
-                let val = v.trim();
-                let val = if val.starts_with('"') && val.ends_with('"') && val.len() >= 2 {
-                    val[1..val.len() - 1].to_string()
-                } else {
-                    val.to_string()
-                };
-                fields.insert(key, val);
+            let colon = Self::find_top_level_colon(part)
+                .ok_or_else(|| format!("expected ':' in JSON field: {part}"))?;
+            let (k, v) = part.split_at(colon);
+            let key = Self::parse_quoted_string(k.trim())?;
+            let val = v[1..].trim();
+            if val.is_empty() {
+                return Err(format!("missing value for JSON field: {key}"));
             }
+            let val = if val.starts_with('"') {
+                Self::parse_quoted_string(val)?
+            } else {
+                val.to_string()
+            };
+            fields.insert(key, val);
         }
         Ok(Self { fields })
     }
 
     /// Split on commas that are not inside braces/brackets/quotes.
-    fn split_top_level(s: &str) -> Vec<String> {
+    fn split_top_level(s: &str) -> Result<Vec<String>, String> {
         let mut parts = Vec::new();
         let mut current = String::new();
         let mut depth = 0_i32;
         let mut in_string = false;
-        let mut prev = '\0';
+        let mut escaped = false;
         for ch in s.chars() {
-            if ch == '"' && prev != '\\' {
-                in_string = !in_string;
-            }
-            if !in_string {
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '"' {
+                    in_string = false;
+                }
+            } else {
                 match ch {
+                    '"' => in_string = true,
                     '{' | '[' => depth += 1,
-                    '}' | ']' => depth -= 1,
+                    '}' | ']' => {
+                        depth -= 1;
+                        if depth < 0 {
+                            return Err("unbalanced closing delimiter in JSON object".to_string());
+                        }
+                    }
                     ',' if depth == 0 => {
                         parts.push(std::mem::take(&mut current));
-                        prev = ch;
                         continue;
                     }
                     _ => {}
                 }
             }
             current.push(ch);
-            prev = ch;
+        }
+        if in_string {
+            return Err("unterminated string in JSON object".to_string());
+        }
+        if depth != 0 {
+            return Err("unbalanced nested delimiter in JSON object".to_string());
         }
         if !current.trim().is_empty() {
             parts.push(current);
+        } else if s.trim_end().ends_with(',') {
+            return Err("trailing comma in JSON object".to_string());
         }
-        parts
+        Ok(parts)
+    }
+
+    fn find_top_level_colon(s: &str) -> Option<usize> {
+        let mut depth = 0_i32;
+        let mut in_string = false;
+        let mut escaped = false;
+        for (idx, ch) in s.char_indices() {
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else if ch == '"' {
+                    in_string = false;
+                }
+            } else {
+                match ch {
+                    '"' => in_string = true,
+                    '{' | '[' => depth += 1,
+                    '}' | ']' => depth -= 1,
+                    ':' if depth == 0 => return Some(idx),
+                    _ => {}
+                }
+            }
+        }
+        None
+    }
+
+    fn parse_quoted_string(s: &str) -> Result<String, String> {
+        if !s.starts_with('"') || !s.ends_with('"') || s.len() < 2 {
+            return Err(format!("expected quoted JSON string: {s}"));
+        }
+        let inner = &s[1..s.len() - 1];
+        let mut output = String::new();
+        let mut chars = inner.chars();
+        while let Some(ch) = chars.next() {
+            if ch != '\\' {
+                if ch == '"' {
+                    return Err("unescaped quote in JSON string".to_string());
+                }
+                if ch.is_control() {
+                    return Err("unescaped control character in JSON string".to_string());
+                }
+                output.push(ch);
+                continue;
+            }
+
+            let escaped =
+                chars.next().ok_or_else(|| "unterminated JSON string escape".to_string())?;
+            match escaped {
+                '"' => output.push('"'),
+                '\\' => output.push('\\'),
+                '/' => output.push('/'),
+                'b' => output.push('\u{0008}'),
+                'f' => output.push('\u{000c}'),
+                'n' => output.push('\n'),
+                'r' => output.push('\r'),
+                't' => output.push('\t'),
+                'u' => {
+                    let mut value = 0_u32;
+                    for _ in 0..4 {
+                        let hex =
+                            chars.next().ok_or_else(|| "short JSON unicode escape".to_string())?;
+                        value = value
+                            .checked_mul(16)
+                            .and_then(|v| hex.to_digit(16).map(|digit| v + digit))
+                            .ok_or_else(|| "invalid JSON unicode escape".to_string())?;
+                    }
+                    let decoded = char::from_u32(value)
+                        .ok_or_else(|| "invalid JSON unicode scalar".to_string())?;
+                    output.push(decoded);
+                }
+                _ => return Err(format!("unsupported JSON string escape: \\{escaped}")),
+            }
+        }
+        Ok(output)
     }
 
     #[must_use]
@@ -144,5 +241,38 @@ mod tests {
     fn rejects_non_object_json() {
         assert!(MinimalJson::parse("not json").is_err());
         assert!(MinimalJson::parse("[1,2]").is_err());
+    }
+
+    #[test]
+    fn handles_escaped_quotes_and_commas_inside_strings() {
+        let j = MinimalJson::parse(r#"{"message":"a \"quoted, comma\" value","next":2}"#).unwrap();
+
+        assert_eq!(j.get_str("message"), Some("a \"quoted, comma\" value".to_string()));
+        assert_eq!(j.get_u32("next"), Some(2));
+    }
+
+    #[test]
+    fn handles_even_backslashes_before_string_quote_boundaries() {
+        let j = MinimalJson::parse(r#"{"path":"C:\\","next":true}"#).unwrap();
+
+        assert_eq!(j.get_str("path"), Some("C:\\".to_string()));
+        assert_eq!(j.get_bool("next"), Some(true));
+    }
+
+    #[test]
+    fn supports_escaped_keys_and_unicode_string_values() {
+        let j = MinimalJson::parse(r#"{"spaced\"key":"line\n\u263a"}"#).unwrap();
+
+        assert_eq!(j.get_str("spaced\"key"), Some("line\n☺".to_string()));
+    }
+
+    #[test]
+    fn rejects_malformed_fields_instead_of_silently_dropping_them() {
+        assert!(MinimalJson::parse(r#"{"ok":1,broken}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"missing":}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"unclosed":"value}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"trailing":1,}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"nested":[1,2}"#).is_err());
+        assert!(MinimalJson::parse(r#"{"quote":"bad " quote"}"#).is_err());
     }
 }


### PR DESCRIPTION
### Motivation
- Strengthen the minimal JSON field extractor to cover real-world edge cases that previously caused silent mis-parsing or data loss. 
- Add deterministic tests to catch escaped quotes, commas inside strings, unicode escapes, backslash boundary cases, and various malformed-field scenarios so future regressions are prevented.

### Description
- Replace permissive splitting/parsing with strict, robust routines: `split_top_level` now validates nesting and string termination and returns `Result<Vec<String>, String>` instead of silently continuing. 
- Add `find_top_level_colon` to locate the field separator while respecting nested structures and quoted strings. 
- Implement `parse_quoted_string` to handle escape sequences (including `\uXXXX` unicode escapes), reject unescaped quotes/control chars, and surface meaningful errors. 
- Update `MinimalJson::parse` to return errors for empty fields, missing values, malformed fields, and trailing commas, and add targeted unit tests covering the new edge cases.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully. 
- Ran `cargo test --locked -p bitnet-minimal-json-core` and all unit tests passed (`11 passed; 0 failed`). 
- Ran `cargo clippy --locked -p bitnet-minimal-json-core --all-targets -- -D warnings` and lints passed with no warnings.

Note: an earlier attempt to run with `--no-default-features --features cpu` was skipped because this microcrate does not define a `cpu` feature; tests were run without feature flags accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ef15748333a11be3edaf1cd43e)