### PR TITLE
SERVER-READY-002: per-request receipt export

### DIFF
--- a/crates/bitnet-server/src/gpu_streaming.rs
+++ b/crates/bitnet-server/src/gpu_streaming.rs
@@ -126,6 +126,7 @@ mod tests {
                 crate::security::SecurityValidator::new(crate::security::SecurityConfig::default())
                     .unwrap(),
             ),
+            receipt_store: std::sync::Arc::new(crate::ServerReceiptStore::default()),
             metrics: std::sync::Arc::new(
                 crate::monitoring::metrics::MetricsCollector::new(
                     &crate::monitoring::MonitoringConfig::default(),

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -40,7 +40,7 @@ pub mod ws_messages;
 use anyhow::Result;
 use axum::{
     Router,
-    extract::{Request, State},
+    extract::{Path, Request, State},
     http::{HeaderMap, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
@@ -54,9 +54,11 @@ use bitnet_inference::{
     },
 };
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, VecDeque};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -85,6 +87,7 @@ const BITNET_QK256_MODEL_SHA256: &str =
 const BITNET_QK256_ROUTE: &str = "bitnet_qk256_cuda";
 const DENSE_QWEN_ROUTE: &str = "dense_regular_llm_cuda";
 const SHARED_ENGINE_ROUTE: &str = "shared_validated_local_inference_engine";
+const MAX_SERVER_RECEIPTS: usize = 128;
 
 #[derive(Deserialize)]
 pub struct InferenceRequest {
@@ -164,7 +167,22 @@ pub struct ChatCompletionResponse {
     pub model: String,
     pub choices: Vec<ChatCompletionChoice>,
     pub usage: ChatCompletionUsage,
+    pub metadata: ChatCompletionResponseMetadata,
     pub receipt: ServerSharedEngineReceipt,
+}
+
+/// Trace metadata attached to an OpenAI-compatible chat response.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChatCompletionResponseMetadata {
+    pub receipt_id: String,
+    pub receipt_path: String,
+    pub latest_receipt_path: String,
+    pub readiness_path: String,
+    pub model_coverage_row: Option<String>,
+    pub model_coverage_tier: Option<String>,
+    pub selected_backend: String,
+    pub selected_route: String,
+    pub fallback_used: bool,
 }
 
 /// OpenAI-compatible chat completion choice.
@@ -226,6 +244,74 @@ pub struct ServerSharedEngineReceipt {
     pub full_cuda_residency_claimed: bool,
     pub dense_regular_llm_cuda_inference_claimed: bool,
     pub bitnet_packed_i2s_qk256_proof: bool,
+}
+
+impl ChatCompletionResponseMetadata {
+    fn from_receipt(receipt: &ServerSharedEngineReceipt) -> Self {
+        Self {
+            receipt_id: receipt.request_id.clone(),
+            receipt_path: format!("/receipts/{}", receipt.request_id),
+            latest_receipt_path: "/receipts/latest".to_string(),
+            readiness_path: "/readiness".to_string(),
+            model_coverage_row: receipt.model_coverage_row.clone(),
+            model_coverage_tier: receipt.model_coverage_tier.clone(),
+            selected_backend: receipt.selected_backend.clone(),
+            selected_route: receipt.selected_route.clone(),
+            fallback_used: receipt.fallback_used,
+        }
+    }
+}
+
+/// Bounded in-memory receipt export store for server request receipts.
+#[derive(Debug, Default)]
+pub struct ServerReceiptStore {
+    inner: RwLock<ServerReceiptStoreInner>,
+}
+
+#[derive(Debug, Default)]
+struct ServerReceiptStoreInner {
+    receipts: BTreeMap<String, ServerSharedEngineReceipt>,
+    order: VecDeque<String>,
+    latest: Option<String>,
+}
+
+impl ServerReceiptStore {
+    pub async fn insert(&self, receipt: ServerSharedEngineReceipt) {
+        let receipt_id = receipt.request_id.clone();
+        let mut inner = self.inner.write().await;
+
+        if inner.receipts.contains_key(&receipt_id) {
+            inner.order.retain(|known| known != &receipt_id);
+        }
+
+        inner.receipts.insert(receipt_id.clone(), receipt);
+        inner.order.push_back(receipt_id.clone());
+        inner.latest = Some(receipt_id);
+
+        while inner.order.len() > MAX_SERVER_RECEIPTS {
+            if let Some(evicted) = inner.order.pop_front() {
+                inner.receipts.remove(&evicted);
+            }
+        }
+    }
+
+    pub async fn latest(&self) -> Option<ServerSharedEngineReceipt> {
+        let inner = self.inner.read().await;
+        inner.latest.as_ref().and_then(|receipt_id| inner.receipts.get(receipt_id)).cloned()
+    }
+
+    pub async fn get(&self, receipt_id: &str) -> Option<ServerSharedEngineReceipt> {
+        let inner = self.inner.read().await;
+        inner.receipts.get(receipt_id).cloned()
+    }
+}
+
+/// Stable error body for receipt lookup endpoints.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReceiptLookupError {
+    pub error_code: String,
+    pub error: String,
+    pub receipt_id: Option<String>,
 }
 
 /// Stable model identity attached to a server shared-engine receipt.
@@ -378,6 +464,9 @@ pub struct ServerReadinessActiveModel {
     pub model_id: String,
     pub model_path: String,
     pub model_sha256: Option<String>,
+    pub model_coverage_row: Option<String>,
+    pub model_coverage_tier: Option<String>,
+    pub selected_route: Option<String>,
     pub device: String,
     pub quantization_type: String,
     pub size_mb: u64,
@@ -423,6 +512,7 @@ pub struct BitNetServer {
     batch_engine: Arc<BatchEngine>,
     concurrency_manager: Arc<ConcurrencyManager>,
     security_validator: Arc<SecurityValidator>,
+    receipt_store: Arc<ServerReceiptStore>,
     monitoring: Arc<MonitoringSystem>,
     health_checker: Arc<HealthChecker>,
     #[cfg(feature = "prometheus")]
@@ -468,6 +558,9 @@ impl BitNetServer {
         // Initialize security validator
         let security_validator = Arc::new(SecurityValidator::new(config.security.clone())?);
 
+        // Initialize bounded per-request receipt export store
+        let receipt_store = Arc::new(ServerReceiptStore::default());
+
         // Load default model if specified
         if let Some(model_path) = &config.server.default_model_path {
             let device = config.server.default_device.resolve();
@@ -498,6 +591,7 @@ impl BitNetServer {
             batch_engine,
             concurrency_manager,
             security_validator,
+            receipt_store,
             monitoring,
             health_checker,
             #[cfg(feature = "prometheus")]
@@ -539,6 +633,7 @@ impl BitNetServer {
             batch_engine: Arc::clone(&self.batch_engine),
             concurrency_manager: Arc::clone(&self.concurrency_manager),
             security_validator: Arc::clone(&self.security_validator),
+            receipt_store: Arc::clone(&self.receipt_store),
             metrics: self.monitoring.metrics(),
             start_time: self.start_time,
         };
@@ -559,6 +654,8 @@ impl BitNetServer {
             .route("/v1/devices", get(device_status_handler))
             .route("/readiness", get(server_readiness_handler))
             .route("/v1/readiness", get(server_readiness_handler))
+            .route("/receipts/latest", get(latest_receipt_handler))
+            .route("/receipts/{receipt_id}", get(receipt_by_id_handler))
             // GPU streaming endpoint
             .route("/api/v1/generate/stream", post(gpu_streaming::gpu_stream_handler))
             // Root endpoint
@@ -662,6 +759,7 @@ pub struct ProductionAppState {
     pub batch_engine: Arc<BatchEngine>,
     pub concurrency_manager: Arc<ConcurrencyManager>,
     pub security_validator: Arc<SecurityValidator>,
+    pub receipt_store: Arc<ServerReceiptStore>,
     pub metrics: Arc<MetricsCollector>,
     pub start_time: Instant,
 }
@@ -955,6 +1053,8 @@ async fn chat_completions_handler(
         )
         .as_ref(),
     );
+    let metadata = ChatCompletionResponseMetadata::from_receipt(&receipt);
+    state.receipt_store.insert(receipt.clone()).await;
     let response = ChatCompletionResponse {
         id: format!("chatcmpl-{request_id}"),
         object: "chat.completion".to_string(),
@@ -966,6 +1066,7 @@ async fn chat_completions_handler(
             finish_reason: "stop".to_string(),
         }],
         usage,
+        metadata,
         receipt,
     };
 
@@ -1290,6 +1391,7 @@ fn server_receipt_generation_policy(
 struct ServerReceiptModelCoverage {
     row: &'static str,
     tier: &'static str,
+    route: &'static str,
 }
 
 fn server_receipt_route(
@@ -1319,14 +1421,53 @@ fn server_receipt_model_coverage(
         return Some(ServerReceiptModelCoverage {
             row: "dense_qwen25_05b_q8_cuda",
             tier: "product_cli_ready",
+            route: DENSE_QWEN_ROUTE,
         });
     }
     if route == BITNET_QK256_ROUTE && is_official_bitnet_qk256_model(request, active_model) {
         return Some(ServerReceiptModelCoverage {
             row: "bitnet_official_2b_i2s_qk256",
             tier: "product_cli_ready",
+            route: BITNET_QK256_ROUTE,
         });
     }
+    None
+}
+
+fn server_model_coverage_for_active_model(
+    configured_device: &DeviceConfig,
+    active_model: &model_manager::ModelMetadata,
+) -> Option<ServerReceiptModelCoverage> {
+    if !matches!(configured_device, DeviceConfig::NvidiaRtx5070TiCuda) {
+        return None;
+    }
+
+    if active_model_device_is_cuda(active_model)
+        && active_model
+            .model_sha256
+            .as_deref()
+            .is_some_and(|sha256| sha256.eq_ignore_ascii_case(DENSE_QWEN25_Q8_MODEL_SHA256))
+    {
+        return Some(ServerReceiptModelCoverage {
+            row: "dense_qwen25_05b_q8_cuda",
+            tier: "product_cli_ready",
+            route: DENSE_QWEN_ROUTE,
+        });
+    }
+
+    if active_model_device_is_cuda(active_model)
+        && active_model
+            .model_sha256
+            .as_deref()
+            .is_some_and(|sha256| sha256.eq_ignore_ascii_case(BITNET_QK256_MODEL_SHA256))
+    {
+        return Some(ServerReceiptModelCoverage {
+            row: "bitnet_official_2b_i2s_qk256",
+            tier: "product_cli_ready",
+            route: BITNET_QK256_ROUTE,
+        });
+    }
+
     None
 }
 
@@ -1528,6 +1669,67 @@ async fn device_status_handler(
     Json(statuses)
 }
 
+/// Latest per-request receipt handler.
+async fn latest_receipt_handler(State(state): State<ProductionAppState>) -> Response {
+    match state.receipt_store.latest().await {
+        Some(receipt) => Json(receipt).into_response(),
+        None => receipt_lookup_error(
+            StatusCode::NOT_FOUND,
+            "NO_RECEIPTS",
+            "no server request receipts have been captured yet",
+            None,
+        ),
+    }
+}
+
+/// Per-request receipt lookup handler.
+async fn receipt_by_id_handler(
+    State(state): State<ProductionAppState>,
+    Path(receipt_id): Path<String>,
+) -> Response {
+    if !valid_server_receipt_id(&receipt_id) {
+        return receipt_lookup_error(
+            StatusCode::BAD_REQUEST,
+            "INVALID_RECEIPT_ID",
+            "receipt id must be 1-128 ASCII letters, digits, '-' or '_' characters",
+            Some(receipt_id),
+        );
+    }
+
+    match state.receipt_store.get(&receipt_id).await {
+        Some(receipt) => Json(receipt).into_response(),
+        None => receipt_lookup_error(
+            StatusCode::NOT_FOUND,
+            "RECEIPT_NOT_FOUND",
+            "server request receipt was not found",
+            Some(receipt_id),
+        ),
+    }
+}
+
+fn receipt_lookup_error(
+    status: StatusCode,
+    error_code: &str,
+    error: &str,
+    receipt_id: Option<String>,
+) -> Response {
+    (
+        status,
+        Json(ServerReceiptLookupError {
+            error_code: error_code.to_string(),
+            error: error.to_string(),
+            receipt_id,
+        }),
+    )
+        .into_response()
+}
+
+fn valid_server_receipt_id(receipt_id: &str) -> bool {
+    !receipt_id.is_empty()
+        && receipt_id.len() <= 128
+        && receipt_id.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+}
+
 /// Readiness and certification handler.
 async fn server_readiness_handler(
     State(state): State<ProductionAppState>,
@@ -1555,6 +1757,7 @@ async fn collect_server_readiness_response(state: &ProductionAppState) -> Server
         active_model,
         state.config.server.default_model_path.is_some(),
         state.config.server.default_device.backend_label(),
+        &state.config.server.default_device,
         state.config.execution_router.fallback_enabled,
         device_statuses,
         selected_backend,
@@ -1566,20 +1769,27 @@ fn build_server_readiness_response(
     active_model: Option<model_manager::ModelMetadata>,
     default_model_configured: bool,
     requested_default_device: String,
+    configured_device: &DeviceConfig,
     configured_fallback_enabled: bool,
     device_statuses: Vec<execution_router::DeviceStatus>,
     selected_backend_label: Option<String>,
 ) -> ServerReadinessResponse {
     let real_server_inference_ready = active_model_supports_shared_inference(active_model.as_ref());
-    let active_model_summary = active_model.as_ref().map(|metadata| ServerReadinessActiveModel {
-        model_id: metadata.model_id.clone(),
-        model_path: metadata.model_path.clone(),
-        model_sha256: metadata.model_sha256.clone(),
-        device: metadata.device.clone(),
-        quantization_type: metadata.quantization_type.clone(),
-        size_mb: metadata.size_mb,
-        parameters: metadata.parameters,
-        context_length: metadata.context_length,
+    let active_model_summary = active_model.as_ref().map(|metadata| {
+        let coverage = server_model_coverage_for_active_model(configured_device, metadata);
+        ServerReadinessActiveModel {
+            model_id: metadata.model_id.clone(),
+            model_path: metadata.model_path.clone(),
+            model_sha256: metadata.model_sha256.clone(),
+            model_coverage_row: coverage.as_ref().map(|coverage| coverage.row.to_string()),
+            model_coverage_tier: coverage.as_ref().map(|coverage| coverage.tier.to_string()),
+            selected_route: coverage.as_ref().map(|coverage| coverage.route.to_string()),
+            device: metadata.device.clone(),
+            quantization_type: metadata.quantization_type.clone(),
+            size_mb: metadata.size_mb,
+            parameters: metadata.parameters,
+            context_length: metadata.context_length,
+        }
     });
     let selected_backend = active_model.as_ref().and(selected_backend_label);
 
@@ -1805,14 +2015,136 @@ fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChatCompletionMessage, ChatCompletionRequest, ChatCompletionUsage, DeviceConfig,
+        BitNetServer, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponseMetadata,
+        ChatCompletionUsage, DeviceConfig, ServerConfig, ServerReceiptStore,
         build_server_readiness_response, build_server_shared_engine_receipt,
         generation_config_from_chat_request, parse_device, render_chat_completion_prompt,
     };
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
     use bitnet_common::Device;
+    use serde_json::Value;
     use std::time::SystemTime;
+    use tower::ServiceExt;
 
     use crate::model_manager::{ModelMemoryStats, ModelMetadata};
+
+    fn qwen25_server_receipt(request_id: &str) -> super::ServerSharedEngineReceipt {
+        let request = ChatCompletionRequest {
+            model: "qwen2.5-0.5b-instruct-q8_0".to_string(),
+            messages: vec![ChatCompletionMessage {
+                role: "user".to_string(),
+                content: "What is working capital?".to_string(),
+            }],
+            max_tokens: Some(16),
+            temperature: Some(0.0),
+            top_p: Some(1.0),
+            stream: Some(false),
+        };
+        let usage =
+            ChatCompletionUsage { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 };
+        let metadata = ModelMetadata {
+            model_id: "qwen2.5-0.5b-instruct-q8_0".to_string(),
+            model_path: "models/qwen2.5-0.5b-q8_0.gguf".to_string(),
+            model_sha256: Some(
+                "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e".to_string(),
+            ),
+            device: "Cuda(0)".to_string(),
+            quantization_type: "Q8_0".to_string(),
+            loaded_at: SystemTime::UNIX_EPOCH,
+            size_mb: 512,
+            parameters: 500_000_000,
+            context_length: 32_768,
+            inference_count: 0,
+            avg_tokens_per_second: 0.0,
+        };
+
+        build_server_shared_engine_receipt(
+            request_id,
+            &request,
+            &metadata,
+            &DeviceConfig::NvidiaRtx5070TiCuda,
+            "chatml",
+            &usage,
+            "Working capital is current assets minus current liabilities.",
+            25,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn server_receipt_store_exports_latest_and_by_id() {
+        let store = ServerReceiptStore::default();
+        let first = qwen25_server_receipt("receipt-1");
+        let second = qwen25_server_receipt("receipt-2");
+
+        store.insert(first).await;
+        store.insert(second).await;
+
+        let latest = store.latest().await.expect("latest receipt");
+        assert_eq!(latest.request_id, "receipt-2");
+        assert_eq!(latest.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+
+        let by_id = store.get("receipt-1").await.expect("receipt by id");
+        assert_eq!(by_id.request_id, "receipt-1");
+        assert_eq!(by_id.selected_route, "dense_regular_llm_cuda");
+    }
+
+    #[tokio::test]
+    async fn server_receipt_endpoints_fail_closed_without_receipts() {
+        let server = BitNetServer::new(ServerConfig::default()).await.expect("server init");
+        let app = server.create_app();
+
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri("/receipts/latest").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.expect("body read");
+        let json: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["error_code"], "NO_RECEIPTS");
+
+        let resp = app
+            .oneshot(Request::builder().uri("/receipts/bad.id").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.expect("body read");
+        let json: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["error_code"], "INVALID_RECEIPT_ID");
+    }
+
+    #[tokio::test]
+    async fn server_receipt_endpoints_export_seeded_receipt() {
+        let server = BitNetServer::new(ServerConfig::default()).await.expect("server init");
+        server.receipt_store.insert(qwen25_server_receipt("receipt-1")).await;
+        let app = server.create_app();
+
+        let latest = app
+            .clone()
+            .oneshot(Request::builder().uri("/receipts/latest").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(latest.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(latest.into_body(), usize::MAX).await.expect("body read");
+        let json: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["request_id"], "receipt-1");
+        assert_eq!(json["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
+        assert_eq!(json["server_ready_claimed"], false);
+
+        let by_id = app
+            .oneshot(Request::builder().uri("/receipts/receipt-1").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(by_id.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(by_id.into_body(), usize::MAX).await.expect("body read");
+        let json: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["request_id"], "receipt-1");
+        assert_eq!(json["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+    }
 
     #[test]
     fn parse_device_supports_vulkan_and_opencl_aliases() {
@@ -1841,6 +2173,7 @@ mod tests {
             None,
             false,
             "Auto".to_string(),
+            &DeviceConfig::Auto,
             true,
             Vec::new(),
             None,
@@ -1886,6 +2219,7 @@ mod tests {
             }),
             true,
             "gpu".to_string(),
+            &DeviceConfig::Gpu(0),
             false,
             Vec::new(),
             Some("Cuda(0)".to_string()),
@@ -1896,6 +2230,10 @@ mod tests {
         assert_eq!(response.reason, None);
         assert!(response.model.default_model_configured);
         assert_eq!(response.model.active_model_id.as_deref(), Some("model-1"));
+        let active_model = response.model.active_model.as_ref().expect("active model");
+        assert!(active_model.model_coverage_row.is_none());
+        assert!(active_model.model_coverage_tier.is_none());
+        assert!(active_model.selected_route.is_none());
         assert_eq!(response.backend.selected_backend.as_deref(), Some("Cuda(0)"));
         assert!(!response.backend.configured_fallback_enabled);
         assert!(response.inference.real_server_inference_ready);
@@ -1905,6 +2243,48 @@ mod tests {
         assert!(!response.claim_boundary.server_ready_claimed);
         assert!(!response.claim_boundary.dense_regular_llm_cuda_inference_claimed);
         assert!(!response.claim_boundary.bitnet_packed_i2s_qk256_proof);
+        assert!(!response.claim_boundary.speedup_claim);
+        assert!(!response.claim_boundary.full_cuda_residency_claimed);
+    }
+
+    #[test]
+    fn server_readiness_links_exact_profile_model_coverage_row() {
+        let response = build_server_readiness_response(
+            ModelMemoryStats {
+                total_models: 1,
+                total_size_mb: 512,
+                active_model_id: Some("model-1".to_string()),
+                cache_size_limit: 3,
+                memory_limit_gb: Some(16.0),
+            },
+            Some(ModelMetadata {
+                model_id: "model-1".to_string(),
+                model_path: "models/qwen2.5-0.5b-q8_0.gguf".to_string(),
+                model_sha256: Some(
+                    "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e".to_string(),
+                ),
+                device: "Cuda(0)".to_string(),
+                quantization_type: "Q8_0".to_string(),
+                loaded_at: SystemTime::UNIX_EPOCH,
+                size_mb: 512,
+                parameters: 500_000_000,
+                context_length: 32_768,
+                inference_count: 0,
+                avg_tokens_per_second: 0.0,
+            }),
+            true,
+            "nvidia-rtx-5070-ti-cuda".to_string(),
+            &DeviceConfig::NvidiaRtx5070TiCuda,
+            false,
+            Vec::new(),
+            Some("nvidia-rtx-5070-ti-cuda".to_string()),
+        );
+
+        let active_model = response.model.active_model.as_ref().expect("active model");
+        assert_eq!(active_model.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+        assert_eq!(active_model.model_coverage_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(active_model.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert!(!response.claim_boundary.server_ready_claimed);
         assert!(!response.claim_boundary.speedup_claim);
         assert!(!response.claim_boundary.full_cuda_residency_claimed);
     }
@@ -2101,6 +2481,17 @@ mod tests {
         assert!(!receipt.speedup_claim);
         assert!(receipt.dense_regular_llm_cuda_inference_claimed);
         assert!(!receipt.bitnet_packed_i2s_qk256_proof);
+
+        let metadata = ChatCompletionResponseMetadata::from_receipt(&receipt);
+        assert_eq!(metadata.receipt_id, "request-1");
+        assert_eq!(metadata.receipt_path, "/receipts/request-1");
+        assert_eq!(metadata.latest_receipt_path, "/receipts/latest");
+        assert_eq!(metadata.readiness_path, "/readiness");
+        assert_eq!(metadata.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+        assert_eq!(metadata.model_coverage_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(metadata.selected_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(metadata.selected_route, "dense_regular_llm_cuda");
+        assert!(!metadata.fallback_used);
     }
 
     #[test]

--- a/crates/bitnet-server/src/streaming.rs
+++ b/crates/bitnet-server/src/streaming.rs
@@ -297,6 +297,7 @@ mod tests {
                 crate::security::SecurityValidator::new(crate::security::SecurityConfig::default())
                     .unwrap(),
             ),
+            receipt_store: Arc::new(crate::ServerReceiptStore::default()),
             metrics: Arc::new(
                 crate::monitoring::metrics::MetricsCollector::new(
                     &crate::monitoring::MonitoringConfig::default(),

--- a/docs/api/v1/inference.json
+++ b/docs/api/v1/inference.json
@@ -191,6 +191,192 @@
       }
     },
 
+    "ChatCompletionResponseMetadata": {
+      "type": "object",
+      "required": [
+        "receipt_id",
+        "receipt_path",
+        "latest_receipt_path",
+        "readiness_path",
+        "selected_backend",
+        "selected_route",
+        "fallback_used"
+      ],
+      "properties": {
+        "receipt_id": {
+          "type": "string"
+        },
+        "receipt_path": {
+          "type": "string",
+          "pattern": "^/receipts/[A-Za-z0-9_-]+$"
+        },
+        "latest_receipt_path": {
+          "type": "string",
+          "const": "/receipts/latest"
+        },
+        "readiness_path": {
+          "type": "string",
+          "const": "/readiness"
+        },
+        "model_coverage_row": {
+          "type": ["string", "null"]
+        },
+        "model_coverage_tier": {
+          "type": ["string", "null"]
+        },
+        "selected_backend": {
+          "type": "string"
+        },
+        "selected_route": {
+          "type": "string"
+        },
+        "fallback_used": {
+          "type": "boolean"
+        }
+      }
+    },
+
+    "ServerSharedEngineReceipt": {
+      "type": "object",
+      "required": [
+        "receipt_kind",
+        "request_id",
+        "runtime_path",
+        "runtime_api",
+        "requested_model",
+        "active_model_id",
+        "selected_backend",
+        "requested_backend",
+        "selected_route",
+        "fallback_used",
+        "server_ready_claimed",
+        "speedup_claim",
+        "full_cuda_residency_claimed"
+      ],
+      "properties": {
+        "receipt_kind": {
+          "type": "string",
+          "const": "server_shared_engine_chat_completion"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "runtime_path": {
+          "type": "string",
+          "const": "shared_local_inference_engine"
+        },
+        "runtime_api": {
+          "type": "string"
+        },
+        "model_coverage_row": {
+          "type": ["string", "null"]
+        },
+        "model_coverage_tier": {
+          "type": ["string", "null"]
+        },
+        "selected_backend": {
+          "type": "string"
+        },
+        "requested_backend": {
+          "type": "string"
+        },
+        "selected_route": {
+          "type": "string"
+        },
+        "fallback_used": {
+          "type": "boolean"
+        },
+        "server_smoke_response_claimed": {
+          "type": "boolean"
+        },
+        "server_ready_claimed": {
+          "type": "boolean",
+          "const": false
+        },
+        "speedup_claim": {
+          "type": "boolean",
+          "const": false
+        },
+        "full_cuda_residency_claimed": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+
+    "ServerReceiptLookupError": {
+      "type": "object",
+      "required": ["error_code", "error", "receipt_id"],
+      "properties": {
+        "error_code": {
+          "type": "string",
+          "enum": ["NO_RECEIPTS", "INVALID_RECEIPT_ID", "RECEIPT_NOT_FOUND"]
+        },
+        "error": {
+          "type": "string"
+        },
+        "receipt_id": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+
+    "ServerReadinessResponse": {
+      "type": "object",
+      "required": ["ready", "status", "model", "backend", "inference", "claim_boundary"],
+      "properties": {
+        "ready": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ready", "not_ready"]
+        },
+        "model": {
+          "type": "object",
+          "properties": {
+            "active_model": {
+              "type": ["object", "null"],
+              "properties": {
+                "model_coverage_row": {
+                  "type": ["string", "null"]
+                },
+                "model_coverage_tier": {
+                  "type": ["string", "null"]
+                },
+                "selected_route": {
+                  "type": ["string", "null"]
+                }
+              }
+            }
+          }
+        },
+        "backend": {
+          "type": "object"
+        },
+        "inference": {
+          "type": "object"
+        },
+        "claim_boundary": {
+          "type": "object",
+          "properties": {
+            "server_ready_claimed": {
+              "type": "boolean",
+              "const": false
+            },
+            "speedup_claim": {
+              "type": "boolean",
+              "const": false
+            },
+            "full_cuda_residency_claimed": {
+              "type": "boolean",
+              "const": false
+            }
+          }
+        }
+      }
+    },
+
     "Error": {
       "type": "object",
       "required": ["code", "message"],
@@ -225,6 +411,70 @@
           "items": {
             "$ref": "#/definitions/ModelConfig"
           }
+        }
+      }
+    },
+    "/readiness": {
+      "GET": {
+        "description": "Server readiness and claim-boundary state with active model coverage linkage when available",
+        "response": {
+          "$ref": "#/definitions/ServerReadinessResponse"
+        }
+      }
+    },
+    "/v1/readiness": {
+      "GET": {
+        "description": "Versioned alias for server readiness and claim-boundary state",
+        "response": {
+          "$ref": "#/definitions/ServerReadinessResponse"
+        }
+      }
+    },
+    "/receipts/latest": {
+      "GET": {
+        "description": "Return the latest in-memory server shared-engine receipt",
+        "response": {
+          "$ref": "#/definitions/ServerSharedEngineReceipt"
+        },
+        "errors": {
+          "$ref": "#/definitions/ServerReceiptLookupError"
+        }
+      }
+    },
+    "/receipts/{receipt_id}": {
+      "GET": {
+        "description": "Return a captured server shared-engine receipt by request/receipt id",
+        "parameters": {
+          "receipt_id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,128}$"
+          }
+        },
+        "response": {
+          "$ref": "#/definitions/ServerSharedEngineReceipt"
+        },
+        "errors": {
+          "$ref": "#/definitions/ServerReceiptLookupError"
+        }
+      }
+    },
+    "/v1/chat/completions": {
+      "POST": {
+        "description": "OpenAI-compatible non-streaming chat completion with receipt metadata and embedded server receipt",
+        "response": {
+          "type": "object",
+          "required": ["id", "object", "created", "model", "choices", "usage", "metadata", "receipt"],
+          "properties": {
+            "metadata": {
+              "$ref": "#/definitions/ChatCompletionResponseMetadata"
+            },
+            "receipt": {
+              "$ref": "#/definitions/ServerSharedEngineReceipt"
+            }
+          }
+        },
+        "errors": {
+          "$ref": "#/definitions/Error"
         }
       }
     },

--- a/docs/tutorials/cuda-receipt-triage.md
+++ b/docs/tutorials/cuda-receipt-triage.md
@@ -51,6 +51,35 @@ claim boundary / not allowed claims
 
 Do not paste private paths, tokens, credentials, or model files.
 
+## Server Response Metadata
+
+For `/v1/chat/completions`, the response metadata links the response to the
+same receipt that is embedded in the response body:
+
+```json
+{
+  "metadata": {
+    "receipt_id": "uuid",
+    "receipt_path": "/receipts/uuid",
+    "latest_receipt_path": "/receipts/latest",
+    "readiness_path": "/readiness",
+    "model_coverage_row": "dense_qwen25_05b_q8_cuda",
+    "model_coverage_tier": "product_cli_ready",
+    "selected_backend": "nvidia-rtx-5070-ti-cuda",
+    "selected_route": "dense_regular_llm_cuda",
+    "fallback_used": false
+  }
+}
+```
+
+Use these server endpoints for support triage:
+
+- `GET /receipts/latest`: latest retained server shared-engine receipt.
+- `GET /receipts/{receipt_id}`: retained receipt by response metadata id.
+- `GET /readiness`: readiness and claim-boundary state.
+- `GET /v1/readiness`: versioned readiness alias.
+- `GET /v1/models`: loaded model inventory.
+
 ## If `fallback_used=true`
 
 The run is not strict RTX 5070 Ti CUDA proof. Treat it as a rejected or


### PR DESCRIPTION
## Summary
- attach receipt metadata to /v1/chat/completions responses (eceipt_id, /receipts/{id}, /receipts/latest, /readiness, model coverage row/tier, backend/route, fallback)
- add a bounded in-memory server receipt store and expose GET /receipts/latest plus GET /receipts/{receipt_id}
- link /readiness active-model state to exact artifact model coverage row/tier/route when the loaded CUDA artifact matches a recognized profile
- document the contract in docs/api/v1/inference.json and CUDA receipt triage docs

## Claim boundaries
- no second inference engine
- no new server_ready promotion
- no speedup or full-residency claim

## Validation
- tk cargo fmt -p bitnet-server -- --check
- tk git diff --check
- tk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc docs/tutorials/cuda-receipt-triage.md
- tk powershell -NoProfile -Command 'Get-Content -Raw docs/api/v1/inference.json | ConvertFrom-Json | Out-Null'
- tk cargo test -p bitnet-server --no-default-features --features cpu server_receipt
- tk cargo test -p bitnet-server --no-default-features --features cpu server_readiness
- tk cargo test -p bitnet-server --no-default-features --features cpu server_shared_engine_receipt
- tk cargo test -p bitnet-server --no-default-features --features cpu (1351 passed)