### PR TITLE
docs: define source-of-truth stack

### DIFF
--- a/.bitnet-rs/goals/README.md
+++ b/.bitnet-rs/goals/README.md
@@ -1,0 +1,49 @@
+# BitNet-rs active goals
+
+This directory holds the cross-lane, machine-readable active goal manifest for
+BitNet-rs when a lane is selected for agent execution.
+
+The active goal is not a replacement for proposals, specs, ADRs, implementation
+plans, support tiers, policy ledgers, or proof receipts. It points to those
+artifacts and tells agents what to execute now.
+
+## Files
+
+```text
+.bitnet-rs/goals/active.toml
+.bitnet-rs/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+`active.toml` may be absent while no cross-lane goal has been activated. If a
+paused manifest is used, prefer this shape:
+
+```toml
+id = "bitnet-rs-paused"
+title = "No selected implementation lane"
+status = "paused"
+owner = "codex-claude"
+created = "2026-05-17"
+reason = "No selected implementation lane."
+```
+
+## Required behavior
+
+- Keep one active cross-lane goal at a time.
+- Archive replaced manifests under `archive/`.
+- Link to the proposal, plan, specs, ADRs, status docs, and policy ledgers that
+  define the lane.
+- Keep work items small and machine-readable.
+- Include proof commands for every ready work item.
+- Do not put generated dashboards or long rationale in TOML.
+
+## Agent boot order
+
+1. Read `AGENTS.md` or `CLAUDE.md`.
+2. Read `docs/reference/SPEC_SYSTEM.md`.
+3. Read `.bitnet-rs/goals/active.toml` if it exists.
+4. Read the linked implementation plan.
+5. Read the linked spec for the selected work item.
+6. Read linked ADRs for constraints.
+7. Inspect `git status`.
+8. Implement exactly one ready work item.
+9. Run the listed proof commands and `git diff --check`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Summary
+
+What changed?
+
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+What this PR explicitly does not do.
+
+## Proof
+
+```bash
+# commands run
+```
+
+## Results
+
+What passed? What failed? What could not run?
+
+## Claim boundary
+
+What may be claimed after this PR? What may not be claimed yet?
+
+## Rollback
+
+How can this PR be reverted safely?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,35 @@ repository. `CLAUDE.md` remains the broader repository guide; this file records
 the campaign authority model that Codex should apply while operating work-item
 branches.
 
+
+## Repo source-of-truth stack
+
+BitNet-rs uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.bitnet-rs/goals/active.toml` when it exists
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. linked ADRs
+
+Work on exactly one work item per PR. Docs-only artifacts should stay separate
+unless the selected plan item says otherwise: proposals explain why, specs define
+behavior, ADRs record durable decisions, plans define sequencing, and active
+goals define current execution.
+
+Run the proof commands listed in the plan item. If proof cannot run, record the
+command, why it is unavailable, substitute evidence if any, and whether the
+missing proof blocks merge. Do not hand-edit generated status; run the named
+generator/checker. If adding a policy exception, update the relevant
+`policy/*.toml` ledger with owner, reason, `covered_by`, `created`, and
+`review_after`.
+
 ## Campaign Work Item Authority
 
 Campaign work items are the source of truth for review, PR, and merge flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,25 @@
 
 Essential guidance for working with the bitnet-rs codebase.
 
+
+## Source-of-truth first read
+
+Before making changes, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.bitnet-rs/goals/active.toml` when it exists
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one work item at a time. Do not create a new lane unless asked;
+do not mix proposal, spec, ADR, plan, active-goal, and runtime changes unless
+the selected work item says to; do not broaden support claims without proof;
+and do not hand-edit generated status. A PR is ready only when the intended
+artifact or code change exists, linked docs are updated as required, proof
+commands have run or are explicitly marked unavailable, claim boundaries are
+respected, and `git diff --check` passes.
+
 ## Project Identity
 
 - **Name:** bitnet-rs — 1-bit LLM inference engine in Rust

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -23,8 +23,16 @@ and proof receipts.
 
 ## BitNet Rule
 
-Do not create `.adze/goals`, `.bitnet/goals`, or another hidden global goals
-file. BitNet-rs already uses campaign-local tracking:
+Use proposals to frame a lane, then link implementation to the active execution
+source rather than reconstructing current state from chat logs or README prose.
+The cross-lane active goal path is:
+
+```text
+.bitnet-rs/goals/active.toml
+```
+
+Existing campaign-local trackers remain valid when linked by a plan or active
+goal:
 
 ```text
 docs/tracking/campaigns/<campaign>/CAMPAIGN.md
@@ -32,9 +40,6 @@ docs/tracking/campaigns/<campaign>/active.toml
 docs/tracking/campaigns/<campaign>/events/
 docs/tracking/campaigns/<campaign>/generated/
 ```
-
-Use proposals to frame a lane, then connect implementation to the campaign
-tracker instead of reconstructing active state from chat logs or README prose.
 
 ## Proposal Shape
 

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,254 @@
+# Repo source-of-truth system
+
+BitNet-rs uses a linked source-of-truth stack so humans and agents can find the
+right kind of truth in the right artifact. Do not make every document do every
+job: separate why, what, durable decisions, sequencing, active execution state,
+and proof.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, lane discovery | Detailed PR queue or proof receipts |
+| Proposal | Why a lane exists, user pain, alternatives, success criteria | Behavior contract or implementation order |
+| Spec | Required behavior, acceptance examples, proof requirements | Product rationale or PR sequencing |
+| ADR | Durable architecture, proof, or operating decision | Task lists or current metric state |
+| Plan | PR order, work items, proof commands, rollback | Product strategy or durable decisions |
+| Active goal | Current machine-readable objective and work item pointers | Generated dashboards or long-form rationale |
+| Support tiers | Public claims and proof pointers | Feature design |
+| Policy ledgers | Exceptions, CI intent, owners, coverage, review dates | Broad architecture |
+
+## Canonical locations
+
+| Question | Source of truth |
+| --- | --- |
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What durable decision constrains it? | `docs/adr/` |
+| What PR lands next? | `plans/<lane>/implementation-plan.md` |
+| What is the agent actively executing? | `.bitnet-rs/goals/active.toml` when present, otherwise the linked campaign `active.toml` named by the plan |
+| What proves a public claim? | `docs/status/`, proof receipts, and CI artifacts |
+| What exceptions exist? | `policy/*.toml` |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan work item says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent proof pointer.
+8. Policy exceptions require owner, reason, coverage, and review date.
+
+## Required headers
+
+Use `n/a` when a header does not apply. New proposal, spec, ADR, and plan
+artifacts should declare the applicable subset of these fields near the top:
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+## Agent workflow
+
+Agents must:
+
+1. Read `AGENTS.md` or `CLAUDE.md`.
+2. Read this file.
+3. Read `.bitnet-rs/goals/active.toml` if it exists.
+4. Read the linked implementation plan.
+5. Read the linked proposal only for why.
+6. Read the linked spec for acceptance.
+7. Read linked ADRs for constraints.
+8. Inspect current git status before editing.
+9. Pick exactly one ready work item.
+10. Implement only that work item.
+11. Run the proof commands listed by the work item.
+12. Update status, receipts, support tiers, or policy ledgers only when the work item requires it.
+13. Commit and open or update one focused PR.
+
+If an agent cannot identify a ready work item, it must not invent one. It should
+write a handoff or report the missing rail.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing, stale, or contradictory;
+- linked files do not exist;
+- the branch contains unrelated staged changes;
+- generated status is dirty and the generator/checker is not identified;
+- proof commands cannot run;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier proof;
+- a policy exception lacks owner, reason, coverage, or review date.
+
+## Active goal lifecycle
+
+The preferred cross-lane active goal path is:
+
+```text
+.bitnet-rs/goals/active.toml
+```
+
+A paused active goal should state:
+
+```toml
+status = "paused"
+reason = "No selected implementation lane."
+```
+
+Archive replaced active goals under:
+
+```text
+.bitnet-rs/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Do not leave multiple active cross-lane goal manifests. Existing campaign-local
+manifests under `docs/tracking/campaigns/<campaign>/active.toml` remain valid
+when a plan or active goal links to them.
+
+## Plan work item shape
+
+```md
+## Work item: <id>
+
+Status: ready | active | blocked | completed | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+### Rollback
+```
+
+## Closeout format
+
+At the end of a lane, create or update `plans/<lane>/closeout.md`:
+
+```md
+# Lane closeout: <lane>
+
+Status: completed
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Active goal archive:
+
+## What shipped
+
+## Proof
+
+## Receipts
+
+## PRs
+
+## CI runs
+
+## Generated status
+
+## Support-tier updates
+
+## Policy updates
+
+## What did not ship
+
+## Deferred work
+
+## Claim boundary
+
+## Next lane recommendation
+```
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused
+on behavior, examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move the why to `docs/proposals/`; keep the plan focused on work items,
+dependencies, proof commands, and rollback.
+
+### Active goal becomes prose
+
+Keep active goals as TOML and link out to docs. Do not put generated tables or
+long rationale in the manifest.
+
+### Generated status is hand-edited
+
+Run the generator/checker named by the plan and record receipts rather than
+manually changing generated truth.
+
+### Support claims drift
+
+Require support-tier impact headers and proof pointers before broadening README,
+release, or user-facing claims.
+
+### Policy exceptions become silent debt
+
+Every exception must have owner, reason, `covered_by`, `created`,
+`review_after`, and an expiry when temporary.
+
+### Mega PR
+
+Split the work: one semantic artifact per PR and one implementation work item
+per runtime PR unless the selected plan item explicitly allows otherwise.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repository answers those questions without chat history, the source-of-
+truth system is working.

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,15 +4,11 @@ Plans translate proposals, specs, and ADRs into PR-sized implementation work.
 They should tell a maintainer or agent what to do next, what not to touch, and
 which commands prove or disprove the claim.
 
-Plans are not active global goals. The active source of truth for executable
-work is still the campaign tracker:
-
-```text
-docs/tracking/campaigns/<campaign>/active.toml
-```
-
-Use plans for sequencing and proof commands. Use campaign manifests for live
-state, ownership, branch names, allowed paths, and merge policy.
+Plans are not active global goals. Use plans for sequencing and proof commands.
+Use `.bitnet-rs/goals/active.toml` for the cross-lane active objective when a
+lane is selected, and link to campaign manifests for live state, ownership,
+branch names, allowed paths, and merge policy when a campaign-local tracker is
+the execution authority.
 
 ## Source-Of-Truth Role
 
@@ -59,7 +55,7 @@ Blocks:
 Plans must not:
 
 - duplicate generated dashboards,
-- create `.adze/goals` or `.bitnet/goals`,
+- create ad-hoc hidden goal directories outside `.bitnet-rs/goals`,
 - claim model answer readiness without the answer artifact gate,
 - claim hardware validation without lane-specific receipts,
 - claim CI budget enforcement unless policy TOMLs and workflow gates enforce it.


### PR DESCRIPTION
### Motivation

- Provide a clear, machine- and agent-friendly source-of-truth system so humans and agents know where to find each kind of truth (why, spec, ADR, plan, active goal, proof). 
- Give agents a deterministic boot order and one-item work rule to prevent drift and accidental scope expansion during automated or semi-automated PR work. 
- Make the cross-lane active-goal location explicit so plans and campaign-local trackers can be linked without ad-hoc hidden directories. 

### Description

- Add `docs/reference/SPEC_SYSTEM.md` that documents the Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof stack, artifact roles, canonical locations, agent workflow, stop conditions, work-item shape, and closeout format. 
- Add `.bitnet-rs/goals/README.md` and an `archive` placeholder to define the cross-lane active-goal manifest shape and agent boot/order expectations for `.bitnet-rs/goals/active.toml`. 
- Add `.github/PULL_REQUEST_TEMPLATE.md` to require source-of-truth links, scope checkboxes, proof commands, claim boundary, and rollback instructions for PRs. 
- Update `AGENTS.md`, `CLAUDE.md`, `docs/proposals/README.md`, and `plans/README.md` to reference the new canonical system and to instruct agents to read `docs/reference/SPEC_SYSTEM.md` and `.bitnet-rs/goals/active.toml` before modifying files, and to avoid hand-editing generated status. 

### Testing

- Ran `git diff --check` to validate whitespace/lint checks and the new files caused no check errors, and the check passed. 
- No runtime/build/test changes were made in this PR and no crate tests or CI validators were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1795a24c8333bbe2480046d7c417)