### PR TITLE
Improve local developer workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ RED := $(shell tput setaf 1 2>/dev/null || echo "")
 NC := $(shell tput sgr0 2>/dev/null || echo "")
 
 # Declare phony targets
-.PHONY: help all quick install dev test bench clean gpu docker run serve repl release deploy update fmt lint check fix docs ci setup \
+.PHONY: help all quick install dev test bench clean gpu docker run serve repl release deploy update fmt fmt-check lint check fix docs ci ci-local setup \
         build test-quick test-gpu test-integration gpu-smoke download-model crossval tree loc size \
         watch flame audit outdated bloat docker-run docker-gpu profile valgrind heaptrack wasm python list verbose \
         guards preflight docs-check \
@@ -51,7 +51,7 @@ help:
 	@echo "$(BLUE)BitNet-rs One-Click Commands$(NC)"
 	@echo ""
 	@echo "$(GREEN)Primary Commands:$(NC)"
-	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z0-9_ -]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+	@awk 'BEGIN {FS = ": "}; /^## [a-zA-Z0-9_-]+: / {name=$$1; sub(/^## /, "", name); printf "  %-20s %s\n", name, $$2}' $(MAKEFILE_LIST) | sort
 	@echo ""
 	@echo "$(YELLOW)Quick Examples:$(NC)"
 	@echo "  make              # Quick start (builds and tests)"
@@ -158,13 +158,19 @@ fmt:
 	@$(CARGO) fmt --all
 	@echo "$(GREEN)✓ Code formatted$(NC)"
 
-## lint: Run clippy lints
-lint:
-	@echo "$(GREEN)Running clippy...$(NC)"
-	@$(CARGO) clippy --workspace --all-targets --all-features -- -D warnings
+## fmt-check: Verify formatting without changing files
+fmt-check:
+	@echo "$(GREEN)Checking code formatting...$(NC)"
+	@$(CARGO) fmt --all -- --check
+	@echo "$(GREEN)✓ Code formatting is clean$(NC)"
 
-## check: Run all checks (fmt, lint, test)
-check: fmt lint test
+## lint: Run clippy lints with detected features
+lint:
+	@echo "$(GREEN)Running clippy with $(FEATURES) features...$(NC)"
+	@$(CARGO) clippy --locked --workspace --all-targets --no-default-features --features $(FEATURES) -- -D warnings
+
+## check: Run all checks (fmt-check, lint, test)
+check: fmt-check lint test
 	@echo "$(GREEN)✓ All checks passed$(NC)"
 
 ## fix: Auto-fix issues
@@ -227,9 +233,13 @@ setup:
 ci:
 	@echo "$(GREEN)Running CI checks...$(NC)"
 	@$(CARGO) fmt --all -- --check
-	@$(CARGO) clippy --workspace --all-targets --all-features -- -D warnings
+	@$(CARGO) clippy --locked --workspace --all-targets --no-default-features --features cpu -- -D warnings
 	@$(CARGO) test --locked --workspace --no-default-features --features cpu
 	@echo "$(GREEN)✓ CI checks passed$(NC)"
+
+## ci-local: Run the focused local CI reproducer used before PRs
+ci-local:
+	@./ci/local.sh
 
 ## guards: Run local preflight guards (floating refs, MSRV, --locked flags)
 guards:

--- a/README.md
+++ b/README.md
@@ -218,13 +218,13 @@ Near-term work is focused on:
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR:
+See [CONTRIBUTING.md](CONTRIBUTING.md). Before opening a PR, run the focused local CI reproducer:
 
 ```bash
-./ci/local.sh
+make ci-local
 ```
 
-New internal maintenance commands belong in `xtask`. `bitnet-task` exists only to preserve legacy `scripts/*.sh` entrypoints while that migration is in flight.
+For faster edit/format feedback, use `make fmt-check`; for the feature-aware local check chain, use `make check`. New internal maintenance commands belong in `xtask`. `bitnet-task` exists only to preserve legacy `scripts/*.sh` entrypoints while that migration is in flight.
 
 See [ROADMAP.md](ROADMAP.md) for project direction.
 

--- a/crates/bitnet-tokenizer-text-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-text-core/src/lib.rs
@@ -262,10 +262,8 @@ mod tests {
 
     #[test]
     fn normalizer_only_strip_accents_keeps_case() {
-        let n = TokenNormalizer::new(NormalizationFlags {
-            strip_accents: true,
-            ..Default::default()
-        });
+        let n =
+            TokenNormalizer::new(NormalizationFlags { strip_accents: true, ..Default::default() });
         assert_eq!(n.normalize("Café Déjà"), "Cafe Deja");
     }
 

--- a/docs/development/build-commands.md
+++ b/docs/development/build-commands.md
@@ -233,9 +233,12 @@ cargo test --no-default-features --features cpu -p bitnet-wasm --target wasm32-u
 # Quick WASM build with enhanced debugging
 cargo build --target wasm32-unknown-unknown -p bitnet-wasm --no-default-features --features "browser,debug"
 
-# Quick lint check
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
+# Quick lint check (CPU/default developer lane)
+make fmt-check
+make lint
+
+# Focused local CI reproduction before opening a PR
+make ci-local
 ```
 
 For more detailed information on specific testing strategies, see:


### PR DESCRIPTION
### Motivation
- Make local developer validation faster and more discoverable by adding lightweight Makefile entrypoints for formatting and CI reproduction.
- Ensure `make help` reliably shows annotated targets so contributors can find common commands quickly.
- Align local CI and lint invocations with the repository's `--locked` and CPU/no-default-features developer lane.

### Description
- Fix `make help` parsing so `## <target>: <description>` entries are shown in the help output by changing the Makefile `awk` selector.
- Add a non-mutating formatting target `fmt-check` and update `check` to depend on `fmt-check` instead of running a mutating `fmt` step.
- Make `lint` feature-aware and use `--locked --no-default-features --features $(FEATURES)` for local developer correctness, and update the `ci` target to run `clippy` with the locked CPU lane.
- Add `ci-local` target that runs the focused local reproducer `./ci/local.sh`, and update `README.md` and `docs/development/build-commands.md` to recommend `make ci-local`, `make fmt-check`, and `make check`.
- Ran `cargo fmt` cleanup on a tokenizer test to satisfy the new `fmt-check` target.

### Testing
- Ran `make help` and confirmed annotated targets appear in the help listing (passed).
- Ran `make fmt-check` and iterated until formatting was clean (after applying `cargo fmt` the check passed).
- Ran dry-run invocations `make -n lint` and `make -n ci-local` to verify generated commands (printed expected `clippy` and `./ci/local.sh`).
- Ran the scoped unit test with `cargo test --locked -p bitnet-tokenizer-text-core --lib normalizer_only_strip_accents_keeps_case` and it passed.
- Ran `git diff --check` to ensure no whitespace or check errors (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083e1210c083339531fd12d2bb6952)