### PR TITLE
test: add qk256 layout core unit coverage

### DIFF
--- a/crates/bitnet-qk256-layout-core/src/lib.rs
+++ b/crates/bitnet-qk256-layout-core/src/lib.rs
@@ -229,6 +229,26 @@ mod tests {
         codes
     }
 
+    fn layout_2x257() -> Qk256Layout {
+        Qk256Layout {
+            rows: 2,
+            row_stride_bytes: 128,
+            cols: 257,
+            blocks_per_row: 2,
+            packed_len_bytes: 256,
+        }
+    }
+
+    fn layout_3x257() -> Qk256Layout {
+        Qk256Layout {
+            rows: 3,
+            row_stride_bytes: 128,
+            cols: 257,
+            blocks_per_row: 2,
+            packed_len_bytes: 384,
+        }
+    }
+
     #[test]
     fn constants_match_qk256_block_geometry() {
         assert_eq!(QK256_BLOCK_COLS, 256);
@@ -257,42 +277,31 @@ mod tests {
 
     #[test]
     fn layout_from_rows_cols_records_derived_sizes() {
-        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
-
-        assert_eq!(
-            layout,
-            Qk256Layout {
-                rows: 3,
-                row_stride_bytes: 128,
-                cols: 257,
-                blocks_per_row: 2,
-                packed_len_bytes: 384,
-            }
-        );
+        assert_eq!(Qk256Layout::from_rows_cols(3, 257), Ok(layout_3x257()));
         assert_eq!(qk256_packed_len_bytes(3, 257), Ok(384));
     }
 
     #[test]
     fn layout_from_rows_cols_allows_zero_sized_layouts() {
         assert_eq!(
-            Qk256Layout::from_rows_cols(0, 257).unwrap(),
-            Qk256Layout {
+            Qk256Layout::from_rows_cols(0, 257),
+            Ok(Qk256Layout {
                 rows: 0,
                 row_stride_bytes: 128,
                 cols: 257,
                 blocks_per_row: 2,
                 packed_len_bytes: 0,
-            }
+            })
         );
         assert_eq!(
-            Qk256Layout::from_rows_cols(3, 0).unwrap(),
-            Qk256Layout {
+            Qk256Layout::from_rows_cols(3, 0),
+            Ok(Qk256Layout {
                 rows: 3,
                 row_stride_bytes: 0,
                 cols: 0,
                 blocks_per_row: 0,
                 packed_len_bytes: 0,
-            }
+            })
         );
     }
 
@@ -307,14 +316,14 @@ mod tests {
     #[test]
     fn layout_from_rows_stride_converts_aligned_stride_to_cols() {
         assert_eq!(
-            Qk256Layout::from_rows_stride(2, 128).unwrap(),
-            Qk256Layout {
+            Qk256Layout::from_rows_stride(2, 128),
+            Ok(Qk256Layout {
                 rows: 2,
                 row_stride_bytes: 128,
                 cols: 512,
                 blocks_per_row: 2,
                 packed_len_bytes: 256,
-            }
+            })
         );
     }
 
@@ -351,13 +360,13 @@ mod tests {
 
     #[test]
     fn validate_packed_len_accepts_exact_length() {
-        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+        let layout = layout_2x257();
         assert_eq!(layout.validate_packed_len(256), Ok(()));
     }
 
     #[test]
     fn validate_packed_len_reports_mismatch_details() {
-        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+        let layout = layout_2x257();
 
         assert_eq!(
             layout.validate_packed_len(255),
@@ -372,7 +381,7 @@ mod tests {
 
     #[test]
     fn row_range_returns_stride_sized_ranges() {
-        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+        let layout = layout_3x257();
 
         assert_eq!(layout.row_range(0), Ok(0..128));
         assert_eq!(layout.row_range(1), Ok(128..256));
@@ -381,14 +390,14 @@ mod tests {
 
     #[test]
     fn row_range_rejects_out_of_bounds_rows() {
-        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+        let layout = layout_3x257();
 
         assert_eq!(layout.row_range(3), Err(Qk256LayoutError::RowOutOfBounds { row: 3, rows: 3 }));
     }
 
     #[test]
     fn block_range_returns_block_sized_ranges_within_row() {
-        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+        let layout = layout_2x257();
 
         assert_eq!(layout.block_range(0, 0), Ok(0..64));
         assert_eq!(layout.block_range(0, 1), Ok(64..128));
@@ -398,7 +407,7 @@ mod tests {
 
     #[test]
     fn block_range_rejects_out_of_bounds_blocks_before_rows() {
-        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+        let layout = layout_2x257();
 
         assert_eq!(
             layout.block_range(99, 2),
@@ -408,7 +417,7 @@ mod tests {
 
     #[test]
     fn block_range_propagates_row_bounds_for_valid_block() {
-        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+        let layout = layout_2x257();
 
         assert_eq!(
             layout.block_range(2, 1),
@@ -418,7 +427,7 @@ mod tests {
 
     #[test]
     fn row_ranges_iterates_all_rows_with_exact_size() {
-        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+        let layout = layout_3x257();
         let mut ranges = layout.row_ranges();
 
         assert_eq!(ranges.len(), 3);
@@ -430,14 +439,14 @@ mod tests {
     #[test]
     fn parse_qk256_layout_accepts_two_dimensional_layout_shape() {
         assert_eq!(
-            parse_qk256_layout("blk.0.weight", &[2, 64]).unwrap(),
-            Qk256Layout {
+            parse_qk256_layout("blk.0.weight", &[2, 64]),
+            Ok(Qk256Layout {
                 rows: 2,
                 row_stride_bytes: 64,
                 cols: 256,
                 blocks_per_row: 1,
                 packed_len_bytes: 128,
-            }
+            })
         );
     }
 
@@ -499,9 +508,10 @@ mod tests {
 
     #[test]
     fn pack_qk256_codes_packs_four_two_bit_codes_per_byte_little_endian() {
-        let packed = pack_qk256_codes(&patterned_codes()).unwrap();
-
-        assert!(packed.iter().all(|byte| *byte == 0b11_10_01_00));
+        assert_eq!(
+            pack_qk256_codes(&patterned_codes()),
+            Ok([0b11_10_01_00; QK256_PACKED_BYTES_PER_BLOCK])
+        );
     }
 
     #[test]
@@ -529,8 +539,6 @@ mod tests {
             *code = ((offset * 17 + offset / 7) % 4) as u8;
         }
 
-        let packed = pack_qk256_codes(&codes).unwrap();
-
-        assert_eq!(unpack_qk256_codes(&packed), codes);
+        assert_eq!(pack_qk256_codes(&codes).map(|packed| unpack_qk256_codes(&packed)), Ok(codes));
     }
 }

--- a/crates/bitnet-qk256-layout-core/src/lib.rs
+++ b/crates/bitnet-qk256-layout-core/src/lib.rs
@@ -216,3 +216,321 @@ pub fn unpack_qk256_codes(packed: &[u8; QK256_PACKED_BYTES_PER_BLOCK]) -> [u8; Q
     }
     codes
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patterned_codes() -> [u8; QK256_BLOCK_COLS] {
+        let mut codes = [0u8; QK256_BLOCK_COLS];
+        for (offset, code) in codes.iter_mut().enumerate() {
+            *code = (offset % 4) as u8;
+        }
+        codes
+    }
+
+    #[test]
+    fn constants_match_qk256_block_geometry() {
+        assert_eq!(QK256_BLOCK_COLS, 256);
+        assert_eq!(QK256_BITS_PER_CODE, 2);
+        assert_eq!(QK256_PACKED_BYTES_PER_BLOCK, 64);
+        assert_eq!(QK256_ROW_ALIGNMENT_BYTES, QK256_PACKED_BYTES_PER_BLOCK);
+    }
+
+    #[test]
+    fn blocks_per_row_rounds_up_to_whole_qk256_blocks() {
+        assert_eq!(qk256_blocks_per_row(0), 0);
+        assert_eq!(qk256_blocks_per_row(1), 1);
+        assert_eq!(qk256_blocks_per_row(255), 1);
+        assert_eq!(qk256_blocks_per_row(256), 1);
+        assert_eq!(qk256_blocks_per_row(257), 2);
+        assert_eq!(qk256_blocks_per_row(512), 2);
+    }
+
+    #[test]
+    fn row_stride_bytes_uses_packed_block_size() {
+        assert_eq!(qk256_row_stride_bytes(0), Ok(0));
+        assert_eq!(qk256_row_stride_bytes(1), Ok(64));
+        assert_eq!(qk256_row_stride_bytes(256), Ok(64));
+        assert_eq!(qk256_row_stride_bytes(257), Ok(128));
+    }
+
+    #[test]
+    fn layout_from_rows_cols_records_derived_sizes() {
+        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+
+        assert_eq!(
+            layout,
+            Qk256Layout {
+                rows: 3,
+                row_stride_bytes: 128,
+                cols: 257,
+                blocks_per_row: 2,
+                packed_len_bytes: 384,
+            }
+        );
+        assert_eq!(qk256_packed_len_bytes(3, 257), Ok(384));
+    }
+
+    #[test]
+    fn layout_from_rows_cols_allows_zero_sized_layouts() {
+        assert_eq!(
+            Qk256Layout::from_rows_cols(0, 257).unwrap(),
+            Qk256Layout {
+                rows: 0,
+                row_stride_bytes: 128,
+                cols: 257,
+                blocks_per_row: 2,
+                packed_len_bytes: 0,
+            }
+        );
+        assert_eq!(
+            Qk256Layout::from_rows_cols(3, 0).unwrap(),
+            Qk256Layout {
+                rows: 3,
+                row_stride_bytes: 0,
+                cols: 0,
+                blocks_per_row: 0,
+                packed_len_bytes: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn layout_from_rows_cols_reports_packed_length_overflow() {
+        assert_eq!(
+            Qk256Layout::from_rows_cols(usize::MAX, 256),
+            Err(Qk256LayoutError::PackedLengthOverflow { rows: usize::MAX, cols: 256 })
+        );
+    }
+
+    #[test]
+    fn layout_from_rows_stride_converts_aligned_stride_to_cols() {
+        assert_eq!(
+            Qk256Layout::from_rows_stride(2, 128).unwrap(),
+            Qk256Layout {
+                rows: 2,
+                row_stride_bytes: 128,
+                cols: 512,
+                blocks_per_row: 2,
+                packed_len_bytes: 256,
+            }
+        );
+    }
+
+    #[test]
+    fn layout_from_rows_stride_rejects_unaligned_stride() {
+        assert_eq!(
+            Qk256Layout::from_rows_stride(1, 63),
+            Err(Qk256LayoutError::InvalidRowStride { row_stride_bytes: 63 })
+        );
+        assert_eq!(
+            Qk256Layout::from_rows_stride(1, 65),
+            Err(Qk256LayoutError::InvalidRowStride { row_stride_bytes: 65 })
+        );
+    }
+
+    #[test]
+    fn layout_from_rows_stride_reports_cols_overflow() {
+        let row_stride_bytes =
+            (usize::MAX / QK256_PACKED_BYTES_PER_BLOCK) * QK256_PACKED_BYTES_PER_BLOCK;
+
+        assert_eq!(
+            Qk256Layout::from_rows_stride(1, row_stride_bytes),
+            Err(Qk256LayoutError::RowStrideOverflow { row_stride_bytes })
+        );
+    }
+
+    #[test]
+    fn layout_from_rows_stride_reports_packed_length_overflow() {
+        assert_eq!(
+            Qk256Layout::from_rows_stride(usize::MAX, 64),
+            Err(Qk256LayoutError::PackedLengthOverflow { rows: usize::MAX, cols: 256 })
+        );
+    }
+
+    #[test]
+    fn validate_packed_len_accepts_exact_length() {
+        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+        assert_eq!(layout.validate_packed_len(256), Ok(()));
+    }
+
+    #[test]
+    fn validate_packed_len_reports_mismatch_details() {
+        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+
+        assert_eq!(
+            layout.validate_packed_len(255),
+            Err(Qk256LayoutError::PackedLengthMismatch {
+                rows: 2,
+                cols: 257,
+                actual_len: 255,
+                expected_len: 256,
+            })
+        );
+    }
+
+    #[test]
+    fn row_range_returns_stride_sized_ranges() {
+        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+
+        assert_eq!(layout.row_range(0), Ok(0..128));
+        assert_eq!(layout.row_range(1), Ok(128..256));
+        assert_eq!(layout.row_range(2), Ok(256..384));
+    }
+
+    #[test]
+    fn row_range_rejects_out_of_bounds_rows() {
+        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+
+        assert_eq!(layout.row_range(3), Err(Qk256LayoutError::RowOutOfBounds { row: 3, rows: 3 }));
+    }
+
+    #[test]
+    fn block_range_returns_block_sized_ranges_within_row() {
+        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+
+        assert_eq!(layout.block_range(0, 0), Ok(0..64));
+        assert_eq!(layout.block_range(0, 1), Ok(64..128));
+        assert_eq!(layout.block_range(1, 0), Ok(128..192));
+        assert_eq!(layout.block_range(1, 1), Ok(192..256));
+    }
+
+    #[test]
+    fn block_range_rejects_out_of_bounds_blocks_before_rows() {
+        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+
+        assert_eq!(
+            layout.block_range(99, 2),
+            Err(Qk256LayoutError::BlockOutOfBounds { block: 2, blocks_per_row: 2 })
+        );
+    }
+
+    #[test]
+    fn block_range_propagates_row_bounds_for_valid_block() {
+        let layout = Qk256Layout::from_rows_cols(2, 257).unwrap();
+
+        assert_eq!(
+            layout.block_range(2, 1),
+            Err(Qk256LayoutError::RowOutOfBounds { row: 2, rows: 2 })
+        );
+    }
+
+    #[test]
+    fn row_ranges_iterates_all_rows_with_exact_size() {
+        let layout = Qk256Layout::from_rows_cols(3, 257).unwrap();
+        let mut ranges = layout.row_ranges();
+
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges.next(), Some(0..128));
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges.collect::<Vec<_>>(), vec![128..256, 256..384]);
+    }
+
+    #[test]
+    fn parse_qk256_layout_accepts_two_dimensional_layout_shape() {
+        assert_eq!(
+            parse_qk256_layout("blk.0.weight", &[2, 64]).unwrap(),
+            Qk256Layout {
+                rows: 2,
+                row_stride_bytes: 64,
+                cols: 256,
+                blocks_per_row: 1,
+                packed_len_bytes: 128,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_qk256_layout_rejects_non_matrix_shapes() {
+        assert_eq!(
+            parse_qk256_layout("blk.0.weight", &[2, 64, 1]),
+            Err(Qk256LayoutError::InvalidQk256Shape {
+                weight_name: "blk.0.weight".to_owned(),
+                dims: vec![2, 64, 1],
+            })
+        );
+    }
+
+    #[test]
+    fn parse_input_shape_accepts_rank_two_as_single_token_sequence() {
+        assert_eq!(
+            parse_input_shape(&[4, 1024]),
+            Ok(Qk256InputShape { batch_size: 4, seq_len: 1, cols: 1024, input_rank: 2 })
+        );
+    }
+
+    #[test]
+    fn parse_input_shape_accepts_rank_three_sequence_batches() {
+        assert_eq!(
+            parse_input_shape(&[4, 8, 1024]),
+            Ok(Qk256InputShape { batch_size: 4, seq_len: 8, cols: 1024, input_rank: 3 })
+        );
+    }
+
+    #[test]
+    fn parse_input_shape_rejects_unsupported_ranks() {
+        assert_eq!(
+            parse_input_shape(&[1024]),
+            Err(Qk256LayoutError::UnsupportedInputShape { dims: vec![1024] })
+        );
+        assert_eq!(
+            parse_input_shape(&[1, 2, 3, 4]),
+            Err(Qk256LayoutError::UnsupportedInputShape { dims: vec![1, 2, 3, 4] })
+        );
+    }
+
+    #[test]
+    fn validate_input_cols_accepts_exact_match() {
+        assert_eq!(validate_input_cols("blk.0.weight", 1024, 1024), Ok(()));
+    }
+
+    #[test]
+    fn validate_input_cols_reports_mismatch() {
+        assert_eq!(
+            validate_input_cols("blk.0.weight", 512, 1024),
+            Err(Qk256LayoutError::DimensionMismatch {
+                weight_name: "blk.0.weight".to_owned(),
+                input_cols: 512,
+                expected_cols: 1024,
+            })
+        );
+    }
+
+    #[test]
+    fn pack_qk256_codes_packs_four_two_bit_codes_per_byte_little_endian() {
+        let packed = pack_qk256_codes(&patterned_codes()).unwrap();
+
+        assert!(packed.iter().all(|byte| *byte == 0b11_10_01_00));
+    }
+
+    #[test]
+    fn pack_qk256_codes_rejects_codes_larger_than_two_bits() {
+        let mut codes = patterned_codes();
+        codes[17] = 4;
+
+        assert_eq!(
+            pack_qk256_codes(&codes),
+            Err(Qk256LayoutError::InvalidCode { offset: 17, code: 4 })
+        );
+    }
+
+    #[test]
+    fn unpack_qk256_codes_extracts_four_two_bit_codes_per_byte_little_endian() {
+        let packed = [0b11_10_01_00; QK256_PACKED_BYTES_PER_BLOCK];
+
+        assert_eq!(unpack_qk256_codes(&packed), patterned_codes());
+    }
+
+    #[test]
+    fn pack_and_unpack_round_trip_for_non_repeating_codes() {
+        let mut codes = [0u8; QK256_BLOCK_COLS];
+        for (offset, code) in codes.iter_mut().enumerate() {
+            *code = ((offset * 17 + offset / 7) % 4) as u8;
+        }
+
+        let packed = pack_qk256_codes(&codes).unwrap();
+
+        assert_eq!(unpack_qk256_codes(&packed), codes);
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the QK256 layout utilities to catch geometry, stride/overflow, range, shape-parsing, and pack/unpack regressions.
- Provide deterministic, small-footprint tests that validate both success paths and error variants for the layout helpers used by higher-level quantization code.

### Description
- Add a `#[cfg(test)] mod tests` to `crates/bitnet-qk256-layout-core/src/lib.rs` containing comprehensive unit tests covering geometry constants, `qk256_blocks_per_row`, `qk256_row_stride_bytes`, `Qk256Layout` constructors, row/block range helpers, packed-length validation, input-shape parsing, and `validate_input_cols`.
- Add byte-exact tests for `pack_qk256_codes` and `unpack_qk256_codes`, including invalid-code rejection and round-trip verification for non-repeating patterns.
- Tests exercise both normal results and error variants such as `InvalidRowStride`, `RowStrideOverflow`, `PackedLengthOverflow`, `PackedLengthMismatch`, `RowOutOfBounds`, `BlockOutOfBounds`, `InvalidQk256Shape`, `UnsupportedInputShape`, and `DimensionMismatch`.

### Testing
- Ran `cargo test -p bitnet-qk256-layout-core --locked --no-default-features --features cpu` and all added tests passed (lib tests + layout tests).
- Ran `cargo fmt --all --check` which succeeded and `cargo clippy -p bitnet-qk256-layout-core --locked --all-targets --no-default-features --features cpu -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ead4c51c8333bada391281c1214a)