### PR TITLE
docs: define BitNet source-of-truth model

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ from campaign manifests and events.
 | ADR | What decision was made and why it is durable |
 | Plan | PR order and proof commands |
 | Campaign `active.toml` | Current executable work |
+| Handoff | Operator transfer context and closeout notes |
 | Policy TOML | Enforceable ledger |
 | Receipt or artifact | Evidence |
 

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,79 @@
+# Handoffs
+
+Handoffs carry operator transfer context after a PR, branch, campaign slice, or
+proof lane changes state. They explain what landed, what evidence exists, what
+is still uncertain, and what the next maintainer or agent should do.
+
+Handoffs do not own product claims, active work state, or policy enforcement.
+Those remain in model coverage ledgers, hardware receipts, status documents,
+campaign manifests, and policy TOMLs.
+
+## Source-Of-Truth Role
+
+| Layer | Owns |
+| --- | --- |
+| Proposal | Why the effort exists |
+| Spec | What must be true |
+| ADR | Durable decision |
+| Plan | PR sequence, proof commands, rollback |
+| Campaign `active.toml` | Current executable work |
+| Campaign events | Append-only lifecycle state |
+| Handoff | Operator transfer context, validation notes, remaining work |
+| Closeout | What landed, what did not, and which follow-up owns the gap |
+| Status document | User-facing claim tier, proof command, artifact link |
+| Policy TOML | Enforceable CI, exception, allowlist, or routing ledger |
+| Receipt or artifact | Evidence for what actually happened |
+
+## When To Write One
+
+Write a handoff when:
+
+- a branch or PR is passed to another operator,
+- a campaign slice closes but follow-up work remains,
+- validation is incomplete for a specific, named reason,
+- a blocker depends on external credentials, hardware, policy, or human review,
+- a proof lane produced receipts that need a durable operator summary.
+
+Campaign-local `events/*.toml` remain the lifecycle audit trail. Handoffs are
+the human-readable transfer layer that points to those events and receipts.
+
+## Handoff Shape
+
+Use this shape when practical:
+
+```md
+# <Lane or PR> Handoff
+
+Status:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Campaign:
+PRs:
+
+## Landed
+
+## Evidence
+
+## Validation
+
+## Remaining Work
+
+## Blockers
+
+## Claim Boundary
+
+## Next Operator Commands
+```
+
+## Boundaries
+
+Handoffs must not:
+
+- promote a model tier without updating the model coverage matrix,
+- claim hardware execution without a hardware receipt,
+- claim server readiness without the server readiness proof surface,
+- rewrite active campaign state instead of updating campaign manifests/events,
+- replace policy TOMLs or workflow gates as CI enforcement,
+- hand-edit generated dashboards.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -17,6 +17,7 @@ and proof receipts.
 | ADR | Durable architecture or proof decision |
 | Plan | PR order, proof commands, rollback path |
 | Campaign `active.toml` | Current executable work item state |
+| Handoff | Operator transfer context, closeout summary, remaining work |
 | Status document | User-facing claim tier, proof command, artifact link |
 | Policy TOML | Enforceable CI, exception, allowlist, or routing ledger |
 | Receipt or artifact | Evidence for what actually happened |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -16,6 +16,7 @@ how that authority is used.
 | What must be true? | `docs/specs/` |
 | What decision did we make? | `docs/adr/` |
 | What PRs execute it? | `plans/` and campaign `active.toml` |
+| What changed and what remains? | `docs/handoffs/`, campaign events, and closeouts |
 | What is currently supported? | `docs/status/` plus proof artifacts |
 | What does CI enforce? | `policy/*.toml` and workflow gates |
 | What happened? | Receipts, artifacts, campaign events, closeouts |

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -15,6 +15,7 @@ diagnostic, advisory, or planned.
 | Capability matrix | Product claim tier, proof command, proof artifact, claim boundary |
 | Claim boundaries | What a proof does and does not allow the README or CLI docs to say |
 | README summary | Short user entry point, not the final proof map |
+| Handoff | Operator transfer context and validation gaps, not claim authority |
 | Receipt/artifact | Evidence for one run, model, backend, or lane |
 
 ## Required Claim Boundary
@@ -53,3 +54,4 @@ These pages summarize proof. They do not replace the operational authorities:
 - `docs/hardware/HARDWARE_MATRIX.md` for hardware lane identity.
 - `docs/ci/cost-and-verification-policy.md` for CI economics.
 - `docs/tracking/TRACKER_MODEL.md` for campaign execution state.
+- `docs/handoffs/` for operator transfer notes and closeout summaries.

--- a/plans/README.md
+++ b/plans/README.md
@@ -25,6 +25,7 @@ state, ownership, branch names, allowed paths, and merge policy.
 | Campaign `active.toml` | Active work state |
 | Campaign events | Append-only lifecycle history |
 | Closeout | What landed and what remains |
+| Handoff | Operator transfer context for follow-on work |
 
 ## Work Item Shape
 

--- a/policy/docs-source-of-truth.toml
+++ b/policy/docs-source-of-truth.toml
@@ -34,6 +34,11 @@ path = "plans/"
 owns = ["pr_sequence", "proof_commands", "rollback"]
 hand_editable = true
 
+[source.handoffs]
+path = "docs/handoffs/"
+owns = ["operator_transfer", "closeout_summary", "remaining_work", "validation_gaps"]
+hand_editable = true
+
 [source.status_docs]
 path = "docs/status/"
 owns = ["user_facing_claim_map", "claim_tiers", "proof_commands", "claim_boundaries"]
@@ -113,4 +118,6 @@ active_execution_state = "docs/tracking/campaigns/<campaign>/active.toml"
 no_hidden_goal_files = [".adze/goals", ".bitnet/goals"]
 readme_role = "summary_not_final_proof_map"
 receipts_role = "evidence_for_what_happened"
+handoffs_role = "operator_transfer_not_claim_authority"
+closeouts_role = "what_landed_what_remains"
 generated_dashboards_hand_editable = false


### PR DESCRIPTION
## Summary
- add docs/handoffs/README.md as the operator transfer and closeout source-of-truth surface
- register handoffs in policy/docs-source-of-truth.toml
- update the existing proposal/spec/ADR/plan/status role tables without changing runtime or claim state

## Validation
- rtk git diff --check
- rtk powershell -NoProfile -Command '... rtk cargo run --locked -p xtask --no-default-features -- campaign doctor'
- rtk powershell -NoProfile -Command '... rtk cargo run --locked -p bitnet-task -- docs-automation'
- rtk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc docs/handoffs/README.md docs/proposals/README.md docs/specs/README.md docs/adr/README.md plans/README.md docs/status/README.md

Note: local docs automation completed its rustdoc path; it reported markdownlint-cli2 and lychee were not installed, so markdownlint was run separately through npm exec.