### PR TITLE
model: expose BitNet CUDA proof rungs in status

### DIFF
--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -65,6 +65,8 @@ required_receipts = [
   "strict_answer_corpus",
   "cpu_cuda_answer_parity",
   "execution_plan",
+  "one_token_strict_cuda",
+  "short_decode_strict_cuda",
   "strict_cuda_ask",
   "warm_session",
   "benchmark_profile_receipt",

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -1378,12 +1378,10 @@ fn print_model_status_group(dashboard: &ModelStatusDashboard, title: &str, categ
         println!("    tier: {}", row.tier);
         println!("    cpu answer: {}", ready_label(row.cpu_answer_ready));
         println!("    cuda answer: {}", ready_label(row.accelerator_answer_ready));
-        if row.model_class == "dense_slm" && row.route.as_deref() == Some("dense_regular_llm_cuda")
-        {
+        println!("    ask: {}", row.ask);
+        if matches!(row.route.as_deref(), Some("dense_regular_llm_cuda" | "bitnet_qk256_cuda")) {
             println!("    one-token: {}", row.one_token);
             println!("    short-decode: {}", row.short_decode);
-        } else {
-            println!("    ask: {}", row.ask);
         }
         println!("    warm-session: {}", row.warm_session);
         println!("    benchmark: {}", row.benchmark);
@@ -3048,6 +3046,8 @@ mod tests {
         assert!(!bitnet.server_ready);
         assert!(!bitnet.full_residency_claim);
         assert_eq!(bitnet.ask, "ready");
+        assert_eq!(bitnet.one_token, "ready");
+        assert_eq!(bitnet.short_decode, "ready");
         assert_eq!(bitnet.warm_session, "ready");
         assert_eq!(bitnet.benchmark, "reviewed, speedup not accepted");
         assert!(bitnet.claim_boundary.contains("does not prove dense regular-LLM CUDA"));


### PR DESCRIPTION
## Summary
- add the BitNet one-token and short-decode CUDA proof rungs to the model coverage row
- make `bitnet model status` print ask plus one-token/short-decode for both BitNet QK256 and dense CUDA routes
- cover the BitNet status row so JSON now reports ask/one_token/short_decode/warm_session as ready while speedup/server/full-residency remain false

## Validation
- `rtk cargo test --locked -p bitnet-cli --lib --no-default-features --features cpu,full-cli model_status_dashboard -- --nocapture`
- `rtk cargo run --release --locked -p xtask --no-default-features -- check-model-coverage`
- `rtk cargo run --release --locked -p xtask --no-default-features -- campaign check nvidia-5070ti`
- `rtk cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `rtk cargo fmt -p bitnet-cli -- --check`
- `rtk git diff --check`
- `rtk cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- model status --device nvidia-rtx-5070-ti-cuda --format json`