### PR TITLE
SERVER-READY-001: exact-profile readiness display

### DIFF
--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -553,6 +553,11 @@ struct ModelStatusRow {
     warm_session: String,
     benchmark: String,
     server: String,
+    server_scope: Option<String>,
+    server_endpoint: Option<String>,
+    server_streaming: Option<bool>,
+    server_smoke: bool,
+    server_reason: Option<String>,
     claim_boundary: String,
     next_proof: String,
 }
@@ -1332,6 +1337,7 @@ fn model_status_row(device: &str, entry: &ModelCoverageEntry) -> ModelStatusRow 
     let ask = ask_status(entry);
     let one_token = dense_receipt_status(entry, "one_token");
     let short_decode = dense_receipt_status(entry, "short_decode");
+    let server = server_status(entry);
 
     ModelStatusRow {
         id: entry.id.clone(),
@@ -1359,9 +1365,67 @@ fn model_status_row(device: &str, entry: &ModelCoverageEntry) -> ModelStatusRow 
         short_decode,
         warm_session,
         benchmark,
-        server: if entry.claims.server_ready { "ready" } else { "not ready" }.to_string(),
+        server: server.label,
+        server_scope: server.scope,
+        server_endpoint: server.endpoint,
+        server_streaming: server.streaming,
+        server_smoke: server.smoke,
+        server_reason: server.reason,
         claim_boundary: entry.claim_boundary.clone(),
         next_proof: entry.next_proof.clone(),
+    }
+}
+
+struct ServerStatus {
+    label: String,
+    scope: Option<String>,
+    endpoint: Option<String>,
+    streaming: Option<bool>,
+    smoke: bool,
+    reason: Option<String>,
+}
+
+fn server_status(entry: &ModelCoverageEntry) -> ServerStatus {
+    let has_shared_engine_receipt = entry
+        .required_receipts
+        .iter()
+        .any(|receipt| receipt == "server_shared_engine_chat_completion");
+    let exact_profile_ready = entry.claims.server_ready
+        && has_shared_engine_receipt
+        && entry.claim_boundary.contains("exact-profile");
+    let server_smoke_only = !entry.claims.server_ready
+        && has_shared_engine_receipt
+        && entry.claim_boundary.contains("server-smoke evidence");
+
+    if exact_profile_ready {
+        return ServerStatus {
+            label: "exact-profile ready (/v1/chat/completions, streaming=false)".to_string(),
+            scope: Some("exact_profile".to_string()),
+            endpoint: Some("/v1/chat/completions".to_string()),
+            streaming: Some(false),
+            smoke: true,
+            reason: None,
+        };
+    }
+
+    if server_smoke_only {
+        return ServerStatus {
+            label: "smoke only, not broad-ready".to_string(),
+            scope: None,
+            endpoint: Some("/v1/chat/completions".to_string()),
+            streaming: Some(false),
+            smoke: true,
+            reason: Some("broad production readiness not qualified".to_string()),
+        };
+    }
+
+    ServerStatus {
+        label: if entry.claims.server_ready { "ready" } else { "not ready" }.to_string(),
+        scope: entry.claims.server_ready.then(|| "unspecified".to_string()),
+        endpoint: None,
+        streaming: None,
+        smoke: false,
+        reason: None,
     }
 }
 
@@ -3059,6 +3123,15 @@ mod tests {
         assert!(!bitnet.benchmark_qualified);
         assert!(!bitnet.speedup_claim);
         assert!(!bitnet.server_ready);
+        assert_eq!(bitnet.server, "smoke only, not broad-ready");
+        assert_eq!(bitnet.server_scope, None);
+        assert_eq!(bitnet.server_endpoint.as_deref(), Some("/v1/chat/completions"));
+        assert_eq!(bitnet.server_streaming, Some(false));
+        assert!(bitnet.server_smoke);
+        assert_eq!(
+            bitnet.server_reason.as_deref(),
+            Some("broad production readiness not qualified")
+        );
         assert!(!bitnet.full_residency_claim);
         assert_eq!(bitnet.ask, "ready");
         assert_eq!(bitnet.one_token, "ready");
@@ -3084,6 +3157,12 @@ mod tests {
         assert!(!dense.benchmark_qualified);
         assert!(!dense.speedup_claim);
         assert!(dense.server_ready);
+        assert_eq!(dense.server, "exact-profile ready (/v1/chat/completions, streaming=false)");
+        assert_eq!(dense.server_scope.as_deref(), Some("exact_profile"));
+        assert_eq!(dense.server_endpoint.as_deref(), Some("/v1/chat/completions"));
+        assert_eq!(dense.server_streaming, Some(false));
+        assert!(dense.server_smoke);
+        assert_eq!(dense.server_reason, None);
         assert!(!dense.full_residency_claim);
         assert_eq!(dense.one_token, "ready");
         assert_eq!(dense.short_decode, "ready");
@@ -3153,6 +3232,11 @@ mod tests {
                     && model["route"] == "dense_regular_llm_cuda"
                     && model["speedup_claim"] == false
                     && model["server_ready"] == true
+                    && model["server_scope"] == "exact_profile"
+                    && model["server_endpoint"] == "/v1/chat/completions"
+                    && model["server_streaming"] == false
+                    && model["server_smoke"] == true
+                    && model["server_reason"].is_null()
                     && model["bitnet_packed_i2s_qk256_proof"] == false
                     && model["dense_regular_llm_cuda_proof"] == true
             })
@@ -3171,8 +3255,21 @@ mod tests {
                     && model["accelerator_answer_ready"] == true
                     && model["speedup_claim"] == false
                     && model["server_ready"] == false
+                    && model["server_smoke"] == false
                     && model["bitnet_packed_i2s_qk256_proof"] == false
                     && model["dense_regular_llm_cuda_proof"] == true
+            })
+        }));
+        assert!(value["models"].as_array().is_some_and(|models| {
+            models.iter().any(|model| {
+                model["id"] == "bitnet_official_2b_i2s_qk256"
+                    && model["selected_route"] == "bitnet_qk256_cuda"
+                    && model["server_ready"] == false
+                    && model["server_scope"].is_null()
+                    && model["server_endpoint"] == "/v1/chat/completions"
+                    && model["server_streaming"] == false
+                    && model["server_smoke"] == true
+                    && model["server_reason"] == "broad production readiness not qualified"
             })
         }));
         Ok(())

--- a/docs/tutorials/cuda-receipt-triage.md
+++ b/docs/tutorials/cuda-receipt-triage.md
@@ -37,6 +37,11 @@ fallback_used
 quality gate result
 speedup_claim
 server_ready
+server_scope
+server_endpoint
+server_streaming
+server_smoke
+server_reason
 full_residency_claim
 bitnet_packed_i2s_qk256_proof
 dense_regular_llm_cuda_proof
@@ -159,6 +164,8 @@ Check:
 - selected backend;
 - fallback status;
 - model coverage row;
+- `server_smoke`, `server_scope`, `server_endpoint`, and `server_streaming`
+  from `bitnet model status --format json`;
 - response quality;
 - receipt emission path;
 - whether the row was explicitly promoted by an exact-profile readiness gate.
@@ -166,6 +173,12 @@ Check:
 Allowed claim: bounded server-smoke evidence when a receipt exists.
 Not allowed: production server readiness, global dense server readiness, or
 BitNet server readiness unless the exact route has its own receipt and row.
+
+For the RTX 5070 Ti lane, Qwen2.5 exact-profile server readiness should show
+`server_ready=true`, `server_scope=exact_profile`, endpoint
+`/v1/chat/completions`, and `server_streaming=false`. Official BitNet QK256
+server smoke should show `server_smoke=true`, `server_ready=false`, and
+`server_reason=broad production readiness not qualified`.
 
 ## If Dense Proof Is Mistaken For BitNet Proof
 

--- a/docs/tutorials/rtx5070ti-bitnet-cuda.md
+++ b/docs/tutorials/rtx5070ti-bitnet-cuda.md
@@ -52,9 +52,10 @@ For automation:
 bitnet model status --device nvidia-rtx-5070-ti-cuda --format json
 ```
 
-The BitNet row should stay scoped to `bitnet_qk256_cuda`, show server readiness
-as false until a server smoke lands, and keep speed unqualified unless a
-profile-specific benchmark review accepts it.
+The BitNet row should stay scoped to `bitnet_qk256_cuda`, show server smoke as
+bounded evidence while keeping `server_ready=false` for broad production
+readiness, and keep speed unqualified unless a profile-specific benchmark
+review accepts it.
 
 ## Verify The Model Artifact
 

--- a/docs/tutorials/rtx5070ti-dense-qwen-cuda.md
+++ b/docs/tutorials/rtx5070ti-dense-qwen-cuda.md
@@ -55,9 +55,10 @@ bitnet model status --device nvidia-rtx-5070-ti-cuda --format json
 ```
 
 The dense Qwen row should show `product_cli_ready`, route
-`dense_regular_llm_cuda`, `speedup_claim=false`, and `server_ready=true` scoped
-only to the exact shared-engine `/v1/chat/completions` profile named by the
-model coverage matrix.
+`dense_regular_llm_cuda`, `speedup_claim=false`, `server_ready=true`,
+`server_scope=exact_profile`, endpoint `/v1/chat/completions`, and
+`server_streaming=false`. That readiness is scoped only to the exact
+shared-engine profile named by the model coverage matrix.
 
 ## Verify The Model Artifact
 


### PR DESCRIPTION
## Summary
- add model-status server profile fields for exact-profile readiness and server-smoke-only states
- show Qwen2.5 as exact-profile /v1/chat/completions non-streaming ready
- show official BitNet QK256 server smoke without promoting broad server_ready
- update CUDA triage and model tutorials for the displayed fields

## Validation
- tk cargo fmt -p bitnet-cli -- --check
- tk git diff --check
- tk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc docs/tutorials/cuda-receipt-triage.md docs/tutorials/rtx5070ti-bitnet-cuda.md docs/tutorials/rtx5070ti-dense-qwen-cuda.md
- tk cargo test -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
- tk cargo run --release --locked -p xtask --no-default-features -- check-model-coverage
- direct itnet model status --device nvidia-rtx-5070-ti-cuda --format json field assertion