### PR TITLE
test: strengthen qk256 layout coverage

### DIFF
--- a/crates/bitnet-qk256-layout-core/tests/layout_tests.rs
+++ b/crates/bitnet-qk256-layout-core/tests/layout_tests.rs
@@ -1,7 +1,7 @@
 use bitnet_qk256_layout_core::{
-    QK256_BLOCK_COLS, QK256_PACKED_BYTES_PER_BLOCK, Qk256Layout, Qk256LayoutError,
-    pack_qk256_codes, parse_input_shape, parse_qk256_layout, qk256_packed_len_bytes,
-    qk256_row_stride_bytes, unpack_qk256_codes, validate_input_cols,
+    QK256_BLOCK_COLS, QK256_PACKED_BYTES_PER_BLOCK, Qk256InputShape, Qk256Layout, Qk256LayoutError,
+    pack_qk256_codes, parse_input_shape, parse_qk256_layout, qk256_blocks_per_row,
+    qk256_packed_len_bytes, qk256_row_stride_bytes, unpack_qk256_codes, validate_input_cols,
 };
 
 #[test]
@@ -15,15 +15,23 @@ fn parses_qk256_layout() {
 }
 
 #[test]
-fn rejects_invalid_qk256_rank() {
-    let err = parse_qk256_layout("w", &[1, 2, 3]).expect_err("should fail");
-    assert!(matches!(err, Qk256LayoutError::InvalidQk256Shape { .. }));
+fn rejects_invalid_qk256_rank_with_weight_name_and_dims() {
+    let err = parse_qk256_layout("blk.weight", &[1, 2, 3]).expect_err("should fail");
+
+    assert_eq!(
+        err,
+        Qk256LayoutError::InvalidQk256Shape {
+            weight_name: "blk.weight".to_string(),
+            dims: vec![1, 2, 3],
+        }
+    );
 }
 
 #[test]
-fn rejects_unaligned_row_stride() {
+fn rejects_unaligned_row_stride_with_stride_value() {
     let err = parse_qk256_layout("w", &[32, 96]).expect_err("should fail");
-    assert!(matches!(err, Qk256LayoutError::InvalidRowStride { .. }));
+
+    assert_eq!(err, Qk256LayoutError::InvalidRowStride { row_stride_bytes: 96 });
 }
 
 #[test]
@@ -39,6 +47,27 @@ fn computes_canonical_geometry_from_rows_cols() {
 }
 
 #[test]
+fn block_rounding_covers_zero_exact_and_partial_column_counts() {
+    assert_eq!(qk256_blocks_per_row(0), 0);
+    assert_eq!(qk256_blocks_per_row(1), 1);
+    assert_eq!(qk256_blocks_per_row(QK256_BLOCK_COLS), 1);
+    assert_eq!(qk256_blocks_per_row(QK256_BLOCK_COLS + 1), 2);
+    assert_eq!(qk256_row_stride_bytes(0).unwrap(), 0);
+    assert_eq!(qk256_row_stride_bytes(QK256_BLOCK_COLS + 1).unwrap(), 128);
+}
+
+#[test]
+fn from_rows_stride_recovers_multi_block_shape() {
+    let layout = Qk256Layout::from_rows_stride(2, QK256_PACKED_BYTES_PER_BLOCK * 3).unwrap();
+
+    assert_eq!(layout.rows, 2);
+    assert_eq!(layout.cols, QK256_BLOCK_COLS * 3);
+    assert_eq!(layout.blocks_per_row, 3);
+    assert_eq!(layout.row_stride_bytes, QK256_PACKED_BYTES_PER_BLOCK * 3);
+    assert_eq!(layout.packed_len_bytes, QK256_PACKED_BYTES_PER_BLOCK * 6);
+}
+
+#[test]
 fn reports_row_and_block_ranges() {
     let layout = Qk256Layout::from_rows_cols(3, 512).expect("layout");
     assert_eq!(layout.row_range(1).expect("row"), 128..256);
@@ -50,12 +79,40 @@ fn reports_row_and_block_ranges() {
 }
 
 #[test]
+fn rejects_out_of_bounds_row_and_block_indices() {
+    let layout = Qk256Layout::from_rows_cols(2, QK256_BLOCK_COLS * 2).unwrap();
+
+    assert_eq!(
+        layout.row_range(2).unwrap_err(),
+        Qk256LayoutError::RowOutOfBounds { row: 2, rows: 2 }
+    );
+    assert_eq!(
+        layout.block_range(0, 2).unwrap_err(),
+        Qk256LayoutError::BlockOutOfBounds { block: 2, blocks_per_row: 2 }
+    );
+}
+
+#[test]
 fn validates_exact_packed_length() {
     let layout = Qk256Layout::from_rows_cols(2, 512).expect("layout");
     layout.validate_packed_len(256).expect("exact length");
+}
+
+#[test]
+fn rejects_packed_length_mismatch_with_expected_length() {
+    let layout = Qk256Layout::from_rows_cols(2, 512).expect("layout");
 
     let err = layout.validate_packed_len(255).expect_err("should fail");
-    assert!(matches!(err, Qk256LayoutError::PackedLengthMismatch { .. }));
+
+    assert_eq!(
+        err,
+        Qk256LayoutError::PackedLengthMismatch {
+            rows: 2,
+            cols: 512,
+            actual_len: 255,
+            expected_len: 256,
+        }
+    );
 }
 
 #[test]
@@ -71,12 +128,32 @@ fn pack_unpack_fixture_is_byte_exact() {
 }
 
 #[test]
-fn rejects_invalid_pack_code() {
+fn pack_qk256_codes_places_two_bit_values_in_little_endian_slots() {
+    let mut codes = [0u8; QK256_BLOCK_COLS];
+    codes[0] = 3;
+    codes[1] = 2;
+    codes[2] = 1;
+    codes[3] = 0;
+    codes[4] = 1;
+    codes[5] = 1;
+    codes[6] = 2;
+    codes[7] = 2;
+
+    let packed = pack_qk256_codes(&codes).expect("pack");
+
+    assert_eq!(packed[0], 0b00_01_10_11);
+    assert_eq!(packed[1], 0b10_10_01_01);
+    assert_eq!(unpack_qk256_codes(&packed), codes);
+}
+
+#[test]
+fn rejects_invalid_pack_code_with_first_invalid_offset() {
     let mut codes = [0u8; QK256_BLOCK_COLS];
     codes[17] = 4;
+    codes[18] = 5;
 
     let err = pack_qk256_codes(&codes).expect_err("should fail");
-    assert!(matches!(err, Qk256LayoutError::InvalidCode { offset: 17, code: 4 }));
+    assert_eq!(err, Qk256LayoutError::InvalidCode { offset: 17, code: 4 });
 }
 
 #[test]
@@ -85,16 +162,34 @@ fn parses_2d_input_shape() {
     assert_eq!(shape.batch_size, 4);
     assert_eq!(shape.seq_len, 1);
     assert_eq!(shape.cols, 256);
+    assert_eq!(shape.input_rank, 2);
 }
 
 #[test]
-fn rejects_input_shape_other_than_2d_or_3d() {
-    let err = parse_input_shape(&[256]).expect_err("should fail");
-    assert!(matches!(err, Qk256LayoutError::UnsupportedInputShape { .. }));
+fn parses_3d_input_shape_with_sequence_length() {
+    assert_eq!(
+        parse_input_shape(&[2, 8, 1024]).expect("shape"),
+        Qk256InputShape { batch_size: 2, seq_len: 8, cols: 1024, input_rank: 3 }
+    );
 }
 
 #[test]
-fn rejects_column_mismatch() {
+fn rejects_input_shape_other_than_2d_or_3d_with_dims() {
+    let err = parse_input_shape(&[1, 2, 3, 4]).expect_err("should fail");
+
+    assert_eq!(err, Qk256LayoutError::UnsupportedInputShape { dims: vec![1, 2, 3, 4] });
+}
+
+#[test]
+fn rejects_column_mismatch_with_weight_name_and_dimensions() {
     let err = validate_input_cols("layer", 255, 256).expect_err("should fail");
-    assert!(matches!(err, Qk256LayoutError::DimensionMismatch { .. }));
+
+    assert_eq!(
+        err,
+        Qk256LayoutError::DimensionMismatch {
+            weight_name: "layer".to_string(),
+            input_cols: 255,
+            expected_cols: 256,
+        }
+    );
 }

--- a/crates/bitnet-qk256-layout-core/tests/layout_tests.rs
+++ b/crates/bitnet-qk256-layout-core/tests/layout_tests.rs
@@ -47,24 +47,26 @@ fn computes_canonical_geometry_from_rows_cols() {
 }
 
 #[test]
-fn block_rounding_covers_zero_exact_and_partial_column_counts() {
+fn block_rounding_covers_zero_exact_and_partial_column_counts() -> Result<(), Qk256LayoutError> {
     assert_eq!(qk256_blocks_per_row(0), 0);
     assert_eq!(qk256_blocks_per_row(1), 1);
     assert_eq!(qk256_blocks_per_row(QK256_BLOCK_COLS), 1);
     assert_eq!(qk256_blocks_per_row(QK256_BLOCK_COLS + 1), 2);
-    assert_eq!(qk256_row_stride_bytes(0).unwrap(), 0);
-    assert_eq!(qk256_row_stride_bytes(QK256_BLOCK_COLS + 1).unwrap(), 128);
+    assert_eq!(qk256_row_stride_bytes(0)?, 0);
+    assert_eq!(qk256_row_stride_bytes(QK256_BLOCK_COLS + 1)?, 128);
+    Ok(())
 }
 
 #[test]
-fn from_rows_stride_recovers_multi_block_shape() {
-    let layout = Qk256Layout::from_rows_stride(2, QK256_PACKED_BYTES_PER_BLOCK * 3).unwrap();
+fn from_rows_stride_recovers_multi_block_shape() -> Result<(), Qk256LayoutError> {
+    let layout = Qk256Layout::from_rows_stride(2, QK256_PACKED_BYTES_PER_BLOCK * 3)?;
 
     assert_eq!(layout.rows, 2);
     assert_eq!(layout.cols, QK256_BLOCK_COLS * 3);
     assert_eq!(layout.blocks_per_row, 3);
     assert_eq!(layout.row_stride_bytes, QK256_PACKED_BYTES_PER_BLOCK * 3);
     assert_eq!(layout.packed_len_bytes, QK256_PACKED_BYTES_PER_BLOCK * 6);
+    Ok(())
 }
 
 #[test]
@@ -79,8 +81,8 @@ fn reports_row_and_block_ranges() {
 }
 
 #[test]
-fn rejects_out_of_bounds_row_and_block_indices() {
-    let layout = Qk256Layout::from_rows_cols(2, QK256_BLOCK_COLS * 2).unwrap();
+fn rejects_out_of_bounds_row_and_block_indices() -> Result<(), Qk256LayoutError> {
+    let layout = Qk256Layout::from_rows_cols(2, QK256_BLOCK_COLS * 2)?;
 
     assert_eq!(
         layout.row_range(2).unwrap_err(),
@@ -90,12 +92,14 @@ fn rejects_out_of_bounds_row_and_block_indices() {
         layout.block_range(0, 2).unwrap_err(),
         Qk256LayoutError::BlockOutOfBounds { block: 2, blocks_per_row: 2 }
     );
+    Ok(())
 }
 
 #[test]
-fn validates_exact_packed_length() {
-    let layout = Qk256Layout::from_rows_cols(2, 512).expect("layout");
-    layout.validate_packed_len(256).expect("exact length");
+fn validates_exact_packed_length() -> Result<(), Qk256LayoutError> {
+    let layout = Qk256Layout::from_rows_cols(2, 512)?;
+    layout.validate_packed_len(256)?;
+    Ok(())
 }
 
 #[test]
@@ -116,19 +120,20 @@ fn rejects_packed_length_mismatch_with_expected_length() {
 }
 
 #[test]
-fn pack_unpack_fixture_is_byte_exact() {
+fn pack_unpack_fixture_is_byte_exact() -> Result<(), Qk256LayoutError> {
     let mut codes = [0u8; QK256_BLOCK_COLS];
     for (offset, code) in codes.iter_mut().enumerate() {
         *code = (offset % 4) as u8;
     }
 
-    let packed = pack_qk256_codes(&codes).expect("pack");
+    let packed = pack_qk256_codes(&codes)?;
     assert_eq!(packed, [0b11_10_01_00u8; QK256_PACKED_BYTES_PER_BLOCK]);
     assert_eq!(unpack_qk256_codes(&packed), codes);
+    Ok(())
 }
 
 #[test]
-fn pack_qk256_codes_places_two_bit_values_in_little_endian_slots() {
+fn pack_qk256_codes_places_two_bit_values_in_little_endian_slots() -> Result<(), Qk256LayoutError> {
     let mut codes = [0u8; QK256_BLOCK_COLS];
     codes[0] = 3;
     codes[1] = 2;
@@ -139,11 +144,12 @@ fn pack_qk256_codes_places_two_bit_values_in_little_endian_slots() {
     codes[6] = 2;
     codes[7] = 2;
 
-    let packed = pack_qk256_codes(&codes).expect("pack");
+    let packed = pack_qk256_codes(&codes)?;
 
     assert_eq!(packed[0], 0b00_01_10_11);
     assert_eq!(packed[1], 0b10_10_01_01);
     assert_eq!(unpack_qk256_codes(&packed), codes);
+    Ok(())
 }
 
 #[test]
@@ -166,11 +172,12 @@ fn parses_2d_input_shape() {
 }
 
 #[test]
-fn parses_3d_input_shape_with_sequence_length() {
+fn parses_3d_input_shape_with_sequence_length() -> Result<(), Qk256LayoutError> {
     assert_eq!(
-        parse_input_shape(&[2, 8, 1024]).expect("shape"),
+        parse_input_shape(&[2, 8, 1024])?,
         Qk256InputShape { batch_size: 2, seq_len: 8, cols: 1024, input_rank: 3 }
     );
+    Ok(())
 }
 
 #[test]

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -2210,7 +2210,8 @@ mod tests {
     }
 
     #[test]
-    fn bitnet_qk256_server_smoke_receipt_records_qk256_claim_boundary() {
+    fn bitnet_qk256_server_smoke_receipt_records_qk256_claim_boundary() -> Result<(), &'static str>
+    {
         let request = ChatCompletionRequest {
             model: "microsoft-bitnet-b1.58-2B-4T-i2s".to_string(),
             messages: vec![ChatCompletionMessage {
@@ -2300,6 +2301,7 @@ mod tests {
             assert_eq!(stats[0].fallback_invocations, 0);
             assert_eq!(stats[0].cpu_fallback_invocations, 0);
         }
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve unit-test rigor for the QK256 layout helpers to catch subtle geometry, bounds, and packing regressions by asserting exact error payloads and byte-level behavior.

### Description
- Replace broad `matches!`-style error checks with exact `assert_eq!` assertions for `Qk256LayoutError` payloads in `crates/bitnet-qk256-layout-core/tests/layout_tests.rs`.
- Add tests that cover block-rounding edge cases, `qk256_blocks_per_row` behaviour, `qk256_row_stride_bytes` for zero/partial columns, and multi-block stride recovery.
- Add explicit out-of-bounds row/block index checks, exact packed-length mismatch checks, and 3D input-shape parsing assertions including `input_rank` verification.
- Add byte-slot packing order checks and ensure `pack_qk256_codes` reports the first invalid code offset exactly, and update test imports to include `Qk256InputShape` and `qk256_blocks_per_row`.

### Testing
- Ran `cargo test -p bitnet-qk256-layout-core --locked --no-default-features --features cpu`, and all tests in the crate passed (17 passed, 0 failed).
- Ran `cargo fmt --all` as part of the change workflow and no formatting issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1b8a3dc833383473cbce6bc6442)