### PR TITLE
qk256: add hot-path instrumentation and expose qk256_hot_path in receipts

### DIFF
--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -320,6 +320,7 @@ impl AnswerCorpusCommand {
             aggregate_case_str(&rows, &["kernel", "selected_kernel"])
                 .unwrap_or(&top_level_runtime_api)
                 .to_string();
+        let aggregate_qk256_hot_path = aggregate_qk256_hot_path(&rows, self.cpu_kernel);
         let top_level_backend_lane =
             answer_corpus_backend_lane(&device, slm_answer_path, &top_level_model_family);
         let answer_ready_artifact_available = corpus_answer_ready_artifact_available(&corpus.model);
@@ -344,6 +345,7 @@ impl AnswerCorpusCommand {
             "tokenizer_source": top_level_tokenizer_source,
             "prompt_template": corpus.defaults.prompt_template.as_str(),
             "selected_kernel_or_runtime": top_level_selected_kernel_or_runtime,
+            "qk256_hot_path": aggregate_qk256_hot_path,
             "corpus": {
                 "id": corpus.corpus_id(),
                 "path": self.corpus.display().to_string(),
@@ -680,6 +682,8 @@ impl AnswerCorpusCommand {
             "latency": run_receipt.get("latency").cloned().unwrap_or(Value::Null),
             "throughput": run_receipt.get("throughput").cloned().unwrap_or(Value::Null),
             "execution_plan": run_receipt.get("execution_plan").cloned().unwrap_or(Value::Null),
+            "execution_coverage": run_receipt.get("execution_coverage").cloned().unwrap_or(Value::Null),
+            "qk256_hot_path": run_receipt.get("qk256_hot_path").cloned().unwrap_or(Value::Null),
             "kernel": {
                 "selected_kernel": run_receipt["kernel"]["kernel_id"].clone(),
                 "family": run_receipt["kernel"]["family"].clone(),
@@ -2768,6 +2772,99 @@ fn value_at<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
 
 fn is_sha256_hex(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn aggregate_qk256_hot_path(rows: &[Value], cpu_kernel: Option<AnswerCpuKernel>) -> Value {
+    let mut f32_avx2 = 0u64;
+    let mut f32_scalar = 0u64;
+    let mut scaled_avx2 = 0u64;
+    let mut scaled_scalar = 0u64;
+    let mut flat = 0u64;
+    let mut input_rows = 0u64;
+    let mut output_rows = 0u64;
+
+    for row in rows {
+        let hot_path = &row["qk256_hot_path"];
+        f32_avx2 +=
+            hot_path["invocations"]["qk256_f32_avx2_gemv_invocations"].as_u64().unwrap_or(0);
+        f32_scalar +=
+            hot_path["invocations"]["qk256_f32_scalar_gemv_invocations"].as_u64().unwrap_or(0);
+        scaled_avx2 +=
+            hot_path["invocations"]["qk256_i8s_scaled_avx2_invocations"].as_u64().unwrap_or(0);
+        scaled_scalar +=
+            hot_path["invocations"]["qk256_i8s_scaled_scalar_invocations"].as_u64().unwrap_or(0);
+        flat +=
+            hot_path["materialization"]["qk256_flat_bytes_extracted_count"].as_u64().unwrap_or(0);
+        input_rows +=
+            hot_path["materialization"]["input_rows_materialized_count"].as_u64().unwrap_or(0);
+        output_rows +=
+            hot_path["materialization"]["output_rows_allocated_count"].as_u64().unwrap_or(0);
+    }
+
+    let scaled = scaled_avx2 + scaled_scalar;
+    let f32 = f32_avx2 + f32_scalar;
+    let path = if scaled > 0 && f32 > 0 {
+        "mixed_scaled_i8s_and_no_scale_f32"
+    } else if scaled > 0 {
+        "scaled_i2s_i8s"
+    } else if f32 > 0 {
+        "no_scale_f32"
+    } else {
+        "not_observed"
+    };
+    let selected_kernel = if scaled_avx2 > 0 {
+        "qk256-avx2-i2s-i8s-gemv"
+    } else if scaled_scalar > 0 {
+        "qk256-scalar-i2s-i8s-gemv"
+    } else if f32_avx2 > 0 {
+        "qk256-avx2-gemv"
+    } else if f32_scalar > 0 {
+        "qk256-scalar-gemv"
+    } else {
+        "not_observed"
+    };
+    let requested_kernel = match cpu_kernel {
+        Some(AnswerCpuKernel::Avx2) if scaled > 0 => "qk256-avx2-i2s-i8s-gemv",
+        Some(AnswerCpuKernel::Avx2) => "qk256-avx2-gemv",
+        Some(AnswerCpuKernel::Scalar) if scaled > 0 => "qk256-scalar-i2s-i8s-gemv",
+        Some(AnswerCpuKernel::Scalar) => "qk256-scalar-gemv",
+        Some(AnswerCpuKernel::Avx512) if scaled > 0 => "qk256-avx512-i2s-i8s-gemv",
+        Some(AnswerCpuKernel::Avx512) => "qk256-avx512-gemv",
+        None => "auto",
+    };
+    let fallback_used = matches!(requested_kernel, "qk256-avx2-i2s-i8s-gemv" | "qk256-avx2-gemv")
+        && selected_kernel.contains("scalar");
+    let fallback_reason = if fallback_used && selected_kernel == "qk256-scalar-i2s-i8s-gemv" {
+        Some(
+            "scaled I2_S×I8_S AVX2 kernel not implemented or not wired; inline-scale path used scalar oracle",
+        )
+    } else if fallback_used {
+        Some("requested AVX2 QK256 kernel selected scalar execution")
+    } else {
+        None
+    };
+
+    json!({
+        "requested_kernel": requested_kernel,
+        "selected_kernel": selected_kernel,
+        "path": path,
+        "scaled_vs_no_scale_path": path,
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
+        "speedup_claim": false,
+        "invocations": {
+            "qk256_f32_avx2_gemv_invocations": f32_avx2,
+            "qk256_f32_scalar_gemv_invocations": f32_scalar,
+            "qk256_i8s_scaled_avx2_invocations": scaled_avx2,
+            "qk256_i8s_scaled_scalar_invocations": scaled_scalar
+        },
+        "materialization": {
+            "qk256_flat_bytes_extracted_count": flat,
+            "input_rows_materialized_count": input_rows,
+            "output_rows_allocated_count": output_rows,
+            "tensor_to_vec_weight_copies_per_token": Value::Null
+        }
+    })
 }
 
 fn aggregate_execution_plan(rows: &[Value], device: &str) -> Value {

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -5341,9 +5341,17 @@ async fn run_simple_generation(
                 "bitnet_linear_layers_total": bitnet_linear_coverage.bitnet_linear_layers_total,
                 "bitnet_linear_layers_on_cuda": bitnet_linear_coverage.bitnet_linear_layers_on_cuda,
                 "bitnet_linear_layers_cpu_fallback": bitnet_linear_coverage.bitnet_linear_layers_cpu_fallback,
+                "qk256_f32_avx2_gemv_invocations": bitnet_linear_coverage.qk256_f32_avx2_gemv_invocations,
+                "qk256_f32_scalar_gemv_invocations": bitnet_linear_coverage.qk256_f32_scalar_gemv_invocations,
+                "qk256_i8s_scaled_avx2_invocations": bitnet_linear_coverage.qk256_i8s_scaled_avx2_invocations,
+                "qk256_i8s_scaled_scalar_invocations": bitnet_linear_coverage.qk256_i8s_scaled_scalar_invocations,
+                "qk256_flat_bytes_extracted_count": bitnet_linear_coverage.qk256_flat_bytes_extracted_count,
+                "input_rows_materialized_count": bitnet_linear_coverage.input_rows_materialized_count,
+                "output_rows_allocated_count": bitnet_linear_coverage.output_rows_allocated_count,
                 "unsupported_ops": bitnet_linear_coverage.unsupported_ops.clone(),
                 "execution_claim": bitnet_linear_coverage.execution_claim,
             },
+            "qk256_hot_path": qk256_hot_path_receipt(&bitnet_linear_coverage),
             "kernel": {
                 "family": kernel_family,
                 "implementation": kernel_implementation,
@@ -7481,6 +7489,27 @@ fn qk256_dispatch_coverage_delta(
             .difference(&unsupported_before)
             .cloned()
             .collect::<Vec<_>>(),
+        qk256_f32_scalar_gemv_invocations: after
+            .qk256_f32_scalar_gemv_invocations
+            .saturating_sub(before.qk256_f32_scalar_gemv_invocations),
+        qk256_f32_avx2_gemv_invocations: after
+            .qk256_f32_avx2_gemv_invocations
+            .saturating_sub(before.qk256_f32_avx2_gemv_invocations),
+        qk256_i8s_scaled_scalar_invocations: after
+            .qk256_i8s_scaled_scalar_invocations
+            .saturating_sub(before.qk256_i8s_scaled_scalar_invocations),
+        qk256_i8s_scaled_avx2_invocations: after
+            .qk256_i8s_scaled_avx2_invocations
+            .saturating_sub(before.qk256_i8s_scaled_avx2_invocations),
+        qk256_flat_bytes_extracted_count: after
+            .qk256_flat_bytes_extracted_count
+            .saturating_sub(before.qk256_flat_bytes_extracted_count),
+        input_rows_materialized_count: after
+            .input_rows_materialized_count
+            .saturating_sub(before.input_rows_materialized_count),
+        output_rows_allocated_count: after
+            .output_rows_allocated_count
+            .saturating_sub(before.output_rows_allocated_count),
         execution_claim: if after.bitnet_linear_layers_on_cuda > before.bitnet_linear_layers_on_cuda
         {
             "cuda_inference_contribution"
@@ -7491,6 +7520,83 @@ fn qk256_dispatch_coverage_delta(
 }
 
 #[cfg(feature = "full-cli")]
+fn qk256_hot_path_receipt(
+    coverage: &bitnet_qk256_dispatch::Qk256DispatchCoverageCounters,
+) -> serde_json::Value {
+    let scaled_invocations =
+        coverage.qk256_i8s_scaled_scalar_invocations + coverage.qk256_i8s_scaled_avx2_invocations;
+    let f32_invocations =
+        coverage.qk256_f32_scalar_gemv_invocations + coverage.qk256_f32_avx2_gemv_invocations;
+    let path = if scaled_invocations > 0 && f32_invocations > 0 {
+        "mixed_scaled_i8s_and_no_scale_f32"
+    } else if scaled_invocations > 0 {
+        "scaled_i2s_i8s"
+    } else if f32_invocations > 0 {
+        "no_scale_f32"
+    } else {
+        "not_observed"
+    };
+    let selected_kernel = if coverage.qk256_i8s_scaled_avx2_invocations > 0 {
+        "qk256-avx2-i2s-i8s-gemv"
+    } else if coverage.qk256_i8s_scaled_scalar_invocations > 0 {
+        "qk256-scalar-i2s-i8s-gemv"
+    } else if coverage.qk256_f32_avx2_gemv_invocations > 0 {
+        "qk256-avx2-gemv"
+    } else if coverage.qk256_f32_scalar_gemv_invocations > 0 {
+        "qk256-scalar-gemv"
+    } else {
+        "not_observed"
+    };
+    let requested_kernel = match std::env::var("BITNET_CPU_KERNEL")
+        .ok()
+        .as_deref()
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("avx2") if scaled_invocations > 0 => "qk256-avx2-i2s-i8s-gemv",
+        Some("avx2") => "qk256-avx2-gemv",
+        Some("scalar") if scaled_invocations > 0 => "qk256-scalar-i2s-i8s-gemv",
+        Some("scalar") => "qk256-scalar-gemv",
+        Some("avx512") if scaled_invocations > 0 => "qk256-avx512-i2s-i8s-gemv",
+        Some("avx512") => "qk256-avx512-gemv",
+        _ => "auto",
+    };
+    let fallback_used = matches!(requested_kernel, "qk256-avx2-i2s-i8s-gemv" | "qk256-avx2-gemv")
+        && selected_kernel.contains("scalar");
+    let fallback_reason = if fallback_used && selected_kernel == "qk256-scalar-i2s-i8s-gemv" {
+        Some(
+            "scaled I2_S×I8_S AVX2 kernel not implemented or not wired; inline-scale path used scalar oracle",
+        )
+    } else if fallback_used {
+        Some("requested AVX2 QK256 kernel selected scalar execution")
+    } else {
+        None
+    };
+
+    serde_json::json!({
+        "requested_kernel": requested_kernel,
+        "selected_kernel": selected_kernel,
+        "path": path,
+        "scaled_vs_no_scale_path": path,
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
+        "speedup_claim": false,
+        "invocations": {
+            "qk256_f32_avx2_gemv_invocations": coverage.qk256_f32_avx2_gemv_invocations,
+            "qk256_f32_scalar_gemv_invocations": coverage.qk256_f32_scalar_gemv_invocations,
+            "qk256_i8s_scaled_avx2_invocations": coverage.qk256_i8s_scaled_avx2_invocations,
+            "qk256_i8s_scaled_scalar_invocations": coverage.qk256_i8s_scaled_scalar_invocations
+        },
+        "materialization": {
+            "qk256_flat_bytes_extracted_count": coverage.qk256_flat_bytes_extracted_count,
+            "input_rows_materialized_count": coverage.input_rows_materialized_count,
+            "output_rows_allocated_count": coverage.output_rows_allocated_count,
+            "tensor_to_vec_weight_copies_per_token": serde_json::Value::Null
+        }
+    })
+}
+
+#[cfg(feature = "full-cli")]
 fn qk256_dispatch_coverage_receipt(
     coverage: &bitnet_qk256_dispatch::Qk256DispatchCoverageCounters,
 ) -> serde_json::Value {
@@ -7498,6 +7604,13 @@ fn qk256_dispatch_coverage_receipt(
         "bitnet_linear_layers_total": coverage.bitnet_linear_layers_total,
         "bitnet_linear_layers_on_cuda": coverage.bitnet_linear_layers_on_cuda,
         "bitnet_linear_layers_cpu_fallback": coverage.bitnet_linear_layers_cpu_fallback,
+        "qk256_f32_avx2_gemv_invocations": coverage.qk256_f32_avx2_gemv_invocations,
+        "qk256_f32_scalar_gemv_invocations": coverage.qk256_f32_scalar_gemv_invocations,
+        "qk256_i8s_scaled_avx2_invocations": coverage.qk256_i8s_scaled_avx2_invocations,
+        "qk256_i8s_scaled_scalar_invocations": coverage.qk256_i8s_scaled_scalar_invocations,
+        "qk256_flat_bytes_extracted_count": coverage.qk256_flat_bytes_extracted_count,
+        "input_rows_materialized_count": coverage.input_rows_materialized_count,
+        "output_rows_allocated_count": coverage.output_rows_allocated_count,
         "unsupported_ops": coverage.unsupported_ops,
         "execution_claim": coverage.execution_claim,
     })
@@ -12503,6 +12616,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 42,
             bitnet_linear_layers_cpu_fallback: 0,
             unsupported_ops: Vec::new(),
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
         let residency = bitnet_qk256_dispatch::Qk256CudaWeightResidency {
@@ -12546,6 +12666,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 1,
             bitnet_linear_layers_cpu_fallback: 1,
             unsupported_ops: vec!["qk256_cpu_fallback".to_string()],
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
 
@@ -12588,6 +12715,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 4,
             bitnet_linear_layers_cpu_fallback: 0,
             unsupported_ops: Vec::new(),
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
         let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
@@ -12615,6 +12749,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 4,
             bitnet_linear_layers_cpu_fallback: 0,
             unsupported_ops: Vec::new(),
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
         let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -26,6 +26,13 @@ static CUDA_QK256_HOST_TO_DEVICE_BYTES: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_DEVICE_TO_HOST_BYTES: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_KERNEL_TIME_MICROS: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_KERNEL_TIME_SAMPLES: AtomicU64 = AtomicU64::new(0);
+static QK256_F32_SCALAR_GEMV_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_F32_AVX2_GEMV_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_I8S_SCALED_SCALAR_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_I8S_SCALED_AVX2_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_FLAT_BYTES_EXTRACTED_COUNT: AtomicU64 = AtomicU64::new(0);
+static QK256_INPUT_ROWS_MATERIALIZED_COUNT: AtomicU64 = AtomicU64::new(0);
+static QK256_OUTPUT_ROWS_ALLOCATED_COUNT: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(feature = "cuda")]
 thread_local! {
@@ -43,6 +50,20 @@ pub struct Qk256DispatchCoverageCounters {
     pub bitnet_linear_layers_cpu_fallback: u64,
     /// Unsupported operations that prevent a full CUDA inference claim.
     pub unsupported_ops: Vec<String>,
+    /// No-scale F32 QK256 GEMV invocations that selected the scalar kernel.
+    pub qk256_f32_scalar_gemv_invocations: u64,
+    /// No-scale F32 QK256 GEMV invocations that selected the AVX2/FMA kernel.
+    pub qk256_f32_avx2_gemv_invocations: u64,
+    /// Inline-scaled BitNet I2_S×I8_S GEMV invocations that used the scalar oracle.
+    pub qk256_i8s_scaled_scalar_invocations: u64,
+    /// Inline-scaled BitNet I2_S×I8_S GEMV invocations that used an AVX2/FMA implementation.
+    pub qk256_i8s_scaled_avx2_invocations: u64,
+    /// Count of QK256 flat byte materializations from Candle tensors.
+    pub qk256_flat_bytes_extracted_count: u64,
+    /// Count of dense activation rows materialized as Rust `Vec<f32>` buffers.
+    pub input_rows_materialized_count: u64,
+    /// Count of output rows allocated as Rust `Vec<f32>` buffers.
+    pub output_rows_allocated_count: u64,
     /// Human-readable claim boundary for partial routing.
     pub execution_claim: &'static str,
 }
@@ -89,6 +110,16 @@ pub fn qk256_dispatch_coverage() -> Qk256DispatchCoverageCounters {
         bitnet_linear_layers_on_cuda: on_cuda,
         bitnet_linear_layers_cpu_fallback: cpu_fallback,
         unsupported_ops,
+        qk256_f32_scalar_gemv_invocations: QK256_F32_SCALAR_GEMV_INVOCATIONS
+            .load(Ordering::Relaxed),
+        qk256_f32_avx2_gemv_invocations: QK256_F32_AVX2_GEMV_INVOCATIONS.load(Ordering::Relaxed),
+        qk256_i8s_scaled_scalar_invocations: QK256_I8S_SCALED_SCALAR_INVOCATIONS
+            .load(Ordering::Relaxed),
+        qk256_i8s_scaled_avx2_invocations: QK256_I8S_SCALED_AVX2_INVOCATIONS
+            .load(Ordering::Relaxed),
+        qk256_flat_bytes_extracted_count: QK256_FLAT_BYTES_EXTRACTED_COUNT.load(Ordering::Relaxed),
+        input_rows_materialized_count: QK256_INPUT_ROWS_MATERIALIZED_COUNT.load(Ordering::Relaxed),
+        output_rows_allocated_count: QK256_OUTPUT_ROWS_ALLOCATED_COUNT.load(Ordering::Relaxed),
         execution_claim: if on_cuda > 0 {
             "cuda_inference_contribution"
         } else if cuda_bitnet_backend_requested() {
@@ -112,6 +143,13 @@ pub fn reset_qk256_dispatch_coverage() {
     CUDA_QK256_DEVICE_TO_HOST_BYTES.store(0, Ordering::Relaxed);
     CUDA_QK256_KERNEL_TIME_MICROS.store(0, Ordering::Relaxed);
     CUDA_QK256_KERNEL_TIME_SAMPLES.store(0, Ordering::Relaxed);
+    QK256_F32_SCALAR_GEMV_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_F32_AVX2_GEMV_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_I8S_SCALED_SCALAR_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_I8S_SCALED_AVX2_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_FLAT_BYTES_EXTRACTED_COUNT.store(0, Ordering::Relaxed);
+    QK256_INPUT_ROWS_MATERIALIZED_COUNT.store(0, Ordering::Relaxed);
+    QK256_OUTPUT_ROWS_ALLOCATED_COUNT.store(0, Ordering::Relaxed);
     reset_cuda_qk256_context();
 }
 
@@ -217,13 +255,14 @@ fn forward_qk256_cpu(
     weight_name: &str,
     inline_scale: Option<f32>,
 ) -> Result<Tensor> {
-    use bitnet_quantization::i2s_qk256::{gemv_qk256, gemv_qk256_bitnet_i8s_scaled};
+    use bitnet_quantization::i2s_qk256::{
+        QK256_AVX2_GEMV_KERNEL_ID, gemv_qk256_bitnet_i8s_scaled, gemv_qk256_with_kernel_selection,
+    };
 
     let prepared = prepare_qk256_forward(input, qk256_tensor, weight_name)?;
-    let mut output_rows = vec![
-        vec![0.0f32; prepared.layout.rows];
-        prepared.shape.batch_size * prepared.shape.seq_len
-    ];
+    let output_row_count = prepared.shape.batch_size * prepared.shape.seq_len;
+    QK256_OUTPUT_ROWS_ALLOCATED_COUNT.fetch_add(output_row_count as u64, Ordering::Relaxed);
+    let mut output_rows = vec![vec![0.0f32; prepared.layout.rows]; output_row_count];
 
     if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && weight_name.contains("layers.0.")
     {
@@ -242,6 +281,7 @@ fn forward_qk256_cpu(
 
     for (row_index, input_row) in prepared.input_rows.iter().enumerate() {
         let gemv_result = if let Some(scale) = inline_scale {
+            QK256_I8S_SCALED_SCALAR_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
             gemv_qk256_bitnet_i8s_scaled(
                 &prepared.flat_bytes,
                 input_row,
@@ -252,14 +292,23 @@ fn forward_qk256_cpu(
                 scale,
             )
         } else {
-            gemv_qk256(
+            gemv_qk256_with_kernel_selection(
                 &prepared.flat_bytes,
                 input_row,
                 &mut output_rows[row_index],
                 prepared.layout.rows,
                 prepared.layout.cols,
                 prepared.layout.row_stride_bytes,
+                None,
+                false,
             )
+            .map(|selection| {
+                if selection.selected_kernel == QK256_AVX2_GEMV_KERNEL_ID {
+                    QK256_F32_AVX2_GEMV_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    QK256_F32_SCALAR_GEMV_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                }
+            })
         };
         gemv_result.map_err(|e| {
             BitNetError::Validation(format!(
@@ -437,6 +486,7 @@ fn prepare_qk256_activation(
             weight_name, e
         ))
     })?;
+    QK256_INPUT_ROWS_MATERIALIZED_COUNT.fetch_add(input_rows.len() as u64, Ordering::Relaxed);
 
     Ok(PreparedQk256Activation { layout, shape, input_rows })
 }
@@ -446,6 +496,7 @@ fn extract_qk256_flat_bytes(
     layout: &Qk256Layout,
     weight_name: &str,
 ) -> Result<Vec<u8>> {
+    QK256_FLAT_BYTES_EXTRACTED_COUNT.fetch_add(1, Ordering::Relaxed);
     let bytes_2d = qk256_tensor.to_vec2::<u8>().map_err(|e| {
         BitNetError::Validation(format!("Failed to extract QK256 bytes for {}: {}", weight_name, e))
     })?;


### PR DESCRIPTION
### Motivation

- Provide diagnostic evidence of which QK256 execution paths are actually exercised (no-scale F32 AVX2 vs scalar, scaled I2_S×I8_S scalar vs AVX2) and measure obvious allocation/copy counts so we can tell whether the real BitNet scaled AVX2 hot path is being used or if the inline-scale path remains scalar.

### Description

- Add global atomic coverage counters in `crates/bitnet-qk256-dispatch/src/lib.rs` for invocations and materialization: `QK256_F32_SCALAR_GEMV_INVOCATIONS`, `QK256_F32_AVX2_GEMV_INVOCATIONS`, `QK256_I8S_SCALED_SCALAR_INVOCATIONS`, `QK256_I8S_SCALED_AVX2_INVOCATIONS`, `QK256_FLAT_BYTES_EXTRACTED_COUNT`, `QK256_INPUT_ROWS_MATERIALIZED_COUNT`, and `QK256_OUTPUT_ROWS_ALLOCATED_COUNT` and wire them into `reset_qk256_dispatch_coverage()` and `qk256_dispatch_coverage()`.
- Instrument QK256 dispatch hot path: record flat-byte extraction, input-row materialization, output-row allocations, and increment invocation counters when calling no-scale or inline-scale GEMV; switch no-scale path to `gemv_qk256_with_kernel_selection` so selection metadata is available at call time.
- Extend `Qk256DispatchCoverageCounters` with the new counters and propagate them into CLI receipts and coverage deltas used by `bitnet-cli`.
- Add a `qk256_hot_path_receipt` helper in `crates/bitnet-cli/src/main.rs` that summarizes observed hot-path shape (mixed vs scaled vs no-scale), requested vs selected kernel labels, invocation totals and materialization counts and inserts `qk256_hot_path` into per-run and aggregate receipts.
- Add `aggregate_qk256_hot_path` into `crates/bitnet-cli/src/commands/answer_corpus.rs` so answer-corpus aggregate receipts include the qk256 hot-path summary per-case and overall.
- Small API/usage tweaks: use `gemv_qk256_with_kernel_selection` for richer selection metadata; adjust receipt generation to include the new fields while keeping `speedup_claim=false`.

### Testing

- Built and type-checked the modified crates with CPU features and CLI features enabled via `cargo check` and the project build completed successfully; the overall workspace and modified crates compiled.
- Ran the quantization parity unit suite `cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests` and all tests passed (17 passed, 0 failed).
- Ran the CLI answer-corpus tests `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus` and the unit test suites completed successfully (answer-corpus and related CLI unit tests passed).
- Executed the xtask campaign check `cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof` which completed as part of the verification workflow; no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa7e7d3b8833385fa3b0681fe54fd)