### PR TITLE
test(bitnet): guard missing pre-rope frontier context

### DIFF
--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -44737,6 +44737,7 @@ mod tests {
                     "key_slot": 13,
                     "query_token": 3,
                     "selected_dim_values": {
+                        "reference_projection": null,
                         "reference_post_rope": 1.4809578657150269_f64,
                         "rust_post_rope": 1.4809563159942627_f64,
                     }


### PR DESCRIPTION
## Summary
- tighten the post-fix score-input frontier regression test for missing pre-RoPE K context
- explicitly cover the present-but-null `selected_dim_values.reference_projection` case
- keep the frontier diagnostic-only and non-promoting

## Validation
- `cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace::tests::post_fix_score_input_frontier -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `rustfmt --edition 2024 --check xtask\src\bitnet_reference_layer_trace.rs`
- `git diff --check`

## Claim boundary
No runtime math changes. No promotion of reference parity, A770 semantic quality, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full residency, performance, or completion.