### PR TITLE
docs(cpu): add AVX2 BitNet hot-path implementation plan

### DIFF
--- a/docs/bitnet/BITNET_CPU_AVX2_STATUS.md
+++ b/docs/bitnet/BITNET_CPU_AVX2_STATUS.md
@@ -1,0 +1,62 @@
+# BitNet CPU AVX2 status
+
+Status: Draft
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: ../specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
+Linked ADRs: ../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: ../../plans/cpu-avx2-bitnet/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: CPU AVX2 BitNet I2_S/QK256 remains exact-profile and receipt-gated.
+Policy impact: none
+
+## Current status
+
+The CPU proof lane has merged strict loader, tokenizer, packed layout, scalar,
+AVX2 dispatch, decode, receipt, benchmark, and answer-corpus rails. The next
+support question is narrower: whether strict real-model AVX2 inference is
+executing the scaled BitNet I2_S x I8_S AVX2 path required by inline-scale
+QK256 tensors, rather than a scalar substitute or the no-scale F32-style AVX2
+GEMV path.
+
+## Claim boundary
+
+| Area | Status | Claim boundary |
+| --- | --- | --- |
+| Official Microsoft BitNet I2_S scalar | Correctness oracle | Scalar remains the oracle for AVX2 parity and generated-token gates. |
+| AVX2 no-scale QK256 F32-style GEMV | Existing support surface | Does not prove inline-scale BitNet I2_S x I8_S production hot-path execution. |
+| AVX2 scaled I2_S x I8_S GEMV | Candidate / unproven | Must be counted, validated, implemented if missing, selected explicitly, and wired before promotion. |
+| Strict fallback truth | Required | Requested AVX2 in strict mode must fail if the selected path is scalar, dequantized, diagnostic, mock, or reference-only. |
+| Answer corpus | Existing strict proof input | Must remain green for scalar and AVX2, or record first divergence and block promotion. |
+| Long decode | Future gate | Requires deterministic scalar-vs-AVX2 token parity or first-divergence evidence. |
+| Speed | Not globally claimed | Exact profiles only after phase receipts and performance review. |
+| Server | False for this lane | No server readiness claim is made by CPU AVX2 hot-path proof. |
+| GPU/NPU/OpenVINO/A770/M4/dense SLM/Qwen | Out of scope | Proof families are separate and cannot inherit this lane's evidence. |
+
+## Near-term board
+
+1. CPU-AVX2-HOTPATH-001: docs/spec/plan/tracker rails.
+2. CPU-AVX2-HOTPATH-002: hot-path counters.
+3. CPU-AVX2-HOTPATH-003: receipt validator for hidden fallback.
+4. CPU-AVX2-HOTPATH-004: scaled I2_S x I8_S fixtures.
+5. CPU-AVX2-HOTPATH-005: scaled AVX2 microkernel.
+6. CPU-AVX2-HOTPATH-006: explicit scaled kernel selection.
+7. CPU-AVX2-HOTPATH-007: dispatch wiring.
+8. CPU-AVX2-HOTPATH-008: packed-view/materialization cleanup.
+9. CPU-AVX2-HOTPATH-009: reusable decode workspace.
+10. CPU-AVX2-HOTPATH-010: phase benchmark receipts.
+11. CPU-AVX2-HOTPATH-011: exact-profile performance review.
+12. CPU-AVX2-HOTPATH-012: answer corpus v2.
+13. CPU-AVX2-HOTPATH-013: long-decode parity.
+14. CPU-AVX2-HOTPATH-014: prefill optimization.
+15. CPU-AVX2-HOTPATH-015: non-QK256 op bottleneck audit.
+16. CPU-AVX2-HOTPATH-016: user-facing support status.
+
+## Next proof
+
+The first runtime proof must add QK256 hot-path counters to strict scalar and
+strict AVX2 receipts. It must distinguish no-scale F32 GEMV from scaled
+I2_S x I8_S GEMV, keep requested/selected kernel and fallback fields explicit,
+preserve scalar-vs-AVX2 answer parity, and make no speed claim.

--- a/docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
+++ b/docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
@@ -1,0 +1,167 @@
+# BITNET-SPEC-CPU-AVX2-HOTPATH: CPU AVX2 BitNet hot-path proof
+
+Status: Draft
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: BITNET-SPEC-0013-model-onboarding-proof-ladder.md, BITNET-SPEC-0014-runtime-performance-contract.md
+Linked ADRs: ../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: ../../plans/cpu-avx2-bitnet/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: CPU AVX2 BitNet I2_S/QK256 remains exact-profile only until receipts promote individual profiles.
+Policy impact: none
+
+## Purpose
+
+This spec defines when the Rust CPU AVX2 lane may say that the official
+Microsoft BitNet I2_S/QK256 model is using the production optimized BitNet hot
+path. It narrows the existing CPU proof lane from "correctness exists" to "the
+normal Rust CPU user path selected the real scaled BitNet AVX2 kernels, did not
+fall back, preserved scalar parity, and emitted phase evidence before any
+performance claim."
+
+## Target end state
+
+The AVX2 CPU path is fully working only when the official Microsoft BitNet
+I2_S/QK256 artifact runs through the normal Rust CPU user path with all of the
+following properties:
+
+- real GGUF loader authority and strict tokenizer authority are used;
+- generated answers are intelligible under the governed answer corpus;
+- selected kernels are AVX2 BitNet kernels for the executed BitNet hot path;
+- strict mode has no hidden scalar, dequantized, diagnostic, mock, or
+  reference-only fallback;
+- scalar and AVX2 generated token IDs remain equal, or the receipt records the
+  first divergence with enough evidence to block promotion;
+- prefill, first-token, and decode performance are measured per profile before
+  a profile is promoted.
+
+## Scope
+
+This spec applies only to the CPU AVX2 BitNet I2_S/QK256 proof family. It does
+not apply to CUDA, NPU, OpenVINO, A770, M4, dense SLMs, Qwen, TL1/TL2,
+GPU-int2, server readiness, or broad chat-quality claims.
+
+## Scalar oracle gate
+
+The canonical scalar packed path remains the correctness oracle. Every AVX2
+kernel added by this lane must compare against scalar fixtures and must preserve
+strict scalar-versus-AVX2 generated-token parity before it can be used as an
+optimization claim.
+
+An AVX2 optimization PR must not merge as a promotion PR if it changes generated
+IDs without a divergence receipt and explicit blocker classification.
+
+## Strict fallback rules
+
+Strict mode fails closed. If the request asks for AVX2 and strict mode is in
+force, the run must fail when the selected path is scalar, dequantized,
+diagnostic-only, mock/reference-only, or any other non-AVX2 substitute.
+Warning-only fallback is not acceptable in proof runs.
+
+Non-strict fallback may select scalar when AVX2/FMA or other required CPU
+features are unavailable, but the receipt must set `fallback_used=true` and must
+record a concrete `fallback_reason`.
+
+## Required receipt fields
+
+Every CPU AVX2 BitNet proof receipt must retain the existing strict CPU fields
+and include the following logical values:
+
+```json
+{
+  "requested_backend": "cpu",
+  "selected_backend": "cpu-rust",
+  "requested_kernel": "...",
+  "selected_kernel": "...",
+  "kernel_family": "i2_s|qk256",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model": {
+    "loader_mode": "real_gguf",
+    "quant_format": "i2_s",
+    "sha256": "..."
+  },
+  "tokenizer": {
+    "source": "...",
+    "strict": true
+  }
+}
+```
+
+Hot-path proof receipts must additionally distinguish the no-scale F32-style
+QK256 path from the scaled BitNet I2_S x I8_S path:
+
+```json
+{
+  "qk256_hot_path": {
+    "scaled_i8s_scalar_invocations": 0,
+    "scaled_i8s_avx2_invocations": 0,
+    "f32_scalar_invocations": 0,
+    "f32_avx2_invocations": 0,
+    "flat_bytes_extracted_count": 0,
+    "input_rows_materialized_count": 0,
+    "output_rows_allocated_count": 0,
+    "tensor_to_vec_count": 0
+  }
+}
+```
+
+The exact schema may nest these fields under the repository's receipt model, but
+`bitnet receipts explain` and validators must be able to report the same facts.
+
+## Scaled I2_S x I8_S hot-path requirement
+
+The official BitNet I2_S/QK256 inline-scale inference path is not satisfied by
+labeling the existing no-scale F32-style AVX2 GEMV as BitNet AVX2. For inline
+scale tensors, the governed production path is:
+
+```text
+activation f32 -> per-token I8_S quantization
+packed I2_S weights + I8_S activation integer dot
+inline weight scale and sum correction
+f32 output
+```
+
+The lane must prove whether strict real BitNet AVX2 inference actually executes
+an optimized scaled I2_S x I8_S AVX2 implementation. If receipts show that
+inline-scale inference only executed the no-scale F32 AVX2 path, scalar
+substitution, tensor dequantization, or per-call materialized rows, the AVX2
+hot-path claim remains blocked.
+
+## Hot-path validator failures
+
+Receipt validation must fail for CPU AVX2 hot-path proof when any of the
+following are true:
+
+- requested AVX2 selected scalar in strict mode;
+- the selected kernel name says AVX2 but AVX2 invocation counters are zero;
+- inline-scale BitNet proof records only no-scale F32 AVX2 invocations;
+- `fallback_used=false` while counters show scalar substitution;
+- audited hot-path materialization counters exceed the profile's accepted
+  boundary.
+
+## Performance promotion requirements
+
+Performance claims require phase receipts. At minimum, a profile promotion must
+record model load, tokenizer load, prompt render, prefill, first-token, decode,
+tokens/sec where applicable, selected backend, selected kernel, fallback status,
+CPU feature set, model identity, workload shape, and profile name.
+
+Promotions are exact-profile only. A speedup for `micro_qk256_scaled_gemv` does
+not imply speedup for first token, decode, prefill, warm sessions, server,
+other models, or other quantization formats.
+
+## Forbidden claims
+
+This lane must not claim:
+
+- CUDA, NPU, OpenVINO, A770, M4, Metal, GPU-int2, TL1/TL2, or dense SLM support;
+- server readiness or deployment readiness;
+- broad chat quality;
+- generic BitNet model support beyond the exact artifact and profile proven;
+- speedup or throughput without accepted exact-profile receipts;
+- AVX2 execution when counters show scalar, no-scale, dequantized, diagnostic,
+  mock, or reference-only execution.

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -801,3 +801,39 @@ must_not_claim = [
   "GPU, NPU, or server inference is involved.",
   "A speedup or throughput claim is proven.",
 ]
+
+[[work_item]]
+id = "CPU-AVX2-HOTPATH-001"
+status = "ready"
+branch = "codex/cpu-avx2-hotpath-001-docs"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU-ANSWER-007"]
+acceptance = "Document CPU AVX2 BitNet hot-path source-of-truth rails: target end state, strict fallback rules, required receipt fields, scalar parity gate, scaled I2_S x I8_S hot-path requirement, performance promotion requirements, forbidden claims, and the follow-on implementation sequence."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof",
+  "git diff --check",
+]
+allowed_paths = [
+  "plans/cpu-avx2-bitnet/**",
+  "docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md",
+  "docs/bitnet/BITNET_CPU_AVX2_STATUS.md",
+  "docs/tracking/campaigns/cpu-proof/active.toml",
+]
+forbidden_paths = [
+  "crates/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "The CPU AVX2 BitNet hot-path implementation plan, spec, status boundary, and tracker entry exist after merge.",
+]
+must_not_claim = [
+  "Scaled I2_S x I8_S AVX2 execution is implemented.",
+  "Strict AVX2 inference selected the scaled I2_S x I8_S AVX2 path.",
+  "CPU AVX2 speedup or throughput is proven.",
+  "Server, GPU, NPU, OpenVINO, dense SLM, Qwen, TL1/TL2, or broad chat quality is proven.",
+]

--- a/plans/cpu-avx2-bitnet/README.md
+++ b/plans/cpu-avx2-bitnet/README.md
@@ -1,0 +1,38 @@
+# CPU AVX2 BitNet hot-path plan
+
+Status: Draft
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: ../../docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
+Linked ADRs: ../../docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: CPU AVX2 BitNet I2_S/QK256 remains candidate/profile-scoped until hot-path and phase receipts promote it.
+Policy impact: none
+
+## Goal
+
+Move the CPU AVX2 BitNet lane from correctness proof to production hot-path
+proof for the official Microsoft I2_S/QK256 artifact. The immediate objective is
+not generic AVX2 optimization; it is proving which QK256 path strict real-model
+inference actually executes, then implementing and wiring the scaled I2_S x I8_S
+AVX2 path if it is missing.
+
+## Documents
+
+- [Spec](../../docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md) defines strict
+  fallback, receipt, parity, hot-path, and claim rules.
+- [Implementation plan](implementation-plan.md) sequences PR-sized work from
+  counters through profile-specific support status.
+- [Status](../../docs/bitnet/BITNET_CPU_AVX2_STATUS.md) records the current
+  claim boundary and near-term board.
+
+## Current claim boundary
+
+The current repository may claim strict CPU correctness and answer-corpus proof
+only to the extent already backed by existing CPU proof receipts. It must not
+claim production-grade AVX2 BitNet hot-path performance until receipts show the
+scaled I2_S x I8_S AVX2 path was selected, invoked, did not fall back, preserved
+scalar parity, and met exact-profile timing gates.

--- a/plans/cpu-avx2-bitnet/implementation-plan.md
+++ b/plans/cpu-avx2-bitnet/implementation-plan.md
@@ -1,0 +1,182 @@
+# CPU AVX2 BitNet hot-path implementation plan
+
+Status: Draft
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: ../../docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
+Linked ADRs: ../../docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Exact-profile CPU AVX2 promotions only after receipts pass.
+Policy impact: none
+
+## Guiding rails
+
+- Scalar packed QK256 remains the correctness oracle.
+- Strict requested AVX2 must fail closed if AVX2 cannot run or if a non-AVX2
+  substitute is selected.
+- Receipts must expose requested backend/kernel, selected backend/kernel,
+  kernel family, runtime API, model and tokenizer authority, fallback truth, and
+  QK256 hot-path counters.
+- Performance claims require phase receipts and exact-profile review.
+- This campaign is CPU AVX2 BitNet I2_S/QK256 only.
+
+## Work items
+
+### CPU-AVX2-HOTPATH-001 — docs/spec/plan/tracker rails
+
+Title: `docs(cpu): add AVX2 BitNet hot-path implementation plan`
+
+Scope: docs only.
+
+Acceptance:
+
+- create the CPU AVX2 hot-path spec;
+- create the repo-local plan and status page;
+- add the tracker item to `docs/tracking/campaigns/cpu-proof/active.toml`;
+- do not change runtime code;
+- run `cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof`;
+- run `git diff --check`.
+
+### CPU-AVX2-HOTPATH-002 — hot-path counters
+
+Title: `diag(cpu): record BitNet QK256 hot-path execution counters`
+
+Add counters for no-scale F32 scalar/AVX2 GEMV, scaled I2_S x I8_S scalar/AVX2
+GEMV, flat byte extraction, input-row materialization, output-row allocation,
+and tensor-to-Vec conversion. Strict scalar and strict AVX2 answer-corpus
+receipts must include these counters and preserve answer parity. No math changes
+and no speed claim.
+
+### CPU-AVX2-HOTPATH-003 — hot-path receipt validation
+
+Title: `receipts(cpu): validate AVX2 hot-path counters`
+
+Fail validation when requested AVX2 selects scalar in strict mode, an AVX2
+selected kernel has zero AVX2 invocations, inline-scale proof records only the
+no-scale F32 path, fallback truth conflicts with counters, or materialization
+exceeds the audited boundary.
+
+### CPU-AVX2-HOTPATH-004 — scaled I2S-I8S parity fixtures
+
+Title: `test(cpu): add scaled I2S-I8S AVX2 parity fixtures`
+
+Add fixture coverage for rows 1/2/7/32, cols 256/257/300/512/513/1024,
+zero/one-ish/repeating/row-varying/pseudorandom packed patterns,
+constant/ramp/centered/pseudorandom activations, and weight scales including
+0.125, 0.5, 1.0, and finite edge values. Compare against
+`gemv_qk256_bitnet_i8s_scaled` exactly; include code3, tail, and repeated-run
+determinism coverage.
+
+### CPU-AVX2-HOTPATH-005 — scaled I2S-I8S AVX2 GEMV
+
+Title: `feat(cpu): add AVX2 scaled I2S-I8S QK256 GEMV`
+
+Implement `gemv_qk256_bitnet_i8s_scaled_avx2` behind x86_64 AVX2 feature gates
+and runtime feature checks. Do not fallback inside the function. Dimension,
+tail, and weight-scale validation must match scalar semantics.
+
+### CPU-AVX2-HOTPATH-006 — explicit scaled kernel selection
+
+Title: `feat(cpu): select scaled AVX2 QK256 kernel explicitly`
+
+Add stable kernel IDs for scalar and AVX2 scaled I8_S GEMV and selection tests
+for auto, strict, non-strict fallback, and scalar requests when inline scale is
+present.
+
+### CPU-AVX2-HOTPATH-007 — transformer dispatch wiring
+
+Title: `feat(cpu): route inline-scale BitNet QK256 through scaled AVX2`
+
+Wire the inline-scale branch through the scaled AVX2 selector. Strict AVX2
+answer-corpus receipts must show selected scaled AVX2 kernel, scaled AVX2
+invocations greater than zero, scaled scalar invocations zero, fallback false,
+and unchanged generated token IDs.
+
+### CPU-AVX2-HOTPATH-008 — packed-view and materialization cleanup
+
+Title: `perf(cpu): cache QK256 packed views for CPU dispatch`
+
+Cache parsed QK256 layouts and flattened packed bytes, expose immutable packed
+tensor views, use flat input/output buffers, and remove avoidable per-token
+`Vec<Vec<_>>` materialization. Generate before/after phase receipts without
+claiming speed until reviewed.
+
+### CPU-AVX2-HOTPATH-009 — reusable CPU workspace
+
+Title: `perf(cpu): add reusable BitNet CPU decode workspace`
+
+Add reusable scratch for activation I8, output F32, optional QK256 code scratch,
+attention, and logits. Receipts should show workspace reuse and memory
+high-water while generated IDs remain unchanged.
+
+### CPU-AVX2-HOTPATH-010 — strict AVX2 phase timing profiles
+
+Title: `bench(cpu): add strict AVX2 phase timing profiles`
+
+Add strict profiles for micro scaled GEMV, layer 0 decode, prefill 128, prefill
+512, first token, decode 32, decode 128, and warm session 3 turns. Receipts must
+split phase timing and keep speedup claims false until review.
+
+### CPU-AVX2-HOTPATH-011 — exact-profile performance review
+
+Title: `docs(cpu): review AVX2 performance qualification`
+
+Turn scalar, AVX2, and previous-CPU timings into accepted/rejected decisions per
+profile. Do not make global speedup claims.
+
+### CPU-AVX2-HOTPATH-012 — answer corpus v2
+
+Title: `test(cpu): add BitNet CPU answer corpus v2`
+
+Expand answer categories while preserving scalar/AVX2 classification and first
+divergence reporting. Do not make broad chat claims.
+
+### CPU-AVX2-HOTPATH-013 — long-decode deterministic parity
+
+Title: `test(cpu): add scalar-vs-AVX2 long decode parity`
+
+Add greedy deterministic profiles for 16, 32, and 128 generated tokens with
+prompt token equality, generated token equality or first divergence, top-k
+logits where available, and fallback false.
+
+### CPU-AVX2-HOTPATH-014 — prefill optimization
+
+Title: `perf(cpu): optimize BitNet QK256 prefill path`
+
+Optimize prefill without hot-path dequantization. Improve prefill_128 and
+prefill_512 receipts or classify the blocker.
+
+### CPU-AVX2-HOTPATH-015 — non-QK256 op bottleneck audit
+
+Title: `diag(cpu): profile non-QK256 transformer CPU ops`
+
+Rank RMSNorm, sub-layernorm, RoPE, QK score, softmax/masking, AV,
+KV append/read, output head/logits, and sampling bottlenecks without runtime
+behavior changes.
+
+### CPU-AVX2-HOTPATH-016 — user-facing support status
+
+Title: `docs(cpu): publish AVX2 BitNet support status`
+
+Publish exact support rows for official Microsoft BitNet I2_S scalar, AVX2
+scaled I8_S, answer corpus, long decode, speed profiles, and server false unless
+separately proven.
+
+## Default validation bundle
+
+Runtime PRs normally run:
+
+```bash
+cargo fmt --all -- --check
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256 --lib
+cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+git diff --check
+```
+
+Performance PRs also add the relevant benchmark build and JSON receipt checks.


### PR DESCRIPTION
### Motivation

- Capture the campaign rails and acceptance criteria for proving the BitNet CPU AVX2 hot path so follow-on runtime PRs do not rediscover scope or accidentally hide fallback.
- Narrow the existing CPU proof lane from "correctness exists" to an auditable production hot-path requirement that requires scalar parity, strict-fallback failure, explicit receipts, and phase timing before any performance promotion.

### Description

- Adds a new spec `docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md` that defines target end state, strict fallback rules, required receipt fields (including QK256 hot-path counters), the scaled I2_S × I8_S hot-path requirement, validator failure cases, and forbidden claims.
- Adds a repo-local plan and implementation sequence under `plans/cpu-avx2-bitnet/` including `README.md` and `implementation-plan.md` that enumerate PR-sized work items from docs through counters, fixtures, AVX2 kernel, selection, wiring, and benchmarks.
- Adds a status page `docs/bitnet/BITNET_CPU_AVX2_STATUS.md` documenting the current claim boundary and near-term board (scaled AVX2 remains candidate/unproven). 
- Registers the docs-only tracker work item `CPU-AVX2-HOTPATH-001` in `docs/tracking/campaigns/cpu-proof/active.toml` and restricts allowed paths to the new docs/plan files so the first runtime PRs follow the specified validation bundle.

### Testing

- Ran the campaign check command `cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof`; the check completed and reported success.
- Ran `git diff --check` to validate whitespace and diff hygiene; the check passed with no issues.
- Parsed the updated `active.toml` to validate TOML structure; parsing succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaad93dd08333ac37836b2ff5aaa9)