### PR TITLE
test: strengthen scenario config coverage

### DIFF
--- a/crates/bitnet-testing-scenarios-core/src/lib.rs
+++ b/crates/bitnet-testing-scenarios-core/src/lib.rs
@@ -239,7 +239,9 @@ impl ScenarioConfigManager {
         &[
             TestingScenario::Unit,
             TestingScenario::Integration,
+            TestingScenario::EndToEnd,
             TestingScenario::Performance,
+            TestingScenario::Smoke,
             TestingScenario::CrossValidation,
             TestingScenario::Debug,
             TestingScenario::Development,
@@ -402,7 +404,54 @@ mod tests {
         let manager = ScenarioConfigManager::default();
         let config = manager.resolve(&TestingScenario::Unit, &EnvironmentType::Ci);
 
-        assert!(config.reporting.formats.contains(&ReportFormat::Junit));
+        assert_eq!(config.reporting.formats, vec![ReportFormat::Junit, ReportFormat::Html]);
         assert_eq!(config.max_parallel_tests, 8);
+        assert_eq!(config.log_level, "debug");
+        assert!(config.reporting.generate_coverage);
+        assert!(config.reporting.upload_reports);
+    }
+
+    #[test]
+    fn available_scenarios_lists_every_configured_scenario() {
+        let scenarios = ScenarioConfigManager::available_scenarios();
+
+        assert_eq!(scenarios.len(), 9);
+        assert_eq!(
+            scenarios,
+            &[
+                TestingScenario::Unit,
+                TestingScenario::Integration,
+                TestingScenario::EndToEnd,
+                TestingScenario::Performance,
+                TestingScenario::Smoke,
+                TestingScenario::CrossValidation,
+                TestingScenario::Debug,
+                TestingScenario::Development,
+                TestingScenario::Minimal,
+            ]
+        );
+
+        let manager = ScenarioConfigManager::default();
+        for scenario in scenarios {
+            let config = manager.get_scenario_config(scenario);
+            assert!(!ScenarioConfigManager::scenario_description(scenario).is_empty());
+            assert!(
+                config.test_timeout > Duration::ZERO,
+                "{scenario:?} should expose a usable timeout"
+            );
+            assert!(
+                !config.reporting.formats.is_empty(),
+                "{scenario:?} should expose at least one report format"
+            );
+        }
+
+        assert_eq!(
+            manager.get_scenario_config(&TestingScenario::EndToEnd).test_timeout,
+            Duration::from_secs(300)
+        );
+        assert_eq!(
+            manager.get_scenario_config(&TestingScenario::Smoke).test_timeout,
+            Duration::from_secs(10)
+        );
     }
 }

--- a/crates/bitnet-testing-scenarios-core/tests/scenarios_core_edge_cases.rs
+++ b/crates/bitnet-testing-scenarios-core/tests/scenarios_core_edge_cases.rs
@@ -150,18 +150,18 @@ fn resolve_unit_ci_uses_ci_parallel_count() {
 }
 
 #[test]
-fn resolve_unit_ci_has_junit_format() {
+fn resolve_unit_ci_uses_exact_ci_report_formats() {
     let mgr = ScenarioConfigManager::default();
     let cfg = mgr.resolve(&TestingScenario::Unit, &EnvironmentType::Ci);
-    assert!(cfg.reporting.formats.contains(&ReportFormat::Junit));
+    assert_eq!(cfg.reporting.formats, vec![ReportFormat::Junit, ReportFormat::Html]);
 }
 
 #[test]
-fn resolve_unit_local_uses_scenario_formats() {
+fn resolve_unit_local_uses_exact_local_report_formats() {
     let mgr = ScenarioConfigManager::default();
     let cfg = mgr.resolve(&TestingScenario::Unit, &EnvironmentType::Local);
-    // Local environment has Html format, which overrides scenario's Json
-    assert!(cfg.reporting.formats.contains(&ReportFormat::Html));
+    // Local environment has Html format, which overrides scenario's Json.
+    assert_eq!(cfg.reporting.formats, vec![ReportFormat::Html]);
 }
 
 #[test]
@@ -173,19 +173,19 @@ fn resolve_perf_ci_keeps_sequential() {
 }
 
 #[test]
-fn resolve_timeout_takes_max() {
+fn resolve_timeout_takes_exact_max() {
     let mgr = ScenarioConfigManager::default();
     let cfg = mgr.resolve(&TestingScenario::Performance, &EnvironmentType::Ci);
-    // Performance has 1800s timeout, CI has default (0s), max should be 1800s
-    assert!(cfg.test_timeout >= Duration::from_secs(1800));
+    // Performance has 1800s timeout; CI inherits the 300s default, so max is 1800s.
+    assert_eq!(cfg.test_timeout, Duration::from_secs(1800));
 }
 
 #[test]
-fn resolve_coverage_threshold_takes_max() {
+fn resolve_coverage_threshold_takes_exact_max() {
     let mgr = ScenarioConfigManager::default();
     let cfg = mgr.resolve(&TestingScenario::EndToEnd, &EnvironmentType::PreProduction);
-    // E2E has 0.9, PreProd has 0.7 → max is 0.9
-    assert!(cfg.coverage_threshold >= 0.9);
+    // E2E has 0.9, PreProd has 0.7, so max is 0.9.
+    assert_eq!(cfg.coverage_threshold, 0.9);
 }
 
 // ---------------------------------------------------------------------------
@@ -283,11 +283,21 @@ fn scenario_descriptions_are_unique() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn available_scenarios_has_unit_integration_perf() {
-    let scenarios = ScenarioConfigManager::available_scenarios();
-    assert!(scenarios.contains(&TestingScenario::Unit));
-    assert!(scenarios.contains(&TestingScenario::Integration));
-    assert!(scenarios.contains(&TestingScenario::Performance));
+fn available_scenarios_has_every_registered_variant_in_order() {
+    assert_eq!(
+        ScenarioConfigManager::available_scenarios(),
+        &[
+            TestingScenario::Unit,
+            TestingScenario::Integration,
+            TestingScenario::EndToEnd,
+            TestingScenario::Performance,
+            TestingScenario::Smoke,
+            TestingScenario::CrossValidation,
+            TestingScenario::Debug,
+            TestingScenario::Development,
+            TestingScenario::Minimal,
+        ]
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__available_scenarios_count.snap
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__available_scenarios_count.snap
@@ -2,4 +2,4 @@
 source: crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
 expression: "format!(\"count={count}\")"
 ---
-count=7
+count=9

--- a/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__scenario_descriptions_all_variants.snap
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__scenario_descriptions_all_variants.snap
@@ -4,7 +4,9 @@ expression: "descs.join(\"\\n\")"
 ---
 Unit: Fast, isolated tests with minimal dependencies and quick feedback.
 Integration: End-to-end integration tests covering realistic flows and services.
+EndToEnd: Complete end-to-end workflow tests with full stack validation.
 Performance: Sequential performance runs that measure latency and throughput.
+Smoke: Quick smoke tests to verify basic functionality.
 CrossValidation: A/B comparison (cross-validation) to check accuracy regressions.
 Debug: Verbose debug runs with thorough logging and artifact capture.
 Development: Local development defaults for quick iteration and diagnostics.

--- a/crates/bitnet-testing-scenarios-core/tests/testing_scenarios_core_edge_cases.rs
+++ b/crates/bitnet-testing-scenarios-core/tests/testing_scenarios_core_edge_cases.rs
@@ -190,19 +190,19 @@ fn resolve_unit_ci_uses_ci_parallelism() {
 }
 
 #[test]
-fn resolve_unit_ci_uses_larger_timeout() {
+fn resolve_unit_ci_uses_exact_larger_timeout() {
     let mgr = ScenarioConfigManager::new();
     let cfg = mgr.resolve(&TestingScenario::Unit, &EnvironmentType::Ci);
-    // max(unit=10s, ci=300s) — CI default timeout comes from TestConfigProfile::default
-    assert!(cfg.test_timeout >= Duration::from_secs(10));
+    // max(unit=10s, ci=300s) — CI default timeout comes from TestConfigProfile::default.
+    assert_eq!(cfg.test_timeout, Duration::from_secs(300));
 }
 
 #[test]
-fn resolve_unit_local_uses_unit_log_level() {
+fn resolve_unit_local_uses_exact_local_log_level() {
     let mgr = ScenarioConfigManager::new();
     let cfg = mgr.resolve(&TestingScenario::Unit, &EnvironmentType::Local);
-    // Unit scenario has "warn" but Local env has "info"; env overrides since it differs from default
-    assert!(!cfg.log_level.is_empty());
+    // Unit scenario has "warn"; Local env matches the base default, so the scenario value remains.
+    assert_eq!(cfg.log_level, "warn");
 }
 
 #[test]
@@ -325,13 +325,19 @@ fn scenario_description_performance() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn available_scenarios_has_unit() {
-    assert!(ScenarioConfigManager::available_scenarios().contains(&TestingScenario::Unit));
-}
+fn available_scenarios_are_comprehensive() {
+    let scenarios = ScenarioConfigManager::available_scenarios();
 
-#[test]
-fn available_scenarios_has_integration() {
-    assert!(ScenarioConfigManager::available_scenarios().contains(&TestingScenario::Integration));
+    assert_eq!(scenarios.len(), 9);
+    assert!(scenarios.contains(&TestingScenario::Unit));
+    assert!(scenarios.contains(&TestingScenario::Integration));
+    assert!(scenarios.contains(&TestingScenario::EndToEnd));
+    assert!(scenarios.contains(&TestingScenario::Performance));
+    assert!(scenarios.contains(&TestingScenario::Smoke));
+    assert!(scenarios.contains(&TestingScenario::CrossValidation));
+    assert!(scenarios.contains(&TestingScenario::Debug));
+    assert!(scenarios.contains(&TestingScenario::Development));
+    assert!(scenarios.contains(&TestingScenario::Minimal));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Improve the unit and edge testing around the scenario/environment policy resolver to make expectations stricter and catch regression risks earlier.
- Ensure the public scenario catalog returned by `ScenarioConfigManager::available_scenarios()` accurately reflects all configured scenarios and that merge behaviour is asserted precisely.

### Description
- Add the `EndToEnd` and `Smoke` variants to `ScenarioConfigManager::available_scenarios()` in `crates/bitnet-testing-scenarios-core/src/lib.rs` so the public catalog includes all configured scenarios.
- Strengthen in-crate unit tests by tightening `test_config_resolution` assertions (exact report formats, `log_level`, coverage/upload flags) and adding `available_scenarios_lists_every_configured_scenario` in `src/lib.rs`.
- Replace loose/contains checks with exact assertions for report formats, timeout merge behaviour, and coverage thresholds in `crates/bitnet-testing-scenarios-core/tests/scenarios_core_edge_cases.rs` and `crates/bitnet-testing-scenarios-core/tests/testing_scenarios_core_edge_cases.rs`.
- Update `insta` snapshot files in `crates/bitnet-testing-scenarios-core/tests/snapshots/` to reflect the expanded 9-scenario catalog.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p bitnet-testing-scenarios-core --locked --no-default-features` and all unit, edge and snapshot tests passed.
- Ran `cargo clippy -p bitnet-testing-scenarios-core --locked --all-targets --no-default-features -- -D warnings` with no warnings.
- Ran `git diff --check` to ensure no whitespace/patch issues (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1b8a3dc833383473cbce6bc6442)