### PR TITLE
docs(cpu): add AVX2 BitNet hot-path plan, spec, status, and tracker rails

### DIFF
--- a/docs/bitnet/BITNET_CPU_AVX2_STATUS.md
+++ b/docs/bitnet/BITNET_CPU_AVX2_STATUS.md
@@ -1,0 +1,52 @@
+# BitNet CPU AVX2 Status
+
+## Current claim boundary
+
+The CPU AVX2 BitNet hot-path campaign is in planning. The repository has merged
+rails for strict loader/tokenizer authority, canonical QK256 layout, scalar truth
+kernels, AVX2 dispatch, CPU decode, receipts, and answer-parity diagnostics, but
+this status page does not yet claim that the real inline-scale BitNet production
+path uses an optimized scaled I2_S x I8_S AVX2 kernel.
+
+## Official Microsoft BitNet I2_S/QK256 artifact
+
+| Area | Status | Evidence requirement before promotion |
+| --- | --- | --- |
+| Scalar packed path | Correctness oracle | Preserve scalar tests and generated-token receipts. |
+| AVX2 no-scale F32 QK256 GEMV | Separate kernel family | Must not substitute for inline-scale I2_S x I8_S proof. |
+| AVX2 scaled I2_S x I8_S GEMV | Candidate / unproven until counters and kernel wiring land | Receipts must show selected scaled AVX2 kernel and scaled AVX2 invocation count greater than zero. |
+| Strict fallback | Required fail-closed behavior | Requested AVX2 in strict mode must error rather than silently select scalar or diagnostic execution. |
+| Answer corpus | Must remain scalar-vs-AVX2 parity gated | Generated token IDs must match or divergence evidence blocks optimization promotion. |
+| Long decode | Planned | Greedy deterministic parity profiles for 16, 32, and 128 generated tokens. |
+| Performance | Exact profiles only | Phase receipts for micro, prefill, first-token, decode, and warm-session profiles before any profile promotion. |
+| Server / GPU / NPU | Not claimed | Out of scope for this campaign. |
+
+## Required hot-path receipt counters
+
+Future hot-path proof receipts must expose:
+
+```text
+qk256_f32_scalar_gemv_invocations
+qk256_f32_avx2_gemv_invocations
+qk256_i8s_scaled_scalar_invocations
+qk256_i8s_scaled_avx2_invocations
+qk256_flat_bytes_extracted_count
+qk256_input_rows_materialized_count
+qk256_output_rows_allocated_count
+qk256_tensor_to_vec_count
+```
+
+The first runtime PR after this documentation rail is diagnostic only: it records
+which path actually runs today and makes no speed claim.
+
+## Promotion policy
+
+Promote support profile by profile, not globally. A row may move from candidate
+to ready only when strict receipts prove:
+
+1. real GGUF loader authority;
+2. strict tokenizer authority;
+3. selected scaled AVX2 kernel where inline scale is present;
+4. `fallback_used=false`;
+5. scalar-vs-AVX2 generated-token parity; and
+6. phase timing good enough for that exact profile.

--- a/docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
+++ b/docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md
@@ -1,0 +1,132 @@
+# BITNET-SPEC-CPU-AVX2-HOTPATH
+
+## Status
+
+Draft implementation spec for the CPU AVX2 BitNet hot-path campaign.
+
+## Purpose
+
+The CPU AVX2 BitNet lane moves from correctness existing somewhere in the tree
+to production hot-path proof. The official Microsoft BitNet I2_S/QK256 model is
+not considered fully working on AVX2 CPU until the normal Rust CPU user path can
+prove strict loader/tokenizer authority, selected AVX2 BitNet kernels, no hidden
+fallback, scalar-vs-AVX2 parity, intelligible answer receipts, and profile-level
+performance evidence.
+
+## Target end state
+
+A strict CPU AVX2 proof run for the official Microsoft BitNet I2_S/QK256 model
+must demonstrate all of the following:
+
+1. `requested_backend` is `cpu` and `selected_backend` is the Rust CPU backend.
+2. GGUF loading is authoritative and records `loader_mode = "real_gguf"`.
+3. Tokenizer resolution is strict, deterministic, and receipt-backed.
+4. The selected kernel is an actual AVX2 BitNet kernel for the production path.
+5. Inline-scale BitNet QK256 inference uses the scaled I2_S x I8_S path, not the
+   no-scale F32 GEMV path as a substitute.
+6. `fallback_used = false` and `fallback_reason = null` in strict proof runs.
+7. Scalar-vs-AVX2 prompt token IDs and generated token IDs remain stable, or a
+   divergence receipt captures the first divergence and blocks optimization
+   promotion.
+8. Performance claims are limited to exact profiles with phase receipts.
+
+## Strict fallback rules
+
+Strict mode fails closed. When the user requests AVX2 in strict mode, the run
+must fail if AVX2 cannot execute the required production kernel. It must not
+continue with scalar, dequantized, diagnostic, mock, reference-only, or no-scale
+F32 execution while presenting the result as strict AVX2.
+
+Non-strict mode may fall back only if the receipt records the requested kernel,
+selected kernel, `fallback_used = true`, and a concrete fallback reason.
+
+## Required receipt fields
+
+Every proof receipt for this campaign must include the existing CPU proof fields
+and the hot-path fields below when applicable:
+
+```json
+{
+  "requested_backend": "cpu",
+  "selected_backend": "cpu-rust",
+  "requested_kernel": "...",
+  "selected_kernel": "...",
+  "kernel_family": "i2_s|qk256",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model": {
+    "loader_mode": "real_gguf",
+    "quant_format": "i2_s",
+    "sha256": "..."
+  },
+  "tokenizer": {
+    "source": "...",
+    "strict": true
+  },
+  "qk256_hot_path": {
+    "scaled_i8s_scalar_invocations": 0,
+    "scaled_i8s_avx2_invocations": 0,
+    "f32_scalar_invocations": 0,
+    "f32_avx2_invocations": 0,
+    "flat_bytes_extracted_count": 0,
+    "input_rows_materialized_count": 0,
+    "output_rows_allocated_count": 0,
+    "tensor_to_vec_count": 0
+  }
+}
+```
+
+Performance receipts must additionally include phase timing fields for model
+load, tokenizer load, prompt rendering, prefill, first token, total decode, and
+tokens per second where the profile supports them.
+
+## Scalar parity gate
+
+Scalar packed QK256/I2_S execution remains the correctness oracle. An AVX2
+optimization PR must preserve scalar-generated token parity. If parity changes,
+the PR must include divergence evidence and must not merge as a performance or
+optimization promotion.
+
+## Scaled I2_S x I8_S hot-path requirement
+
+The real inline-scale BitNet path quantizes activations to I8_S, computes an
+integer dot over packed I2_S data, and applies the scale/sum correction. The
+no-scale F32 AVX2 GEMV path is a separate kernel family and must not be used as
+a substitute for the production inline-scale path.
+
+The campaign therefore requires distinct counters, kernel IDs, selectors, tests,
+and receipts for:
+
+- no-scale QK256 F32 scalar GEMV;
+- no-scale QK256 F32 AVX2 GEMV;
+- scaled I2_S x I8_S scalar GEMV; and
+- scaled I2_S x I8_S AVX2 GEMV.
+
+## Performance promotion requirements
+
+A speed claim requires before/after receipts for at least one stable profile and
+must state exactly which profile is promoted. Raw timing receipts alone are not a
+global speedup claim. Accepted profile rows must record scalar timing, AVX2
+timing, previous CPU timing where available, acceptance decision, and reason.
+
+## Forbidden claims
+
+This spec does not authorize claims about CUDA, NPU, OpenVINO, Intel Arc A770,
+Apple M4, dense SLMs, Qwen, server readiness, broad chat quality, or all BitNet
+models. It applies only to the official Microsoft BitNet I2_S/QK256 CPU AVX2
+proof path unless a later spec explicitly extends it.
+
+## Acceptance for the docs rail
+
+The documentation rail is accepted when:
+
+- this spec exists;
+- the implementation plan exists;
+- the user-facing status page exists;
+- the `cpu-proof` tracker includes the docs rail and the next hot-path counter
+  item;
+- no runtime files are changed;
+- `cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof`
+  passes; and
+- `git diff --check` passes.

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -801,3 +801,85 @@ must_not_claim = [
   "GPU, NPU, or server inference is involved.",
   "A speedup or throughput claim is proven.",
 ]
+
+[[work_item]]
+id = "CPU-AVX2-HOTPATH-000"
+status = "in_progress"
+branch = "codex/cpu-avx2-hotpath-000-docs"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU-ANSWER-007"]
+acceptance = "Document the AVX2 BitNet hot-path implementation plan, behavior spec, status page, and tracker rails without runtime changes."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof",
+  "git diff --check",
+]
+allowed_paths = [
+  "plans/cpu-avx2-bitnet/**",
+  "docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md",
+  "docs/bitnet/BITNET_CPU_AVX2_STATUS.md",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "benches/**",
+  "tests/**",
+  "ci/**",
+]
+may_claim = [
+  "The CPU AVX2 BitNet hot-path plan, spec, status page, and tracker rails are documented after merge.",
+]
+must_not_claim = [
+  "The scaled I2_S x I8_S AVX2 kernel exists.",
+  "Strict AVX2 inference uses the optimized scaled BitNet path.",
+  "CPU performance is proven.",
+  "GPU, NPU, OpenVINO, server, dense SLM, Qwen, or broad chat quality is proven.",
+]
+
+[[work_item]]
+id = "CPU-AVX2-HOTPATH-001"
+status = "ready"
+branch = "codex/cpu-avx2-hotpath-001-counters"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU-AVX2-HOTPATH-000"]
+acceptance = "Strict scalar and strict AVX2 answer-corpus receipts include QK256 hot-path counters that distinguish no-scale F32 GEMV from scaled I2_S x I8_S GEMV, preserve requested/selected kernel and fallback fields, preserve scalar-vs-AVX2 answer parity, and make no speed claim."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256 --lib",
+  "cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus",
+  "cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-cli/**",
+  "crates/bitnet-receipts/**",
+  "crates/bitnet-receipts-core/**",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+  "tests/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "Strict CPU answer receipts can expose which QK256 hot path actually executed after merge.",
+  "Receipts can distinguish no-scale F32 QK256 GEMV from scaled I2_S x I8_S GEMV after merge.",
+]
+must_not_claim = [
+  "The scaled I2_S x I8_S AVX2 kernel is implemented.",
+  "Strict AVX2 inference is optimized.",
+  "CPU performance is proven.",
+  "GPU, NPU, OpenVINO, server, dense SLM, Qwen, or broad chat quality is proven.",
+]

--- a/plans/cpu-avx2-bitnet/README.md
+++ b/plans/cpu-avx2-bitnet/README.md
@@ -1,0 +1,54 @@
+# CPU AVX2 BitNet Hot-Path Plan
+
+This plan scopes the CPU AVX2 BitNet campaign that follows the completed
+loader, tokenizer, packed-layout, scalar-kernel, AVX2-dispatch, decode, receipt,
+and answer-parity rails in the `cpu-proof` tracker.
+
+## Goal
+
+AVX2 CPU support is fully working only when the official Microsoft BitNet
+I2_S/QK256 model runs through the normal Rust CPU user path with:
+
+- strict GGUF loader authority;
+- strict tokenizer authority;
+- canonical packed QK256 layout;
+- scalar packed kernels as the correctness oracle;
+- selected AVX2 BitNet kernels for the real production hot path;
+- no hidden scalar, dequantized, diagnostic, mock, or reference-only fallback;
+- scalar-vs-AVX2 generated-token parity; and
+- phase-timed prefill, first-token, and decode receipts good enough to promote
+  exact profiles one by one.
+
+## Scope boundary
+
+This campaign is only for CPU AVX2 BitNet I2_S/QK256 execution. It does not
+claim CUDA, NPU, OpenVINO, Intel Arc A770, Apple M4, dense SLM, Qwen, server
+readiness, or broad chat quality.
+
+## Source-of-truth links
+
+- Spec: [`docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md`](../../docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md)
+- Implementation sequence: [`implementation-plan.md`](implementation-plan.md)
+- Status: [`docs/bitnet/BITNET_CPU_AVX2_STATUS.md`](../../docs/bitnet/BITNET_CPU_AVX2_STATUS.md)
+- Campaign tracker: [`docs/tracking/campaigns/cpu-proof/active.toml`](../../docs/tracking/campaigns/cpu-proof/active.toml)
+
+## Near-term board
+
+| Item | Purpose | Claim boundary |
+| --- | --- | --- |
+| CPU-AVX2-HOTPATH-000 | Add the docs/spec/plan/tracker rails. | Planning only; no runtime change. |
+| CPU-AVX2-HOTPATH-001 | Record QK256 hot-path execution counters. | Observability only; no speed claim. |
+| CPU-AVX2-HOTPATH-002 | Validate receipts for hidden fallback. | Receipt truth only; no new kernel. |
+| CPU-AVX2-HOTPATH-003 | Add scaled I2_S x I8_S parity fixtures. | Fixture behavior only. |
+| CPU-AVX2-HOTPATH-004 | Implement scaled I2_S x I8_S AVX2 GEMV. | Microkernel parity only until wired. |
+| CPU-AVX2-HOTPATH-005 | Select scaled AVX2 kernels explicitly. | Selection metadata only. |
+| CPU-AVX2-HOTPATH-006 | Route inline-scale transformer dispatch through scaled AVX2. | Strict AVX2 path only if counters prove it. |
+| CPU-AVX2-HOTPATH-007 | Cache packed views and reduce materialization. | Performance evidence only with receipts. |
+| CPU-AVX2-HOTPATH-008 | Add reusable CPU decode workspace. | Allocation reduction only. |
+| CPU-AVX2-HOTPATH-009 | Add strict phase timing profiles. | Raw timing evidence only. |
+| CPU-AVX2-HOTPATH-010 | Review exact-profile performance qualification. | Exact-profile promotions only. |
+| CPU-AVX2-HOTPATH-011 | Expand BitNet CPU answer corpus v2. | Corpus quality evidence only. |
+| CPU-AVX2-HOTPATH-012 | Add long-decode deterministic parity. | Parity evidence only. |
+| CPU-AVX2-HOTPATH-013 | Optimize prefill path. | Prefill evidence only. |
+| CPU-AVX2-HOTPATH-014 | Profile non-QK256 CPU support ops. | Bottleneck ranking only. |
+| CPU-AVX2-HOTPATH-015 | Publish user-facing AVX2 support status. | Status reflects proven receipts only. |

--- a/plans/cpu-avx2-bitnet/implementation-plan.md
+++ b/plans/cpu-avx2-bitnet/implementation-plan.md
@@ -1,0 +1,154 @@
+# CPU AVX2 BitNet Hot-Path Implementation Plan
+
+## Operating rules
+
+1. Work one tracker item per PR.
+2. Keep scalar packed QK256/I2_S execution as the correctness oracle.
+3. Keep strict mode fail-closed: requested AVX2 must not silently select scalar,
+   dequantized, diagnostic, mock, or reference-only execution.
+4. Keep receipt fields explicit for requested/selected backend, requested/selected
+   kernel, runtime API, kernel family, fallback state, model authority, tokenizer
+   authority, hot-path counters, and phase timing when performance is discussed.
+5. Do not change tokenizer policy, prompt policy, or scalar semantics in this
+   campaign unless a later spec explicitly supersedes this one.
+6. Do not claim speed until exact-profile phase receipts have been reviewed.
+
+## Implementation sequence
+
+### CPU-AVX2-HOTPATH-000 -- docs/spec/plan/tracker rails
+
+Add this plan, the behavior spec, the status document, and tracker entries for
+the new campaign slice. This PR is documentation-only and makes no runtime claim.
+
+Validation:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+git diff --check
+```
+
+### CPU-AVX2-HOTPATH-001 -- hot-path counters
+
+Add counters that prove which QK256 path actually runs today:
+
+- `qk256_f32_scalar_gemv_invocations`
+- `qk256_f32_avx2_gemv_invocations`
+- `qk256_i8s_scaled_scalar_invocations`
+- `qk256_i8s_scaled_avx2_invocations`
+- `qk256_flat_bytes_extracted_count`
+- `qk256_input_rows_materialized_count`
+- `qk256_output_rows_allocated_count`
+- `qk256_tensor_to_vec_count`
+
+Receipts must distinguish no-scale F32 GEMV from the real inline-scale
+I2_S x I8_S path. This PR must not change math or make a speed claim.
+
+### CPU-AVX2-HOTPATH-002 -- hot-path receipt validation
+
+Make receipt validation fail hidden fallback cases:
+
+- requested AVX2 selected scalar in strict mode;
+- selected kernel says AVX2 but AVX2 invocation count is zero;
+- inline-scale BitNet path records only no-scale F32 AVX2;
+- `fallback_used=false` but counters show scalar substitution; or
+- tensor materialization exceeds the audited boundary for a hot-path proof run.
+
+### CPU-AVX2-HOTPATH-003 -- scaled I2_S x I8_S fixtures
+
+Add scalar-grounded fixtures for rows `1, 2, 7, 32`, columns `256, 257, 300,
+512, 513, 1024`, code patterns including code `3` and tails, activation
+patterns, repeated-run determinism, and representative finite `weight_scale`
+values. Fixtures compare to `gemv_qk256_bitnet_i8s_scaled` and must mirror the
+scalar function exactly.
+
+### CPU-AVX2-HOTPATH-004 -- scaled AVX2 GEMV
+
+Add `gemv_qk256_bitnet_i8s_scaled_avx2` behind x86_64 AVX2/FMA feature gates and
+runtime gating. The function must not fallback internally. Dimension checks,
+tail handling, and `weight_scale` validation must match scalar behavior.
+
+### CPU-AVX2-HOTPATH-005 -- explicit scaled kernel selection
+
+Add stable kernel IDs for scaled scalar and scaled AVX2 I8_S GEMV, selection
+metadata, strict fallback errors, and non-strict fallback receipts.
+
+### CPU-AVX2-HOTPATH-006 -- transformer dispatch wiring
+
+Route the inline-scale BitNet QK256 transformer branch through the scaled AVX2
+selector when AVX2 is requested or auto-selected. Strict AVX2 answer-corpus
+receipts must show the scaled AVX2 kernel, scaled AVX2 invocation count greater
+than zero, scaled scalar count equal to zero, and `fallback_used=false`.
+
+### CPU-AVX2-HOTPATH-007 -- packed-view/materialization cleanup
+
+Cache parsed QK256 layout and flattened packed bytes at model load, expose an
+immutable packed tensor view, use flat input/output buffers, and prove reduced
+materialization counters without changing generated token IDs.
+
+### CPU-AVX2-HOTPATH-008 -- reusable CPU decode workspace
+
+Add a reusable workspace for activation I8 buffers, output F32 buffers, optional
+QK256 scratch, attention scratch, and logits scratch. Receipts must show reuse
+and memory high-water information when available.
+
+### CPU-AVX2-HOTPATH-009 -- strict phase timing profiles
+
+Add strict AVX2 phase timing profiles for micro QK256 scaled GEMV, layer-0
+decode, prefill 128, prefill 512, first token, decode 32, decode 128, and warm
+three-turn sessions. These receipts are evidence only; they do not by themselves
+promote a speed claim.
+
+### CPU-AVX2-HOTPATH-010 -- exact-profile performance review
+
+Review scalar, AVX2, and previous-CPU timings profile by profile. Promote only
+exact profiles with acceptable evidence. If AVX2 is slower, record the blocker
+and next target.
+
+### CPU-AVX2-HOTPATH-011 -- answer corpus v2
+
+Expand the BitNet CPU answer corpus across math, factual, copy/repeat, yes/no,
+short extraction, format following, multi-token continuation, stop-token, and
+prompt-conditioning categories. Keep broad chat quality out of scope.
+
+### CPU-AVX2-HOTPATH-012 -- long-decode deterministic parity
+
+Add greedy deterministic scalar-vs-AVX2 parity for 16, 32, and 128 generated
+tokens with fixed seeds where applicable. Receipts must record prompt token IDs,
+generated token IDs, first divergence, top-k evidence when available, and
+`fallback_used=false`.
+
+### CPU-AVX2-HOTPATH-013 -- prefill path optimization
+
+Optimize prefill separately from decode GEMV. Acceptable directions include
+batched GEMV, tiled GEMM if needed, conservative threading, and no hot-path
+weight dequantization. Receipts must prove prefill profile effects.
+
+### CPU-AVX2-HOTPATH-014 -- non-QK256 CPU op audit
+
+Measure RMSNorm, sub-layernorm, RoPE, QK score, softmax/masking, AV, KV
+append/read, output head/logits, and sampling so the next optimization target is
+chosen from evidence.
+
+### CPU-AVX2-HOTPATH-015 -- user-facing AVX2 status
+
+Publish the exact support status for the official Microsoft BitNet I2_S artifact:
+scalar correctness oracle, AVX2 scaled I8_S readiness, answer corpus state,
+long-decode state, exact speed profiles, and non-claims.
+
+## Default validation bundle for runtime PRs
+
+Most runtime PRs should run the scoped bundle below in addition to the item
+specific commands when their touched crates support it:
+
+```bash
+cargo fmt --all -- --check
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256 --lib
+cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+git diff --check
+```
+
+Performance PRs also add a no-run benchmark build and JSON receipt validation
+for any new receipt artifact.


### PR DESCRIPTION
### Motivation

- Establish an explicit, repo-local implementation plan and spec so the CPU AVX2 BitNet campaign has a single source of truth for strict-mode semantics, required receipts, and the scaled I2_S × I8_S hot-path requirement. 
- Prevent hidden fallback and unclear claims by defining required hot-path counters, strict fail-closed rules, and a phased PR-by-PR sequence before any runtime kernel or performance changes. 

### Description

- Add a new plan under `plans/cpu-avx2-bitnet/` with `README.md` and `implementation-plan.md` that enumerate operating rules, PR sequence (hot-path counters, validator, fixtures, AVX2 microkernel, selection, wiring, perf work), and the default validation bundle. 
- Add the behavior spec `docs/specs/BITNET-SPEC-CPU-AVX2-HOTPATH.md` that defines the target end-state, required receipt fields (including `qk256_hot_path` counters), strict fallback rules, scalar parity gate, and forbidden claims. 
- Add a user-facing status page `docs/bitnet/BITNET_CPU_AVX2_STATUS.md` that documents the current claim boundary, required counters, and the promotion policy. 
- Update the `cpu-proof` tracker `docs/tracking/campaigns/cpu-proof/active.toml` with two work items (`CPU-AVX2-HOTPATH-000` docs rail in-progress and `CPU-AVX2-HOTPATH-001` hot-path counters marked ready) and their scoped commands and allowed/forbidden paths; no runtime/crate sources were modified. 

### Testing

- Ran the campaign check with `cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof` and it passed. 
- Verified repository diff hygiene with `git diff --check` and there were no issues. 
- No runtime or kernel tests were changed in this PR; the change is documentation and tracker-only and therefore does not alter runtime behavior or test coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaad93dd08333ac37836b2ff5aaa9)