### PR TITLE
test: expand quantization bit-packing coverage

### DIFF
--- a/crates/bitnet-quantization-bits/src/lib.rs
+++ b/crates/bitnet-quantization-bits/src/lib.rs
@@ -97,4 +97,64 @@ mod tests {
         let unpacked = unpack_unsigned_2bit(&packed, values.len());
         assert_eq!(unpacked, values);
     }
+
+    #[test]
+    fn signed_exact_byte_layout_is_little_endian_by_lane() {
+        // Signed values are offset by +2 before packing, so [-2, -1, 0, 1]
+        // becomes [0, 1, 2, 3]. Lane 0 occupies the least-significant bits.
+        let values = [-2, -1, 0, 1];
+
+        assert_eq!(pack_signed_2bit(&values), vec![0b1110_0100]);
+        assert_eq!(unpack_signed_2bit(&[0b1110_0100], values.len()), values);
+    }
+
+    #[test]
+    fn unsigned_exact_byte_layout_is_little_endian_by_lane() {
+        let values = [0, 1, 2, 3];
+
+        assert_eq!(pack_unsigned_2bit(&values), vec![0b1110_0100]);
+        assert_eq!(unpack_unsigned_2bit(&[0b1110_0100], values.len()), values);
+    }
+
+    #[test]
+    fn partial_chunks_do_not_fill_unused_lanes() {
+        assert_eq!(pack_signed_2bit(&[1]), vec![0b0000_0011]);
+        assert_eq!(pack_signed_2bit(&[-1, 0, 1]), vec![0b0011_1001]);
+        assert_eq!(pack_unsigned_2bit(&[0, 1, 2]), vec![0b0010_0100]);
+    }
+
+    #[test]
+    fn unpack_respects_requested_output_length() {
+        let packed = [0b1110_0100, 0b0001_1011];
+
+        assert_eq!(unpack_signed_2bit(&packed, 0), Vec::<i8>::new());
+        assert_eq!(unpack_signed_2bit(&packed, 3), vec![-2, -1, 0]);
+        assert_eq!(unpack_unsigned_2bit(&packed, 5), vec![0, 1, 2, 3, 3]);
+    }
+
+    #[test]
+    fn unsigned_pack_masks_each_input_to_two_bits() {
+        let values = [-1, -2, -3, -4, 4, 5, 6, 7];
+        let packed = pack_unsigned_2bit(&values);
+
+        assert_eq!(unpack_unsigned_2bit(&packed, values.len()), vec![3, 2, 1, 0, 0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn signed_pack_exhaustively_roundtrips_all_single_byte_patterns() {
+        for byte in u8::MIN..=u8::MAX {
+            let unpacked = unpack_signed_2bit(&[byte], 4);
+
+            assert_eq!(pack_signed_2bit(&unpacked), vec![byte], "failed for byte 0x{byte:02x}");
+        }
+    }
+
+    #[test]
+    fn unsigned_pack_exhaustively_roundtrips_all_single_byte_patterns() {
+        for byte in u8::MIN..=u8::MAX {
+            let unpacked = unpack_unsigned_2bit(&[byte], 4);
+
+            assert_eq!(pack_unsigned_2bit(&unpacked), vec![byte], "failed for byte 0x{byte:02x}");
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Improve confidence in the 2-bit quantization codecs by locking down exact byte-layout semantics and lane ordering and by covering common edge cases and pathological inputs.

### Description
- Add new unit tests in `crates/bitnet-quantization-bits/src/lib.rs` that assert exact signed and unsigned byte layouts and that lanes are little-endian.
- Add tests covering partial chunks, unpack truncation by requested output length, and unsigned input masking behavior.
- Add exhaustive single-byte roundtrip tests for both signed and unsigned codecs to ensure every byte pattern roundtrips.

### Testing
- Ran `cargo test --locked -p bitnet-quantization-bits --no-default-features` and all tests passed.
- Ran `cargo fmt --all -- --check` and formatting check succeeded.
- Ran `cargo clippy --locked -p bitnet-quantization-bits --all-targets --no-default-features -- -D warnings` and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1b8a3dc833383473cbce6bc6442)