### PR TITLE
diag(reference): capture selected query pre-rope source

### DIFF
--- a/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
+++ b/ci/reference-instrumentation/bitnet-rs-layer-trace-main.patch
@@ -4,9 +4,8 @@
 # Created: 2026-05-15
 # Review-By: 2026-06-15
 # Author: BitNet-rs maintainers
-
 diff --git a/src/llama.cpp b/src/llama.cpp
-index 666fcc4d..23ee29ff 100644
+index 666fcc4d..f3fe764a 100644
 --- a/src/llama.cpp
 +++ b/src/llama.cpp
 @@ -74,9 +74,11 @@
@@ -29,7 +28,7 @@ index 666fcc4d..23ee29ff 100644
  #include <numeric>
  #include <set>
  #include <sstream>
-@@ -3441,6 +3444,1738 @@ struct llama_context {
+@@ -3441,6 +3444,1877 @@ struct llama_context {
      struct ggml_tensor * inp_KQ_mask_cross; // F32 [n_outputs_enc, n_batch]
  };
  
@@ -746,6 +745,129 @@ index 666fcc4d..23ee29ff 100644
 +    }
 +}
 +
++static void bitnet_rs_reference_layer_trace_write_query_projection_history_records(
++    std::ostream & out,
++    struct ggml_tensor * tensor,
++    const std::vector<float> & values,
++    int graph_index,
++    int layer,
++    uint32_t n_tokens,
++    int64_t head_dim,
++    int64_t head_count,
++    int64_t query_dim
++) {
++    if (tensor == nullptr || n_tokens == 0 || head_dim <= 0 || head_count <= 0 || query_dim <= 0) {
++        return;
++    }
++    const int64_t token_capacity = tensor->ne[1];
++    const int64_t token_count = token_capacity < (int64_t) n_tokens ? token_capacity : (int64_t) n_tokens;
++    const int64_t source_nelements = ggml_nelements(tensor);
++    if (tensor->ne[0] != query_dim || token_count <= 0 || head_dim * head_count > query_dim || (size_t) source_nelements > values.size()) {
++        return;
++    }
++    const size_t source_nbytes = ggml_nbytes(tensor);
++    const char * source_name = ggml_get_name(tensor);
++    for (int64_t head = 0; head < head_count; ++head) {
++        const int64_t head_nelements = head_dim * token_count;
++        double head_sum = 0.0;
++        double head_sq_sum = 0.0;
++        double head_min = std::numeric_limits<double>::infinity();
++        double head_max = -std::numeric_limits<double>::infinity();
++        std::vector<float> head_values;
++        head_values.reserve((size_t) head_nelements);
++        bool complete = true;
++        for (int64_t dim = 0; dim < head_dim; ++dim) {
++            for (int64_t token = 0; token < token_count; ++token) {
++                const int64_t source_index = head * head_dim + dim + query_dim * token;
++                if (source_index < 0 || source_index >= source_nelements || (size_t) source_index >= values.size()) {
++                    complete = false;
++                    break;
++                }
++                const float value_f32 = values[(size_t) source_index];
++                const double value = value_f32;
++                head_values.push_back(value_f32);
++                head_sum += value;
++                head_sq_sum += value * value;
++                head_min = value < head_min ? value : head_min;
++                head_max = value > head_max ? value : head_max;
++            }
++            if (!complete) {
++                break;
++            }
++        }
++        if (!complete || (int64_t) head_values.size() != head_nelements) {
++            continue;
++        }
++        const uint64_t head_hash = bitnet_rs_reference_layer_trace_hash(head_values);
++        const double head_mean = head_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : head_sum / (double) head_nelements;
++        const double head_rms = head_nelements <= 0 ? std::numeric_limits<double>::quiet_NaN() : std::sqrt(head_sq_sum / (double) head_nelements);
++        std::ostringstream head_name;
++        head_name << "q_projection_history_head" << head << "_ref_layout-" << layer;
++        std::ostringstream head_stage;
++        head_stage << "q_projection_history_head" << head << "_ref_layout";
++        out << ",{";
++        out << "\"graph_index\":" << graph_index;
++        out << ",\"name\":";
++        bitnet_rs_reference_layer_trace_json_string(out, head_name.str().c_str());
++        out << ",\"stage\":";
++        bitnet_rs_reference_layer_trace_json_string(out, head_stage.str().c_str());
++        out << ",\"layer\":" << layer;
++        out << ",\"graph_op\":";
++        bitnet_rs_reference_layer_trace_json_string(out, ggml_op_name(tensor->op));
++        out << ",\"graph_sources\":[";
++        bool first_source = true;
++        for (int src_i = 0; src_i < GGML_MAX_SRC; ++src_i) {
++            struct ggml_tensor * graph_source = tensor->src[src_i];
++            if (graph_source == nullptr) {
++                continue;
++            }
++            if (!first_source) {
++                out << ",";
++            }
++            bitnet_rs_reference_layer_trace_write_tensor_provenance(out, graph_source);
++            first_source = false;
++        }
++        out << "]";
++        out << ",\"view_source\":";
++        bitnet_rs_reference_layer_trace_write_tensor_provenance(out, tensor->view_src);
++        out << ",\"view_offset\":" << tensor->view_offs;
++        out << ",\"dtype\":";
++        bitnet_rs_reference_layer_trace_json_string(out, ggml_type_name(tensor->type));
++        out << ",\"shape\":[" << head_dim << "," << token_count << ",1,1]";
++        out << ",\"nelements\":" << head_nelements;
++        out << ",\"full_shape\":[" << tensor->ne[0] << "," << tensor->ne[1] << "," << tensor->ne[2] << "," << tensor->ne[3] << "]";
++        out << ",\"full_nelements\":" << source_nelements;
++        out << ",\"token_axis\":-1";
++        out << ",\"sample_offset\":0";
++        out << ",\"head_index\":" << head;
++        out << ",\"source_tensor_name\":";
++        bitnet_rs_reference_layer_trace_json_string(out, source_name);
++        out << ",\"layout\":\"dim_major_token_minor\"";
++        out << ",\"nbytes\":" << source_nbytes;
++        out << ",\"contiguous\":" << (ggml_is_contiguous(tensor) ? "true" : "false");
++        out << ",\"values_available\":true";
++        out << ",\"values_unavailable_reason\":null";
++        out << ",\"stats\":{\"mean\":";
++        bitnet_rs_reference_layer_trace_json_number(out, head_mean);
++        out << ",\"rms\":";
++        bitnet_rs_reference_layer_trace_json_number(out, head_rms);
++        out << ",\"min\":";
++        bitnet_rs_reference_layer_trace_json_number(out, head_min);
++        out << ",\"max\":";
++        bitnet_rs_reference_layer_trace_json_number(out, head_max);
++        out << ",\"fnv1a64\":\"" << std::hex << head_hash << std::dec << "\"}";
++        out << ",\"first_values\":[";
++        const size_t head_sample_count = bitnet_rs_reference_layer_trace_first_values_limit((size_t) head_nelements);
++        for (size_t i = 0; i < head_sample_count; ++i) {
++            if (i > 0) {
++                out << ",";
++            }
++            bitnet_rs_reference_layer_trace_json_number(out, head_values[i]);
++        }
++        out << "]}";
++    }
++}
++
 +static bool bitnet_rs_reference_layer_trace_is_warmup(
 +    llama_context & lctx,
 +    const llama_ubatch & ubatch,
@@ -1048,6 +1170,22 @@ index 666fcc4d..23ee29ff 100644
 +        bitnet_rs_qcur_history_stage != nullptr
 +        && strcmp(bitnet_rs_qcur_history_stage, "Qcur") == 0
 +        && bitnet_rs_qcur_history_layer == bitnet_rs_requested_history_layer;
++    if (bitnet_rs_is_requested_qcur_history && values_available && n_tokens > 0 && tensor->ne[0] > 0 && tensor->ne[1] >= (int64_t) n_tokens && tensor->ne[2] <= 1) {
++        const auto & hparams = lctx.model.hparams;
++        const int64_t head_dim = hparams.n_embd_head_k;
++        const int64_t head_count = hparams.n_head((uint32_t) bitnet_rs_qcur_history_layer);
++        const int64_t query_dim = hparams.n_embd;
++        bitnet_rs_reference_layer_trace_write_query_projection_history_records(
++            out,
++            tensor,
++            values,
++            graph_index,
++            bitnet_rs_qcur_history_layer,
++            n_tokens,
++            head_dim,
++            head_count,
++            query_dim);
++    }
 +    if (bitnet_rs_is_requested_qcur_history && values_available && n_tokens > 0 && tensor->ne[0] > 0 && tensor->ne[1] > 0 && tensor->ne[2] >= (int64_t) n_tokens) {
 +        const int64_t head_dim = tensor->ne[0];
 +        const int64_t head_count = tensor->ne[1];
@@ -1768,7 +1906,7 @@ index 666fcc4d..23ee29ff 100644
  struct llama_lora_weight {
      struct ggml_tensor * a = nullptr;
      struct ggml_tensor * b = nullptr;
-@@ -9505,6 +10858,14 @@ static struct ggml_tensor * llm_build_norm(
+@@ -9506,7 +11380,15 @@ static struct ggml_tensor * llm_build_norm(
      }
  
      if (mw || mb) {
@@ -1783,7 +1921,8 @@ index 666fcc4d..23ee29ff 100644
 +        }
      }
  
-@@ -15460,6 +16816,7 @@ struct ggml_cgraph * build_bitnet_158() {
+     if (mw) {
+@@ -15461,6 +17343,7 @@ struct llm_build_context {
                  cur = llm_build_kv(ctx0, lctx, kv_self, gf,
                          NULL, NULL,
                          Kcur, Vcur, Qcur, KQ_mask, n_tokens, kv_head, n_kv, 1.0f/sqrtf(float(n_embd_head)), cb, il);
@@ -1791,7 +1930,7 @@ index 666fcc4d..23ee29ff 100644
              
                  cur = llm_build_norm(ctx0, cur, hparams,
                          model.layers[il].attn_sub_norm, NULL,
-@@ -17655,8 +18881,37 @@ static int llama_decode_internal(
+@@ -17655,8 +19538,37 @@ static int llama_decode_internal(
  
          llama_set_inputs(lctx, ubatch);
  
@@ -1829,7 +1968,6 @@ index 666fcc4d..23ee29ff 100644
          // update the kv ring buffer
          {
              kv_self.head += n_tokens;
-
 diff --git a/ggml/src/ggml.c b/ggml/src/ggml.c
 index 121f72da..02ddfd91 100644
 --- a/ggml/src/ggml.c

--- a/xtask/src/bitnet_reference_layer_trace.rs
+++ b/xtask/src/bitnet_reference_layer_trace.rs
@@ -31828,8 +31828,14 @@ fn selected_query_pre_score_rope_source_next_diagnostic(classification: &str) ->
         "selected_query_pre_score_rope_source_rust_capture_precision" => {
             "pin Rust selected query post-RoPE capture precision before changing query RoPE math"
         }
-        "selected_query_pre_score_rope_source_pinned" => {
-            "selected query pre-score RoPE source is pinned; rerun f64 score-input residual attribution"
+        "selected_query_pre_score_rope_source_pre_rope_projection_bucket" => {
+            "localize selected query projection/input source bucket before changing query RoPE math"
+        }
+        "selected_query_pre_score_rope_source_pre_rope_projection_epsilon" => {
+            "quantify selected query pre-RoPE projection epsilon before changing query RoPE math"
+        }
+        "selected_query_pre_score_rope_source_rope_numeric_policy" => {
+            "reference and Rust selected query pre-RoPE values align; localize selected query RoPE numeric policy"
         }
         "selected_query_pre_score_rope_source_not_active" => {
             "localize selected query score-input bucket source before pre-score RoPE source attribution"
@@ -31850,12 +31856,28 @@ fn reference_query_pre_rope_candidate_count(reference_records: &[ReferenceTraceR
             let stage = record.stage.as_str();
             record.values_available
                 && !record.first_values.is_empty()
-                && stage.contains('q')
-                && (stage.contains("pre_rope")
-                    || stage.contains("q_projection")
-                    || stage.contains("query_projection"))
+                && (stage.starts_with("q_projection_history_head")
+                    || (stage.contains('q')
+                        && (stage.contains("pre_rope")
+                            || stage.contains("q_projection")
+                            || stage.contains("query_projection"))))
         })
         .count()
+}
+
+fn reference_query_pre_rope_selected_value(
+    reference_records: &[ReferenceTraceRecord],
+    head: usize,
+    dim: usize,
+    token: usize,
+) -> Option<f32> {
+    let stage = format!("q_projection_history_head{head}_ref_layout");
+    let record = reference_records.iter().find(|record| {
+        record.stage == stage && record.values_available && !record.first_values.is_empty()
+    })?;
+    let token_count = usize::try_from(*record.shape.get(1)?).ok()?;
+    let index = dim.checked_mul(token_count)?.checked_add(token)?;
+    record.first_values.get(index).copied()
 }
 
 fn rust_query_flat_selected_value(
@@ -31966,8 +31988,31 @@ fn attention_selected_f64_query_pre_score_rope_source(
         .is_some_and(|(flat, history)| flat.to_bits() == history.to_bits());
     let reference_pre_rope_candidate_count =
         reference_query_pre_rope_candidate_count(reference_records);
-    let active =
+    let reference_pre_rope =
+        head.zip(selected_dim).zip(selected_token).and_then(|((head, dim), token)| {
+            reference_query_pre_rope_selected_value(reference_records, head, dim, token)
+        });
+    let source_boundary = selected_query_source
+        .pointer("/query_boundary_first_material_boundary")
+        .and_then(Value::as_str);
+    let exact_reference_to_rope_bucket = selected_query_source
+        .pointer("/reference_to_rust_rope/exact_selected_bucket")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let source_classification_active =
         source_classification == Some("selected_query_score_input_bucket_source_reference_to_rope");
+    let source_boundary_active = source_classification
+        == Some("selected_query_score_input_bucket_source_missing_context")
+        && source_boundary == Some("reference_to_rust_query_rope")
+        && exact_reference_to_rope_bucket;
+    let active = source_classification_active || source_boundary_active;
+    let pre_rope_bucket_crossing =
+        reference_pre_rope.zip(rust_pre_rope).is_some_and(|(reference, rust)| {
+            f32_to_f16_bits_nearest_even(reference) != f32_to_f16_bits_nearest_even(rust)
+        });
+    let pre_rope_matches = reference_pre_rope
+        .zip(rust_pre_rope)
+        .is_some_and(|(reference, rust)| reference.to_bits() == rust.to_bits());
 
     let mut blocked_reasons = Vec::<String>::new();
     if !active {
@@ -32006,10 +32051,14 @@ fn attention_selected_f64_query_pre_score_rope_source(
         "selected_query_pre_score_rope_source_rust_trace_view_layout"
     } else if !rust_history_matches_boundary {
         "selected_query_pre_score_rope_source_rust_capture_precision"
-    } else if reference_pre_rope_candidate_count == 0 {
+    } else if reference_pre_rope.is_none() {
         "selected_query_pre_score_rope_source_reference_pre_rope_missing"
+    } else if pre_rope_bucket_crossing {
+        "selected_query_pre_score_rope_source_pre_rope_projection_bucket"
+    } else if !pre_rope_matches {
+        "selected_query_pre_score_rope_source_pre_rope_projection_epsilon"
     } else {
-        "selected_query_pre_score_rope_source_pinned"
+        "selected_query_pre_score_rope_source_rope_numeric_policy"
     };
 
     json!({
@@ -32018,25 +32067,33 @@ fn attention_selected_f64_query_pre_score_rope_source(
         "policy": "Selected f64 query pre-score RoPE source is diagnostic-only evidence for whether the selected query bucket has enough Rust pre-RoPE/post-RoPE trace binding and reference pre-RoPE source binding; it does not change runtime math and does not promote reference parity, A770 semantic quality, attention score residency, selected attention, resident KV, softmax residency, value-mix residency, full residency, performance, or completion",
         "classification": classification,
         "selected_query_source_classification": source_classification,
+        "selected_query_source_boundary": source_boundary,
+        "selected_query_source_classification_active": source_classification_active,
+        "selected_query_source_boundary_active": source_boundary_active,
         "head": head,
         "selected_dim": selected_dim,
         "selected_token": selected_token,
         "head_dim": head_dim,
         "reference_pre_rope_candidate_count": reference_pre_rope_candidate_count,
-        "reference_pre_rope_available": reference_pre_rope_candidate_count > 0,
+        "reference_pre_rope_available": reference_pre_rope.is_some(),
+        "reference_pre_rope_stage": head.map(|head| format!("q_projection_history_head{head}_ref_layout")),
         "rust_pre_rope_stage": "attention_q",
         "rust_rope_flat_stage": "attention_q_rope",
         "rust_rope_history_stage": head.map(|head| format!("attention_q_rope_head{head}_history_ref_layout")),
+        "reference_pre_rope_value": selected_query_value_bits(reference_pre_rope),
         "rust_pre_rope_value": selected_query_value_bits(rust_pre_rope),
         "rust_rope_flat_value": selected_query_value_bits(rust_rope_flat),
         "rust_rope_history_value": selected_query_value_bits(rust_rope_history),
         "boundary_reference_value": boundary_reference_value,
         "boundary_rust_value": boundary_rust_value,
+        "reference_pre_rope_to_rust_pre_rope_abs_delta": value_delta_abs(reference_pre_rope, rust_pre_rope),
         "rust_pre_rope_to_rope_abs_delta": value_delta_abs(rust_pre_rope, rust_rope_history),
         "rust_rope_flat_to_history_abs_delta": value_delta_abs(rust_rope_flat, rust_rope_history),
         "rust_rope_history_to_boundary_abs_delta": rust_rope_history.zip(boundary_rust_value).map(|(value, boundary)| (f64::from(value) - boundary).abs()),
+        "pre_rope_f16_bucket": reference_pre_rope.zip(rust_pre_rope).map(|(reference, rust)| f16_bucket_pair_probe(reference, rust)),
         "rust_flat_matches_history": rust_flat_matches_history,
         "rust_history_matches_boundary": rust_history_matches_boundary,
+        "reference_pre_rope_matches_rust_pre_rope": pre_rope_matches,
         "source_row": selected_query_source.clone(),
         "blocked_reasons": blocked_reasons,
         "next_diagnostic": selected_query_pre_score_rope_source_next_diagnostic(classification),
@@ -48021,6 +48078,17 @@ mod tests {
         records
     }
 
+    fn selected_query_reference_pre_rope_records(pre_rope: f32) -> Vec<ReferenceTraceRecord> {
+        let mut first_values = vec![0.0; 128 * 18];
+        first_values[69 * 18 + 17] = pre_rope;
+        let mut record =
+            test_reference_trace_record("q_projection_history_head5_ref_layout", first_values);
+        record.shape = vec![128, 18, 1, 1];
+        record.full_shape = vec![128, 18, 1, 1];
+        record.nelements = (128 * 18) as u64;
+        vec![record]
+    }
+
     #[test]
     fn selected_query_pre_score_rope_source_reports_reference_pre_rope_missing() {
         let selected_source = selected_query_source_fixture();
@@ -48047,6 +48115,88 @@ mod tests {
                 "capture reference selected query pre-RoPE projection/source operands before changing Rust query RoPE or score-input math"
             ))
         );
+    }
+
+    #[test]
+    fn selected_query_pre_score_rope_source_reports_pre_rope_projection_bucket() {
+        let selected_source = selected_query_source_fixture();
+        let reference_records = selected_query_reference_pre_rope_records(0.75);
+        let records =
+            selected_query_rust_records(0.751, -0.2525635361671448_f32, -0.2525635361671448_f32);
+
+        let report = attention_selected_f64_query_pre_score_rope_source(
+            &selected_source,
+            &reference_records,
+            &records,
+        );
+
+        assert_eq!(
+            report.pointer("/classification"),
+            Some(&json!("selected_query_pre_score_rope_source_pre_rope_projection_bucket"))
+        );
+        assert_eq!(report.pointer("/reference_pre_rope_available"), Some(&json!(true)));
+        assert_eq!(report.pointer("/reference_pre_rope_candidate_count"), Some(&json!(1)));
+        assert_eq!(report.pointer("/pre_rope_f16_bucket/f16_bucket_match"), Some(&json!(false)));
+        assert_eq!(
+            report.pointer("/next_diagnostic"),
+            Some(&json!(
+                "localize selected query projection/input source bucket before changing query RoPE math"
+            ))
+        );
+    }
+
+    #[test]
+    fn selected_query_pre_score_rope_source_reports_rope_numeric_policy() {
+        let selected_source = selected_query_source_fixture();
+        let reference_records = selected_query_reference_pre_rope_records(0.75);
+        let records =
+            selected_query_rust_records(0.75, -0.2525635361671448_f32, -0.2525635361671448_f32);
+
+        let report = attention_selected_f64_query_pre_score_rope_source(
+            &selected_source,
+            &reference_records,
+            &records,
+        );
+
+        assert_eq!(
+            report.pointer("/classification"),
+            Some(&json!("selected_query_pre_score_rope_source_rope_numeric_policy"))
+        );
+        assert_eq!(report.pointer("/reference_pre_rope_matches_rust_pre_rope"), Some(&json!(true)));
+        assert_eq!(
+            report.pointer("/next_diagnostic"),
+            Some(&json!(
+                "reference and Rust selected query pre-RoPE values align; localize selected query RoPE numeric policy"
+            ))
+        );
+    }
+
+    #[test]
+    fn selected_query_pre_score_rope_source_uses_boundary_when_source_missing_context() {
+        let mut selected_source = selected_query_source_fixture();
+        selected_source["classification"] =
+            json!("selected_query_score_input_bucket_source_missing_context");
+        selected_source["query_boundary_first_material_boundary"] =
+            json!("reference_to_rust_query_rope");
+        let reference_records = selected_query_reference_pre_rope_records(0.75);
+        let records = selected_query_rust_records(
+            0.7500001,
+            -0.2525635361671448_f32,
+            -0.2525635361671448_f32,
+        );
+
+        let report = attention_selected_f64_query_pre_score_rope_source(
+            &selected_source,
+            &reference_records,
+            &records,
+        );
+
+        assert_eq!(
+            report.pointer("/classification"),
+            Some(&json!("selected_query_pre_score_rope_source_pre_rope_projection_epsilon"))
+        );
+        assert_eq!(report.pointer("/selected_query_source_boundary_active"), Some(&json!(true)));
+        assert_eq!(report.pointer("/blocked_reasons"), Some(&json!([])));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend the reference layer-trace patch to emit per-head `q_projection_history_headN_ref_layout` records for requested `Qcur` tensors
- consume those reference pre-RoPE query projection histories in `bitnet-reference-layer-trace-compare`
- keep the selected-query source diagnostic active when the selected boundary is `reference_to_rust_query_rope`, even if the broader f64 residual remains missing-context

## Live diagnostic result
Refreshed compare stays diagnostic-only and reports:

```text
attention_selected_f64_query_pre_score_rope_source.classification = selected_query_pre_score_rope_source_pre_rope_projection_epsilon
head = 5
selected_dim = 69
selected_token = 17
reference_pre_rope_stage = q_projection_history_head5_ref_layout
reference_pre_rope_to_rust_pre_rope_abs_delta = 1.1920928955078125e-7
pre_rope_f16_bucket.f16_bucket_match = true
rust_flat_matches_history = true
rust_history_matches_boundary = true
claim_allowed = false
```

Interpretation: the selected reference/Rust pre-RoPE query operands differ by a tiny non-bucket epsilon. The selected F16 bucket crossing still appears after RoPE, so this PR does not justify a runtime math change.

## Claim boundary
No runtime math changes. No promotion of reference parity, A770 semantic quality, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full residency, performance, or completion.

## Validation
```text
cargo test --locked -p xtask --no-default-features --bin xtask bitnet_reference_layer_trace -- --nocapture
cargo check --locked -p xtask --no-default-features
rustfmt --edition 2024 --check xtask\src\bitnet_reference_layer_trace.rs
git diff --check
git -C target\external\BitNet-reference\3rdparty\llama.cpp apply --check E:\Code\Rust\BitNet-rs\ci\reference-instrumentation\bitnet-rs-layer-trace-main.patch
```