### PR TITLE
Fix clippy regressions in test targets

### DIFF
--- a/crates/bitnet-kernels/src/opencl_session_manager.rs
+++ b/crates/bitnet-kernels/src/opencl_session_manager.rs
@@ -1339,7 +1339,7 @@ mod tests {
         let m = s.complete().unwrap();
         assert_eq!(m.prompt_tokens, 5);
         assert_eq!(m.generated_tokens, 2);
-        assert!(m.total_time > Duration::ZERO || true);
+        assert!(m.total_time > Duration::ZERO);
     }
 
     // ── Cancellation tests ──────────────────────────────────────────

--- a/crates/bitnet-kernels/tests/metal_batch_norm_shader_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_batch_norm_shader_tests.rs
@@ -1221,8 +1221,8 @@ mod tests {
             let input_a = make_input(2 * channels * spatial, 95.0);
             let mut input_b = input_a.clone();
             // Modify second sample.
-            for i in channels * spatial..2 * channels * spatial {
-                input_b[i] = 100.0;
+            for value in input_b.iter_mut().skip(channels * spatial).take(channels * spatial) {
+                *value = 100.0;
             }
             let out_a = instance_norm_cpu(&input_a, &gamma, &beta, channels, spatial, BN_EPSILON);
             let out_b = instance_norm_cpu(&input_b, &gamma, &beta, channels, spatial, BN_EPSILON);
@@ -1285,8 +1285,8 @@ mod tests {
             let (gamma, beta) = identity_affine(channels);
             let (output, _, var) =
                 batch_norm_forward_cpu(&input, &gamma, &beta, channels, spatial, BN_EPSILON);
-            for c in 0..channels {
-                assert!(var[c].abs() < 1e-6, "constant input var should be ~0");
+            for channel_var in var.iter().take(channels) {
+                assert!(channel_var.abs() < 1e-6, "constant input var should be ~0");
             }
             assert!(output.iter().all(|x| x.is_finite()), "constant: non-finite output");
         }

--- a/crates/bitnet-kernels/tests/metal_format_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_format_tests.rs
@@ -586,26 +586,26 @@ mod data_type_conversion {
     fn i8_to_u8_quantized_format_offset() {
         // Quantized i8 [-128..127] → u8 [0..255] via offset 128
         let i8_val: i8 = -128;
-        let u8_val = (i8_val as i16 + 128) as u8;
+        let u8_val = (i16::from(i8_val) + 128) as u8;
         assert_eq!(u8_val, 0);
 
         let i8_val: i8 = 0;
-        let u8_val = (i8_val as i16 + 128) as u8;
+        let u8_val = (i16::from(i8_val) + 128) as u8;
         assert_eq!(u8_val, 128);
 
         let i8_val: i8 = 127;
-        let u8_val = (i8_val as i16 + 128) as u8;
+        let u8_val = (i16::from(i8_val) + 128) as u8;
         assert_eq!(u8_val, 255);
     }
 
     #[test]
     fn u8_to_i8_quantized_format_offset() {
         let u8_val: u8 = 0;
-        let i8_val = (u8_val as i16 - 128) as i8;
+        let i8_val = (i16::from(u8_val) - 128) as i8;
         assert_eq!(i8_val, -128);
 
         let u8_val: u8 = 128;
-        let i8_val = (u8_val as i16 - 128) as i8;
+        let i8_val = (i16::from(u8_val) - 128) as i8;
         assert_eq!(i8_val, 0);
     }
 

--- a/crates/bitnet-kernels/tests/metal_shared_memory.rs
+++ b/crates/bitnet-kernels/tests/metal_shared_memory.rs
@@ -990,8 +990,8 @@ mod shared_memory_patterns {
 
     #[test]
     fn reduction_max_all_same() {
-        let data = vec![3.14f32; 64];
-        assert!((parallel_reduction_max(&data) - 3.14).abs() < 1e-6);
+        let data = vec![3.125f32; 64];
+        assert!((parallel_reduction_max(&data) - 3.125).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/bitnet-prompt-templates-core/benches/template_ops.rs
+++ b/crates/bitnet-prompt-templates-core/benches/template_ops.rs
@@ -3,7 +3,9 @@
 //! Measures throughput of template detection, application, and multi-turn
 //! chat rendering across representative template families.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use bitnet_prompt_templates_core::{ChatRole, ChatTurn, TemplateType};
 

--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -786,9 +786,7 @@ mod tests {
     fn unpack_block_smoke() {
         // Pattern: BitNet.cpp grouped lanes [0, 1, 2, 3].
         let mut qs = [0u8; QK256_PACKED_BYTES];
-        for b in &mut qs {
-            *b = 0b_00_01_10_11;
-        }
+        qs.fill(0b_00_01_10_11);
         let mut codes = [0u8; QK256_BLOCK];
         unpack_qk256_block(&qs, &mut codes);
 
@@ -1317,8 +1315,12 @@ mod tests {
             weight_scale,
         )?;
 
-        let expected_int_dot = 0 * -127 + 1 * -1 + 2 * 1 + 3 * 127;
-        let expected_act_sum = -127 - 1 + 1 + 127;
+        let expected_int_dot: i32 = [0, 1, 2, 3]
+            .into_iter()
+            .zip([-127, -1, 1, 127])
+            .map(|(code, activation)| code * activation)
+            .sum();
+        let expected_act_sum: i32 = [-127, -1, 1, 127].into_iter().sum();
         let expected = ((expected_int_dot - expected_act_sum) as f32 / 1.0) * weight_scale;
         assert_eq!(expected, 95.5);
         assert!((y_out[0] - expected).abs() < 1e-6, "got {}, expected {}", y_out[0], expected);

--- a/crates/bitnet-server/src/bin/server.rs
+++ b/crates/bitnet-server/src/bin/server.rs
@@ -129,25 +129,6 @@ fn parse_default_device_arg(device: &str) -> Result<DeviceConfig> {
     device.parse()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::parse_default_device_arg;
-    use bitnet_server::DeviceConfig;
-
-    #[test]
-    fn parses_strict_rtx_5070_ti_cuda_device_arg() {
-        assert!(matches!(
-            parse_default_device_arg("nvidia-rtx-5070-ti-cuda"),
-            Ok(DeviceConfig::NvidiaRtx5070TiCuda)
-        ));
-    }
-
-    #[test]
-    fn rejects_unknown_device_arg() {
-        assert!(parse_default_device_arg("generic-fast-gpu").is_err());
-    }
-}
-
 /// Wait for shutdown signals
 async fn wait_for_shutdown() {
     let ctrl_c = async {
@@ -170,5 +151,24 @@ async fn wait_for_shutdown() {
         _ = terminate => {
             info!("Received SIGTERM");
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_default_device_arg;
+    use bitnet_server::DeviceConfig;
+
+    #[test]
+    fn parses_strict_rtx_5070_ti_cuda_device_arg() {
+        assert!(matches!(
+            parse_default_device_arg("nvidia-rtx-5070-ti-cuda"),
+            Ok(DeviceConfig::NvidiaRtx5070TiCuda)
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_device_arg() {
+        assert!(parse_default_device_arg("generic-fast-gpu").is_err());
     }
 }

--- a/crates/bitnet-tokenizers/src/universal.rs
+++ b/crates/bitnet-tokenizers/src/universal.rs
@@ -266,44 +266,6 @@ impl UniversalTokenizer {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::UniversalTokenizer;
-
-    #[test]
-    fn infer_model_type_maps_sentencepiece_like_architectures_to_llama() {
-        for arch in
-            ["llama", "llama3", "mistral", "gemma", "qwen", "qwen2", "qwen3", "phi", "phi2", "phi3"]
-        {
-            assert_eq!(
-                UniversalTokenizer::infer_model_type_from_architecture(arch),
-                "llama",
-                "{arch}"
-            );
-        }
-    }
-
-    #[test]
-    fn infer_model_type_maps_bpe_architectures_to_gpt2() {
-        for arch in ["gpt2", "gpt-2", "bloom", "falcon", "gpt-j", "gptj", "gpt-neox", "gpt_neox"] {
-            assert_eq!(
-                UniversalTokenizer::infer_model_type_from_architecture(arch),
-                "gpt2",
-                "{arch}"
-            );
-        }
-    }
-
-    #[test]
-    fn infer_model_type_returns_unknown_for_unmapped_architecture() {
-        assert_eq!(
-            UniversalTokenizer::infer_model_type_from_architecture("totally-new-arch"),
-            "unknown"
-        );
-        assert_eq!(UniversalTokenizer::infer_model_type_from_architecture(""), "unknown");
-    }
-}
-
 impl Tokenizer for UniversalTokenizer {
     fn encode(&self, text: &str, add_bos: bool, add_special: bool) -> Result<Vec<u32>> {
         // Apply pre-tokenization if needed
@@ -351,5 +313,43 @@ impl Tokenizer for UniversalTokenizer {
             InternalTokenizerBackend::SentencePiece(t) => t.token_to_piece(token),
             InternalTokenizerBackend::Mock(t) => t.token_to_piece(token),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UniversalTokenizer;
+
+    #[test]
+    fn infer_model_type_maps_sentencepiece_like_architectures_to_llama() {
+        for arch in
+            ["llama", "llama3", "mistral", "gemma", "qwen", "qwen2", "qwen3", "phi", "phi2", "phi3"]
+        {
+            assert_eq!(
+                UniversalTokenizer::infer_model_type_from_architecture(arch),
+                "llama",
+                "{arch}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_model_type_maps_bpe_architectures_to_gpt2() {
+        for arch in ["gpt2", "gpt-2", "bloom", "falcon", "gpt-j", "gptj", "gpt-neox", "gpt_neox"] {
+            assert_eq!(
+                UniversalTokenizer::infer_model_type_from_architecture(arch),
+                "gpt2",
+                "{arch}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_model_type_returns_unknown_for_unmapped_architecture() {
+        assert_eq!(
+            UniversalTokenizer::infer_model_type_from_architecture("totally-new-arch"),
+            "unknown"
+        );
+        assert_eq!(UniversalTokenizer::infer_model_type_from_architecture(""), "unknown");
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve new Clippy and linter regressions that surfaced in test/bench code so CI remains green for targeted crates. 
- Keep runtime items before `#[cfg(test)]` modules to satisfy `clippy::items-after-test-module` without disabling the lint. 
- Replace deprecated or problematic test idioms (deprecated `criterion::black_box`, manual slice filling, index-only loops and imprecise constants) with clearer, lint-friendly code. 

### Description
- Moved trailing test modules to the end of files to avoid runtime items after `#[cfg(test)]` blocks in `bitnet-server` and `bitnet-tokenizers`. 
- Replaced deprecated `criterion::black_box` usage with `std::hint::black_box` in `bitnet-prompt-templates-core` benchmark. 
- Reworked several test-only code patterns in `bitnet-kernels` (use iterators instead of index-only loops, fixed widening casts, replaced approximate PI use with exact test values) to satisfy Clippy suggestions. 
- Simplified QK256 test setup by using `qs.fill(...)` and replaced hand-rolled arithmetic with iterator-based sums in `bitnet-quantization`. 
- Tightened an OpenCL session metrics assertion so it actually verifies non-zero elapsed time in `opencl_session_manager` tests. 

### Testing
- Ran `cargo clippy` for the modified crates (`bitnet-server`, `bitnet-tokenizers`, `bitnet-prompt-templates-core`) with the applied changes and the targeted Clippy checks passed. 
- Ran unit/bench tests for the modified areas: `bitnet-quantization` QK256 tests passed. 
- Ran selected `bitnet-kernels` test suites (`metal_batch_norm_shader_tests`, `metal_shared_memory`, `metal_format_tests`) and they passed. 
- One targeted lib-level test invocation was transiently blocked by a full-disk error before `cargo clean`, after cleanup the targeted test runs used in validation succeeded; unrelated full-workspace Clippy warnings in `bitnet-kernels` remain outside this patch and were not changed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084339d1608333a4fbef723a93e2d3)