### PR TITLE
test: add unit coverage for SPIR-V and SafeTensors helpers

### DIFF
--- a/crates/bitnet-safetensors-ln/tests/safetensors_ln_unit_tests.rs
+++ b/crates/bitnet-safetensors-ln/tests/safetensors_ln_unit_tests.rs
@@ -1,0 +1,139 @@
+//! Unit tests for LayerNorm SafeTensors helpers using synthetic in-memory tensors.
+
+use bitnet_safetensors_ln::{
+    cast_ln_to_f16, iter_ln_tensors, read_safetensors_bytes, rms_for_tensor,
+};
+use half::{bf16, f16};
+use safetensors::Dtype;
+use safetensors::tensor::TensorView;
+
+fn read_u16_le(bytes: &[u8]) -> Vec<u16> {
+    bytes.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect()
+}
+
+fn tensor_view<'a>(dtype: Dtype, shape: Vec<usize>, data: &'a [u8]) -> TensorView<'a> {
+    TensorView::new(dtype, shape, data).expect("test tensor view should be well formed")
+}
+
+fn build_safetensors(tensors: &[(&str, Dtype, Vec<usize>, &[u8])]) -> Vec<u8> {
+    let views: Vec<(&str, TensorView<'_>)> = tensors
+        .iter()
+        .map(|(name, dtype, shape, data)| (*name, tensor_view(*dtype, shape.clone(), data)))
+        .collect();
+    safetensors::serialize(views, None).expect("synthetic safetensors should serialize")
+}
+
+#[test]
+fn rms_for_f32_tensor_matches_known_value() {
+    let data = [3.0_f32, 4.0];
+    let tensor = tensor_view(Dtype::F32, vec![2], bytemuck::cast_slice(&data));
+
+    let rms = rms_for_tensor(&tensor).expect("f32 RMS should be supported");
+
+    assert!((rms - 12.5_f64.sqrt()).abs() < 1e-6);
+}
+
+#[test]
+fn rms_for_integer_tensor_squares_signed_values() {
+    let data = [-3_i16, 4];
+    let tensor = tensor_view(Dtype::I16, vec![2], bytemuck::cast_slice(&data));
+
+    let rms = rms_for_tensor(&tensor).expect("i16 RMS should be supported");
+
+    assert!((rms - 12.5_f64.sqrt()).abs() < 1e-10);
+}
+
+#[test]
+fn rms_for_zero_sized_tensor_is_zero_without_reading_data() {
+    let tensor = tensor_view(Dtype::F32, vec![0], &[]);
+
+    assert_eq!(rms_for_tensor(&tensor).expect("empty tensor RMS should succeed"), 0.0);
+}
+
+#[test]
+fn rms_rejects_unsupported_dtype_with_dtype_in_message() {
+    let data = [true, false];
+    let tensor = tensor_view(Dtype::BOOL, vec![2], bytemuck::cast_slice(&data));
+
+    let err = rms_for_tensor(&tensor).expect_err("bool RMS should be unsupported");
+
+    assert!(err.to_string().contains("BOOL"));
+}
+
+#[test]
+fn cast_ln_to_f16_converts_f32_values_to_little_endian_half_bytes() {
+    let data = [1.0_f32, -2.5, 0.5];
+    let tensor = tensor_view(Dtype::F32, vec![3], bytemuck::cast_slice(&data));
+
+    let bytes = cast_ln_to_f16(&tensor).expect("f32 cast should succeed");
+    let halves = read_u16_le(&bytes);
+
+    let expected: Vec<u16> = data.iter().map(|&value| f16::from_f32(value).to_bits()).collect();
+    assert_eq!(halves, expected);
+}
+
+#[test]
+fn cast_ln_to_f16_returns_f16_input_bytes_unchanged() {
+    let halves = [f16::from_f32(1.25).to_bits(), f16::from_f32(-0.75).to_bits()];
+    let bytes: &[u8] = bytemuck::cast_slice(&halves);
+    let tensor = tensor_view(Dtype::F16, vec![2], bytes);
+
+    assert_eq!(cast_ln_to_f16(&tensor).expect("f16 should pass through"), bytes);
+}
+
+#[test]
+fn cast_ln_to_f16_converts_bf16_and_unsigned_integer_inputs() {
+    let bf16_values = [bf16::from_f32(2.0).to_bits(), bf16::from_f32(-3.0).to_bits()];
+    let bf16_tensor = tensor_view(Dtype::BF16, vec![2], bytemuck::cast_slice(&bf16_values));
+    let bf16_halves = read_u16_le(&cast_ln_to_f16(&bf16_tensor).expect("bf16 cast"));
+    assert_eq!(bf16_halves, vec![f16::from_f32(2.0).to_bits(), f16::from_f32(-3.0).to_bits()]);
+
+    let u8_values = [2_u8, 7];
+    let u8_tensor = tensor_view(Dtype::U8, vec![2], &u8_values);
+    let u8_halves = read_u16_le(&cast_ln_to_f16(&u8_tensor).expect("u8 cast"));
+    assert_eq!(u8_halves, vec![f16::from_f32(2.0).to_bits(), f16::from_f32(7.0).to_bits()]);
+}
+
+#[test]
+fn cast_ln_to_f16_rejects_unsupported_dtype_with_dtype_in_message() {
+    let data = [true];
+    let tensor = tensor_view(Dtype::BOOL, vec![1], bytemuck::cast_slice(&data));
+
+    let err = cast_ln_to_f16(&tensor).expect_err("bool cast should be unsupported");
+
+    assert!(err.to_string().contains("BOOL"));
+}
+
+#[test]
+fn iter_ln_tensors_filters_to_layernorm_gamma_names() {
+    let ln = [1.0_f32, 2.0];
+    let dense = [3.0_f32, 4.0];
+    let bytes = build_safetensors(&[
+        ("model.layers.0.input_layernorm.weight", Dtype::F32, vec![2], bytemuck::cast_slice(&ln)),
+        ("model.layers.0.mlp.down_proj.weight", Dtype::F32, vec![2], bytemuck::cast_slice(&dense)),
+        ("model.norm.weight", Dtype::F32, vec![2], bytemuck::cast_slice(&ln)),
+    ]);
+
+    let mut names: Vec<String> = iter_ln_tensors(&bytes)
+        .expect("synthetic safetensors should deserialize")
+        .map(|(name, _)| name)
+        .collect();
+    names.sort();
+
+    assert_eq!(names, vec!["model.layers.0.input_layernorm.weight", "model.norm.weight"]);
+}
+
+#[test]
+fn iter_ln_tensors_rejects_invalid_safetensors_bytes() {
+    assert!(iter_ln_tensors(b"not a safetensors file").is_err());
+}
+
+#[test]
+fn read_safetensors_bytes_reads_file_contents_exactly() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("fixture.safetensors");
+    let bytes = b"fixture bytes";
+    std::fs::write(&path, bytes).expect("write fixture");
+
+    assert_eq!(read_safetensors_bytes(&path).expect("read fixture"), bytes);
+}

--- a/crates/bitnet-spirv/tests/spirv_unit_tests.rs
+++ b/crates/bitnet-spirv/tests/spirv_unit_tests.rs
@@ -1,0 +1,173 @@
+//! Unit tests for SPIR-V validation, hashing, compiler façade, and cache behavior.
+
+use bitnet_spirv::{
+    CompileOptions, CompilerBackend, OptimizationLevel, SPIRV_MAGIC, SpirVCache, SpirVCompiler,
+    SpirVError, SpirVModule, SpirVValidator, build_test_spirv, source_hash,
+};
+
+fn words_to_bytes(words: &[u32]) -> Vec<u8> {
+    words.iter().flat_map(|word| word.to_le_bytes()).collect()
+}
+
+fn valid_header_words() -> [u32; 5] {
+    [SPIRV_MAGIC, 0x0001_0000, 0, 1, 0]
+}
+
+#[test]
+fn default_compile_options_use_full_optimization_without_target_or_defines() {
+    let options = CompileOptions::default();
+
+    assert_eq!(options.target_device, None);
+    assert_eq!(options.optimization_level, OptimizationLevel::Full);
+    assert!(options.defines.is_empty());
+}
+
+#[test]
+fn compiler_with_no_backend_reports_no_compiler_available() {
+    let compiler = SpirVCompiler::with_backend(None);
+
+    let err = compiler
+        .compile_to_spirv("__kernel void noop() {}", &CompileOptions::default())
+        .expect_err("compilation should fail before invoking any external compiler");
+
+    assert!(matches!(err, SpirVError::NoCompilerAvailable));
+    assert_eq!(compiler.backend(), None);
+}
+
+#[test]
+fn compiler_with_explicit_backend_exposes_backend_for_testability() {
+    let compiler = SpirVCompiler::with_backend(Some(CompilerBackend::Clang));
+
+    assert_eq!(compiler.backend(), Some(CompilerBackend::Clang));
+}
+
+#[test]
+fn source_hash_is_deterministic_for_identical_source_and_options() {
+    let options = CompileOptions {
+        target_device: Some("pvc".to_string()),
+        optimization_level: OptimizationLevel::Basic,
+        defines: vec![("TILE".to_string(), "16".to_string())],
+    };
+
+    assert_eq!(source_hash("kernel", &options), source_hash("kernel", &options));
+}
+
+#[test]
+fn source_hash_changes_when_compile_inputs_change() {
+    let base = CompileOptions::default();
+    let mut with_define = base.clone();
+    with_define.defines.push(("WIDTH".to_string(), "32".to_string()));
+
+    let mut with_target = base.clone();
+    with_target.target_device = Some("dg2".to_string());
+
+    let mut with_optimization = base.clone();
+    with_optimization.optimization_level = OptimizationLevel::None;
+
+    let baseline = source_hash("kernel", &base);
+    assert_ne!(baseline, source_hash("kernel2", &base));
+    assert_ne!(baseline, source_hash("kernel", &with_define));
+    assert_ne!(baseline, source_hash("kernel", &with_target));
+    assert_ne!(baseline, source_hash("kernel", &with_optimization));
+}
+
+#[test]
+fn build_test_spirv_creates_minimal_valid_header_for_supported_versions() {
+    let bytes = build_test_spirv(1, 6);
+
+    assert_eq!(bytes.len(), 20);
+    SpirVValidator::validate_bytes(&bytes).expect("SPIR-V 1.6 header should validate");
+}
+
+#[test]
+fn validator_rejects_short_bad_magic_and_unsupported_version_inputs() {
+    let short = vec![0; 19];
+    assert!(matches!(
+        SpirVValidator::validate_bytes(&short),
+        Err(SpirVError::ValidationFailed(message)) if message.contains("too short")
+    ));
+
+    let bad_magic = words_to_bytes(&[0xDEAD_BEEF, 0x0001_0000, 0, 1, 0]);
+    assert!(matches!(
+        SpirVValidator::validate_bytes(&bad_magic),
+        Err(SpirVError::ValidationFailed(message)) if message.contains("bad magic")
+    ));
+
+    let unsupported = build_test_spirv(1, 7);
+    assert!(matches!(
+        SpirVValidator::validate_bytes(&unsupported),
+        Err(SpirVError::ValidationFailed(message)) if message.contains("unsupported SPIR-V version 1.7")
+    ));
+}
+
+#[test]
+fn has_capability_detects_matching_op_capability_operand() {
+    let mut words = valid_header_words().to_vec();
+    words.push((2 << 16) | 0x0011); // OpCapability, word count 2.
+    words.push(1); // Shader capability.
+    words.push((1 << 16) | 0x000e); // A non-capability instruction to prove iteration advances.
+    let bytes = words_to_bytes(&words);
+
+    assert!(SpirVValidator::has_capability(&bytes, 1));
+    assert!(!SpirVValidator::has_capability(&bytes, 2));
+}
+
+#[test]
+fn has_capability_returns_false_for_truncated_or_malformed_instruction_streams() {
+    assert!(!SpirVValidator::has_capability(&build_test_spirv(1, 0), 1));
+
+    let mut words = valid_header_words().to_vec();
+    words.push(0); // Malformed zero word-count instruction should terminate scanning.
+    words.push(1);
+    assert!(!SpirVValidator::has_capability(&words_to_bytes(&words), 1));
+}
+
+#[test]
+fn cache_starts_empty_round_trips_modules_and_can_be_cleared() {
+    let cache = SpirVCache::new();
+    assert!(cache.is_empty());
+    assert_eq!(cache.len(), 0);
+    assert!(cache.get("missing").is_none());
+
+    let module = SpirVModule {
+        bytecode: build_test_spirv(1, 0),
+        source_hash: "abc123".to_string(),
+        compiler: Some(CompilerBackend::Ocloc),
+    };
+    cache.insert(module.clone());
+
+    assert!(!cache.is_empty());
+    assert_eq!(cache.len(), 1);
+    let cached = cache.get("abc123").expect("cached module");
+    assert_eq!(cached.bytecode, module.bytecode);
+    assert_eq!(cached.source_hash, module.source_hash);
+    assert_eq!(cached.compiler, module.compiler);
+
+    cache.clear();
+    assert!(cache.is_empty());
+    assert!(cache.get("abc123").is_none());
+}
+
+#[test]
+fn cache_replaces_existing_module_with_same_source_hash() {
+    let cache = SpirVCache::default();
+    let first = SpirVModule {
+        bytecode: build_test_spirv(1, 0),
+        source_hash: "same".to_string(),
+        compiler: Some(CompilerBackend::Clang),
+    };
+    let second = SpirVModule {
+        bytecode: build_test_spirv(1, 1),
+        source_hash: "same".to_string(),
+        compiler: Some(CompilerBackend::Ocloc),
+    };
+
+    cache.insert(first);
+    cache.insert(second.clone());
+
+    assert_eq!(cache.len(), 1);
+    let cached = cache.get("same").expect("replacement module");
+    assert_eq!(cached.bytecode, second.bytecode);
+    assert_eq!(cached.source_hash, second.source_hash);
+    assert_eq!(cached.compiler, second.compiler);
+}


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for SPIR-V utilities and SafeTensors LayerNorm helpers to catch edge cases and regressions.
- Validate SPIR-V header/version/capability scanning, deterministic `source_hash` semantics, and cache insert/replace/clear behaviour.
- Exercise `rms_for_tensor` and `cast_ln_to_f16` across a variety of dtypes and file/serialization paths to catch alignment and serialization issues. 

### Description
- Add `crates/bitnet-spirv/tests/spirv_unit_tests.rs` containing tests for `CompileOptions`, `SpirVCompiler` behavior, `source_hash` stability/sensitivity, `SpirVValidator` header/version/magic checks, capability scanning, and `SpirVCache` operations. 
- Add `crates/bitnet-safetensors-ln/tests/safetensors_ln_unit_tests.rs` containing tests for `rms_for_tensor`, `cast_ln_to_f16` conversions for multiple dtypes, unsupported-dtype errors, `iter_ln_tensors` filtering, and `read_safetensors_bytes` file reads. 
- Fix `cast_ln_to_f16` to emit explicit little-endian `u16` bytes (`out.into_iter().flat_map(u16::to_le_bytes).collect()`) instead of `bytemuck::cast_vec(out)`, preventing alignment-related panics in tests. 
- Add `tempfile` as a `dev-dependency` in `crates/bitnet-safetensors-ln/Cargo.toml` for file-backed tests and commit the updated `Cargo.lock`. 
- Adjust tests to compare `SpirVModule` fields (`bytecode`, `source_hash`, `compiler`) rather than requiring `PartialEq` on the struct. 

### Testing
- Ran `cargo test -p bitnet-spirv -p bitnet-safetensors-ln --locked --no-default-features`; initial run exposed two failing SafeTensors tests due to `bytemuck::cast_vec` alignment, the code was patched and the final run completed successfully with all new tests passing. 
- Ran `cargo clippy -p bitnet-spirv -p bitnet-safetensors-ln --all-targets --locked --no-default-features -- -D warnings`; lint pass succeeded. 
- Ran `git diff --check` to ensure whitespace/format hygiene; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ead4c51c8333bada391281c1214a)