### PR TITLE
docs: define source-of-truth stack

### DIFF
--- a/.bitnet-rs/goals/README.md
+++ b/.bitnet-rs/goals/README.md
@@ -1,0 +1,97 @@
+# BitNet-rs active goals
+
+This directory is the repo-level entrypoint for machine-readable active goals.
+It exists to point agents at the current lane without making proposals, specs,
+ADRs, plans, status documents, or generated campaign dashboards do each
+other's jobs.
+
+## Role
+
+Active goal manifests own:
+
+- the current lane identifier and status;
+- links to the proposal, specs, ADRs, and implementation plan;
+- the ready work items an agent may select;
+- proof commands for each work item;
+- claim boundaries and status pointers.
+
+They do not own product rationale, behavior contracts, durable decisions,
+generated metrics, or public support claims.
+
+## Files
+
+```text
+.bitnet-rs/goals/active.toml
+.bitnet-rs/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+If `active.toml` is absent, agents must use an explicitly named campaign item or
+stop and report that no repo-level active goal is selected.
+
+## Relationship to campaign tracking
+
+BitNet-rs also has campaign-local manifests under
+`docs/tracking/campaigns/<campaign>/active.toml`. Those campaign manifests
+remain authoritative for campaign event history, generated dashboards, branch
+metadata, and campaign-specific merge policy. A repo-level active goal should
+link to the relevant campaign manifest when campaign tracking is the executable
+work authority.
+
+## Manifest shape
+
+```toml
+id = "bitnet-lane-id"
+title = "Human-readable lane title"
+status = "active"
+owner = "codex-claude"
+created = "YYYY-MM-DD"
+
+proposal = "docs/proposals/BITNET-PROP-0001-lane.md"
+plan = "plans/lane/implementation-plan.md"
+
+specs = [
+  "docs/specs/BITNET-SPEC-0001-contract.md",
+]
+
+adrs = [
+  "docs/adr/BITNET-ADR-0001-decision.md",
+]
+
+campaigns = [
+  "docs/tracking/campaigns/example/active.toml",
+]
+
+objective = """
+State the current lane objective in one paragraph.
+"""
+
+end_state = [
+  "Checkable end-state outcome.",
+]
+
+claim_boundaries = [
+  "Do not broaden support claims without proof.",
+]
+
+status_docs = [
+  "docs/status/README.md",
+]
+
+[[work_item]]
+id = "work-item-id"
+status = "ready"
+spec = "docs/specs/BITNET-SPEC-0001-contract.md"
+adr = "docs/adr/BITNET-ADR-0001-decision.md"
+plan = "plans/lane/implementation-plan.md#work-item-work-item-id"
+campaign = "docs/tracking/campaigns/example/active.toml"
+claim_boundary = "What this work item may and may not claim."
+commands = [
+  "git diff --check",
+]
+```
+
+## Agent rule
+
+Read `docs/reference/SPEC_SYSTEM.md` before interpreting a manifest. Select one
+ready work item, run the listed proof commands, and stop instead of inventing
+work when the manifest or linked artifacts are missing.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,35 @@
 
 <!-- Brief description of what this PR accomplishes -->
 
+
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal or campaign manifest:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+<!-- What this PR explicitly does not do -->
+
+## Claim boundary
+
+<!-- What may be claimed after this PR, and what may not be claimed yet -->
+
 ## CI Requirements (check all that apply)
 
 <!-- These are enforced by the Guards workflow - violations will block merge -->
@@ -64,6 +93,10 @@ See: docs/ci/cost-and-verification-policy.md
 - [ ] README updated (if user-facing changes)
 - [ ] CLAUDE.md updated (if development workflow changes)
 - [ ] API documentation updated (if public API changes)
+
+## Rollback
+
+<!-- How to revert safely if needed -->
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,36 @@ repository. `CLAUDE.md` remains the broader repository guide; this file records
 the campaign authority model that Codex should apply while operating work-item
 branches.
 
+## Repo Source-Of-Truth Stack
+
+BitNet-rs uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files, Codex agents must read:
+
+1. `docs/reference/SPEC_SYSTEM.md`;
+2. `.bitnet-rs/goals/active.toml` when present, otherwise the campaign
+   `active.toml` explicitly named by the task;
+3. the linked implementation plan;
+4. the linked spec for the selected work item;
+5. linked ADRs for durable constraints.
+
+Work on exactly one ready work item per PR. Proposal PRs explain why, spec PRs
+define behavior, ADR PRs record durable decisions, plan PRs define sequencing,
+active-goal PRs define current execution state, and runtime PRs must link to
+the spec and plan item they implement.
+
+Run the proof commands listed by the selected plan or active goal, plus
+`git diff --check`. If a proof command cannot run, record the unavailable
+command, why it cannot run, substitute evidence if any, and whether that blocks
+merge. Do not hand-edit generated status; run the named generator or checker.
+
+Policy exceptions must update the relevant `policy/*.toml` ledger with owner,
+reason, coverage, creation date, review date, and expiry when temporary.
+
 ## Campaign Work Item Authority
 
 Campaign work items are the source of truth for review, PR, and merge flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,35 @@
 
 Essential guidance for working with the bitnet-rs codebase.
 
+## Repo Source-Of-Truth Stack
+
+BitNet-rs uses this linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before making changes, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`;
+2. `.bitnet-rs/goals/active.toml` when present, otherwise the campaign
+   `active.toml` explicitly named by the task;
+3. the linked implementation plan;
+4. the linked spec for the selected work item;
+5. any linked ADRs.
+
+Work on exactly one ready work item at a time. Do not create a new lane, mix
+proposal/spec/ADR/plan/runtime changes, broaden support claims, or hand-edit
+generated status unless the selected work item explicitly requires it. A change
+is ready only when the intended artifact exists, linked docs are updated, proof
+commands have run or are honestly marked unavailable, claim boundaries are
+respected, and `git diff --check` passes.
+
+Stop and report instead of guessing when the active goal is missing or stale,
+linked specs are missing, proof commands cannot run, generated status differs
+from committed status, requested work conflicts with an ADR, or unrelated staged
+changes exist.
+
 ## Project Identity
 
 - **Name:** bitnet-rs — 1-bit LLM inference engine in Rust

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -23,8 +23,15 @@ and proof receipts.
 
 ## BitNet Rule
 
-Do not create `.adze/goals`, `.bitnet/goals`, or another hidden global goals
-file. BitNet-rs already uses campaign-local tracking:
+Use proposals to frame a lane, then connect implementation to active manifests
+instead of reconstructing state from chat logs or README prose. BitNet-rs uses a
+repo-level active-goal entrypoint when present:
+
+```text
+.bitnet-rs/goals/active.toml
+```
+
+BitNet-rs also keeps campaign-local tracking for campaign execution:
 
 ```text
 docs/tracking/campaigns/<campaign>/CAMPAIGN.md
@@ -33,8 +40,7 @@ docs/tracking/campaigns/<campaign>/events/
 docs/tracking/campaigns/<campaign>/generated/
 ```
 
-Use proposals to frame a lane, then connect implementation to the campaign
-tracker instead of reconstructing active state from chat logs or README prose.
+A proposal may link either authority, but it must not become the live work queue.
 
 ## Proposal Shape
 

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,171 @@
+# Repo source-of-truth system
+
+BitNet-rs uses a linked source-of-truth stack so humans and agents can find the
+right authority without reconstructing intent from chat history, stale status
+notes, or generated dashboards.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, lane discovery | Detailed PR order or proof receipts |
+| Proposal | Why the work exists, users, alternatives, risks | Behavior contracts or active queues |
+| Spec | Required behavior, acceptance examples, proof requirements | Product rationale or PR sequencing |
+| ADR | Durable architecture, proof, or operating decisions | Current task lists or generated status |
+| Plan | PR order, dependencies, proof commands, rollback | Product strategy or durable decisions |
+| Active goal | Machine-readable current lane and work items | Generated metrics or long prose |
+| Campaign tracker | Campaign-local execution state, events, generated dashboards | Cross-lane product rationale |
+| Support tiers | Public claim tier and proof pointer | Feature design |
+| Policy ledgers | Exceptions, CI routing, owners, coverage, review dates | Broad architecture |
+
+## BitNet-rs authority mapping
+
+- Proposals live in `docs/proposals/` and answer why a lane exists.
+- Specs live in `docs/specs/` and define what must be true.
+- ADRs live in `docs/adr/` and record decisions that should still matter after
+  the implementation plan is complete.
+- Plans live in `plans/<lane>/` and sequence PR-sized work.
+- Active goal manifests live in `.bitnet-rs/goals/` when a lane needs a
+  repo-level agent entrypoint; campaign-local active manifests remain in
+  `docs/tracking/campaigns/<campaign>/active.toml` for campaign execution.
+- Generated campaign dashboards and events remain under
+  `docs/tracking/campaigns/<campaign>/generated/` and
+  `docs/tracking/campaigns/<campaign>/events/`.
+- Public support claims belong in `docs/status/`, hardware matrices, model
+  artifact gates, and receipts.
+- Policy exceptions and CI routing belong in `policy/*.toml`.
+
+## Rules
+
+1. Keep one kind of truth per artifact.
+2. Use one semantic artifact per PR unless the selected plan item says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable decisions.
+5. Active goals tell agents what to do now and link to the plan/spec/ADR.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier, hardware, model-artifact, or receipt proof.
+8. Policy exceptions require owner, reason, coverage, and review date.
+
+## Required headers
+
+New proposals, specs, ADRs, and plans should declare the applicable source links
+near the top of the file. Use `n/a` where a field does not apply.
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+Existing legacy artifacts may use older headings, but new work should converge
+on these fields instead of adding another status vocabulary.
+
+## Agent workflow
+
+Before changing files, agents should:
+
+1. read `AGENTS.md` or `CLAUDE.md`;
+2. read this file;
+3. read `.bitnet-rs/goals/active.toml` if present, otherwise the relevant
+   campaign `active.toml` named by the task;
+4. read the linked plan;
+5. read the linked spec for acceptance;
+6. read linked ADRs for constraints;
+7. inspect `git status --short` for unrelated staged or modified files;
+8. pick exactly one ready work item;
+9. implement only that item;
+10. run the listed proof commands plus `git diff --check`;
+11. update only required status, receipt, policy, or tracking files.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- no active goal, campaign item, or explicit task scope exists;
+- a linked proposal, spec, ADR, or plan is missing;
+- proof commands cannot run and no substitute evidence is allowed;
+- generated status is dirty but no generator command is provided;
+- unrelated staged changes exist;
+- requested work conflicts with an ADR or claim boundary;
+- a public claim lacks support-tier, receipt, hardware, or model-artifact proof.
+
+## Active goal lifecycle
+
+A repo-level active goal lives at:
+
+```text
+.bitnet-rs/goals/active.toml
+```
+
+Use `status = "active"` for an executable lane and `status = "paused"` when no
+lane is selected. Archive retired manifests under:
+
+```text
+.bitnet-rs/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Do not leave multiple repo-level active manifests. If a campaign-local
+`docs/tracking/campaigns/<campaign>/active.toml` is the executable authority,
+link it from the repo-level manifest or from the selected plan item.
+
+## Closeout format
+
+At the end of a lane, write a closeout under `plans/<lane>/closeout.md` with:
+
+- what shipped;
+- proof commands and receipts;
+- PRs and CI runs;
+- generated status, support-tier, and policy updates;
+- deferred work;
+- claim boundary;
+- next lane recommendation.
+
+## Common failure modes
+
+- If a spec becomes a task list, move PR order to `plans/<lane>/implementation-plan.md`.
+- If a plan becomes product rationale, move why-text to `docs/proposals/`.
+- If an active goal becomes prose, move details to the plan and keep TOML linked.
+- If generated status is hand-edited, add or run the generator/checker.
+- If support claims drift, add support-tier proof or narrow the claim.
+- If policy exceptions become silent debt, add owner, reason, coverage, and review date.
+- If a PR grows into multiple semantic changes, split it by artifact or work item.
+
+## What good looks like
+
+A new contributor or agent can answer these questions from repository files
+alone:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,15 +4,11 @@ Plans translate proposals, specs, and ADRs into PR-sized implementation work.
 They should tell a maintainer or agent what to do next, what not to touch, and
 which commands prove or disprove the claim.
 
-Plans are not active global goals. The active source of truth for executable
-work is still the campaign tracker:
-
-```text
-docs/tracking/campaigns/<campaign>/active.toml
-```
-
-Use plans for sequencing and proof commands. Use campaign manifests for live
-state, ownership, branch names, allowed paths, and merge policy.
+Plans are not generated status or product strategy. Use plans for sequencing and
+proof commands. Use `.bitnet-rs/goals/active.toml` as the repo-level agent
+entrypoint when present, and use campaign manifests for campaign-local live
+state, ownership, branch names, allowed paths, event history, generated
+dashboards, and merge policy.
 
 ## Source-Of-Truth Role
 


### PR DESCRIPTION
### Motivation

- Provide a single, machine- and human-readable source-of-truth so agents and maintainers know which artifact owns each kind of truth (why, what, decision, plan, active work, proof). 
- Add a repo-level agent entrypoint and clear agent workflow so automated agents pick one ready work item, run proof commands, and do not hand-edit generated status. 
- Make PRs and proposals explicit about scope, claim boundaries, and rollback so reviewers and agents can verify proofs before merge.

### Description

- Added `docs/reference/SPEC_SYSTEM.md` that documents the Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof stack, artifact roles, required headers, agent workflow, stop conditions, active-goal lifecycle, closeout format, and common failure modes. 
- Added `.bitnet-rs/goals/README.md` to define the repo-level active-goal manifest shape and agent rule for selecting one ready work item. 
- Updated agent guidance in `AGENTS.md` and `CLAUDE.md` to require reading the source-of-truth stack, selecting one ready work item, running proof commands (including `git diff --check`), and respecting claim boundaries. 
- Adjusted `docs/proposals/README.md` and `plans/README.md` to reference the repo-level active-goal entrypoint alongside existing campaign-local tracking. 
- Extended the PR template `.github/pull_request_template.md` with `Source-of-truth links`, `Scope` checkboxes, `Non-goals`, `Claim boundary`, and `Rollback` sections.

### Testing

- Ran `git diff --check` as the proof command and it passed. 
- Verified repository status with `git status --short` to confirm only the intended documentation files were staged. 
- No runtime or CI behavioral changes were introduced; this is documentation-only and therefore no code tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1795a24c8333bbe2480046d7c417)