### PR TITLE
chore(devex): add local dev check helper

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -57,6 +57,14 @@ docs:
 docs-automation:
     scripts/docs_automation.sh
 
+# Fast local contributor check (fmt check, default-member build, unit tests)
+dev-check:
+    scripts/dev-check.sh quick
+
+# Full local contributor check (fmt check, workspace clippy, workspace tests)
+dev-check-full:
+    scripts/dev-check.sh full
+
 # Format and lint code
 fmt:
     cargo fmt --all

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ NC := $(shell tput sgr0 2>/dev/null || echo "")
 .PHONY: help all quick install dev test bench clean gpu docker run serve repl release deploy update fmt lint check fix docs ci setup \
         build test-quick test-gpu test-integration gpu-smoke download-model crossval tree loc size \
         watch flame audit outdated bloat docker-run docker-gpu profile valgrind heaptrack wasm python list verbose \
-        guards preflight docs-check \
+        guards preflight docs-check dev-check dev-check-full \
         b t r c f l d g bt bf cf cb ct fr ft q a i
 
 # Detect OS and features
@@ -162,6 +162,14 @@ fmt:
 lint:
 	@echo "$(GREEN)Running clippy...$(NC)"
 	@$(CARGO) clippy --workspace --all-targets --all-features -- -D warnings
+
+## dev-check: Fast local contributor check (fmt check, default-member build, unit tests)
+dev-check:
+	@./scripts/dev-check.sh quick
+
+## dev-check-full: Full local contributor check (fmt check, workspace clippy, workspace tests)
+dev-check-full:
+	@./scripts/dev-check.sh full
 
 ## check: Run all checks (fmt, lint, test)
 check: fmt lint test

--- a/README.md
+++ b/README.md
@@ -185,7 +185,20 @@ Nix: `nix develop && nix build .#bitnet-cli && nix flake check` - see [Nix guide
 
 ## Testing
 
+For fast local feedback while developing, run the default dev check. It verifies
+formatting, checks the Cargo default-members with `--locked --no-default-features --features cpu`,
+and runs their library tests without opting into every workspace crate.
+
 ```bash
+./scripts/dev-check.sh
+# or: just dev-check
+# or: make dev-check
+```
+
+Before opening a broader PR, run the full workspace check:
+
+```bash
+./scripts/dev-check.sh full
 cargo nextest run --locked --workspace --no-default-features --features cpu
 cargo fmt --all -- --check
 cargo clippy --locked --workspace --all-targets --no-default-features --features cpu -- -D warnings

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CARGO_BIN="${CARGO:-cargo}"
+FEATURES="${BITNET_DEV_FEATURES:-cpu}"
+MODE="${1:-quick}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev-check.sh [quick|full|fmt|clippy|test]
+
+Fast local feedback for contributors. By default this checks the workspace
+Cargo default-members with the CPU feature set, which avoids accidentally
+running every opt-in crate while still catching common format, build, and unit
+test issues.
+
+Environment:
+  CARGO                Cargo executable to use (default: cargo)
+  BITNET_DEV_FEATURES  Feature set to pass with --no-default-features (default: cpu)
+USAGE
+}
+
+run() {
+  printf '\n+'
+  local arg
+  for arg in "$@"; do
+    printf ' %q' "$arg"
+  done
+  printf '\n'
+  "$@"
+}
+
+case "$MODE" in
+  quick)
+    run "$CARGO_BIN" fmt --all -- --check
+    run "$CARGO_BIN" check --locked --no-default-features --features "$FEATURES"
+    run "$CARGO_BIN" test --locked --lib --no-default-features --features "$FEATURES"
+    ;;
+  full)
+    run "$CARGO_BIN" fmt --all -- --check
+    run "$CARGO_BIN" clippy --locked --workspace --all-targets --no-default-features --features "$FEATURES" -- -D warnings
+    run "$CARGO_BIN" test --locked --workspace --no-default-features --features "$FEATURES"
+    ;;
+  fmt)
+    run "$CARGO_BIN" fmt --all -- --check
+    ;;
+  clippy)
+    run "$CARGO_BIN" clippy --locked --workspace --all-targets --no-default-features --features "$FEATURES" -- -D warnings
+    ;;
+  test)
+    run "$CARGO_BIN" test --locked --lib --no-default-features --features "$FEATURES"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "error: unknown dev-check mode: $MODE" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
### Motivation
- Provide a fast, low-friction local feedback command to catch formatting, build, and common unit-test issues without running every opt-in workspace crate. 
- Surface a clear, documented contributor flow by wiring the helper into existing Make/Just workflows and README guidance.

### Description
- Add `scripts/dev-check.sh`, a portable helper with `quick`, `full`, `fmt`, `clippy`, and `test` modes that runs `cargo fmt`, `cargo check`, and targeted tests with `--no-default-features --features cpu` by default. 
- Wire the helper into task runners by adding `dev-check` and `dev-check-full` targets to `Justfile`. 
- Add `dev-check` and `dev-check-full` Make targets and mark them phony in `Makefile`. 
- Update the `README.md` Testing section to document the fast dev-check path and recommend the full workspace checks before PRs.

### Testing
- `./scripts/dev-check.sh --help` succeeded. 
- `bash -n scripts/dev-check.sh` (syntax check) succeeded. 
- `make -n dev-check` (dry run of Make target) succeeded. 
- `make help` executed and printed help output successfully. 
- `git diff --check` reported no whitespace/patch issues. 
- `./scripts/dev-check.sh fmt` failed due to pre-existing formatting drift in `crates/bitnet-tokenizer-text-core/src/lib.rs` (this failure is unrelated to the new helper and indicates an upstream formatting mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083e1210c083339531fd12d2bb6952)