### PR TITLE
fix(score): reject zero batch size

### DIFF
--- a/crates/bitnet-cli/src/score.rs
+++ b/crates/bitnet-cli/src/score.rs
@@ -188,7 +188,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_score_args_accepts_positive_batch_size() {
-        validate_score_args(&score_args_with_batch_size(1)).unwrap();
+    fn validate_score_args_accepts_positive_batch_size() -> Result<()> {
+        validate_score_args(&score_args_with_batch_size(1))?;
+        Ok(())
     }
 }

--- a/crates/bitnet-cli/src/score.rs
+++ b/crates/bitnet-cli/src/score.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Args;
 use serde_json::json;
 use std::{fs, path::PathBuf, sync::Arc, time::Instant};
@@ -41,6 +41,8 @@ pub struct ScoreArgs {
 }
 
 pub async fn run_score(args: &ScoreArgs) -> Result<()> {
+    validate_score_args(args)?;
+
     // Read GGUF (counts for JSON)
     let gguf_bytes =
         fs::read(&args.model).with_context(|| format!("read {}", args.model.display()))?;
@@ -151,4 +153,42 @@ pub async fn run_score(args: &ScoreArgs) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&out)?);
     }
     Ok(())
+}
+
+fn validate_score_args(args: &ScoreArgs) -> Result<()> {
+    if args.batch_size == 0 {
+        bail!("--batch-size must be greater than 0");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn score_args_with_batch_size(batch_size: usize) -> ScoreArgs {
+        ScoreArgs {
+            model: PathBuf::from("model.gguf"),
+            tokenizer: None,
+            file: PathBuf::from("prompts.txt"),
+            max_tokens: 0,
+            device: "cpu".to_string(),
+            batch_size,
+            json_out: None,
+        }
+    }
+
+    #[test]
+    fn validate_score_args_rejects_zero_batch_size() {
+        let err = validate_score_args(&score_args_with_batch_size(0)).unwrap_err();
+        assert!(
+            err.to_string().contains("--batch-size must be greater than 0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_score_args_accepts_positive_batch_size() {
+        validate_score_args(&score_args_with_batch_size(1)).unwrap();
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent a non-obvious panic and wasted work when `--batch-size 0` reaches `lines.chunks(0)` by validating args early and returning a clear error before loading models or tokenizers.

### Description
- Add `validate_score_args` and call it at the start of `run_score`, import `bail` from `anyhow`, and add unit tests in `crates/bitnet-cli/src/score.rs` to reject zero and accept positive `batch_size` values.

### Testing
- Ran `cargo check --locked --workspace --no-default-features --features cpu` and it passed; ran `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli score::tests` and the added tests passed; ran `cargo fmt --all --check` and `git diff --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084339d1608333a4fbef723a93e2d3)