### PR TITLE
docs: define source-of-truth stack

### DIFF
--- a/.bitnet-rs/goals/README.md
+++ b/.bitnet-rs/goals/README.md
@@ -1,0 +1,91 @@
+# BitNet-rs active goals
+
+This directory holds the machine-readable active goal manifest for the BitNet-rs
+source-of-truth stack.
+
+## Role
+
+`.bitnet-rs/goals/active.toml` answers what an agent is actively executing now.
+It does not replace proposals, specs, ADRs, implementation plans, status
+receipts, or policy ledgers.
+
+Use the stack in this order:
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Files
+
+- `active.toml` — the current active or paused lane manifest.
+- `archive/` — immutable archived manifests named `YYYY-MM-DD-<lane>.toml`.
+
+`active.toml` may be absent during the scaffold rollout. When it exists, agents
+must read it before selecting work. Until all existing BitNet-rs campaigns are
+migrated, a plan may explicitly point to a campaign-local manifest under
+`docs/tracking/campaigns/<campaign>/active.toml`; that pointer is the temporary
+execution authority for that lane.
+
+## Active manifest shape
+
+```toml
+id = "bitnet-lane-id"
+title = "Human readable lane title"
+status = "active"
+owner = "codex-claude"
+created = "2026-05-17"
+
+proposal = "docs/proposals/BITNET-PROP-0001-lane.md"
+plan = "plans/lane/implementation-plan.md"
+
+specs = [
+  "docs/specs/BITNET-SPEC-0001-contract.md",
+]
+
+adrs = [
+  "docs/adr/BITNET-ADR-0001-decision.md",
+]
+
+objective = """
+State the current lane objective in one paragraph.
+"""
+
+end_state = [
+  "Checkable end-state outcome.",
+]
+
+claim_boundaries = [
+  "Do not claim a public capability without support-tier proof.",
+]
+
+status_docs = [
+  "docs/status/README.md",
+]
+
+[[work_item]]
+id = "work-item-id"
+status = "ready"
+spec = "docs/specs/BITNET-SPEC-0001-contract.md"
+adr = "docs/adr/BITNET-ADR-0001-decision.md"
+plan = "plans/lane/implementation-plan.md#work-item-work-item-id"
+current_pointer = "docs/status/README.md"
+claim_boundary = "What this work item may and may not claim."
+commands = [
+  "git diff --check",
+]
+```
+
+## Rules
+
+1. Keep active goals machine-readable TOML.
+2. Work on exactly one ready work item per PR.
+3. Do not broaden claims beyond the linked spec, status row, and proof commands.
+4. Archive an old manifest before replacing it with a new lane.
+5. Do not hand-edit generated status; run the named generator/checker.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,48 @@
 ## Summary
 
-<!-- Brief description of what this PR accomplishes -->
+<!-- What changed? -->
+
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+<!-- What this PR explicitly does not do. -->
+
+## Proof
+
+```bash
+# commands run
+```
+
+## Results
+
+<!-- What passed? What failed? What could not run? -->
+
+## Claim boundary
+
+<!-- What may be claimed after this PR? What may not be claimed yet? -->
+
+## Rollback
+
+<!-- How to revert safely. -->
 
 ## CI Requirements (check all that apply)
 
@@ -8,27 +50,9 @@
 
 - [ ] Actions are **SHA-pinned** (no @vN/@main/@stable/@latest)
 - [ ] Workflow `cargo`/`cross` commands use **--locked**
-- [ ] Toolchain respects **rust-toolchain.toml** (MSRV 1.89.0)
+- [ ] Toolchain respects **rust-toolchain.toml**
 - [ ] Receipt workflow: builds exclude Python/WASM (`--exclude bitnet-py --exclude bitnet-wasm`) in CPU+GPU lanes (if touching `verify-receipts.yml`)
 - [ ] **Guards** passes in CI (and locally if you run it)
-
-<!-- optional local preflight -->
-<!-- make guards  # or run scripts/guard equivalents locally -->
-
-## Changes
-
-<!-- List the main changes in this PR -->
-
-- <!-- Add a bullet point for each meaningful change -->
--
-
-## Testing
-
-<!-- Describe how you tested these changes -->
-
-- [ ] Tests pass locally with `cargo test --workspace --no-default-features --features cpu`
-- [ ] Code formatted with `cargo fmt --all`
-- [ ] Linting passes with `cargo clippy --all-targets --all-features -- -D warnings`
 
 ## CI cost and verification discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,61 @@ repository. `CLAUDE.md` remains the broader repository guide; this file records
 the campaign authority model that Codex should apply while operating work-item
 branches.
 
+
+## Repo source-of-truth stack
+
+BitNet-rs uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.bitnet-rs/goals/active.toml` when present, or the campaign manifest named by the selected plan item
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Linked ADRs
+
+### Scope rule
+
+Implement one work item per PR. Docs-only artifacts are separate PRs unless the
+selected plan item explicitly says otherwise:
+
+- proposal PRs explain why;
+- spec PRs define behavior;
+- ADR PRs record durable decisions;
+- plan PRs define sequencing;
+- active goal PRs define current execution state.
+
+Runtime/code PRs must link to the spec and plan item they implement.
+
+### Proof rule
+
+Run the proof commands listed in the plan item. If a proof command cannot run,
+record the command, why it was unavailable, substitute evidence if any, and
+whether the missing proof blocks merge. Do not claim success without proof.
+
+### Generated status rule
+
+Do not hand-edit generated status. Run the generator/checker named in the plan
+or stop and report that the source-of-truth stack needs a generator/checker
+work item.
+
+### Policy rule
+
+If you add an exception, add or update the relevant `policy/*.toml` ledger with
+owner, reason, `covered_by`, `created`, `review_after`, and `expires` when the
+exception is temporary.
+
+### Stop conditions
+
+Stop and report instead of guessing when the active goal is missing or stale,
+linked specs or plans are missing, proof commands cannot run, unrelated staged
+changes exist, generated status is dirty, or requested behavior contradicts an
+ADR.
+
 ## Campaign Work Item Authority
 
 Campaign work items are the source of truth for review, PR, and merge flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,35 @@ Essential guidance for working with the bitnet-rs codebase.
 - **MSRV:** 1.93.0 (Rust 2024 edition, pinned in `rust-toolchain.toml`)
 - **Status:** CPU inference works with SIMD optimization. GPU backends are scaffolded but not validated. Do not use in production.
 
+
+## Source-of-truth stack
+
+BitNet-rs uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before making changes, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.bitnet-rs/goals/active.toml` when present, or the campaign manifest named by the selected plan item
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one work item at a time. Do not create a new lane, mix
+proposal/spec/ADR/plan/runtime changes, broaden support claims, or hand-edit
+generated status unless the selected plan item explicitly requires it. A PR is
+ready only when the intended artifact or code change exists, linked docs are
+updated, proof commands have run or are honestly marked unavailable, claim
+boundaries are respected, and `git diff --check` passes.
+
+Stop and report instead of guessing when the active goal is missing or stale,
+linked specs or plans are missing, proof commands cannot run, generated status
+differs from committed status, requested work conflicts with an ADR, or the
+branch contains unrelated staged changes.
+
 ## Rust 1.95 Rollout Rails
 
 The Rust 1.95 / next minor rollout is a continuation of the Rust 1.93 CI

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,8 +4,9 @@ ADRs record durable BitNet-rs decisions. Use them when a lane needs a stable
 architecture, proof, or policy choice that should survive individual PRs.
 
 ADRs do not own active work state or generated dashboards. Active execution
-state belongs in campaign-local `active.toml`; generated dashboards are derived
-from campaign manifests and events.
+state belongs in `.bitnet-rs/goals/active.toml` or an explicitly linked
+campaign-local `active.toml`; generated dashboards are derived from active
+manifests, campaign manifests, and events.
 
 ## Current ADRs
 
@@ -21,7 +22,7 @@ from campaign manifests and events.
 | Spec | What must be true |
 | ADR | What decision was made and why it is durable |
 | Plan | PR order and proof commands |
-| Campaign `active.toml` | Current executable work |
+| Active goal / campaign `active.toml` | Current executable work |
 | Policy TOML | Enforceable ledger |
 | Receipt or artifact | Evidence |
 

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -5,7 +5,7 @@ current repo authorities it will use. They are durable context for humans and
 agents before a lane becomes a spec, ADR, plan, or campaign item.
 
 Proposals do not own implementation status, active work, or product claims.
-Those belong to campaign manifests, plans, status documents, policy ledgers,
+Those belong to active goals, campaign manifests, plans, status documents, policy ledgers,
 and proof receipts.
 
 ## Source-Of-Truth Role
@@ -16,15 +16,17 @@ and proof receipts.
 | Spec | What must be true before a claim or behavior is accepted |
 | ADR | Durable architecture or proof decision |
 | Plan | PR order, proof commands, rollback path |
-| Campaign `active.toml` | Current executable work item state |
+| Active goal / campaign `active.toml` | Current executable work item state |
 | Status document | User-facing claim tier, proof command, artifact link |
 | Policy TOML | Enforceable CI, exception, allowlist, or routing ledger |
 | Receipt or artifact | Evidence for what actually happened |
 
 ## BitNet Rule
 
-Do not create `.adze/goals`, `.bitnet/goals`, or another hidden global goals
-file. BitNet-rs already uses campaign-local tracking:
+Use `.bitnet-rs/goals/active.toml` for the repo-level active goal when a
+lane has been migrated to the linked source-of-truth stack. Existing BitNet-rs
+campaigns may continue to use campaign-local tracking while their plans point
+to it explicitly:
 
 ```text
 docs/tracking/campaigns/<campaign>/CAMPAIGN.md
@@ -33,8 +35,9 @@ docs/tracking/campaigns/<campaign>/events/
 docs/tracking/campaigns/<campaign>/generated/
 ```
 
-Use proposals to frame a lane, then connect implementation to the campaign
-tracker instead of reconstructing active state from chat logs or README prose.
+Use proposals to frame a lane, then connect implementation to `.bitnet-rs/goals/active.toml`
+or an explicitly linked campaign tracker instead of reconstructing active state
+from chat logs or README prose.
 
 ## Proposal Shape
 

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,314 @@
+# Repo source-of-truth system
+
+BitNet-rs uses a linked source-of-truth stack so humans and agents can find the
+right kind of truth in one place without reconstructing intent from chat logs,
+stale status notes, or generated reports.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> Issue / PR
+              -> Proof command
+              -> CI receipt
+              -> Support-tier update
+              -> Policy ledger update
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, lane inventory | Detailed PR queue, live proof state |
+| Proposal | Why, users, alternatives, risks, success criteria | Behavior contract, PR order, generated metrics |
+| Spec | Required behavior, acceptance examples, proof requirements | Product rationale, PR sequence |
+| ADR | Durable architecture or operating decision | Current task list, metric state |
+| Plan | Work-item order, dependencies, proof commands, rollback | Product rationale, durable architecture |
+| Active goal | Current machine-readable lane, selected work items, claim boundaries | Generated dashboards, long prose, durable decisions |
+| Support tiers | Public claim level, proof pointer, limitations, promotion rule | Feature design, implementation queue |
+| Policy ledgers | Exceptions, CI intent, owner, reason, coverage, review date | Broad architecture, informal allowlists |
+| Receipts / CI | Evidence for what actually ran | Product intent or future promises |
+
+## Source-of-truth map
+
+| Question | Source of truth |
+| --- | --- |
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What durable decision constrains it? | `docs/adr/` |
+| What PR lands next? | `plans/<lane>/implementation-plan.md` |
+| What is the agent actively executing? | `.bitnet-rs/goals/active.toml` when active, or an explicitly linked campaign `active.toml` while a legacy lane still owns execution |
+| What proves a public claim? | `docs/status/`, receipts, and CI artifacts |
+| What exception exists? | `policy/*.toml` |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan item explicitly says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable choices.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent proof pointer.
+8. Policy exceptions require owner, reason, coverage, creation date, and review date.
+9. Runtime/code PRs must link to the spec and plan work item they implement.
+10. Proof commands must be run before claiming success, or explicitly recorded as unavailable with the blocking reason.
+
+## Required headers
+
+Use `n/a` when a field does not apply. Proposal, spec, ADR, and plan files
+should include the fields relevant to their role.
+
+### Proposal headers
+
+```text
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+```
+
+### Spec headers
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+### ADR headers
+
+```text
+Status:
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+```
+
+### Plan headers
+
+```text
+Status:
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Active goal:
+```
+
+## Agent workflow
+
+Agents must:
+
+1. Read `AGENTS.md` / `CLAUDE.md` and this file.
+2. Read `.bitnet-rs/goals/active.toml` if present; otherwise read the campaign manifest named by the task.
+3. Read the linked implementation plan.
+4. Select exactly one ready work item.
+5. Read the linked proposal only for why.
+6. Read the linked spec for acceptance and proof requirements.
+7. Read linked ADRs for constraints.
+8. Inspect git status before editing.
+9. Implement only the selected work item.
+10. Run the proof commands listed in the plan item.
+11. Update receipts, status, or policy ledgers only when the plan item requires it.
+12. Commit and open or update one focused PR.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- no active goal or campaign work item can be identified;
+- linked files do not exist;
+- a linked spec or plan is missing;
+- requested work conflicts with an ADR;
+- generated status is dirty and no generator/checker is specified;
+- proof commands cannot run and no substitute evidence is specified;
+- unrelated staged changes exist;
+- a public claim lacks support-tier proof;
+- a policy exception lacks owner, reason, coverage, or review date.
+
+## Active goal lifecycle
+
+### Activate
+
+Create or update:
+
+```text
+.bitnet-rs/goals/active.toml
+```
+
+with:
+
+```toml
+status = "active"
+```
+
+### Pause
+
+Use a paused manifest instead of deleting execution state:
+
+```toml
+status = "paused"
+reason = "No selected implementation lane."
+```
+
+### Archive
+
+Move an old active manifest to:
+
+```text
+.bitnet-rs/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Then create a new active manifest. Do not leave multiple active goals.
+
+## Work item shape
+
+Plans should define PR-sized work items with explicit acceptance and proof:
+
+````md
+## Work item: short-id
+
+Status: ready | active | blocked | completed | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+````
+
+## Closeout format
+
+At the end of a lane, add:
+
+```text
+plans/<lane>/closeout.md
+```
+
+with:
+
+```md
+# Lane closeout: <lane>
+
+Status: completed
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Active goal archive:
+
+## What shipped
+
+## Proof
+
+## Receipts
+
+## PRs
+
+## CI runs
+
+## Support-tier updates
+
+## Policy updates
+
+## What did not ship
+
+## Deferred work
+
+## Claim boundary
+
+## Next lane recommendation
+```
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused
+on behavior, examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move why and user pain to `docs/proposals/`; keep the plan focused on work
+items, dependencies, proof commands, and rollback.
+
+### Active goal becomes prose
+
+Keep `.bitnet-rs/goals/active.toml` machine-readable. Link to prose artifacts
+instead of embedding long narrative tables.
+
+### Generated status is hand-edited
+
+Run the named generator/checker. If none exists, stop and add or request a plan
+item for the generator/checker rather than mutating generated status by hand.
+
+### Support claims drift
+
+Require a support-tier row or equivalent proof pointer before broadening README,
+release, or product claims.
+
+### Policy exceptions become silent debt
+
+Every policy exception must have an owner, reason, `covered_by`, `created`, and
+`review_after`; temporary exceptions should also have an expiry.
+
+### Mega PR
+
+Split by source-of-truth role or by one implementation work item. Do not mix a
+new proposal, a new spec, an ADR, a plan, an active goal, and runtime behavior
+unless the selected plan item explicitly requires that combined change.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -15,7 +15,7 @@ how that authority is used.
 | Why does this lane exist? | `docs/proposals/` |
 | What must be true? | `docs/specs/` |
 | What decision did we make? | `docs/adr/` |
-| What PRs execute it? | `plans/` and campaign `active.toml` |
+| What PRs execute it? | `plans/` and `.bitnet-rs/goals/active.toml` or explicitly linked campaign `active.toml` |
 | What is currently supported? | `docs/status/` plus proof artifacts |
 | What does CI enforce? | `policy/*.toml` and workflow gates |
 | What happened? | Receipts, artifacts, campaign events, closeouts |

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,15 +4,17 @@ Plans translate proposals, specs, and ADRs into PR-sized implementation work.
 They should tell a maintainer or agent what to do next, what not to touch, and
 which commands prove or disprove the claim.
 
-Plans are not active global goals. The active source of truth for executable
-work is still the campaign tracker:
+Plans are not active global goals. The repo-level source of truth for
+executable work is `.bitnet-rs/goals/active.toml`; existing campaign lanes may
+continue to use explicitly linked campaign trackers during migration:
 
 ```text
 docs/tracking/campaigns/<campaign>/active.toml
 ```
 
-Use plans for sequencing and proof commands. Use campaign manifests for live
-state, ownership, branch names, allowed paths, and merge policy.
+Use plans for sequencing and proof commands. Use active goal or campaign
+manifests for live state, ownership, branch names, allowed paths, and merge
+policy.
 
 ## Source-Of-Truth Role
 
@@ -22,7 +24,7 @@ state, ownership, branch names, allowed paths, and merge policy.
 | Spec | What must be true |
 | ADR | Durable decision |
 | Plan | PR sequence, proof commands, rollback |
-| Campaign `active.toml` | Active work state |
+| Active goal / campaign `active.toml` | Active work state |
 | Campaign events | Append-only lifecycle history |
 | Closeout | What landed and what remains |
 
@@ -59,7 +61,7 @@ Blocks:
 Plans must not:
 
 - duplicate generated dashboards,
-- create `.adze/goals` or `.bitnet/goals`,
+- create repo-hidden goal directories other than `.bitnet-rs/goals`,
 - claim model answer readiness without the answer artifact gate,
 - claim hardware validation without lane-specific receipts,
 - claim CI budget enforcement unless policy TOMLs and workflow gates enforce it.


### PR DESCRIPTION
### Motivation

- Provide a clear, machine- and agent-friendly source-of-truth system so humans and agents know where each kind of truth (why, what, decision, plan, active work, proof) lives. 
- Prevent agent drift and noisy PRs by giving a canonical active-goal manifest and explicit agent first-read and stop-condition rules. 
- Make plans and specs interoperable with an explicit active-goal scaffold to ease migration from campaign-local manifests. 
- Improve PR discipline by requiring source-of-truth links, proof commands, and claim boundaries in the PR template. 

### Description

- Add `docs/reference/SPEC_SYSTEM.md` to define the stack, artifact roles, required headers, agent workflow, stop conditions, active-goal lifecycle, work-item shape, and failure modes. 
- Add `.bitnet-rs/goals/README.md` with the repo-level active-goal scaffold, manifest template, and rules for archive/activate/pause. 
- Update agent runbooks by extending `AGENTS.md` and `CLAUDE.md` to instruct agents to read `docs/reference/SPEC_SYSTEM.md`, the active-goal manifest (or explicitly linked campaign manifest), the linked plan, spec, and ADRs, and to follow the one-work-item and proof rules. 
- Update artifact READMEs to reference the repo-level active goal during migration (`docs/proposals/README.md`, `docs/specs/README.md`, `docs/adr/README.md`, `plans/README.md`) and replace the PR template at ` .github/pull_request_template.md` to include source-of-truth links, scope checkboxes, proof/results/claim-boundary/rollback sections. 

### Testing

- Ran `git diff --check` to validate whitespace and basic diff hygiene, which passed. 
- Ran `git diff --cached --check` to validate staged changes, which passed. 
- Verified the modified files include `docs/reference/SPEC_SYSTEM.md`, `.bitnet-rs/goals/README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/proposals/README.md`, `docs/specs/README.md`, `docs/adr/README.md`, `plans/README.md`, and `.github/pull_request_template.md` as the intended scaffold and instruction updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1795a24c8333bbe2480046d7c417)