### PR TITLE
docs: define source-of-truth stack

### DIFF
--- a/.bitnet/goals/README.md
+++ b/.bitnet/goals/README.md
@@ -1,0 +1,88 @@
+# BitNet-rs active goals
+
+This directory holds repo-level active goal manifests for the BitNet-rs
+source-of-truth stack.
+
+The active manifest is optional until a lane is explicitly promoted to a
+repo-level goal. Campaign-local work may continue to use
+`docs/tracking/campaigns/<campaign>/active.toml`, but each work item must have
+one clear active execution authority.
+
+## Files
+
+```text
+.bitnet/goals/active.toml
+.bitnet/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+## Manifest role
+
+An active goal owns only current machine-readable execution state:
+
+- lane id and title;
+- linked proposal, specs, ADRs, and plan;
+- current objective;
+- checkable end state;
+- claim boundaries;
+- work items and proof commands;
+- status and support-tier pointers.
+
+It does not own product rationale, durable decisions, generated metrics, or
+public support claims. Link to the proposal, spec, ADR, plan, status docs, and
+policy ledgers for those truths.
+
+## Template
+
+```toml
+id = "bitnet-lane-id"
+title = "Human readable lane title"
+status = "active"
+owner = "codex-claude"
+created = "YYYY-MM-DD"
+
+proposal = "docs/proposals/BITNET-PROP-0001-lane.md"
+plan = "plans/lane/implementation-plan.md"
+
+specs = [
+  "docs/specs/BITNET-SPEC-0001-contract.md",
+]
+
+adrs = [
+  "docs/adr/BITNET-ADR-0001-decision.md",
+]
+
+objective = """
+State the current lane objective in one paragraph.
+"""
+
+end_state = [
+  "Checkable end-state outcome.",
+]
+
+claim_boundaries = [
+  "Do not claim answer readiness until support-tier proof exists.",
+]
+
+status_docs = [
+  "docs/status/SUPPORT_TIERS.md",
+]
+
+[[work_item]]
+id = "work-item-id"
+status = "ready"
+spec = "docs/specs/BITNET-SPEC-0001-contract.md"
+adr = "docs/adr/BITNET-ADR-0001-decision.md"
+plan = "plans/lane/implementation-plan.md#work-item-work-item-id"
+current_pointer = "docs/status/SUPPORT_TIERS.md"
+claim_boundary = "What this work item may and may not claim."
+commands = [
+  "git diff --check",
+]
+```
+
+## Lifecycle
+
+- Create `active.toml` only when a lane has a selected plan and proof contract.
+- Archive a replaced active goal under `archive/` before activating a new one.
+- Use `status = "paused"` with a `reason` when there is no selected lane.
+- Do not leave multiple active repo-level goals.

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -1,0 +1,36 @@
+---
+name: Work item
+about: Track one source-of-truth implementation work item
+title: "[work-item] "
+labels: []
+assignees: []
+---
+
+## Work item
+
+ID:
+
+## Linked artifacts
+
+Proposal:
+Spec:
+ADR:
+Plan:
+Active goal or campaign item:
+
+## Goal
+
+## Acceptance
+
+## Proof commands
+
+```bash
+
+```
+
+## Non-goals
+
+## Notes
+
+Issues should not become mini-specs unless they are creating a spec PR. Link to
+the spec for behavior and the plan for sequencing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,42 @@
 
 <!-- Brief description of what this PR accomplishes -->
 
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal or campaign item:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+<!-- What this PR explicitly does not do -->
+
+## Proof
+
+```bash
+# commands run
+```
+
+Results:
+
+Claim boundary:
+
+Rollback:
+
 ## CI Requirements (check all that apply)
 
 <!-- These are enforced by the Guards workflow - violations will block merge -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,60 @@ repository. `CLAUDE.md` remains the broader repository guide; this file records
 the campaign authority model that Codex should apply while operating work-item
 branches.
 
+
+## Repo Source-of-Truth Stack
+
+BitNet-rs uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.bitnet/goals/active.toml` when present, or the campaign-local
+   `docs/tracking/campaigns/<campaign>/active.toml` named by the task
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. linked ADRs
+
+### Scope rule
+
+Implement one work item per PR. Docs-only artifacts are separate semantic
+changes unless the plan explicitly says to bundle them:
+
+- proposal PRs explain why;
+- spec PRs define behavior;
+- ADR PRs record durable decisions;
+- plan PRs define sequencing;
+- active goal PRs define current execution state.
+
+Runtime/code PRs must link to the spec and plan item they implement.
+
+### Proof rule
+
+Run the proof commands listed in the plan item and `git diff --check`. If a
+proof command cannot run, record the command, why it is unavailable, substitute
+evidence if any, and whether that blocks merge.
+
+### Generated status rule
+
+Do not hand-edit generated status. Run the generator/checker named in the plan.
+
+### Policy rule
+
+If you add an exception, add or update the relevant `policy/*.toml` ledger with
+owner, reason, `covered_by`, `created`, `review_after`, and `expires` when the
+exception is temporary.
+
+### Stop conditions
+
+Stop and report instead of guessing when the active goal or campaign item is
+missing, linked specs/plans are missing, proof commands cannot run, generated
+status is dirty, unrelated staged changes exist, or requested behavior
+contradicts an ADR.
+
 ## Campaign Work Item Authority
 
 Campaign work items are the source of truth for review, PR, and merge flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,39 @@ Essential guidance for working with the bitnet-rs codebase.
 - **MSRV:** 1.93.0 (Rust 2024 edition, pinned in `rust-toolchain.toml`)
 - **Status:** CPU inference works with SIMD optimization. GPU backends are scaffolded but not validated. Do not use in production.
 
+
+## Repo Source-of-Truth Stack
+
+BitNet-rs uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before making changes, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.bitnet/goals/active.toml` when present, or the campaign-local
+   `docs/tracking/campaigns/<campaign>/active.toml` named by the task
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. any linked ADRs
+
+Work on exactly one work item at a time. Do not create a new lane unless asked,
+do not mix proposal/spec/ADR/plan/runtime changes unless the selected work item
+says to, do not broaden support claims without support-tier proof, and do not
+hand-edit generated status unless the plan names that edit as the source of
+truth.
+
+A PR is ready only when the intended artifact or code change exists, linked docs
+are updated, proof commands have run or are explicitly marked unavailable,
+claim boundaries are respected, and `git diff --check` passes.
+
+Stop and report instead of guessing when the active goal or campaign item is
+missing or stale, linked specs are missing, proof commands cannot run, generated
+status differs from committed status, requested work conflicts with an ADR, or
+the branch contains unrelated staged changes.
+
 ## Rust 1.95 Rollout Rails
 
 The Rust 1.95 / next minor rollout is a continuation of the Rust 1.93 CI

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,11 +1,13 @@
 # Architectural Decision Records
 
 ADRs record durable BitNet-rs decisions. Use them when a lane needs a stable
-architecture, proof, or policy choice that should survive individual PRs.
+architecture, proof, or policy choice that should survive individual PRs and
+still matter months later.
 
-ADRs do not own active work state or generated dashboards. Active execution
-state belongs in campaign-local `active.toml`; generated dashboards are derived
-from campaign manifests and events.
+ADRs do not own active work state, PR queues, or generated dashboards. Active
+execution state belongs in `.bitnet/goals/active.toml` or the selected
+campaign-local `active.toml`; generated dashboards are derived from campaign
+manifests, events, and receipts.
 
 ## Current ADRs
 
@@ -13,7 +15,7 @@ from campaign manifests and events.
 - ADR-0002: [GPU Backend Strategy](./0002-gpu-backend-strategy.md)
 - BITNET-ADR-0004: [9950X3D + RTX 5070 Ti CUDA Product Bench](./BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
 
-## Source-Of-Truth Role
+## Source-of-truth role
 
 | Layer | Owns |
 | --- | --- |
@@ -21,7 +23,7 @@ from campaign manifests and events.
 | Spec | What must be true |
 | ADR | What decision was made and why it is durable |
 | Plan | PR order and proof commands |
-| Campaign `active.toml` | Current executable work |
+| Active goal or campaign manifest | Current executable work |
 | Policy TOML | Enforceable ledger |
 | Receipt or artifact | Evidence |
 
@@ -37,13 +39,25 @@ cross-lane proof decision needs a stable identifier:
 
 ```md
 # ADR-NNNN: Title
-- **Status:** Proposed | Accepted | Superseded by NNNN | Rejected
-- **Date:** YYYY-MM-DD
-- **Linked proposal/spec:** <paths>
-- **Context:** <problem / forces>
-- **Decision:** <what we chose and why>
-- **Consequences:** <positive/negative trade-offs>
-- **Claim boundary:** <what this decision does not prove>
-- **Alternatives considered:** <brief bullets>
-- **How to revert:** <what to change back if needed>
+
+Status: Proposed | Accepted | Superseded by NNNN | Rejected
+Date: YYYY-MM-DD
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+
+## Decision
+
+## Context
+
+## Consequences
+
+## Alternatives considered
+
+## Follow-up specs / plans
+
+## Claim boundary
+
+## How to revert
 ```

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,54 +1,61 @@
 # Proposals
 
-Proposals explain why a BitNet-rs effort exists, what success means, and which
-current repo authorities it will use. They are durable context for humans and
-agents before a lane becomes a spec, ADR, plan, or campaign item.
+Proposals explain why a BitNet-rs effort exists, what user pain or repo risk it
+addresses, and what success means before a lane becomes a spec, ADR, plan, or
+active work item.
 
-Proposals do not own implementation status, active work, or product claims.
-Those belong to campaign manifests, plans, status documents, policy ledgers,
-and proof receipts.
+Proposals do not own implementation status, active work, generated status, or
+public support claims. Those belong to plans, active goals, status documents,
+policy ledgers, and proof receipts.
 
-## Source-Of-Truth Role
+## Source-of-truth role
 
-| Layer | Owns |
+| Question | Source of truth |
 | --- | --- |
-| Proposal | Why the effort exists, user value, constraints, success criteria |
-| Spec | What must be true before a claim or behavior is accepted |
-| ADR | Durable architecture or proof decision |
-| Plan | PR order, proof commands, rollback path |
-| Campaign `active.toml` | Current executable work item state |
-| Status document | User-facing claim tier, proof command, artifact link |
-| Policy TOML | Enforceable CI, exception, allowlist, or routing ledger |
-| Receipt or artifact | Evidence for what actually happened |
+| Why does this lane exist? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What decision did we make? | `docs/adr/` |
+| What PRs execute it? | `plans/` plus the active goal or campaign manifest |
+| What is actively executing now? | `.bitnet/goals/active.toml` or `docs/tracking/campaigns/<campaign>/active.toml` |
+| What is currently supported? | `docs/status/` plus proof artifacts |
+| What does policy enforce or except? | `policy/*.toml` and workflow gates |
+| What happened? | Receipts, artifacts, campaign events, closeouts |
 
-## BitNet Rule
-
-Do not create `.adze/goals`, `.bitnet/goals`, or another hidden global goals
-file. BitNet-rs already uses campaign-local tracking:
-
-```text
-docs/tracking/campaigns/<campaign>/CAMPAIGN.md
-docs/tracking/campaigns/<campaign>/active.toml
-docs/tracking/campaigns/<campaign>/events/
-docs/tracking/campaigns/<campaign>/generated/
-```
-
-Use proposals to frame a lane, then connect implementation to the campaign
-tracker instead of reconstructing active state from chat logs or README prose.
-
-## Proposal Shape
-
-New proposals should include:
-
-- `Status`
-- `Owner`
-- `Problem`
-- `Goals`
-- `Non-goals`
-- `Source-of-truth links`
-- `Success criteria`
-- `Rollback or exit criteria`
+## BitNet claim rules
 
 Every proposal that affects user-visible capability claims should link to the
 status, model-artifact, hardware, CI, and campaign surfaces that will carry the
-actual proof.
+actual proof. A proposal may describe intended outcomes, but it must not claim
+support without support-tier proof or an equivalent receipt pointer.
+
+## Proposal shape
+
+New proposals should include:
+
+```text
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support-tier impact:
+Policy impact:
+```
+
+Recommended sections:
+
+- Problem
+- Users and surfaces
+- Success criteria
+- Proposed shape
+- Alternatives considered
+- Specs to create or update
+- ADRs needed
+- Implementation campaign shape
+- Evidence plan
+- Risks
+- Non-goals
+- Exit criteria
+- Claim boundary

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,183 @@
+# Repo source-of-truth system
+
+BitNet-rs uses a linked source-of-truth stack so humans and agents can find the
+right kind of truth in the right place without relying on chat history.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, lane inventory | Detailed PR queue, live status, proof receipts |
+| Proposal | Why the effort exists, users, alternatives, success criteria | Behavior contract, implementation queue, generated status |
+| Spec | Required behavior, acceptance, proof, claim boundaries | Product rationale, PR order, active queue |
+| ADR | Durable architecture or operating decision | Task list, current metric state, implementation queue |
+| Plan | PR order, work items, proof commands, rollback | Product rationale, durable decisions, generated status truth |
+| Active goal | Current machine-readable work, claim boundaries, proof pointers | Long prose, generated metrics, durable decisions |
+| Support tiers | Public claim tier, proof commands, limitations, promotion rule | Feature design or task sequencing |
+| Policy ledgers | Exceptions, CI/policy receipts, owners, review dates | Broad architecture or product strategy |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the plan says otherwise.
+3. Proposals explain why; specs define what must be true.
+4. ADRs record durable decisions; plans define sequencing.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent receipt pointer.
+8. Policy exceptions require owner, reason, coverage, and review date.
+
+## Required headers
+
+Use `n/a` when a header is not applicable. New proposals, specs, ADRs, and
+plans should include the relevant subset of these fields:
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Agent workflow
+
+Agents must:
+
+1. read repo instructions (`AGENTS.md` and/or `CLAUDE.md`);
+2. read this file;
+3. read `.bitnet/goals/active.toml` when present, or the campaign-local
+   `docs/tracking/campaigns/<campaign>/active.toml` named by the task;
+4. choose exactly one ready work item;
+5. read the linked plan, spec, and ADRs;
+6. implement only that item;
+7. run the listed proof commands and `git diff --check`;
+8. update receipts, status, policy, or support tiers only when the work item
+   requires it;
+9. stop on missing or contradictory source-of-truth artifacts.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal or campaign item is missing or stale;
+- linked files do not exist;
+- generated status is dirty;
+- proof commands cannot run and no substitute evidence is defined;
+- unrelated staged changes exist;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier proof.
+
+## Active goal lifecycle
+
+The repo-level active goal, when used, lives at:
+
+```text
+.bitnet/goals/active.toml
+```
+
+Campaign-local trackers may also use:
+
+```text
+docs/tracking/campaigns/<campaign>/active.toml
+```
+
+Use exactly one active execution authority for a work item. If a new repo-level
+active goal replaces an old one, archive the old manifest at:
+
+```text
+.bitnet/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+A paused repo-level goal should use:
+
+```toml
+status = "paused"
+reason = "No selected implementation lane."
+```
+
+## Closeout format
+
+At the end of a lane, write the closeout where the plan lives, normally:
+
+```text
+plans/<lane>/closeout.md
+```
+
+A closeout should record what shipped, proof commands, receipts, PRs, CI runs,
+support-tier updates, policy updates, deferred work, claim boundaries, and the
+next lane recommendation.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused
+on behavior, examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move the why to `docs/proposals/`; keep plans focused on work items, proof, and
+rollback.
+
+### Active goal becomes prose
+
+Keep the active goal as TOML. Link to docs instead of embedding long generated
+tables or design rationale.
+
+### Agent hand-edits generated status
+
+Run the named generator/checker. If no generator exists, stop and record the
+missing tool rather than silently editing generated state.
+
+### Support claims drift
+
+Require a support-tier impact header and a support-tier row or proof pointer
+before adding README or marketing claims.
+
+### Policy exceptions become silent debt
+
+Every exception must have an owner, reason, `covered_by`, `created`, and
+`review_after`; temporary exceptions should also have `expires`.
+
+### Mega PR
+
+Keep one semantic artifact or one implementation work item per PR unless the
+plan explicitly authorizes bundling.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repository answers those questions without chat history, the source-of-
+truth system is working.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,23 +4,24 @@ Specs define what must be true before BitNet-rs accepts a behavior, claim,
 proof boundary, or policy contract. They are the acceptance layer between a
 proposal and implementation work.
 
-Specs should not duplicate long operational ledgers. They should point to the
-authoritative gate, policy TOML, matrix, manifest, or receipt format and define
-how that authority is used.
+Specs should not duplicate product rationale, active queues, or operational
+ledgers. They should point to the authoritative gate, policy TOML, matrix,
+manifest, or receipt format and define how that authority is used.
 
-## Source-Of-Truth Role
+## Source-of-truth role
 
 | Question | Source of truth |
 | --- | --- |
 | Why does this lane exist? | `docs/proposals/` |
 | What must be true? | `docs/specs/` |
 | What decision did we make? | `docs/adr/` |
-| What PRs execute it? | `plans/` and campaign `active.toml` |
+| What PRs execute it? | `plans/` plus the active goal or campaign manifest |
+| What is actively executing now? | `.bitnet/goals/active.toml` or `docs/tracking/campaigns/<campaign>/active.toml` |
 | What is currently supported? | `docs/status/` plus proof artifacts |
 | What does CI enforce? | `policy/*.toml` and workflow gates |
 | What happened? | Receipts, artifacts, campaign events, closeouts |
 
-## BitNet Claim Rules
+## BitNet claim rules
 
 Specs for model, hardware, or CI claims must preserve these boundaries:
 
@@ -33,7 +34,7 @@ Specs for model, hardware, or CI claims must preserve these boundaries:
 - Expensive CI evidence belongs on risk-routed, main, nightly, release, or
   campaign lanes unless policy explicitly promotes it.
 
-## Existing Operational Authorities
+## Existing operational authorities
 
 Specs should link to these maintained authorities instead of copying them:
 
@@ -47,15 +48,32 @@ Specs should link to these maintained authorities instead of copying them:
 - `policy/ci-budget.toml`
 - `policy/ci-risk-packs.toml`
 
-## Spec Shape
+## Spec shape
 
 New specs should include:
 
-- `Status`
-- `Linked proposal`
-- `Applies to`
-- `Requirements`
-- `Claim boundary`
-- `Proof commands`
-- `Non-goals`
-- `Related policy or manifest sources`
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+Recommended sections:
+
+- Problem
+- Behavior
+- Non-goals
+- Required evidence
+- Acceptance examples
+- Test mapping
+- Implementation mapping
+- CI proof
+- Metrics / promotion rule
+- Claim boundaries

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,20 +1,15 @@
 # Plans
 
 Plans translate proposals, specs, and ADRs into PR-sized implementation work.
-They should tell a maintainer or agent what to do next, what not to touch, and
-which commands prove or disprove the claim.
+They tell a maintainer or agent what to do next, what not to touch, which
+commands prove or disprove the claim, and how to roll back safely.
 
-Plans are not active global goals. The active source of truth for executable
-work is still the campaign tracker:
+Plans are queues, not product strategy. Product rationale belongs in proposals;
+required behavior belongs in specs; durable choices belong in ADRs; live
+execution state belongs in `.bitnet/goals/active.toml` or the selected
+campaign-local `active.toml`.
 
-```text
-docs/tracking/campaigns/<campaign>/active.toml
-```
-
-Use plans for sequencing and proof commands. Use campaign manifests for live
-state, ownership, branch names, allowed paths, and merge policy.
-
-## Source-Of-Truth Role
+## Source-of-truth role
 
 | Layer | Owns |
 | --- | --- |
@@ -22,22 +17,22 @@ state, ownership, branch names, allowed paths, and merge policy.
 | Spec | What must be true |
 | ADR | Durable decision |
 | Plan | PR sequence, proof commands, rollback |
-| Campaign `active.toml` | Active work state |
+| Active goal or campaign manifest | Active work state |
 | Campaign events | Append-only lifecycle history |
 | Closeout | What landed and what remains |
 
-## Work Item Shape
+## Work item shape
 
 Plan work items should use this shape when practical:
 
-```md
+````md
 ## Work item: <id>
 
-Status: ready
+Status: ready | active | blocked | completed | superseded
 Linked proposal:
 Linked specs:
 Linked ADRs:
-Campaign item:
+Active goal or campaign item:
 Blocked by:
 Blocks:
 
@@ -51,15 +46,21 @@ Blocks:
 
 ### Proof commands
 
-### Rollback
+```bash
+git diff --check
 ```
+
+### Rollback
+
+### Notes
+````
 
 ## Boundaries
 
 Plans must not:
 
-- duplicate generated dashboards,
-- create `.adze/goals` or `.bitnet/goals`,
-- claim model answer readiness without the answer artifact gate,
-- claim hardware validation without lane-specific receipts,
-- claim CI budget enforcement unless policy TOMLs and workflow gates enforce it.
+- duplicate generated dashboards;
+- claim model answer readiness without the answer artifact gate;
+- claim hardware validation without lane-specific receipts;
+- claim CI budget enforcement unless policy TOMLs and workflow gates enforce it;
+- turn specs into task lists or ADRs into implementation queues.


### PR DESCRIPTION
### Motivation

- Establish a single, machine- and human-oriented source-of-truth system so agents and contributors know where each kind of repository truth should live. 
- Prevent agents from drifting by codifying a first-read order, one-work-item rule, proof requirements, stop conditions, and generated-status/policy rules. 
- Provide lightweight templates and guidance so proposals, specs, ADRs, plans, active goals, PRs, and work items are consistent and discoverable. 

### Description

- Add `docs/reference/SPEC_SYSTEM.md` describing the Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof stack, artifact roles, required headers, agent workflow, stop conditions, lifecycle, and common failure modes. 
- Add `.bitnet/goals/README.md` documenting the repo-level active goal manifest template and lifecycle guidance without activating any lane. 
- Update `AGENTS.md` and `CLAUDE.md` with repo first-read sequence, scope/proof/generated-status/policy rules, and stop conditions for agents. 
- Refresh `docs/proposals/README.md`, `docs/specs/README.md`, `docs/adr/README.md`, and `plans/README.md` to align artifact shapes and roles, extend the PR template at `.github/pull_request_template.md` with source-of-truth links and proof/rollback sections, and add a work-item issue template at `.github/ISSUE_TEMPLATE/work_item.md`. 
- No runtime, build, or behavioral code changes were made and no active `active.toml` was created in this PR. 

### Testing

- Ran `git diff --check` to validate whitespace and basic diffs, which returned clean results. 
- Ran a newline-safety script via `python` that checked each modified/new file for a trailing newline, and the check passed for all target files. 
- Performed repository file checks (`git status` / `git diff --stat`) to verify the intended set of documentation and template files were staged for the change, with no unexpected modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1795a24c8333bbe2480046d7c417)