### PR TITLE
docs(agent): clarify PR branch refresh authority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,23 +21,28 @@ Codex agents are authorized and expected to:
 3. commit,
 4. push,
 5. open or update the PR,
-6. address CI, bot, and reviewer feedback,
-7. merge the PR when required checks are green and GitHub reports it mergeable,
-8. create and merge closeout tracker PRs when required.
+6. refresh the agent-owned PR branch when needed, including merge-from-main,
+   rebase, `gh pr update-branch`, or `--force-with-lease` after branch, status,
+   and diff inspection,
+7. address CI, bot, and reviewer feedback,
+8. merge the PR when required checks are green and GitHub reports it mergeable,
+9. create and merge closeout tracker PRs when required.
 
-Commit, push, PR creation, CI/bot/reviewer repair, merge, and tracker closeout
-are agent responsibilities for those items. They are not human approval gates.
+Commit, push, PR creation, agent-owned PR branch refresh, CI/bot/reviewer
+repair, merge, and tracker closeout are agent responsibilities for those items.
+They are not human approval gates.
 
 ## Human Gates
 
 Human involvement is required only for true blockers:
 
 - GitHub permissions or branch protection prevent the merge.
-- Destructive data loss or secret/model-binary exposure is possible.
+- Direct mutation of `origin/main`, destructive cleanup, or secret/model-binary
+  exposure is possible.
 - Kernel, math, tokenizer, or loader semantics are in unresolved conflict.
 - Acceptance criteria conflict with repository policy.
 - A cost, exposure, or release decision is genuinely outside the ticket scope.
 
 Older runbook language that routes ordinary commit, push, PR creation, CI
-repair, merge, or tracker closeout to manual intervention is superseded by the
-campaign work item policy above.
+repair, PR branch refresh, merge, or tracker closeout to manual intervention is
+superseded by the campaign work item policy above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,20 +204,24 @@ Campaign work items are authoritative for review and merge flow. For items with
 `review_mode = "codex_premerge"`,
 `merge_policy = "automerge_when_green"`, and
 `human_gate = "on_blocker_only"`, Codex agents are expected to edit, validate,
-commit, push, open or update the PR, address CI/bot/reviewer feedback, merge
-when GitHub reports the PR green and mergeable, and close out tracker PRs when
-required. Commit, push, PR creation, CI/bot/reviewer repair, merge, and tracker
-closeout are not human approval gates.
+commit, push, open or update the PR, refresh the agent-owned PR branch when
+needed through merge-from-main, rebase, `gh pr update-branch`, or
+`--force-with-lease` after branch/status/diff inspection, address
+CI/bot/reviewer feedback, merge when GitHub reports the PR green and mergeable,
+and close out tracker PRs when required. Commit, push, PR creation, agent-owned
+PR branch refresh, CI/bot/reviewer repair, merge, and tracker closeout are not
+human approval gates.
 
 Human involvement is required only for true blockers: permissions or branch
-protection prevent the merge, destructive data loss or secret/model-binary
-exposure is possible, kernel/math/tokenizer/loader semantics are in unresolved
-conflict, acceptance criteria conflict with repository policy, or a
-cost/exposure/release decision is outside the ticket scope.
+protection prevent the merge, direct mutation of `origin/main`, destructive
+cleanup, or secret/model-binary exposure is possible, kernel/math/tokenizer/
+loader semantics are in unresolved conflict, acceptance criteria conflict with
+repository policy, or a cost/exposure/release decision is outside the ticket
+scope.
 
 This policy supersedes older agent runbook wording that treats ordinary commit,
-push, PR creation, CI repair, merge, or tracker closeout as a human approval
-boundary for `codex_premerge` plus `automerge_when_green` plus
+push, PR creation, PR branch refresh, CI repair, merge, or tracker closeout as a
+human approval boundary for `codex_premerge` plus `automerge_when_green` plus
 `on_blocker_only` work items.
 
 ## Critical Gotchas

--- a/docs/tracking/TRACKER_MODEL.md
+++ b/docs/tracking/TRACKER_MODEL.md
@@ -122,22 +122,26 @@ For work items with `review_mode = "codex_premerge"`,
 3. commit,
 4. push,
 5. open or update the PR,
-6. address CI, bot, and reviewer feedback,
-7. merge the PR when required checks are green and GitHub reports it mergeable,
-8. create and merge closeout tracker PRs when required.
+6. refresh the agent-owned PR branch when needed, including merge-from-main,
+   rebase, `gh pr update-branch`, or `--force-with-lease` after branch, status,
+   and diff inspection,
+7. address CI, bot, and reviewer feedback,
+8. merge the PR when required checks are green and GitHub reports it mergeable,
+9. create and merge closeout tracker PRs when required.
 
-The commit, push, PR creation, CI/bot/reviewer repair, merge, and tracker
-closeout boundaries are not human gates for those items. Human involvement is
-required only for true blockers: GitHub permissions or branch protection
-preventing merge, destructive data loss or secret/model-binary exposure risk,
-unresolved kernel/math/tokenizer/loader semantic conflict, acceptance criteria
-that conflict with repo policy, or a cost/exposure/release decision genuinely
-outside the ticket scope.
+The commit, push, PR creation, agent-owned PR branch refresh, CI/bot/reviewer
+repair, merge, and tracker closeout boundaries are not human gates for those
+items. Human involvement is required only for true blockers: GitHub permissions
+or branch protection preventing merge, direct mutation of `origin/main`,
+destructive cleanup, secret/model-binary exposure risk, unresolved
+kernel/math/tokenizer/loader semantic conflict, acceptance criteria that
+conflict with repo policy, or a cost/exposure/release decision genuinely outside
+the ticket scope.
 
 This campaign work item policy is the authority for campaign branches. If an
 older agent runbook describes default human approvals, maintainer-ready handoff,
-or manual intervention for ordinary commit, push, PR, CI repair, merge, or
-closeout work, follow the campaign work item policy instead.
+or manual intervention for ordinary commit, push, PR, PR branch refresh, CI
+repair, merge, or closeout work, follow the campaign work item policy instead.
 
 Allowed `review_mode` values are:
 


### PR DESCRIPTION
## Summary
- clarify that campaign-owned PR branch refresh is normal Codex maintenance for codex_premerge/automerge/on_blocker_only items
- keep true blockers scoped to permissions, direct origin/main mutation, destructive cleanup, exposure, policy conflicts, or unresolved semantics
- align AGENTS, CLAUDE, and tracker model wording

## Validation
- rtk git diff --check
