### PR TITLE
chore: improve local dev checks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -34,7 +34,12 @@ gpu-parity = "test --package bitnet-kernels --test gpu_parity --no-default-featu
 gpu-build = "build --workspace --no-default-features --features gpu"
 
 # Development quality check aliases
-check-all = "fmt --all && clippy -p bitnet-cli --all-targets -- -D warnings && clippy -p bitnet-server --all-targets -- -D warnings && test -p bitnet-server --all-targets && test -p bitnet-server --all-targets --features degraded-ok"
+dev-fmt = "fmt --all -- --check"
+dev-check = "check --locked --workspace --all-targets --no-default-features --features cpu"
+dev-cpu-check = "check --locked --workspace --all-targets --no-default-features --features cpu"
+dev-clippy = "clippy --locked --workspace --all-targets --no-default-features --features cpu -- -D warnings"
+dev-test = "test --locked --workspace --no-default-features --features cpu"
+check-all = "check --locked --workspace --all-targets --no-default-features --features cpu"
 contracts = "public-api -p bitnet-common"
 
 [target.wasm32-unknown-unknown]

--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ Nix: `nix develop && nix build .#bitnet-cli && nix flake check` - see [Nix guide
 
 ## Testing
 
+For a fast local loop, use the development check wrapper:
+
+```bash
+scripts/dev-check.sh quick
+scripts/dev-check.sh all
+```
+
+The same single-command CPU check is available as a Cargo alias:
+
+```bash
+cargo dev-check
+```
+
+The underlying CI-style commands remain available when you need to run each gate manually:
+
 ```bash
 cargo nextest run --locked --workspace --no-default-features --features cpu
 cargo fmt --all -- --check
@@ -218,9 +233,10 @@ Near-term work is focused on:
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR:
+See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR, run the fast local wrapper first and then the fuller local CI gate when applicable:
 
 ```bash
+scripts/dev-check.sh all
 ./ci/local.sh
 ```
 

--- a/crates/bitnet-tokenizer-text-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-text-core/src/lib.rs
@@ -262,10 +262,8 @@ mod tests {
 
     #[test]
     fn normalizer_only_strip_accents_keeps_case() {
-        let n = TokenNormalizer::new(NormalizationFlags {
-            strip_accents: true,
-            ..Default::default()
-        });
+        let n =
+            TokenNormalizer::new(NormalizationFlags { strip_accents: true, ..Default::default() });
         assert_eq!(n.normalize("Café Déjà"), "Cafe Deja");
     }
 

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Common local development checks for bitnet-rs.
+#
+# The workspace intentionally has empty default features, so this wrapper keeps
+# the CPU feature set and --locked flag consistent across fast local validation
+# commands. Related one-step Cargo aliases live in .cargo/config.toml.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/dev-check.sh [COMMAND] [-- CARGO_ARGS...]
+
+Commands:
+  quick     Run rustfmt --check and cargo check for the CPU workspace (default)
+  fmt       Run rustfmt in check mode
+  check     Run cargo check for the CPU workspace
+  clippy    Run cargo clippy for the CPU workspace with -D warnings
+  test      Run CPU workspace tests, preferring cargo-nextest when installed
+  all       Run fmt, check, clippy, and test
+  help      Show this help text
+
+Examples:
+  scripts/dev-check.sh quick
+  scripts/dev-check.sh clippy -- -p bitnet-cli
+  scripts/dev-check.sh test -- -p bitnet-cli
+
+Arguments after "--" are appended to cargo check/clippy/test commands before
+feature flags and test-runner arguments. The fmt command ignores extra cargo
+arguments.
+USAGE
+}
+
+info() {
+    printf '[dev-check] %s\n' "$*"
+}
+
+run_fmt() {
+    info 'cargo fmt --all -- --check'
+    cargo fmt --all -- --check
+}
+
+run_check() {
+    local extra_args=("$@")
+    info "cargo check ${extra_args[*]} --locked --workspace --all-targets --no-default-features --features cpu"
+    cargo check "${extra_args[@]}" --locked --workspace --all-targets --no-default-features --features cpu
+}
+
+run_clippy() {
+    local extra_args=("$@")
+    info "cargo clippy ${extra_args[*]} --locked --workspace --all-targets --no-default-features --features cpu -- -D warnings"
+    cargo clippy "${extra_args[@]}" --locked --workspace --all-targets --no-default-features --features cpu -- -D warnings
+}
+
+run_test() {
+    local extra_args=("$@")
+
+    if command -v cargo-nextest >/dev/null 2>&1; then
+        info "cargo nextest run ${extra_args[*]} --locked --workspace --no-default-features --features cpu"
+        cargo nextest run "${extra_args[@]}" --locked --workspace --no-default-features --features cpu
+    else
+        info "cargo test ${extra_args[*]} --locked --workspace --no-default-features --features cpu"
+        cargo test "${extra_args[@]}" --locked --workspace --no-default-features --features cpu
+    fi
+}
+
+command_name=${1:-quick}
+if [[ $# -gt 0 ]]; then
+    shift
+fi
+
+cargo_args=()
+if [[ $# -gt 0 ]]; then
+    if [[ $1 != '--' ]]; then
+        printf 'error: unexpected argument %q; put cargo args after --\n\n' "$1" >&2
+        usage >&2
+        exit 2
+    fi
+    shift
+    cargo_args=("$@")
+fi
+
+case "$command_name" in
+    quick)
+        run_fmt
+        run_check "${cargo_args[@]}"
+        ;;
+    fmt)
+        run_fmt
+        ;;
+    check)
+        run_check "${cargo_args[@]}"
+        ;;
+    clippy)
+        run_clippy "${cargo_args[@]}"
+        ;;
+    test)
+        run_test "${cargo_args[@]}"
+        ;;
+    all)
+        run_fmt
+        run_check "${cargo_args[@]}"
+        run_clippy "${cargo_args[@]}"
+        run_test "${cargo_args[@]}"
+        ;;
+    help|--help|-h)
+        usage
+        ;;
+    *)
+        printf 'error: unknown command %q\n\n' "$command_name" >&2
+        usage >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
### Motivation

- Provide a single, easy local entrypoint for the common dev loop (fmt, check, clippy, test) to improve developer UX and reduce friction. 
- Replace a broken multi-command Cargo alias with explicit, valid aliases that respect the workspace's empty default features and `--locked` policy. 
- Ensure the recommended fast-local checks are discoverable in the README so contributors run the correct lightweight gates before CI. 

### Description

- Add `scripts/dev-check.sh`, a local wrapper that exposes `quick`, `fmt`, `check`, `clippy`, `test`, and `all` commands and enforces `--locked --no-default-features --features cpu` for checks and tests. 
- Replace the invalid `check-all` alias with explicit Cargo aliases in `.cargo/config.toml`: `dev-fmt`, `dev-check`, `dev-cpu-check`, `dev-clippy`, `dev-test`, and a new `check-all` that maps to the CPU `check` invocation. 
- Update `README.md` to document the fast local wrapper and the `cargo dev-check` alias and recommend running the wrapper before the fuller local CI gate. 
- Apply a rustfmt cleanup to a tokenizer test snippet in `crates/bitnet-tokenizer-text-core/src/lib.rs` so `cargo fmt --all -- --check` passes. 

### Testing

- Ran `cargo fmt --all -- --check` and it passed. 
- Verified script syntax with `bash -n scripts/dev-check.sh` and `scripts/dev-check.sh help` which produced the expected usage output. 
- Confirmed the Cargo alias help flows with `cargo dev-check --help` and `cargo check-all --help`. 
- Executed the fast local loop via `scripts/dev-check.sh quick` which completed successfully (run finished in ~28m 40s and emitted only expected compiler/bench warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083e1210c083339531fd12d2bb6952)