### PR TITLE
docs(cuda): sync dense Qwen server status

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -167,7 +167,7 @@ the claim boundary before new runtime work.
 | Lane | Current state | Last real receipt | Next missing proof |
 |---|---|---|---|
 | BitNet official 2B I2_S CUDA | product CLI ready, speed false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-003-warm-session-benchmark.json` | profile-specific benchmark qualification |
-| Dense Qwen2.5 0.5B Q8_0 CUDA | product CLI ready in model coverage; real strict runtime receipts and benchmark qualification reviews exist; direct ask/chat hardware receipts not found | `docs/reports/CUDA_DENSE_QWEN25_Q8_PRODUCT_AUDIT.md` | direct ask/chat user-path receipts if required, then server reuse |
+| Dense Qwen2.5 0.5B Q8_0 CUDA | product CLI ready in model coverage; strict one-token, short-decode, warm-session, benchmark-review, and exact-profile server-readiness receipts exist; speed, full residency, broad dense GGUF, and broad server readiness remain false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-17/server-strict-dense-qwen25-q8-smoke.json` | governed speedup/full-residency evidence, and any broader server readiness, require later exact-profile receipts |
 | Qwen3 0.6B | accelerator-ready dense SLM candidate with artifact, CPU sanity, all-layer plan, one-token strict CUDA proof, bounded short-decode strict CUDA proof, warm-session strict CUDA proof, and benchmark qualification review; product CLI, speed, server, full-residency, and BitNet QK256 claims remain false | `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-15/qwen3-0_6b-benchmark-qualification.json` | user-facing ask/chat product UX or repeated comparator evidence before any product CLI or speed profile promotion |
 | SmolLM2 360M | structurally valid artifact contract; strict CPU retry reached one-token generation with `fallback_used=false` but failed the math quality gate; wrong-first-token diagnosis and comparator contract are recorded | `ci/slm-cpu/windows-9950x3d-rtx5070ti/2026-05-16/smollm2-360m-reference-comparator-contract.json` | same-prompt first-token/top-k or checkpoint comparator capture before CPU answer readiness, all-layer planning, or CUDA |
 | Llama 3.2 1B | registered candidate | none | artifact contract, tokenizer/prompt authority, CPU sanity |
@@ -260,6 +260,9 @@ receipt resolves it to `nvidia-rtx-5070-ti-cuda`.
 | CUDA-SERVER-001 | merged | PR #4820 added claim-safe strict dense Qwen server receipt classification without promoting server readiness or speed. |
 | CUDA-SERVER-002 | merged | PR #4854 committed the exact bounded dense Qwen strict RTX 5070 Ti server-smoke receipt before any server-ready coverage promotion. |
 | CUDA-SERVER-003 | merged | PR #5190 audited the bounded dense Qwen server-smoke receipt against BITNET-SPEC-0010 and recorded that `server_ready` remains false until a refreshed or supplemental receipt carries artifact checksum identity, endpoint/profile scope, and generation-policy fields. |
+| CUDA-SERVER-004 | merged | PR #5393 hardened shared-engine server receipt fields and validation for exact-profile server-readiness evidence while keeping coverage promotion out of that slice. |
+| CUDA-SERVER-005 | merged | PR #5410 promoted dense Qwen2.5 Q8_0 `server_ready=true` only for the exact non-streaming RTX 5070 Ti shared-engine `/v1/chat/completions` receipt, without speed, full-residency, deployment, concurrency, or BitNet proof claims. |
+| CUDA-SERVER-006 | merged | PR #5439 added separate official BitNet I2_S/QK256 strict server-smoke evidence for the `bitnet_qk256_cuda` route while keeping broad production server readiness false. |
 | CUDA-STATUS-001 | merged | PR #5158 added a user-facing CUDA capability matrix page backed by model coverage and campaign proof state without promoting model, speed, server, or residency claims. |
 
 ## Review Policy

--- a/docs/tutorials/rtx5070ti-dense-qwen-cuda.md
+++ b/docs/tutorials/rtx5070ti-dense-qwen-cuda.md
@@ -12,12 +12,12 @@ The claim is intentionally narrow:
 - route: `dense_regular_llm_cuda`
 - fallback: rejected in strict CUDA receipts
 - speed: reviewed, not accepted
-- server readiness: not broadly ready
+- server readiness: exact-profile only
 - BitNet proof: false
 
 Official BitNet I2_S/QK256 receipts do not prove this dense lane. This dense
 lane also does not prove BitNet packed I2_S/QK256 behavior, QK256 kernels,
-global dense GGUF support, full CUDA residency, accepted speedup, or production
+global dense GGUF support, full CUDA residency, accepted speedup, or broad
 server readiness.
 
 ## Prerequisites
@@ -55,7 +55,9 @@ bitnet model status --device nvidia-rtx-5070-ti-cuda --format json
 ```
 
 The dense Qwen row should show `product_cli_ready`, route
-`dense_regular_llm_cuda`, `speedup_claim=false`, and `server_ready=false`.
+`dense_regular_llm_cuda`, `speedup_claim=false`, and `server_ready=true` scoped
+only to the exact shared-engine `/v1/chat/completions` profile named by the
+model coverage matrix.
 
 ## Verify The Model Artifact
 
@@ -110,7 +112,8 @@ For a bounded chat-style session:
 
 The committed warm-session proof is a bounded CLI/session proof. It records
 model, tokenizer, and CUDA context reuse for the proof run, but it does not
-claim full CUDA residency, broad chat quality, server readiness, or speedup.
+itself claim full CUDA residency, broad chat quality, server readiness, or
+speedup.
 
 ## Explain Dense Receipts
 


### PR DESCRIPTION
## Summary
- update the dense Qwen CUDA guide to report exact-profile server readiness instead of stale server_ready=false wording
- update the NVIDIA 5070 Ti campaign current-state ledger and work-item table for CUDA-SERVER-004 through CUDA-SERVER-006
- preserve the claim boundary: no broad server readiness, speedup, full-residency, deployment, concurrency, or BitNet proof promotion

## Validation
- rtk rg -n 'server_ready=false|direct ask/chat hardware receipts not found|direct ask/chat user-path receipts if required|not broadly ready' docs\\tutorials\\rtx5070ti-dense-qwen-cuda.md docs\\tracking\\campaigns\\nvidia-5070ti\\CAMPAIGN.md (no matches)
- rtk cargo run --release --locked -p xtask --no-default-features -- check-model-coverage
- rtk cargo run --release --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
- rtk cargo run --release --locked -p xtask --no-default-features -- campaign generate --check
- rtk git diff --check

Note: the xtask commands were run through the Visual Studio 2019 developer environment with CARGO_TARGET_DIR=C:\\bntarget\\bn-cuda-server-006-vs2019 and CMAKE_GENERATOR=Visual Studio 16 2019 to match the existing Windows native build cache.