### PR TITLE
CUDA-UX-011: stable model-status / receipts-explain JSON

### DIFF
--- a/crates/bitnet-cli/src/commands/receipts.rs
+++ b/crates/bitnet-cli/src/commands/receipts.rs
@@ -6,7 +6,7 @@
 //! actually ran without needing to know every receipt variant.
 
 use anyhow::{Context, Result, anyhow, bail};
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -40,12 +40,33 @@ pub enum ReceiptsAction {
         /// Emit normalized JSON instead of text.
         #[arg(long, default_value_t = false)]
         json: bool,
+
+        /// Emit text or normalized JSON. Equivalent to --json when set to json.
+        #[arg(long, value_enum)]
+        format: Option<ReceiptExplainFormat>,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ReceiptExplainFormat {
+    Text,
+    Json,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct ReceiptExplanation {
+    pub schema_version: u32,
     pub path: String,
+    pub model_coverage_row: Option<String>,
+    pub current_tier: Option<String>,
+    pub selected_backend: Option<String>,
+    pub selected_route: Option<String>,
+    pub fallback_used: Option<bool>,
+    pub server_ready: Option<bool>,
+    pub speedup_claim: Option<bool>,
+    pub full_residency_claim: Option<bool>,
+    pub bitnet_packed_i2s_qk256_proof: Option<bool>,
+    pub dense_regular_llm_cuda_proof: Option<bool>,
     pub artifact_kind: Option<String>,
     pub claim: Option<String>,
     pub model: Option<String>,
@@ -70,6 +91,7 @@ pub struct ModelCoverageExplanation {
     pub speedup_claim: Option<bool>,
     pub benchmark_qualified: Option<bool>,
     pub server_ready: Option<bool>,
+    pub full_residency_claim: Option<bool>,
     pub bitnet_packed_i2s_qk256_proof: Option<bool>,
     pub dense_regular_llm_cuda_proof: Option<bool>,
     pub claim_boundary: Option<String>,
@@ -193,6 +215,7 @@ struct ModelCoverageClaims {
     benchmark_qualified: bool,
     server_ready: bool,
     speedup_claim: bool,
+    full_residency_claim: bool,
     bitnet_packed_i2s_qk256_proof: bool,
     dense_regular_llm_cuda_proof: bool,
 }
@@ -200,11 +223,12 @@ struct ModelCoverageClaims {
 impl ReceiptsCommand {
     pub async fn execute(&self) -> Result<()> {
         match &self.action {
-            ReceiptsAction::Explain { path, latest, json } => {
+            ReceiptsAction::Explain { path, latest, json, format } => {
                 let receipt_path = resolve_receipt_path(path.as_deref(), *latest)?;
                 let receipt = read_receipt_json(&receipt_path)?;
                 let explanation = explain_receipt(&receipt_path, &receipt);
-                if *json {
+                let output_json = *json || matches!(format, Some(ReceiptExplainFormat::Json));
+                if output_json {
                     println!("{}", serde_json::to_string_pretty(&explanation)?);
                 } else {
                     print_receipt_explanation(&explanation);
@@ -280,7 +304,18 @@ fn consider_latest_file(path: &Path, latest: &mut Option<(SystemTime, PathBuf)>)
 
 pub fn explain_receipt(path: &Path, receipt: &Value) -> ReceiptExplanation {
     let mut explanation = ReceiptExplanation {
+        schema_version: 1,
         path: path.display().to_string(),
+        model_coverage_row: None,
+        current_tier: None,
+        selected_backend: None,
+        selected_route: None,
+        fallback_used: None,
+        server_ready: None,
+        speedup_claim: None,
+        full_residency_claim: None,
+        bitnet_packed_i2s_qk256_proof: None,
+        dense_regular_llm_cuda_proof: None,
         artifact_kind: string_at(receipt, &["artifact_kind"]),
         claim: string_at(receipt, &["claim"]),
         model: model_summary(receipt),
@@ -295,7 +330,36 @@ pub fn explain_receipt(path: &Path, receipt: &Value) -> ReceiptExplanation {
         claim_limits: claim_limits_explanation(receipt),
     };
     explanation.model_coverage = model_coverage_explanation(&explanation, receipt);
+    apply_receipt_json_contract_aliases(&mut explanation);
     explanation
+}
+
+fn apply_receipt_json_contract_aliases(explanation: &mut ReceiptExplanation) {
+    explanation.model_coverage_row = explanation.model_coverage.row.clone();
+    explanation.current_tier = explanation.model_coverage.current_tier.clone();
+    explanation.selected_backend = explanation.backend.selected_backend.clone();
+    explanation.selected_route = explanation
+        .execution_plan
+        .selected_route
+        .clone()
+        .or_else(|| explanation.model_coverage.route.clone());
+    explanation.fallback_used = explanation.backend.fallback_used;
+    explanation.server_ready = explanation.model_coverage.server_ready;
+    explanation.speedup_claim =
+        explanation.model_coverage.speedup_claim.or(explanation.claim_limits.speedup_claim);
+    explanation.full_residency_claim = explanation
+        .model_coverage
+        .full_residency_claim
+        .or(explanation.residency.full_cuda_residency_claimed)
+        .or(explanation.claim_limits.full_cuda_residency_claimed);
+    explanation.bitnet_packed_i2s_qk256_proof = explanation
+        .model_coverage
+        .bitnet_packed_i2s_qk256_proof
+        .or(explanation.claim_limits.bitnet_packed_i2s_qk256_proof);
+    explanation.dense_regular_llm_cuda_proof = explanation
+        .model_coverage
+        .dense_regular_llm_cuda_proof
+        .or(explanation.claim_limits.dense_gguf_inference_claimed);
 }
 
 fn backend_explanation(receipt: &Value) -> BackendExplanation {
@@ -593,6 +657,7 @@ fn model_coverage_explanation(
         coverage.speedup_claim = Some(entry.claims.speedup_claim);
         coverage.benchmark_qualified = Some(entry.claims.benchmark_qualified);
         coverage.server_ready = Some(entry.claims.server_ready);
+        coverage.full_residency_claim = Some(entry.claims.full_residency_claim);
         coverage.bitnet_packed_i2s_qk256_proof = Some(entry.claims.bitnet_packed_i2s_qk256_proof);
         coverage.dense_regular_llm_cuda_proof = Some(entry.claims.dense_regular_llm_cuda_proof);
         coverage.claim_boundary = Some(entry.claim_boundary.clone());
@@ -1340,7 +1405,25 @@ fn sum_kernel_f64(receipt: &Value, field: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use serde_json::json;
+
+    #[derive(Parser, Debug)]
+    struct TestReceiptsCli {
+        #[command(subcommand)]
+        action: ReceiptsAction,
+    }
+
+    #[test]
+    fn receipts_explain_accepts_format_json_alias() {
+        let cli =
+            TestReceiptsCli::parse_from(["receipts", "explain", "--latest", "--format", "json"]);
+
+        let ReceiptsAction::Explain { latest, json, format, .. } = cli.action;
+        assert!(latest);
+        assert!(!json);
+        assert_eq!(format, Some(ReceiptExplainFormat::Json));
+    }
 
     #[test]
     fn explain_receipt_extracts_cuda_plan_and_claim_limits() {
@@ -1402,6 +1485,10 @@ mod tests {
         assert_eq!(explanation.claim_limits.speedup_claim, Some(false));
         assert_eq!(explanation.claim_limits.dense_gguf_inference_claimed, Some(false));
         assert_eq!(explanation.claim_limits.bitnet_packed_i2s_qk256_proof, Some(false));
+        assert_eq!(explanation.schema_version, 1);
+        assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
+        assert_eq!(explanation.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert_eq!(explanation.fallback_used, Some(false));
     }
 
     #[test]
@@ -1499,8 +1586,18 @@ mod tests {
         assert_eq!(explanation.model_coverage.route.as_deref(), Some("bitnet_qk256_cuda"));
         assert_eq!(explanation.model_coverage.speedup_claim, Some(false));
         assert_eq!(explanation.model_coverage.server_ready, Some(false));
+        assert_eq!(explanation.server_ready, Some(false));
         assert_eq!(explanation.model_coverage.bitnet_packed_i2s_qk256_proof, Some(true));
         assert_eq!(explanation.model_coverage.dense_regular_llm_cuda_proof, Some(false));
+        assert_eq!(explanation.model_coverage_row.as_deref(), Some("bitnet_official_2b_i2s_qk256"));
+        assert_eq!(explanation.current_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
+        assert_eq!(explanation.selected_route.as_deref(), Some("bitnet_qk256_cuda"));
+        assert_eq!(explanation.fallback_used, Some(false));
+        assert_eq!(explanation.speedup_claim, Some(false));
+        assert_eq!(explanation.full_residency_claim, Some(false));
+        assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(true));
+        assert_eq!(explanation.dense_regular_llm_cuda_proof, Some(false));
         assert!(
             explanation
                 .model_coverage
@@ -1541,9 +1638,19 @@ mod tests {
         assert_eq!(explanation.model_coverage.current_tier.as_deref(), Some("product_cli_ready"));
         assert_eq!(explanation.model_coverage.route.as_deref(), Some("dense_regular_llm_cuda"));
         assert_eq!(explanation.model_coverage.speedup_claim, Some(false));
-        assert_eq!(explanation.model_coverage.server_ready, Some(false));
+        assert_eq!(explanation.model_coverage.server_ready, Some(true));
         assert_eq!(explanation.model_coverage.bitnet_packed_i2s_qk256_proof, Some(false));
         assert_eq!(explanation.model_coverage.dense_regular_llm_cuda_proof, Some(true));
+        assert_eq!(explanation.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+        assert_eq!(explanation.current_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
+        assert_eq!(explanation.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert_eq!(explanation.fallback_used, Some(false));
+        assert_eq!(explanation.server_ready, Some(true));
+        assert_eq!(explanation.speedup_claim, Some(false));
+        assert_eq!(explanation.full_residency_claim, Some(false));
+        assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(false));
+        assert_eq!(explanation.dense_regular_llm_cuda_proof, Some(true));
         assert!(
             explanation
                 .model_coverage
@@ -1622,10 +1729,20 @@ mod tests {
         assert_eq!(explanation.backend.runtime_api.as_deref(), Some("cuda"));
         assert_eq!(explanation.backend.fallback_used, Some(false));
         assert_eq!(explanation.quality.answer_quality_passed, Some(true));
-        assert_eq!(explanation.model_coverage.server_ready, Some(false));
+        assert_eq!(explanation.model_coverage.server_ready, Some(true));
         assert_eq!(explanation.model_coverage.speedup_claim, Some(false));
         assert_eq!(explanation.model_coverage.dense_regular_llm_cuda_proof, Some(true));
         assert_eq!(explanation.model_coverage.bitnet_packed_i2s_qk256_proof, Some(false));
+        assert_eq!(explanation.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+        assert_eq!(explanation.current_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
+        assert_eq!(explanation.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert_eq!(explanation.fallback_used, Some(false));
+        assert_eq!(explanation.server_ready, Some(true));
+        assert_eq!(explanation.speedup_claim, Some(false));
+        assert_eq!(explanation.full_residency_claim, Some(false));
+        assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(false));
+        assert_eq!(explanation.dense_regular_llm_cuda_proof, Some(true));
         assert!(
             !explanation
                 .model_coverage
@@ -1711,14 +1828,14 @@ mod tests {
             "receipt_kind": "server_shared_engine_chat_completion",
             "runtime_path": "shared_local_inference_engine",
             "runtime_api": "cuda",
-            "requested_model": "qwen2.5-0.5b-instruct-q8_0",
-            "active_model_id": "model-1",
-            "active_model_path": "models/qwen2.5-0.5b-instruct-q8_0/qwen2.5-0.5b-instruct-q8_0.gguf",
-            "model_coverage_row": "dense_qwen25_05b_q8_cuda",
+            "requested_model": "microsoft-bitnet-b1.58-2B-4T-i2s",
+            "active_model_id": "bitnet-model-1",
+            "active_model_path": "models/microsoft-bitnet-b1.58-2B-4T-i2s/ggml-model-i2_s.gguf",
+            "model_coverage_row": "bitnet_official_2b_i2s_qk256",
             "model_coverage_tier": "product_cli_ready",
             "requested_backend": "nvidia-rtx-5070-ti-cuda",
             "selected_backend": "nvidia-rtx-5070-ti-cuda",
-            "selected_route": "dense_regular_llm_cuda",
+            "selected_route": "bitnet_qk256_cuda",
             "fallback_used": false,
             "quality_gate": {
                 "passed": true
@@ -1726,14 +1843,16 @@ mod tests {
             "server_smoke_response_claimed": true,
             "server_ready_claimed": true,
             "speedup_claim": false,
-            "dense_regular_llm_cuda_inference_claimed": true,
-            "bitnet_packed_i2s_qk256_proof": false
+            "dense_regular_llm_cuda_inference_claimed": false,
+            "bitnet_packed_i2s_qk256_proof": true
         });
 
         let explanation = explain_receipt(Path::new("server-smoke-stale.json"), &receipt);
         let warnings = &explanation.model_coverage.warnings;
 
-        assert_eq!(explanation.model_coverage.row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+        assert_eq!(explanation.model_coverage.row.as_deref(), Some("bitnet_official_2b_i2s_qk256"));
+        assert_eq!(explanation.server_ready, Some(false));
+        assert_eq!(explanation.selected_route.as_deref(), Some("bitnet_qk256_cuda"));
         assert!(warnings.iter().any(|warning| warning.contains("missing exact artifact checksum")));
         assert!(
             warnings.iter().any(|warning| warning.contains("missing endpoint/request profile"))

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -12310,6 +12310,7 @@ mod tests {
                     path: None,
                     latest: true,
                     json: false,
+                    format: None,
                 },
             }))),
             Some("warn")

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -528,12 +528,17 @@ struct ModelStatusDashboard {
 #[derive(Debug, Serialize)]
 struct ModelStatusRow {
     id: String,
+    model_coverage_row: String,
     display_name: String,
     model_class: String,
     route: Option<String>,
+    selected_route: Option<String>,
+    selected_backend: String,
     tier: String,
+    current_tier: String,
     status: String,
     category: String,
+    fallback_used: Option<bool>,
     cpu_answer_ready: bool,
     accelerator_answer_ready: bool,
     benchmark_qualified: bool,
@@ -1290,7 +1295,7 @@ fn model_status_dashboard(
         .entry
         .iter()
         .filter(|entry| model_status_includes_entry(device, entry))
-        .map(model_status_row)
+        .map(|entry| model_status_row(device, entry))
         .collect();
 
     ModelStatusDashboard {
@@ -1318,7 +1323,7 @@ fn model_status_includes_entry(device: &str, entry: &ModelCoverageEntry) -> bool
         && matches!(entry.model_class.as_str(), "dense_slm" | "small_llm")
 }
 
-fn model_status_row(entry: &ModelCoverageEntry) -> ModelStatusRow {
+fn model_status_row(device: &str, entry: &ModelCoverageEntry) -> ModelStatusRow {
     let route = entry.accelerator_routes.first().cloned();
     let category =
         if entry.claims.product_cli_ready { "supported" } else { "candidate" }.to_string();
@@ -1330,12 +1335,17 @@ fn model_status_row(entry: &ModelCoverageEntry) -> ModelStatusRow {
 
     ModelStatusRow {
         id: entry.id.clone(),
+        model_coverage_row: entry.id.clone(),
         display_name: model_status_display_name(entry),
         model_class: entry.model_class.clone(),
-        route,
+        route: route.clone(),
+        selected_route: route.clone(),
+        selected_backend: device.to_string(),
         tier: entry.current_tier.clone(),
+        current_tier: entry.current_tier.clone(),
         status: entry.status.clone(),
         category,
+        fallback_used: route.is_some().then_some(false),
         cpu_answer_ready: entry.claims.cpu_answer_ready,
         accelerator_answer_ready: entry.claims.accelerator_answer_ready,
         benchmark_qualified: entry.claims.benchmark_qualified,
@@ -3034,6 +3044,11 @@ mod tests {
 
         let bitnet = model_status_row_for(&dashboard, "bitnet_official_2b_i2s_qk256")?;
         assert_eq!(bitnet.display_name, "microsoft-bitnet-b1.58-2B-4T-i2s");
+        assert_eq!(bitnet.model_coverage_row, "bitnet_official_2b_i2s_qk256");
+        assert_eq!(bitnet.current_tier, "product_cli_ready");
+        assert_eq!(bitnet.selected_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(bitnet.selected_route.as_deref(), Some("bitnet_qk256_cuda"));
+        assert_eq!(bitnet.fallback_used, Some(false));
         assert_eq!(bitnet.category, "supported");
         assert_eq!(bitnet.model_class, "bitnet");
         assert_eq!(bitnet.route.as_deref(), Some("bitnet_qk256_cuda"));
@@ -3054,6 +3069,11 @@ mod tests {
 
         let dense = model_status_row_for(&dashboard, "dense_qwen25_05b_q8_cuda")?;
         assert_eq!(dense.display_name, "qwen2.5-0.5b-instruct-q8_0");
+        assert_eq!(dense.model_coverage_row, "dense_qwen25_05b_q8_cuda");
+        assert_eq!(dense.current_tier, "product_cli_ready");
+        assert_eq!(dense.selected_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(dense.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert_eq!(dense.fallback_used, Some(false));
         assert_eq!(dense.category, "supported");
         assert_eq!(dense.model_class, "dense_slm");
         assert_eq!(dense.route.as_deref(), Some("dense_regular_llm_cuda"));
@@ -3125,6 +3145,11 @@ mod tests {
         assert!(value["models"].as_array().is_some_and(|models| {
             models.iter().any(|model| {
                 model["id"] == "dense_qwen25_05b_q8_cuda"
+                    && model["model_coverage_row"] == "dense_qwen25_05b_q8_cuda"
+                    && model["current_tier"] == "product_cli_ready"
+                    && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
+                    && model["selected_route"] == "dense_regular_llm_cuda"
+                    && model["fallback_used"] == false
                     && model["route"] == "dense_regular_llm_cuda"
                     && model["speedup_claim"] == false
                     && model["server_ready"] == true
@@ -3135,7 +3160,12 @@ mod tests {
         assert!(value["models"].as_array().is_some_and(|models| {
             models.iter().any(|model| {
                 model["id"] == "dense_qwen3_06b_q8_candidate"
+                    && model["model_coverage_row"] == "dense_qwen3_06b_q8_candidate"
                     && model["category"] == "candidate"
+                    && model["current_tier"] == "accelerator_answer_ready"
+                    && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
+                    && model["selected_route"] == "dense_regular_llm_cuda"
+                    && model["fallback_used"] == false
                     && model["tier"] == "accelerator_answer_ready"
                     && model["route"] == "dense_regular_llm_cuda"
                     && model["accelerator_answer_ready"] == true

--- a/docs/reports/CUDA_UX_001_RECEIPTS_EXPLAIN.md
+++ b/docs/reports/CUDA_UX_001_RECEIPTS_EXPLAIN.md
@@ -8,6 +8,7 @@
 bitnet receipts explain <receipt.json>
 bitnet receipts explain --latest
 bitnet receipts explain <receipt.json> --json
+bitnet receipts explain --latest --format json
 ```
 
 The command reads existing BitNet-rs JSON receipts and prints a compact proof
@@ -35,7 +36,8 @@ May claim:
   UX;
 - `--latest` can select the newest local JSON receipt under
   `target/bitnet/receipts`;
-- `--json` emits the normalized explanation object for tooling.
+- `--json` and `--format json` emit the normalized explanation object for
+  tooling.
 
 Must not claim:
 
@@ -67,7 +69,7 @@ Dense regular-LLM CUDA fixture receipt:
 cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- `
   receipts explain `
   ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/dense-f16-gemm-residency.json `
-  --json
+  --format json
 ```
 
 ## Next Step

--- a/docs/reports/CUDA_UX_007_RECEIPTS_EXPLAIN_BENCHMARK_REPORT.md
+++ b/docs/reports/CUDA_UX_007_RECEIPTS_EXPLAIN_BENCHMARK_REPORT.md
@@ -22,6 +22,7 @@ already use for CUDA ask/chat receipts:
 ```powershell
 bitnet receipts explain <benchmark-qualification-receipt.json>
 bitnet receipts explain <benchmark-qualification-receipt.json> --json
+bitnet receipts explain <benchmark-qualification-receipt.json> --format json
 ```
 
 Claim boundary:


### PR DESCRIPTION
## Summary
- add stable flat JSON contract aliases to CUDA model status rows: model_coverage_row, current_tier, selected_backend, selected_route, and fallback_used
- add schema_version and flat claim aliases to receipts explain JSON, while preserving the existing nested explanation objects
- accept receipts explain --format json as a compatibility alias for --json and update UX docs

## Validation
- rtk git diff --check
- rtk cargo fmt -p bitnet-cli -- --check
- rtk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc docs/reports/CUDA_UX_001_RECEIPTS_EXPLAIN.md docs/reports/CUDA_UX_007_RECEIPTS_EXPLAIN_BENCHMARK_REPORT.md
- rtk cargo test -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
- rtk cargo test -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
- rtk cargo run --release --locked -p xtask --no-default-features -- check-model-coverage
- rtk cargo build -p bitnet-cli --no-default-features --features cpu,full-cli
- direct JSON smoke: bitnet.exe model status --device nvidia-rtx-5070-ti-cuda --format json
- direct JSON smoke: bitnet.exe receipts explain ci/hardware/windows-9950x3d-rtx5070ti/2026-05-17/server-strict-dense-qwen25-q8-smoke.json --format json

## Validation note
- Full bitnet-cli package test was also attempted and hit an unrelated existing Lunar Lake assertion: commands::lunar_lake::tests::regression_bundle_v2_indexes_corpus_fixture_and_profile_comparison expected 11 and observed 12. Focused model-status and receipts-explain contract tests pass.