### PR TITLE
plans(native-inference): add implementation plan

### DIFF
--- a/plans/native-rust-inference/README.md
+++ b/plans/native-rust-inference/README.md
@@ -1,0 +1,44 @@
+# Native Rust Inference Plan
+
+This plan sequences the native Rust inference product lane described by
+[BITNET-PROP-0003](../../docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md).
+It turns the proof-carrying local inference direction into PR-sized work while
+leaving active execution state in campaign `active.toml` files.
+
+## Source-Of-Truth Links
+
+| Surface | Path |
+| --- | --- |
+| Product proposal | `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md` |
+| Model onboarding ladder | `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md` |
+| Runtime performance contract | `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md` |
+| Proof-family ADR | `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md` |
+| CUDA product contract | `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md` |
+| Server readiness boundary | `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` |
+| Model claims | `ci/model-artifacts/model-coverage-matrix.toml` |
+| NVIDIA campaign | `docs/tracking/campaigns/nvidia-5070ti/active.toml` |
+
+## Plan Files
+
+| File | Owns |
+| --- | --- |
+| `implementation-plan.md` | PR order and dependency map |
+| `bitnet-official-i2s.md` | Official BitNet I2_S/QK256 performance and residency work |
+| `bitnet-tl2.md` | TL/TL2 diagnostic lane boundaries |
+| `dense-qwen25.md` | Dense Qwen2.5 optimization and requalification |
+| `dense-qwen3.md` | Qwen3 product CLI promotion path |
+| `smollm2.md` | SmolLM2 comparator and CPU/CUDA readiness path |
+| `small-llm-candidates.md` | Llama/Gemma/Phi candidate order |
+| `runtime-performance.md` | Timing, transfer, residency, and speedup proof work |
+| `ci-economics.md` | Default PR cost and risk-routed expensive proof |
+| `server-readiness.md` | Exact-profile server truth and receipt export |
+
+## Operating Rules
+
+- Do not create `.adze/goals`, `.bitnet/goals`, or another active work store.
+- Use campaign manifests and events for active execution state.
+- Keep generated dashboards generated.
+- Keep BitNet, dense CUDA, benchmark, residency, and server proof families
+  separate.
+- Treat speedup, server readiness, and full residency as exact-profile claims
+  until later specs promote broader scope.

--- a/plans/native-rust-inference/bitnet-official-i2s.md
+++ b/plans/native-rust-inference/bitnet-official-i2s.md
@@ -1,0 +1,158 @@
+# Official BitNet I2_S/QK256
+
+Official BitNet 2B I2_S/QK256 is product CLI-ready on RTX 5070 Ti CUDA and has
+BitNet QK256 proof. Speedup, full residency, and broad server readiness remain
+false.
+
+## Work item: CUDA-BITNET-PERF-005
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-BITNET-PERF-006, CUDA-BITNET-OPS-001
+Blocked by: native inference plan
+
+### Goal
+
+Run repeated current-source profiles for the official Microsoft I2_S artifact.
+
+### Production delta
+
+Receipts cover one-token, short decode, prefill/decode, warm-session, and warm
+decode profiles for CPU AVX-512 and RTX 5070 Ti CUDA comparators.
+
+### Non-goals
+
+No global speedup, dense proof, broad server claim, or full-residency claim.
+
+### Acceptance
+
+Receipts include same artifact/tokenizer/prompt authority, fallback false,
+TTFT, prefill, decode, kernel time, launch count, H2D/D2H timing, VRAM
+high-water, and `speedup_claim=false`.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- bench --device cuda --model <official-i2s> --profile short_decode_32
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- receipts explain --latest --format json
+```
+
+### Rollback
+
+Revert benchmark review artifacts and keep existing product CLI state.
+
+## Work item: CUDA-BITNET-PERF-006
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: exact-profile status updates
+Blocked by: CUDA-BITNET-PERF-005
+
+### Goal
+
+Accept or reject official BitNet speed by exact profile.
+
+### Production delta
+
+Only profiles accepted by governed review may set speed-related claim state.
+
+### Non-goals
+
+No global speedup, dense proof, broad server claim, or full-residency claim.
+
+### Acceptance
+
+Review records accepted and rejected profiles with reasons.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+### Rollback
+
+Set speed claim booleans back to false for rejected or unsupported profiles.
+
+## Work item: CUDA-BITNET-OPS-001
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-BITNET-OPS-002
+Blocked by: CUDA-BITNET-PERF-005
+
+### Goal
+
+Audit TTFT and residency bottlenecks for official BitNet.
+
+### Production delta
+
+Report where KV, norm, RoPE, attention, LM head, H2D/D2H transfer, first token,
+and warm decode time are spent.
+
+### Non-goals
+
+No optimization in the audit PR.
+
+### Acceptance
+
+Audit ranks the next op or transfer that should move.
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the report.
+
+## Work item: CUDA-BITNET-OPS-002
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: requalification review
+Blocked by: CUDA-BITNET-OPS-001
+
+### Goal
+
+Add persistent session optimization.
+
+### Production delta
+
+Model, CUDA context, weights, and workspace are reused where the route supports
+it.
+
+### Non-goals
+
+No speedup claim until review.
+
+### Acceptance
+
+Receipt shows `model_loaded_once=true`, `cuda_context_once=true`,
+`weights_uploaded_once=true`, `workspace_reused=true`,
+`per_request_model_load=false`, and `fallback_used=false`.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- chat --device cuda --model <official-i2s>
+```
+
+### Rollback
+
+Disable persistent handles and return to prior request lifecycle.

--- a/plans/native-rust-inference/bitnet-tl2.md
+++ b/plans/native-rust-inference/bitnet-tl2.md
@@ -1,0 +1,43 @@
+# BitNet TL/TL2 And GPU-int2 Diagnostic Lanes
+
+BitNet TL1/TL2 and GPU-int2 paths are registered candidates or diagnostic
+lanes. They do not inherit official I2_S/QK256 proof.
+
+## Work item: BITNET-TL2-001
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: TL/TL2 artifact contracts
+Blocked by: native inference plan
+
+### Goal
+
+Record TL/TL2 and GPU-int2 as separate proof families with explicit unsupported
+routes where proof is absent.
+
+### Production delta
+
+Status and model coverage surfaces reject inherited I2_S/QK256 proof for TL/TL2
+and GPU-int2.
+
+### Non-goals
+
+No kernel work and no model promotion.
+
+### Acceptance
+
+Rows or docs say which proof is missing and which claims remain forbidden.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+### Rollback
+
+Remove diagnostic lane additions and keep existing registered state.

--- a/plans/native-rust-inference/ci-economics.md
+++ b/plans/native-rust-inference/ci-economics.md
@@ -1,0 +1,121 @@
+# CI Economics Rollout
+
+The default PR lane should be Linux-only, model-free, hardware-free,
+Docker-free, coverage-free, and crate/risk scoped. Expensive proof remains
+available through labels, main, schedule, release, workflow dispatch, or
+hardware campaigns.
+
+## Work item: CI-1
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md`
+Linked ADRs:
+Campaign:
+Blocks: CI-2
+Blocked by: native inference plan
+
+### Goal
+
+Remove macOS from ordinary PRs.
+
+### Production delta
+
+macOS runs on main/manual/merge-group/path-risk/labels instead of every
+ordinary PR.
+
+### Non-goals
+
+No weakening of release or risk-routed proof.
+
+### Acceptance
+
+Default PRs no longer run macOS format or clippy lanes unless selected by
+policy.
+
+### Proof commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### Rollback
+
+Restore macOS PR triggers.
+
+## Work item: CI-2
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs:
+Campaign:
+Blocks: CI-3
+Blocked by: CI-1
+
+### Goal
+
+Move performance tracking off default PRs.
+
+### Production delta
+
+Performance runs on main, schedule, workflow dispatch, or performance labels.
+
+### Non-goals
+
+No removal of performance proof.
+
+### Acceptance
+
+Skipped PR performance lanes report policy skip instead of pass.
+
+### Proof commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### Rollback
+
+Restore default PR performance trigger.
+
+## Work item: CI-5
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md`
+Linked ADRs:
+Campaign:
+Blocks: CI-6, CI-7, CI-8, CI-9
+Blocked by: CI-1, CI-2
+
+### Goal
+
+Emit stable `ci-plan.json` routing schema.
+
+### Production delta
+
+PR Gate can distinguish selected blocking lanes, advisory lanes, skipped lanes,
+changed packages, canaries, and budget estimates.
+
+### Non-goals
+
+No broad CI expansion.
+
+### Acceptance
+
+Schema version, classification booleans, selected/skipped lanes, package set,
+and LEM budget fields are stable.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- ci-plan --format json
+git diff --check
+```
+
+### Rollback
+
+Remove the generated plan and keep current PR Gate behavior.

--- a/plans/native-rust-inference/dense-qwen25.md
+++ b/plans/native-rust-inference/dense-qwen25.md
@@ -1,0 +1,155 @@
+# Dense Qwen2.5 Optimization
+
+Qwen2.5 0.5B Q8_0 is dense CUDA product CLI-ready and exact-profile
+server-ready. Speedup, full residency, and BitNet proof remain false.
+
+## Work item: CUDA-DENSE-QWEN25-OPS-001
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-DENSE-QWEN25-OPS-002
+Blocked by: native inference plan
+
+### Goal
+
+Produce `docs/reports/CUDA_DENSE_QWEN25_RESIDENCY_BOTTLENECKS.md`.
+
+### Production delta
+
+Report ranks model load, H2D upload, D2H logits, launch count, KV movement,
+workspace reuse, and per-token wall-time blockers.
+
+### Non-goals
+
+No optimization or claim promotion.
+
+### Acceptance
+
+Report cites one-token, short-decode, warm-session, benchmark review, H2D/D2H,
+and server readiness receipts.
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the report.
+
+## Work item: CUDA-DENSE-QWEN25-OPS-002
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-DENSE-QWEN25-OPS-003
+Blocked by: CUDA-DENSE-QWEN25-OPS-001
+
+### Goal
+
+Add persistent handles for dense Qwen2.5.
+
+### Production delta
+
+Avoid per-request model/context/weight setup where the route can safely reuse
+state.
+
+### Non-goals
+
+No speedup or full-residency claim.
+
+### Acceptance
+
+Receipt shows `model_loaded_once=true`, `cuda_context_once=true`,
+`weights_uploaded_once=true`, `per_request_model_load=false`,
+`workspace_reused=true`, and `fallback_used=false`.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- chat --device cuda --model <qwen25>
+```
+
+### Rollback
+
+Return to previous lifecycle and keep existing exact-profile server readiness.
+
+## Work item: CUDA-DENSE-QWEN25-OPS-003
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-DENSE-QWEN25-PERF-007
+Blocked by: CUDA-DENSE-QWEN25-OPS-002
+
+### Goal
+
+Reduce logits/top-k transfer when greedy or top-k proof is sufficient.
+
+### Production delta
+
+Reduce D2H bytes or explain why reduction is not possible while preserving
+selected-token equality and top-k evidence.
+
+### Non-goals
+
+No quality regression and no speedup claim.
+
+### Acceptance
+
+Quality receipts remain unchanged and D2H byte change is recorded.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- ask --device cuda --model <qwen25> "..."
+```
+
+### Rollback
+
+Restore full logits transfer.
+
+## Work item: CUDA-DENSE-QWEN25-PERF-007
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: exact-profile status updates
+Blocked by: CUDA-DENSE-QWEN25-OPS-002, CUDA-DENSE-QWEN25-OPS-003
+
+### Goal
+
+Review Qwen2.5 speed/residency requalification after optimization.
+
+### Production delta
+
+Accept or reject exact profiles; keep BitNet proof false.
+
+### Non-goals
+
+No broad speedup or full residency without proof.
+
+### Acceptance
+
+Model coverage and status docs agree with governed review decisions.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+### Rollback
+
+Demote any accepted claims whose receipts do not satisfy the spec.

--- a/plans/native-rust-inference/dense-qwen3.md
+++ b/plans/native-rust-inference/dense-qwen3.md
@@ -1,0 +1,159 @@
+# Dense Qwen3 Product Promotion
+
+Qwen3 0.6B Q8_0 is accelerator-answer-ready candidate evidence. It is not yet
+product CLI-ready, server-ready, speed-qualified, or full-residency-proven.
+
+## Work item: CUDA-MODEL-009
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-MODEL-010
+Blocked by: native inference plan
+
+### Goal
+
+Produce `docs/reports/CUDA_MODEL_009_QWEN3_PRODUCT_UX_AUDIT.md`.
+
+### Production delta
+
+No runtime delta. The audit maps `model verify`, ask, chat/warm path, receipt
+explain, model status, fallback rejection, quality gate, benchmark review, and
+claim booleans.
+
+### Non-goals
+
+No product promotion.
+
+### Acceptance
+
+Audit lists every user-path gap before Qwen3 can become product CLI-ready.
+
+### Proof commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+```
+
+### Rollback
+
+Revert the audit report.
+
+## Work item: CUDA-MODEL-010
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-MODEL-011
+Blocked by: CUDA-MODEL-009
+
+### Goal
+
+Capture a strict Qwen3 ask user-path receipt.
+
+### Production delta
+
+The normal `bitnet ask` path produces valid decoded text with
+`selected_backend=nvidia-rtx-5070-ti-cuda`, route `dense_regular_llm_cuda`, and
+`fallback_used=false`.
+
+### Non-goals
+
+No speedup, server readiness, or product CLI promotion.
+
+### Acceptance
+
+Receipt explain works and `product_cli_ready` remains false unless review
+promotes it.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- ask --device cuda --model <qwen3> "..."
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- receipts explain --latest --format json
+```
+
+### Rollback
+
+Revert user-path changes and keep existing proof receipts unchanged.
+
+## Work item: CUDA-MODEL-011
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-MODEL-012
+Blocked by: CUDA-MODEL-010
+
+### Goal
+
+Capture Qwen3 chat or warm-session receipts.
+
+### Production delta
+
+Normal chat or warm-session path records model/tokenizer/context/weights loaded
+once across multiple prompts.
+
+### Non-goals
+
+No server or speedup promotion.
+
+### Acceptance
+
+Session summary receipt shows `fallback_used=false`, `speedup=false`, and
+`server=false`.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- chat --device cuda --model <qwen3>
+```
+
+### Rollback
+
+Revert Qwen3 warm-session changes.
+
+## Work item: CUDA-MODEL-012
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: Qwen3 server readiness review
+Blocked by: CUDA-MODEL-010, CUDA-MODEL-011
+
+### Goal
+
+Review whether Qwen3 should be promoted to `product_cli_ready`.
+
+### Production delta
+
+If accepted, set Qwen3 product CLI booleans while keeping server, speedup, and
+full residency false.
+
+### Non-goals
+
+No server-ready or speedup claim.
+
+### Acceptance
+
+Model coverage and status docs agree on the promoted tier and forbidden claims.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+### Rollback
+
+Demote the row and revert status docs if review rejects promotion.

--- a/plans/native-rust-inference/implementation-plan.md
+++ b/plans/native-rust-inference/implementation-plan.md
@@ -1,0 +1,70 @@
+# Native Rust Inference Implementation Plan
+
+This file gives the first executable sequence for the native Rust inference
+product lane. Each item should become a narrow PR or a campaign work item before
+runtime implementation starts.
+
+## Sequence
+
+| Order | Item | File |
+| --- | --- | --- |
+| 0 | Normalize autonomous PR operations | landed before this plan |
+| 1 | Define BitNet source-of-truth model | landed before this plan |
+| 2 | Add native Rust inference product proposal | landed before this plan |
+| 3 | Add model onboarding proof ladder | landed before this plan |
+| 4 | Add runtime performance contract | landed before this plan |
+| 5 | Record non-interchangeable proof families ADR | landed before this plan |
+| 6 | Add this implementation plan | this PR |
+| 7 | Stable model-status and receipts-explain JSON | `server-readiness.md` |
+| 8 | CUDA receipt triage guide | `server-readiness.md` |
+| 9 | Exact-profile readiness display | `server-readiness.md` |
+| 10 | Per-request receipt export | `server-readiness.md` |
+| 11-14 | Qwen3 product promotion | `dense-qwen3.md` |
+| 15-18 | Official BitNet performance and residency | `bitnet-official-i2s.md` |
+| 19-22 | Dense Qwen2.5 optimization and requalification | `dense-qwen25.md` |
+| 23-26 | SmolLM2 comparator, CPU, and CUDA path | `smollm2.md` |
+| CI-1+ | CI economics rollout | `ci-economics.md` |
+
+## Work item: NRI-PLAN-000
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`,
+`docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: product UX, server readiness, Qwen3 promotion, performance work, CI economics
+Blocked by: none
+
+### Goal
+
+Add the native inference plan files so future runtime and CI PRs have a shared
+sequence and proof contract.
+
+### Production delta
+
+No runtime delta. This is planning infrastructure for follow-on PRs.
+
+### Non-goals
+
+Do not edit model coverage rows, receipts, runtime code, CI workflows, policy
+TOMLs, or generated dashboards.
+
+### Acceptance
+
+- Plan files exist under `plans/native-rust-inference/`.
+- Each lane file names source links, non-goals, acceptance, proof commands, and
+  rollback.
+- Proof-family and exact-profile boundaries are repeated where the work might
+  otherwise blur them.
+
+### Proof commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+```
+
+### Rollback
+
+Revert `plans/native-rust-inference/` and leave active campaign state unchanged.

--- a/plans/native-rust-inference/runtime-performance.md
+++ b/plans/native-rust-inference/runtime-performance.md
@@ -1,0 +1,81 @@
+# Runtime Performance Work
+
+Runtime performance work implements
+[BITNET-SPEC-0014](../../docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md).
+
+## Work item: PERF-CONTRACT-001
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: benchmark qualification reviews
+Blocked by: native inference plan
+
+### Goal
+
+Add receipt schema support for the runtime performance fields.
+
+### Production delta
+
+Benchmark and receipt explanation paths can report phase timing, transfer,
+launch, VRAM, power/thermal context, fallback, profile, backend, and route
+identity.
+
+### Non-goals
+
+No speedup claim.
+
+### Acceptance
+
+Missing phase fields are explicit `not_applicable` or `missing`, not zero.
+
+### Proof commands
+
+```bash
+cargo test --workspace --no-default-features --features cpu
+git diff --check
+```
+
+### Rollback
+
+Remove new schema fields and preserve older receipt decoding where possible.
+
+## Work item: PERF-CONTRACT-002
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: exact-profile speed reviews
+Blocked by: PERF-CONTRACT-001
+
+### Goal
+
+Teach `receipts explain` to separate reported metrics from accepted claims.
+
+### Production delta
+
+Users can see TTFT, throughput, speedup, residency, and server readiness status
+without assuming raw timing equals a promoted claim.
+
+### Non-goals
+
+No model promotion.
+
+### Acceptance
+
+Explanation emits `qualified`, `reported_only`, `not_available`, `accepted`,
+`rejected`, or `not_reviewed` states where appropriate.
+
+### Proof commands
+
+```bash
+cargo test --workspace --no-default-features --features cpu
+```
+
+### Rollback
+
+Revert explain output changes.

--- a/plans/native-rust-inference/server-readiness.md
+++ b/plans/native-rust-inference/server-readiness.md
@@ -1,0 +1,175 @@
+# Server Readiness And Product UX
+
+## Work item: CUDA-UX-011
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`,
+`docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: server display, support triage, automation dashboards
+Blocked by: native inference plan
+
+### Goal
+
+Make `bitnet model status --device nvidia-rtx-5070-ti-cuda --format json` and
+`bitnet receipts explain --latest --format json` stable enough for automation.
+
+### Production delta
+
+Machine-readable status exposes model coverage row, current tier, selected
+backend, selected route, fallback status, server scope, speedup, residency,
+BitNet proof, and dense CUDA proof.
+
+### Non-goals
+
+No runtime route change, model promotion, speedup claim, or server-ready
+promotion.
+
+### Acceptance
+
+JSON includes at least:
+
+```json
+{
+  "model_coverage_row": "dense_qwen25_05b_q8_cuda",
+  "current_tier": "product_cli_ready",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_route": "dense_regular_llm_cuda",
+  "fallback_used": false,
+  "server_ready": true,
+  "speedup_claim": false,
+  "full_residency_claim": false,
+  "bitnet_packed_i2s_qk256_proof": false,
+  "dense_regular_llm_cuda_proof": true
+}
+```
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- model status --device nvidia-rtx-5070-ti-cuda --format json
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- receipts explain --latest --format json
+```
+
+### Rollback
+
+Remove the JSON additions and keep text status behavior unchanged.
+
+## Work item: CUDA-UX-012
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: support issue templates
+Blocked by: CUDA-UX-011 optional
+
+### Goal
+
+Add `docs/tutorials/cuda-receipt-triage.md` so users and maintainers can debug
+receipt failures without reading model coverage TOML.
+
+### Production delta
+
+Support docs explain `fallback_used=true`, generic CUDA selection, tokenizer
+authority gaps, prompt template gaps, quality failures, false speed/server
+claims, and dense-vs-BitNet proof mistakes.
+
+### Non-goals
+
+No CLI behavior change and no claim promotion.
+
+### Acceptance
+
+Guide includes what to paste into a GitHub issue and the forbidden-claim
+boundaries for dense CUDA versus BitNet proof.
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the tutorial.
+
+## Work item: SERVER-READY-001
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: per-request receipt export
+Blocked by: CUDA-UX-011
+
+### Goal
+
+Display server readiness scope plainly in model status.
+
+### Production delta
+
+Qwen2.5 shows exact-profile readiness for non-streaming
+`/v1/chat/completions`; official BitNet shows server smoke evidence while broad
+`server_ready` remains false.
+
+### Non-goals
+
+No new server promotion.
+
+### Acceptance
+
+Status distinguishes `server_ready=true scope=exact_profile` from
+`server_smoke=true server_ready=false`.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- model status --device nvidia-rtx-5070-ti-cuda --format json
+```
+
+### Rollback
+
+Revert the display changes without touching receipts.
+
+## Work item: SERVER-READY-002
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: server support workflows
+Blocked by: SERVER-READY-001
+
+### Goal
+
+Export per-request receipts from server paths.
+
+### Production delta
+
+Expose `/receipts/latest`, `/receipts/{id}`, `/readiness`, and `/v1/models`
+without adding a second inference engine.
+
+### Non-goals
+
+No new `server_ready` promotion.
+
+### Acceptance
+
+Response metadata includes a receipt ID, and the readiness row links to the
+model coverage row.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- serve --device cuda --model <model>
+```
+
+### Rollback
+
+Remove receipt export endpoints and retain existing server behavior.

--- a/plans/native-rust-inference/small-llm-candidates.md
+++ b/plans/native-rust-inference/small-llm-candidates.md
@@ -1,0 +1,71 @@
+# Small LLM Candidates
+
+Start with one small LLM at a time. Do not batch-promote candidate families.
+
+## Recommended Order
+
+1. Llama 3.2 1B
+2. SmolLM2 1.7B
+3. Llama 3.2 3B
+4. Gemma small
+5. Phi small
+
+## Work item: SMALL-LLM-001
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: per-model artifact contracts
+Blocked by: native inference plan
+
+### Goal
+
+Select the first small dense LLM candidate and open a per-model artifact
+contract PR.
+
+### Production delta
+
+One model gets a registered-to-structural path without promoting other
+candidates.
+
+### Non-goals
+
+No CPU, CUDA, speed, server, or product CLI claim.
+
+### Acceptance
+
+Chosen model records artifact contract, tokenizer/prompt authority plan, CPU
+sanity command, all-layer plan placeholder, and forbidden claims.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+### Rollback
+
+Remove the candidate row or demote it back to registered.
+
+## Shared Ladder
+
+Each selected model follows:
+
+```text
+artifact contract
+CPU sanity
+all-layer plan
+model-boundary fixtures
+KV/sampling policy
+one-token CUDA
+short decode
+warm session
+benchmark review
+product UX review
+```
+
+Dense small-LLM CUDA proof remains separate from dense SLM CUDA and BitNet
+QK256 proof.

--- a/plans/native-rust-inference/smollm2.md
+++ b/plans/native-rust-inference/smollm2.md
@@ -1,0 +1,153 @@
+# SmolLM2 360M
+
+SmolLM2 360M is structurally valid. CPU answer readiness is blocked by
+same-prompt/reference comparator work.
+
+## Work item: CUDA-MODEL-SMOLLM2-002
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-MODEL-SMOLLM2-003
+Blocked by: native inference plan
+
+### Goal
+
+Capture a same-prompt comparator for SmolLM2.
+
+### Production delta
+
+Classifies mismatch source as prompt policy, tokenizer, shared dense CPU math,
+or reference mismatch.
+
+### Non-goals
+
+No CUDA claim.
+
+### Acceptance
+
+Comparator uses same prompt, tokenizer policy, prompt template, and
+first-token/top-k evidence.
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert comparator artifacts.
+
+## Work item: CUDA-MODEL-SMOLLM2-003
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-MODEL-SMOLLM2-004
+Blocked by: CUDA-MODEL-SMOLLM2-002
+
+### Goal
+
+Retry CPU answer sanity after comparator evidence.
+
+### Production delta
+
+Promote to CPU answer-ready only if the answer gate passes.
+
+### Non-goals
+
+No accelerator claim.
+
+### Acceptance
+
+Model coverage row updates only if CPU proof passes.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+```
+
+### Rollback
+
+Keep or restore SmolLM2 to structurally valid.
+
+## Work item: CUDA-MODEL-SMOLLM2-004
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: CUDA-MODEL-SMOLLM2-005
+Blocked by: CUDA-MODEL-SMOLLM2-003
+
+### Goal
+
+Create the SmolLM2 all-layer accelerator plan.
+
+### Production delta
+
+Plan maps model boundaries, unsupported operations, and required dense CUDA
+route work.
+
+### Non-goals
+
+No CUDA proof.
+
+### Acceptance
+
+Plan names blockers before one-token CUDA proof.
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+Revert the plan.
+
+## Work item: CUDA-MODEL-SMOLLM2-005
+
+Status: blocked
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: short decode and warm-session proof
+Blocked by: CUDA-MODEL-SMOLLM2-004
+
+### Goal
+
+Capture one-token strict CUDA proof for SmolLM2.
+
+### Production delta
+
+Receipt proves selected backend, selected route, fallback rejection, and
+one-token evidence for the exact SmolLM2 artifact.
+
+### Non-goals
+
+No product CLI, speedup, or server claim.
+
+### Acceptance
+
+Receipt explain reports SmolLM2 proof only and keeps inherited Qwen/BitNet
+claims false.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- ask --device cuda --model <smollm2> "..."
+```
+
+### Rollback
+
+Revert route changes and keep the model below accelerator answer-ready.


### PR DESCRIPTION
## Summary
- add the native Rust inference plan index and implementation sequence
- add lane plans for official BitNet I2_S/QK256, TL/TL2, dense Qwen2.5, Qwen3, SmolLM2, small-LLM candidates, runtime performance, CI economics, and server readiness
- keep active execution in campaign state while preserving proof-family and exact-profile claim boundaries

## Validation
- rtk git diff --check
- rtk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc plans/native-rust-inference/*.md
- rtk powershell -NoProfile -Command '... rtk cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti'