### PR TITLE
chore(devex): add local environment doctor and improve Makefile help / guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ NC := $(shell tput sgr0 2>/dev/null || echo "")
 .PHONY: help all quick install dev test bench clean gpu docker run serve repl release deploy update fmt lint check fix docs ci setup \
         build test-quick test-gpu test-integration gpu-smoke download-model crossval tree loc size \
         watch flame audit outdated bloat docker-run docker-gpu profile valgrind heaptrack wasm python list verbose \
-        guards preflight docs-check \
+        guards preflight docs-check doctor \
         b t r c f l d g bt bf cf cb ct fr ft q a i
 
 # Detect OS and features
@@ -51,13 +51,17 @@ help:
 	@echo "$(BLUE)BitNet-rs One-Click Commands$(NC)"
 	@echo ""
 	@echo "$(GREEN)Primary Commands:$(NC)"
-	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z0-9_ -]+:.*?## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+	@awk '/^## / { line = $$0; sub(/^## /, "", line); target = line; sub(/:.*/, "", target); desc = line; sub(/^[^:]*: */, "", desc); printf "  %-20s %s\n", target, desc }' $(MAKEFILE_LIST) | sort
 	@echo ""
 	@echo "$(YELLOW)Quick Examples:$(NC)"
 	@echo "  make              # Quick start (builds and tests)"
 	@echo "  make run          # Run the CLI"
 	@echo "  make test         # Run all tests"
 	@echo "  make bench        # Run benchmarks"
+	@echo "  make doctor       # Diagnose local toolchain and optional dev tools"
+	@echo ""
+	@echo "$(YELLOW)Detected Defaults:$(NC)"
+	@echo "  FEATURES=$(FEATURES) OS=$(OS) ARCH=$(ARCH) JOBS=$(JOBS)"
 	@echo ""
 
 ## quick: One-click quick start (default)
@@ -184,6 +188,10 @@ docs-check:
 	@echo "$(GREEN)Running documentation automation checks...$(NC)"
 	@scripts/docs_automation.sh
 
+## doctor: Diagnose local toolchain and optional developer tools
+doctor:
+	@./scripts/doctor.sh
+
 #############################################################################
 # GPU TARGETS
 #############################################################################
@@ -257,27 +265,34 @@ guards:
 	@echo "$(GREEN)✅ All actions pinned to 40-hex SHAs$(NC)"
 	@echo ""
 	@# Check for stale MSRV references in workflow config
-	@echo "$(BLUE)Checking for stale MSRV versions (should be 1.93.0 or dynamic)...$(NC)"
-	@wrong_msrv=$$(rg --color=never --glob '!guards.yml' \
+	@echo "$(BLUE)Checking for stale MSRV versions (should match rust-toolchain.toml or be dynamic)...$(NC)"
+	@expected_msrv=$$(sed -n 's/^channel = "\([^"]*\)"/\1/p' rust-toolchain.toml | head -n 1); \
+	wrong_msrv=$$(rg --color=never --glob '!guards.yml' \
 	      -e 'toolchain:\s*"?1\.89\.0"?' \
 	      -e 'toolchain:\s*"?1\.90\.0"?' \
 	      -e 'toolchain:\s*"?1\.91\.0"?' \
 	      -e 'toolchain:\s*"?1\.92\.0"?' \
+	      -e 'toolchain:\s*"?1\.93\.0"?' \
+	      -e 'toolchain:\s*"?1\.94\.0"?' \
 	      -e 'rust-version\s*=\s*"1\.89\.0"' \
 	      -e 'rust-version\s*=\s*"1\.90\.0"' \
 	      -e 'rust-version\s*=\s*"1\.91\.0"' \
 	      -e 'rust-version\s*=\s*"1\.92\.0"' \
+	      -e 'rust-version\s*=\s*"1\.93\.0"' \
+	      -e 'rust-version\s*=\s*"1\.94\.0"' \
 	      -e '"RUST_VERSION"\s*:\s*"1\.89\.0"' \
 	      -e '"RUST_VERSION"\s*:\s*"1\.90\.0"' \
 	      -e '"RUST_VERSION"\s*:\s*"1\.91\.0"' \
 	      -e '"RUST_VERSION"\s*:\s*"1\.92\.0"' \
+	      -e '"RUST_VERSION"\s*:\s*"1\.93\.0"' \
+	      -e '"RUST_VERSION"\s*:\s*"1\.94\.0"' \
 	      .github/workflows 2>/dev/null || true); \
 	if [ -n "$$wrong_msrv" ]; then \
-	   echo "$(RED)❌ Found stale MSRV in workflows (expected 1.93.0 or dynamic):$(NC)"; \
+	   echo "$(RED)❌ Found stale MSRV in workflows (expected $$expected_msrv or dynamic):$(NC)"; \
 	   echo "$$wrong_msrv"; \
 	   exit 1; \
 	fi
-	@echo "$(GREEN)✅ No stale MSRV versions found (1.93.0 or dynamic from rust-toolchain.toml)$(NC)"
+	@echo "$(GREEN)✅ No stale MSRV versions found (matches rust-toolchain.toml or dynamic)$(NC)"
 	@echo ""
 	@# Check cargo/cross --locked flags
 	@echo "$(BLUE)Checking cargo/cross --locked flags...$(NC)"

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ See [docs/hardware/HARDWARE_MATRIX.md](docs/hardware/HARDWARE_MATRIX.md).
 
 ## Building
 
+Before building, run the local environment doctor to confirm the pinned Rust toolchain, Cargo metadata, default feature detection, and optional helper tools:
+
+```bash
+make doctor
+```
+
 ```bash
 cargo build --locked --no-default-features --features cpu
 cargo build --locked -p bitnet-cli --no-default-features --features cpu,full-cli

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env sh
+# Lightweight local environment diagnostic for BitNet-rs contributors.
+# Keep this script POSIX-sh compatible so it works before optional dev tooling is installed.
+
+set -u
+
+failures=0
+warnings=0
+
+info() {
+  printf 'ℹ️  %s\n' "$*"
+}
+
+pass() {
+  printf '✅ %s\n' "$*"
+}
+
+warn() {
+  warnings=$((warnings + 1))
+  printf '⚠️  %s\n' "$*"
+}
+
+fail() {
+  failures=$((failures + 1))
+  printf '❌ %s\n' "$*"
+}
+
+need_cmd() {
+  if command -v "$1" >/dev/null 2>&1; then
+    pass "found $1: $(command -v "$1")"
+  else
+    fail "missing required command: $1"
+  fi
+}
+
+optional_cmd() {
+  if command -v "$1" >/dev/null 2>&1; then
+    pass "found optional $1: $(command -v "$1")"
+  else
+    warn "optional command not found: $1 ($2)"
+  fi
+}
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root" || exit 1
+
+info "BitNet-rs developer environment doctor"
+info "repo: $repo_root"
+printf '\n'
+
+need_cmd git
+need_cmd cargo
+need_cmd rustc
+
+expected_toolchain=$(sed -n 's/^channel = "\([^"]*\)"/\1/p' rust-toolchain.toml | head -n 1)
+if [ -z "$expected_toolchain" ]; then
+  fail "could not read channel from rust-toolchain.toml"
+elif command -v rustc >/dev/null 2>&1; then
+  rustc_version=$(rustc --version 2>/dev/null || true)
+  case "$rustc_version" in
+    *" $expected_toolchain"*) pass "rustc matches rust-toolchain.toml ($rustc_version)" ;;
+    *) fail "rustc does not match rust-toolchain.toml: expected $expected_toolchain, got ${rustc_version:-unknown}" ;;
+  esac
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+  cargo_version=$(cargo --version 2>/dev/null || true)
+  info "cargo: ${cargo_version:-unknown}"
+fi
+
+printf '\n'
+info "Checking workspace metadata with Cargo.lock pinned dependencies"
+if command -v cargo >/dev/null 2>&1; then
+  if cargo metadata --locked --no-deps --format-version 1 >/dev/null; then
+    pass "cargo metadata --locked --no-deps"
+  else
+    fail "cargo metadata --locked --no-deps failed"
+  fi
+fi
+
+printf '\n'
+info "Checking common optional developer tools"
+optional_cmd cargo-nextest "recommended for fast workspace test runs"
+optional_cmd cargo-watch "used by make watch"
+optional_cmd cargo-audit "used by make audit"
+optional_cmd cargo-outdated "used by make outdated"
+optional_cmd cargo-bloat "used by make bloat"
+optional_cmd tokei "used by make loc"
+optional_cmd tree "used by make tree"
+optional_cmd docker "used by make docker"
+
+printf '\n'
+info "Detected runtime feature default"
+if command -v nvidia-smi >/dev/null 2>&1; then
+  pass "nvidia-smi detected; Makefile will default FEATURES=gpu"
+else
+  os_name=$(uname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')
+  arch_name=$(uname -m 2>/dev/null)
+  if [ "$os_name" = "darwin" ] && [ "$arch_name" = "arm64" ]; then
+    pass "Apple Silicon detected; Makefile will default FEATURES=gpu"
+  else
+    pass "no default GPU signal detected; Makefile will default FEATURES=cpu"
+  fi
+fi
+
+printf '\n'
+if [ "$failures" -eq 0 ]; then
+  if [ "$warnings" -eq 0 ]; then
+    pass "doctor completed with no failures or warnings"
+  else
+    pass "doctor completed with no failures ($warnings warning(s))"
+  fi
+  exit 0
+fi
+
+fail "doctor found $failures failure(s) and $warnings warning(s)"
+exit 1


### PR DESCRIPTION
### Motivation
- Provide contributors a quick, POSIX-friendly diagnostic to validate the pinned Rust toolchain, Cargo metadata, detected default features, and common optional dev tools before building. 
- Make `make help` more robust for the repository's `## target: description` annotation style and surface runtime defaults for easier onboarding. 
- Harden MSRV guard checks to compare workflows against the declared `rust-toolchain.toml` channel and catch a few newer stale references.

### Description
- Add a POSIX shell diagnostic script at `scripts/doctor.sh` that checks required commands (`git`, `cargo`, `rustc`), ensures `rustc` matches `rust-toolchain.toml`, runs `cargo metadata --locked --no-deps`, and reports optional tooling (`cargo-nextest`, `cargo-watch`, `cargo-audit`, `cargo-outdated`, `cargo-bloat`, `tokei`, `tree`, `docker`).
- Wire `make doctor` into the `Makefile` and include it in the `help` output with detected defaults shown via `FEATURES`, `OS`, `ARCH`, and `JOBS` variables.
- Replace the `make help` `awk` snippet with one that parses `## target: description` lines reliably across the Makefile.
- Update the `guards` target in `Makefile` to derive `expected_msrv` from `rust-toolchain.toml`, expand stale-MSRV detection to include `1.93`/`1.94` patterns, and improve guard messaging accordingly.
- Document the new diagnostic in `README.md` by recommending `make doctor` in the build flow.

### Testing
- Ran `make help` and verified annotated targets, `make doctor` and observed expected checks and warnings; the command completed successfully. (passed)
- Ran a syntax check `sh -n scripts/doctor.sh` to validate the script is POSIX shell parsable. (passed)
- Performed a dry-run `make -n guards` and executed `make guards` to validate the updated MSRV and `--locked` checks; all guards passed in this environment. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083e1210c083339531fd12d2bb6952)