### PR TITLE
docs(cpu): add AVX2 BitNet hot-path implementation plan

### DIFF
--- a/docs/bitnet/BITNET_CPU_AVX2_STATUS.md
+++ b/docs/bitnet/BITNET_CPU_AVX2_STATUS.md
@@ -1,0 +1,40 @@
+# BitNet CPU AVX2 Status
+
+This page records the current claim boundary for the CPU AVX2 BitNet I2_S/QK256
+hot-path campaign. It is intentionally narrower than general CPU inference.
+
+## Current status
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Official Microsoft BitNet I2_S/QK256 scalar | correctness oracle | Existing scalar packed path remains the reference for AVX2 parity. |
+| Existing no-scale QK256 AVX2 GEMV | proven helper lane | It is not proof of inline-scale BitNet I2_S x I8_S AVX2 execution. |
+| Scaled I2_S x I8_S AVX2 hot path | planned | The next runtime item must first record counters that prove what executes today. |
+| Strict loader/tokenizer authority | required | Hot-path proof must keep real GGUF loading and strict tokenizer source in receipts. |
+| Hidden fallback | forbidden | Strict AVX2 proof must fail closed instead of warning-only scalar/dequant fallback. |
+| Answer corpus parity | required | Scalar-vs-AVX2 generated token IDs must remain stable or divergence must block promotion. |
+| Performance | unpromoted | No AVX2 speedup is claimed until exact-profile phase receipts are reviewed. |
+| Server, GPU, NPU, dense SLM | out of scope | This campaign does not promote those proof families. |
+
+## Promotion checklist
+
+A CPU AVX2 BitNet profile can be promoted only after receipts show:
+
+1. `requested_backend=cpu` and `selected_backend=cpu-rust`;
+2. requested and selected kernel IDs name the intended scaled path;
+3. `fallback_used=false` and `fallback_reason=null`;
+4. `loader_mode=real_gguf`, `quant_format=i2_s`, and a model SHA;
+5. strict tokenizer source and prompt policy are recorded;
+6. scaled I2_S x I8_S AVX2 invocation counters are positive;
+7. scaled scalar, dequantized, diagnostic, mock, and no-scale F32 substitution
+   counters do not contradict the selected AVX2 path;
+8. scalar-vs-AVX2 generated-token parity passes for the governed corpus/profile;
+9. phase timing exists for the exact promoted profile.
+
+## Next evidence gap
+
+The immediate evidence gap is not generic AVX2 optimization. The immediate gap
+is proving whether strict real BitNet CPU inference runs an optimized scaled
+I2_S x I8_S AVX2 kernel or only reaches scalar/no-scale helper paths. The next
+runtime PR must add hot-path counters and receipt fields without changing math
+or claiming speed.

--- a/docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
+++ b/docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
@@ -1,0 +1,142 @@
+# BITNET-SPEC-CPU-AVX2-HOTPATH: CPU AVX2 BitNet Hot-Path Contract
+
+Status: proposed
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`,
+`docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADR: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Linked plan: `plans/cpu-avx2-bitnet/implementation-plan.md`
+Applies to: official Microsoft BitNet I2_S/QK256 CPU AVX2 proof, strict CPU
+answer receipts, QK256 kernel selection, CPU AVX2 performance receipts, and
+user-facing CPU AVX2 status claims.
+
+## Target end state
+
+AVX2 CPU is fully working only when the official BitNet I2_S/QK256 model runs
+through the normal Rust CPU user path with strict GGUF loader authority, strict
+tokenizer authority, correct intelligible answer receipts, selected AVX2 BitNet
+kernels, no hidden scalar/dequantized fallback, stable scalar-vs-AVX2 generated
+token parity, and exact-profile prefill/first-token/decode performance that has
+been reviewed and promoted profile-by-profile.
+
+## Requirements
+
+The requirements below define the minimum behavior before this lane may promote
+CPU AVX2 BitNet I2_S/QK256 execution.
+
+## Strict fallback rules
+
+- Strict requested AVX2 must fail if AVX2/FMA or any other required CPU feature
+  is unavailable.
+- Strict requested AVX2 must fail if the selected path is scalar, dequantized,
+  diagnostic, mock, reference-only, or the no-scale F32 helper when inline-scale
+  BitNet execution is required.
+- `fallback_used=false` is invalid if hot-path counters show scalar
+  substitution, dequantized execution, or missing AVX2 invocations for a
+  selected AVX2 kernel.
+- Non-strict fallback may select scalar only if the receipt records the selected
+  scalar kernel and an explicit fallback reason.
+
+## Required receipt fields
+
+Every strict CPU AVX2 proof receipt must include these fields or their canonical
+schema equivalents:
+
+```json
+{
+  "requested_backend": "cpu",
+  "selected_backend": "cpu-rust",
+  "requested_kernel": "...",
+  "selected_kernel": "...",
+  "kernel_family": "i2_s|qk256",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model": {
+    "loader_mode": "real_gguf",
+    "quant_format": "i2_s",
+    "sha256": "..."
+  },
+  "tokenizer": {
+    "source": "...",
+    "strict": true
+  },
+  "qk256_hot_path": {
+    "scaled_i8s_scalar_invocations": 0,
+    "scaled_i8s_avx2_invocations": 0,
+    "f32_scalar_invocations": 0,
+    "f32_avx2_invocations": 0,
+    "flat_bytes_extracted_count": 0,
+    "input_rows_materialized_count": 0,
+    "output_rows_allocated_count": 0,
+    "tensor_to_vec_count": 0
+  }
+}
+```
+
+Performance receipts must additionally include phase timings for the profile
+being claimed, including model load, tokenizer load, prompt rendering, prefill,
+first token, decode total, tokens per second, workload shape, CPU feature set,
+model identity, selected backend/kernel, and fallback status.
+
+## Scalar parity gate
+
+The canonical scalar packed path remains the correctness oracle. AVX2 kernel
+work must compare directly against scalar packed results, and transformer-level
+optimization work must preserve generated token IDs against scalar under greedy,
+deterministic settings. Any generated-token drift requires a divergence receipt
+and blocks optimization promotion until it is classified and accepted.
+
+## Scaled I2_S x I8_S hot-path requirement
+
+Inline-scale BitNet inference must use the scaled I2_S x I8_S flow: quantize
+activations to I8_S, compute over packed I2_S codes, and apply the same scale
+and correction semantics as the scalar `gemv_qk256_bitnet_i8s_scaled` oracle.
+The no-scale F32 QK256 AVX2 GEMV is not a substitute for this path and must not
+be counted as scaled BitNet AVX2 proof.
+
+A selected scaled AVX2 kernel is valid only when the receipt records
+`scaled_i8s_avx2_invocations > 0`, `scaled_i8s_scalar_invocations = 0` for the
+strict AVX2 proof run, `fallback_used=false`, and a selected kernel ID that
+names the scaled AVX2 path.
+
+## Performance promotion requirements
+
+Performance promotion is exact-profile only. Each promoted profile must have a
+receipt-backed scalar comparator and AVX2 measurement for the same model
+artifact, tokenizer authority, prompt policy, workload shape, and output rule.
+Promotion decisions must state accepted/rejected and why for profiles such as
+micro scaled GEMV, first token, `decode_128`, `prefill_128`, `prefill_512`, and
+warm session profiles. A result for one profile does not imply another.
+
+## Proof commands
+
+Documentation-only changes for this spec run:
+
+```bash
+cargo fmt --all -- --check
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+git diff --check
+```
+
+Runtime changes must also run the scoped CPU AVX2 commands listed by their
+campaign work item and emit or validate the receipts required by this spec.
+
+## Claim boundary
+
+A claim is valid only for the exact model artifact, tokenizer source, prompt
+policy, backend, selected kernel, workload profile, and receipt named by the
+proof. Adjacent BitNet, dense, accelerator, server, or quality families are not
+promoted by implication.
+
+## Non-goals and forbidden claims
+
+CPU AVX2 BitNet hot-path proof must not claim any of the following unless a
+separate authority and receipt family proves it:
+
+- CUDA, NPU, OpenVINO, A770, Apple M4, or other accelerator support;
+- dense SLM, Qwen, Llama, Gemma, Phi, or broad small-LLM support;
+- server readiness, streaming, concurrency, or endpoint performance;
+- global speedup without exact-profile review;
+- broad chat quality beyond the governed answer corpus and artifact gate;
+- support for all BitNet models from one official Microsoft I2_S/QK256 artifact.

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -801,3 +801,84 @@ must_not_claim = [
   "GPU, NPU, or server inference is involved.",
   "A speedup or throughput claim is proven.",
 ]
+
+[[work_item]]
+id = "CPU-AVX2-HOTPATH-001"
+status = "ready"
+branch = "codex/cpu-avx2-hotpath-001-plan"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU-ANSWER-007"]
+acceptance = "Document the CPU AVX2 BitNet hot-path campaign rails, add a repo-local implementation plan and spec, update user-facing CPU AVX2 status, and register the next runtime proof item without changing runtime behavior."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof",
+  "git diff --check",
+]
+allowed_paths = [
+  "plans/cpu-avx2-bitnet/**",
+  "docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md",
+  "docs/bitnet/BITNET_CPU_AVX2_STATUS.md",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "docs/tracking/generated/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "The CPU AVX2 BitNet hot-path implementation plan, spec, status boundary, and tracker item exist after merge.",
+]
+must_not_claim = [
+  "Runtime behavior changed.",
+  "Scaled I2_S x I8_S AVX2 execution is implemented or selected.",
+  "AVX2 performance or speedup is proven.",
+  "GPU, NPU, OpenVINO, server, dense SLM, Qwen, or broad chat quality is proven.",
+]
+
+[[work_item]]
+id = "CPU-AVX2-HOTPATH-002"
+status = "proposed"
+branch = "codex/cpu-avx2-hotpath-002-counters"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU-AVX2-HOTPATH-001"]
+acceptance = "Strict scalar and strict AVX2 answer-corpus receipts include QK256 hot-path counters that distinguish scaled I2_S x I8_S scalar/AVX2 from no-scale F32 scalar/AVX2 and materialization counters, while answer parity remains green and no speed claim is made."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256 --lib",
+  "cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus",
+  "cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-cli/**",
+  "crates/bitnet-receipts/**",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "Strict CPU receipts record actual QK256 hot-path counters after merge.",
+]
+must_not_claim = [
+  "Math semantics changed.",
+  "Scaled I2_S x I8_S AVX2 is implemented if counters show it is not.",
+  "AVX2 performance or speedup is proven.",
+  "GPU, NPU, OpenVINO, server, dense SLM, Qwen, or broad chat quality is proven.",
+]

--- a/plans/cpu-avx2-bitnet/README.md
+++ b/plans/cpu-avx2-bitnet/README.md
@@ -1,0 +1,34 @@
+# CPU AVX2 BitNet Hot-Path Plan
+
+This plan owns the follow-on campaign that moves the official Microsoft BitNet
+I2_S/QK256 CPU lane from correctness proof to production hot-path proof.
+
+The governed end state is narrow: AVX2 CPU is considered fully working only
+when the normal Rust CPU user path runs the official BitNet I2_S/QK256 artifact
+with strict GGUF loader and tokenizer authority, intelligible answer receipts,
+selected AVX2 BitNet kernels, no hidden scalar or dequant fallback, stable
+scalar-vs-AVX2 token parity, and exact-profile phase timing good enough to
+promote profile-by-profile.
+
+## Authority
+
+- Spec: `docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md`
+- Existing CPU path authority: `docs/bitnet/BITNET_CPU_PATH_PLAN.md`
+- Status page: `docs/bitnet/BITNET_CPU_AVX2_STATUS.md`
+- Active tracker: `docs/tracking/campaigns/cpu-proof/active.toml`
+- Durable proof-family boundary:
+  `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+
+## Scope
+
+This lane is only for CPU AVX2 BitNet I2_S/QK256. It does not claim CUDA, NPU,
+OpenVINO, A770, Apple M4, dense SLM, Qwen, server readiness, or broad chat
+quality.
+
+## Current next item
+
+The first runtime item after this documentation item is
+`CPU-AVX2-HOTPATH-002`: record QK256 hot-path execution counters and emit them
+in strict CPU answer receipts. That diagnostic item must prove whether real
+strict BitNet inference executes scaled I2_S x I8_S AVX2, scaled scalar, or the
+older no-scale F32 QK256 GEMV path.

--- a/plans/cpu-avx2-bitnet/implementation-plan.md
+++ b/plans/cpu-avx2-bitnet/implementation-plan.md
@@ -1,0 +1,79 @@
+# CPU AVX2 BitNet Hot-Path Implementation Plan
+
+## Goal
+
+Get the official Microsoft BitNet I2_S/QK256 model from strict CPU correctness
+proof to production-grade strict AVX2 execution on the normal Rust CPU user
+path. Production-grade means the receipts prove real optimized BitNet AVX2
+execution, not an AVX2 label over scalar, diagnostic, dequantized, or no-scale
+F32 helper execution.
+
+## Non-negotiable rails
+
+1. **Scalar is the oracle.** Every AVX2 kernel is compared against the canonical
+   scalar packed path. Generated-token parity must be preserved or a divergence
+   receipt must block promotion.
+2. **Strict mode fails closed.** If strict requested AVX2 cannot run AVX2, the
+   run errors. Warning-only scalar, dequantized, diagnostic, mock, or reference
+   fallback is forbidden in proof runs.
+3. **Receipts are mandatory.** Proof receipts must include requested and
+   selected backend, requested and selected kernel, kernel family, runtime API,
+   fallback status and reason, real GGUF model identity, quant format, and
+   tokenizer source/strictness.
+4. **Performance claims need phase receipts.** No speedup or throughput claim is
+   allowed without model/tokenizer identity, workload shape, phase timings, CPU
+   features, selected kernel, fallback status, and exact-profile review.
+5. **Proof families stay separate.** CPU AVX2 BitNet I2_S/QK256 evidence does
+   not promote CUDA, NPU, OpenVINO, Apple M4, dense SLM, Qwen, server, or broad
+   chat claims.
+
+## Technical issue to prove first
+
+The existing AVX2 QK256 path covers the older no-scale F32-style GEMV. Real
+BitNet I2_S inline-scale inference uses the BitNet.cpp-aligned scaled I2_S x
+I8_S activation flow: quantize activations to I8_S, compute over packed I2_S
+codes, then apply scale and correction. The transformer dispatch already takes
+the inline-scale branch through `gemv_qk256_bitnet_i8s_scaled`; therefore the
+first runtime proof must distinguish scaled I2_S x I8_S scalar, scaled I2_S x
+I8_S AVX2, no-scale F32 scalar, and no-scale F32 AVX2 execution.
+
+## PR sequence
+
+| Item | Title | Purpose | Claim boundary |
+| --- | --- | --- | --- |
+| CPU-AVX2-HOTPATH-001 | `docs(cpu): add AVX2 BitNet hot-path implementation plan` | Encode this plan, spec, status page, and tracker rails. | Documentation only; no runtime behavior changes. |
+| CPU-AVX2-HOTPATH-002 | `diag(cpu): record BitNet QK256 hot-path execution counters` | Emit counters for scaled I8S scalar/AVX2, F32 scalar/AVX2, flat-byte extraction, row materialization, output allocation, and tensor-to-vec conversion. | No math changes and no speed claim. |
+| CPU-AVX2-HOTPATH-003 | `receipts(cpu): validate AVX2 hot-path counters` | Make hidden fallback invalid in strict AVX2 receipts. | Validation only. |
+| CPU-AVX2-HOTPATH-004 | `test(cpu): add scaled I2S-I8S AVX2 parity fixtures` | Define rows, tails, code patterns, activations, scales, code3 behavior, and determinism before new SIMD work. | Fixtures compare to scalar semantics. |
+| CPU-AVX2-HOTPATH-005 | `feat(cpu): add AVX2 scaled I2S-I8S QK256 GEMV` | Implement a runtime-gated AVX2 scaled I2_S x I8_S GEMV with no internal fallback. | No transformer wiring until direct parity passes. |
+| CPU-AVX2-HOTPATH-006 | `feat(cpu): select scaled AVX2 QK256 kernel explicitly` | Add explicit scaled scalar and scaled AVX2 kernel IDs and strict fallback behavior. | Selection metadata only. |
+| CPU-AVX2-HOTPATH-007 | `feat(cpu): route inline-scale BitNet QK256 through scaled AVX2` | Wire strict/auto inline-scale dispatch to the scaled AVX2 selector. | Generated-token parity must remain green. |
+| CPU-AVX2-HOTPATH-008 | `perf(cpu): cache QK256 packed views for CPU dispatch` | Remove avoidable flat-byte extraction and per-call row/output materialization. | Before/after receipts required; no global speed claim. |
+| CPU-AVX2-HOTPATH-009 | `perf(cpu): add reusable BitNet CPU decode workspace` | Reuse activation, output, attention, logits, and optional code scratch buffers. | No generated-token drift. |
+| CPU-AVX2-HOTPATH-010 | `bench(cpu): add strict AVX2 phase timing profiles` | Emit micro, layer, prefill, first-token, decode, and warm-session phase receipts. | Timing evidence only; promotion waits for review. |
+| CPU-AVX2-HOTPATH-011 | `docs(cpu): review AVX2 performance qualification` | Accept or reject exact-profile promotions from scalar/AVX2/comparator timings. | No global speedup claim. |
+| CPU-AVX2-HOTPATH-012 | `test(cpu): add BitNet CPU answer corpus v2` | Broaden deterministic CPU prompts and classify scalar/AVX2 failures. | No broad chat claim. |
+| CPU-AVX2-HOTPATH-013 | `test(cpu): add scalar-vs-AVX2 long decode parity` | Check 16/32/128-token greedy parity and record first divergence evidence. | Fallback must remain false. |
+| CPU-AVX2-HOTPATH-014 | `perf(cpu): optimize BitNet QK256 prefill path` | Improve prefill with batched GEMV or tiled GEMM without dequant fallback. | Exact prefill receipts only. |
+| CPU-AVX2-HOTPATH-015 | `diag(cpu): profile non-QK256 transformer CPU ops` | Rank RMSNorm, RoPE, attention, softmax, KV, logits, sampling, and other support-op bottlenecks. | Diagnostic report only. |
+| CPU-AVX2-HOTPATH-016 | `docs(cpu): publish AVX2 BitNet support status` | Publish exact status after receipts and performance review. | Exact profile/status rows only. |
+
+## Default validation bundle
+
+Documentation-only items run:
+
+```bash
+cargo fmt --all -- --check
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+git diff --check
+```
+
+Runtime and validation items add the scoped CPU AVX2 tests named by the active
+tracker item. Performance items also add receipt JSON validation for every new
+receipt.
+
+## Rollback
+
+Each item should be revertible independently. Runtime items must keep scalar
+semantics unchanged so reverting an optimization or selector leaves the scalar
+truth lane intact.


### PR DESCRIPTION
### Motivation

- Provide a repo-local plan and spec to move BitNet CPU AVX2 from correctness proof to a measurable production hot path. 
- Make strict-mode, scalar-parity, receipt, and proof-family rules explicit so runtime work cannot hide fallback or mislabel kernels. 
- Narrow the campaign scope to official Microsoft BitNet I2_S/QK256 and sequence the small PRs needed to prove or implement the scaled I2_S × I8_S AVX2 hot path. 

### Description

- Add plan and implementation sequencing under `plans/cpu-avx2-bitnet/README.md` and `plans/cpu-avx2-bitnet/implementation-plan.md` to enumerate PR-by-PR work and validation bundles. 
- Add the hot-path spec `docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md` defining target end state, strict-fallback rules, required receipt fields (including `qk256_hot_path` counters), scalar-parity gate, and promotion rules. 
- Add a user-facing status page `docs/bitnet/BITNET_CPU_AVX2_STATUS.md` documenting the current claim boundary and promotion checklist. 
- Register two campaign tracker work items in `docs/tracking/campaigns/cpu-proof/active.toml`: `CPU-AVX2-HOTPATH-001` (docs ready) and proposed `CPU-AVX2-HOTPATH-002` (hot-path counters/receipts), with allowed/forbidden paths and proof commands. 

### Testing

- Ran `cargo fmt --all -- --check` and it succeeded. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof` and the campaign validation passed. 
- Ran `git diff --check` (and basic repo checks) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaad93dd08333ac37836b2ff5aaa9)