### PR TITLE
docs(cpu): add AVX-512 kernel contract and ISA selection; plan and tracker

### DIFF
--- a/docs/bitnet/BITNET_KERNEL_MATRIX.md
+++ b/docs/bitnet/BITNET_KERNEL_MATRIX.md
@@ -46,7 +46,16 @@ Kernel family and kernel implementation are different fields. For example:
 | `qk256` | `qk256-scalar-gemv` | Scalar packed decode truth kernel |
 | `qk256` | `qk256-scalar-gemm` | Scalar packed prefill truth kernel |
 | `qk256` | `qk256-avx2-gemv` | AVX2 decode-first packed GEMV |
+| `qk256` | `qk256-avx512-f32-gemv` | AVX-512 no-scale F32-style decode GEMV |
+| `qk256` | `qk256-avx512-i8s-scaled-gemv` | AVX-512 BitNet I2_S × I8_S inline-scale decode GEMV |
+| `qk256` | `qk256-avx512-i8s-scaled-gemm` | AVX-512 BitNet I2_S × I8_S inline-scale prefill GEMM |
 | `qk256` | `qk256-neon-gemv` | ARM64 NEON decode-first packed GEMV |
+
+AVX-512 is a wider x86 lane, not a separate proof family. It must inherit
+scalar packed parity and compare against AVX2 before speed claims. AVX-512
+detection or an AVX-512 receipt label is not optimized AVX-512 kernel proof;
+strict receipts must prove selected kernel ID, fallback status, and AVX-512
+hot-path invocation counters.
 
 Strict receipts must record both `kernel_family` and requested/selected kernel IDs.
 

--- a/docs/specs/BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md
@@ -1,0 +1,188 @@
+# BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT: CPU AVX-512 Kernel Contract
+
+Status: proposed
+Linked roadmap: [AMD Ryzen 9 9950X3D CPU Roadmap](amd-9950x3d-cpu-roadmap.md)
+Linked plan: [CPU AVX-512 implementation plan](../../plans/cpu-avx512/implementation-plan.md)
+Applies to: CPU QK256/I2_S AVX-512 kernels, strict CPU kernel selection,
+answer-corpus receipts, parity receipts, microbench receipts, phase benchmark
+receipts, 9950X3D proof artifacts
+
+## Purpose
+
+AVX-512 support must not be inferred from CPUID detection, a receipt label, or
+an AVX2 proof run. This spec defines the evidence needed before BitNet-rs may
+claim that the CPU AVX-512 lane is detected, selectable, executed, correct,
+faster for a specific profile, or sustained on the 9950X3D lane.
+
+The contract is intentionally staged: first prove that AVX-512 can be requested
+and executed as a distinct QK256 kernel, then prove scalar/AVX2 parity, then
+record profile and sustained-performance receipts before any speed claim or
+auto-selection promotion.
+
+## Proof Terms
+
+| Term | Required evidence | Allowed claim |
+| --- | --- | --- |
+| AVX-512 detection proof | Runtime CPUID/subfeature probe records the detected x86 features. | AVX-512 was detected on this machine. |
+| AVX-512 dispatch proof | A strict or explicit request records requested kernel, selected kernel, fallback status, fallback reason, and required features. | AVX-512 was selected or strict selection failed honestly. |
+| AVX-512 kernel execution proof | The selected AVX-512 stable kernel ID is distinct from scalar/AVX2 IDs and invocation counters for that AVX-512 hot path are greater than zero. | AVX-512 kernel code executed for this workload. |
+| AVX-512 parity proof | Scalar-vs-AVX512 and AVX2-vs-AVX512 comparisons pass for the governed synthetic and real QK256 fixtures. | AVX-512 matches the governed reference for this fixture/profile. |
+| AVX-512 performance proof | Micro, layer, prefill, first-token, and decode receipts compare scalar, AVX2, and AVX-512 for the same model/profile. | AVX-512 is faster only for the measured profile whose receipt accepts the comparison. |
+| AVX-512 sustained-performance proof | Long-running 9950X3D receipts record duration, power/thermal context when available, core/CCD/cache-domain context, and AVX2 comparator behavior. | AVX-512 sustains the measured profile under the recorded platform conditions. |
+
+A lower proof level never implies a higher proof level. For example, detection
+proof does not imply dispatch proof, and execution proof does not imply speedup.
+
+## Stable Kernel IDs
+
+The AVX-512 lane must use stable kernel IDs that cannot be confused with scalar
+or AVX2 execution:
+
+```rust
+pub const QK256_AVX512_F32_GEMV_KERNEL_ID: &str =
+    "qk256-avx512-f32-gemv";
+
+pub const QK256_AVX512_I8S_SCALED_GEMV_KERNEL_ID: &str =
+    "qk256-avx512-i8s-scaled-gemv";
+
+pub const QK256_AVX512_I8S_SCALED_GEMM_KERNEL_ID: &str =
+    "qk256-avx512-i8s-scaled-gemm";
+```
+
+`qk256-avx512-f32-gemv` may land first because it mirrors the existing
+no-scale F32-style AVX2 GEMV structure. The production decode target is
+`qk256-avx512-i8s-scaled-gemv`, which must mirror the scalar BitNet I2_S × I8_S
+inline-scale semantics before any speed-oriented VNNI variant lands. The prefill
+target is `qk256-avx512-i8s-scaled-gemm`.
+
+A future VNNI implementation must use its own stable ID, such as
+`qk256-avx512vnni-i8s-scaled-gemv`, because a different accumulation strategy is
+a separate proof surface.
+
+## Required Feature Probes
+
+Receipts and strict dispatch must distinguish detected, required, and used
+subfeatures. The baseline scaled AVX-512 kernel may require only `avx512f` and
+`avx512bw`; VNNI must not be assumed unless it is probed.
+
+Required helper surface for follow-on implementation PRs:
+
+```rust
+pub fn avx512_f_available() -> bool;
+pub fn avx512_bw_available() -> bool;
+pub fn avx512_vl_available() -> bool;
+pub fn avx512_vnni_available() -> bool;
+pub fn avx512_f_bw_available() -> bool;
+pub fn avx512_f_bw_vl_available() -> bool;
+pub fn avx512_bitnet_i8s_available() -> bool;
+```
+
+All helpers must return `false` on unsupported architectures or builds without
+panicking.
+
+## Required Receipt Fields
+
+Strict AVX-512 proof receipts must record requested and selected CPU state plus
+exact hot-path counters. Field names may live in the repo's receipt schema, but
+the following information is mandatory:
+
+```json
+{
+  "requested_backend": "cpu",
+  "selected_backend": "amd-9950x3d-cpu-avx512",
+  "requested_kernel": "qk256-avx512-i8s-scaled-gemv",
+  "selected_kernel": "qk256-avx512-i8s-scaled-gemv",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "cpu": {
+    "arch": "x86_64",
+    "features_detected": ["avx512f", "avx512bw", "avx512vl", "avx512vnni"],
+    "features_required": ["avx512f", "avx512bw"],
+    "features_used": ["avx512f", "avx512bw"],
+    "threads": 16
+  },
+  "qk256_hot_path": {
+    "f32_scalar_invocations": 0,
+    "f32_avx2_invocations": 0,
+    "f32_avx512_invocations": 0,
+    "i8s_scaled_scalar_invocations": 0,
+    "i8s_scaled_avx2_invocations": 0,
+    "i8s_scaled_avx512_invocations": 420
+  },
+  "parity": {
+    "reference_kernel": "qk256-scalar-i8s-scaled-gemv",
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0,
+    "generated_token_agreement": true
+  }
+}
+```
+
+For answer-corpus receipts, an AVX-512 label alone is insufficient. At least one
+AVX-512 invocation counter for the selected hot path must be greater than zero,
+and scalar/AVX2 counters must distinguish fallback from intentional comparator
+runs.
+
+## Strict Fallback Requirement
+
+A strict request for an AVX-512 kernel must fail if the required AVX-512
+subfeatures or target-feature-gated kernel are unavailable. It must not silently
+select scalar or AVX2 while recording `fallback_used=false`.
+
+Non-strict explicit AVX-512 requests may fall back only if the receipt records:
+
+- requested kernel;
+- selected fallback kernel;
+- `fallback_used=true`;
+- a non-null fallback reason;
+- detected, required, and missing CPU features.
+
+## Implementation Rails
+
+- Do not compile the whole workspace with `-C target-cpu=native` to create the
+  AVX-512 lane. Use target-feature-gated functions and runtime checks.
+- Implement the exact/scalar-equivalent path before optimized variants.
+- Keep no-scale F32 GEMV and scaled BitNet I2_S × I8_S GEMV as separate proof
+  surfaces with separate kernel IDs and counters.
+- Treat AVX-512 VNNI as a later, separately identified kernel family member.
+- Keep auto-selection disabled for AVX-512 until parity, answer-corpus, phase,
+  and sustained receipts justify profile-specific promotion.
+
+## Claim Boundary
+
+- AVX-512 detection does not prove AVX-512 dispatch.
+- AVX-512 dispatch does not prove AVX-512 kernel execution.
+- AVX-512 execution does not prove speedup.
+- AVX-512 microbench speedup does not prove decode speedup.
+- AVX-512 short-burst performance does not prove sustained performance.
+- AVX-512 CPU proof does not prove CUDA, OpenCL, OpenVINO, NPU, Metal, WGPU,
+  server readiness, or general answer quality.
+
+## Proof Commands
+
+Documentation-only contract changes must run:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+```
+
+Follow-on runtime PRs must add the scoped cargo test, clippy, benchmark, and
+receipt validation commands listed by the implementation plan and active goal.
+
+## Non-Goals
+
+- No CUDA, OpenCL, OpenVINO, NPU, Metal, WGPU, or server support is added by this
+  contract.
+- No AVX-512 speedup is claimed by this contract.
+- No auto-selection promotion is authorized before the required receipts exist.
+- No model answer-quality claim is made without a strict answer-corpus receipt.
+
+## Related Sources
+
+- [CPU ISA selection spec](BITNET-SPEC-CPU-ISA-SELECTION.md)
+- [AMD Ryzen 9 9950X3D CPU Roadmap](amd-9950x3d-cpu-roadmap.md)
+- [BitNet Kernel Matrix](../bitnet/BITNET_KERNEL_MATRIX.md)
+- [BitNet CPU Path Plan](../bitnet/BITNET_CPU_PATH_PLAN.md)
+- [CPU AVX-512 implementation plan](../../plans/cpu-avx512/implementation-plan.md)

--- a/docs/specs/BITNET-SPEC-CPU-ISA-SELECTION.md
+++ b/docs/specs/BITNET-SPEC-CPU-ISA-SELECTION.md
@@ -1,0 +1,142 @@
+# BITNET-SPEC-CPU-ISA-SELECTION: Strict CPU ISA Selection
+
+Status: proposed
+Linked spec: [CPU AVX-512 kernel contract](BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md)
+Linked plan: [CPU AVX-512 implementation plan](../../plans/cpu-avx512/implementation-plan.md)
+Applies to: CPU kernel request modes, QK256/I2_S dispatch, strict fallback
+policy, CPU proof receipts, answer-corpus receipts, benchmark receipts
+
+## Purpose
+
+CPU ISA selection must be explicit enough to prove what ran. The selector must
+separate auto-selection, user-forced scalar/AVX2/AVX-512 requests, strict
+failure behavior, and non-strict fallback receipts.
+
+This spec prevents hidden fallback where a user requests AVX-512 but scalar or
+AVX2 execution is recorded as successful AVX-512 proof.
+
+## Required Request Modes
+
+CPU kernel selection must support these conceptual request modes. CLI spelling
+may use stable kernel IDs or aliases, but receipts must preserve the normalized
+mode or kernel ID that was requested.
+
+```text
+auto
+scalar
+avx2
+avx512
+avx512-vnni
+```
+
+The `avx512-vnni` mode is reserved until a separately identified VNNI kernel
+lands and passes parity. It must not alias to the baseline AVX-512BW kernel in
+strict receipts.
+
+## Selection Rules
+
+| Request | Runtime features | Strict? | Result |
+| --- | --- | ---: | --- |
+| `auto` | AVX-512 available and profile promotion accepted | n/a | Select promoted AVX-512 kernel for that profile. |
+| `auto` | AVX2 and FMA available | n/a | Select AVX2 when no AVX-512 promotion applies. |
+| `auto` | Neither AVX2/FMA nor promoted AVX-512 available | n/a | Select scalar. |
+| `avx512` | Required AVX-512 features available | true or false | Select the requested AVX-512 kernel. |
+| `avx512` | Required AVX-512 features missing | true | Error before fallback execution. |
+| `avx512` | Required AVX-512 features missing | false | Select scalar or AVX2 fallback and record `fallback_used=true`. |
+| `avx512-vnni` | Required AVX-512 and VNNI features available | true or false | Select the requested VNNI kernel. |
+| `avx512-vnni` | Required VNNI features missing | true | Error before fallback execution. |
+| `avx512-vnni` | Required VNNI features missing | false | Select baseline AVX-512, AVX2, or scalar fallback and record `fallback_used=true`. |
+| `avx2` | AVX2 and FMA available | true or false | Select AVX2. |
+| `avx2` | AVX2 or FMA missing | true | Error before fallback execution. |
+| `avx2` | AVX2 or FMA missing | false | Select scalar fallback and record `fallback_used=true`. |
+| `scalar` | Any | true or false | Select scalar. |
+
+## Auto-Selection Rail
+
+Auto mode must not choose AVX-512 merely because CPUID reports AVX-512. Auto may
+select AVX-512 for a specific profile only after all of the following exist and
+are accepted for that profile:
+
+- scalar parity;
+- AVX2 comparison;
+- answer-corpus proof when model-level answers are in scope;
+- phase benchmark showing the AVX-512 profile beats the comparator it replaces;
+- sustained run showing no profile regression under recorded 9950X3D platform
+  conditions;
+- receipt validator or promotion ledger accepts the profile-specific rule;
+- `fallback_used=false` in the promotion evidence.
+
+Until those gates land, AVX-512 is explicit-request or campaign-only.
+
+## Receipt Requirements
+
+Each CPU dispatch receipt must record:
+
+```text
+requested_backend
+selected_backend
+requested_kernel
+selected_kernel
+kernel_family
+fallback_used
+fallback_reason
+strict
+features_detected
+features_required
+features_used
+missing_features
+profile_name
+```
+
+For auto-selection, receipts must also identify why AVX-512 was or was not
+eligible for the profile. Absence of a promotion record must be interpreted as
+"not promoted," not as permission to use AVX-512 globally.
+
+## Error Requirements
+
+Strict selection errors must be actionable. A strict AVX-512 failure must name:
+
+- requested kernel or request mode;
+- selected kernel, if any, before execution;
+- required CPU features;
+- detected CPU features;
+- missing CPU features;
+- whether the binary was compiled with the needed feature gate.
+
+The process must not emit a success receipt that implies AVX-512 execution when
+execution did not occur.
+
+## Claim Boundary
+
+- `auto` does not mean "widest detected ISA".
+- A successful scalar or AVX2 fallback is not AVX-512 proof.
+- A strict selection failure is valid proof that hidden fallback was rejected.
+- `avx512-vnni` is not proven by baseline `avx512f,avx512bw` execution.
+- Profile-specific AVX-512 promotion does not imply global AVX-512 promotion.
+
+## Proof Commands
+
+Documentation-only selection changes must run:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+```
+
+Runtime selection PRs must add unit tests for strict and non-strict behavior for
+each request mode they introduce.
+
+## Non-Goals
+
+- This spec does not implement AVX-512 kernels.
+- This spec does not promote AVX-512 auto-selection.
+- This spec does not change GPU, NPU, OpenVINO, CUDA, OpenCL, Metal, WGPU, or
+  server selection rules.
+
+## Related Sources
+
+- [CPU AVX-512 kernel contract](BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md)
+- [AMD Ryzen 9 9950X3D CPU Roadmap](amd-9950x3d-cpu-roadmap.md)
+- [BitNet Kernel Matrix](../bitnet/BITNET_KERNEL_MATRIX.md)
+- [BitNet CPU Path Plan](../bitnet/BITNET_CPU_PATH_PLAN.md)

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,5 +1,27 @@
 # Specs Index
 
+
+## CPU AVX-512 Kernel Proof
+
+Use these specs before implementing or claiming AVX-512 CPU kernel support:
+
+1. [CPU AVX-512 Kernel Contract](BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md)
+   - Defines the difference between AVX-512 detection, dispatch, execution,
+     parity, performance, and sustained-performance proof.
+2. [CPU ISA Selection](BITNET-SPEC-CPU-ISA-SELECTION.md)
+   - Defines strict `auto`, `scalar`, `avx2`, `avx512`, and `avx512-vnni`
+     request behavior and fallback receipts.
+3. [AMD Ryzen 9 9950X3D CPU Roadmap](amd-9950x3d-cpu-roadmap.md)
+   - Defines the 9950X3D CPU-only lane, required profiles, comparisons, and
+     sustained/cache-domain metadata.
+4. [CPU AVX-512 Implementation Plan](../../plans/cpu-avx512/implementation-plan.md)
+   - Defines the PR-by-PR sequence from documentation rails to profile-scoped
+     auto-selection promotion.
+
+Do not proceed from AVX-512 detection or an AVX-512 receipt label to speed or
+execution claims. Claims require distinct selected kernel IDs, strict fallback
+truth, invocation counters, parity, and profile/sustained receipts.
+
 ## A770 BitNet Productization
 
 Use these specs before implementing or claiming A770 BitNet product support:

--- a/docs/specs/amd-9950x3d-cpu-roadmap.md
+++ b/docs/specs/amd-9950x3d-cpu-roadmap.md
@@ -40,7 +40,11 @@ This is a dual-CCD X3D CPU. Receipts should record scheduler, core placement, an
 ## Claim Boundary
 
 - AVX-512 detection is not AVX-512 kernel proof.
+- An AVX-512 receipt label is not AVX-512 hot-path execution proof without a
+  distinct selected kernel ID and AVX-512 invocation counters.
 - AVX2 proof is not AVX-512 proof.
+- AVX-512 execution is not an AVX-512 speedup claim.
+- AVX-512 microbench speedup is not decode, warm-session, or sustained proof.
 - Short boost behavior is not sustained performance.
 - X3D/cache-sensitive wins must be tied to benchmark receipts.
 - CPU proof is not GPU/NPU proof.
@@ -51,10 +55,45 @@ This is a dual-CCD X3D CPU. Receipts should record scheduler, core placement, an
 | Level | Evidence | Allowed claim |
 |---|---|---|
 | 0 | CPU model detected | 9950X3D detected |
-| 1 | Runtime feature probe records AVX2 and AVX-512 | CPU feature profile recorded |
-| 2 | Scalar, AVX2, and AVX-512 kernel smoke pass | CPU kernel smoke tested |
-| 3 | Strict CPU inference receipt validates | CPU proof receipt backed |
-| 4 | Cache-sensitive and sustained-power baselines exist | Modern desktop CPU benchmark recorded |
+| 1 | Runtime feature probe records AVX2 and AVX-512 subfeatures | CPU feature profile recorded |
+| 2 | Scalar, AVX2, and AVX-512 kernel smoke pass with distinct kernel IDs | CPU kernel smoke tested |
+| 3 | Strict CPU inference receipt validates selected kernel, fallback=false, and AVX-512 invocation counters | CPU proof receipt backed |
+| 4 | Scalar-vs-AVX512 and AVX2-vs-AVX512 parity receipts pass | AVX-512 parity recorded for the governed profile |
+| 5 | Cache-sensitive phase benchmark baselines exist | Modern desktop CPU phase benchmark recorded |
+| 6 | Sustained-power baseline exists with cache-domain/core-affinity context | Sustained 9950X3D CPU profile recorded |
+
+## Required AVX-512 Profiles
+
+The AVX-512 lane must keep profile names precise. At minimum, the 9950X3D proof
+queue must cover:
+
+```text
+micro_qk256_f32_gemv
+micro_qk256_i8s_scaled_gemv
+layer_0_decode
+prefill_128
+prefill_512
+first_token
+decode_32
+decode_128
+warm_session_3_turns
+sustained_decode_10min
+```
+
+## Required Comparisons
+
+AVX-512 receipts must compare against the narrower CPU proof lanes before any
+speed claim:
+
+```text
+scalar vs avx2
+scalar vs avx512
+avx2 vs avx512
+avx512 vs cuda diagnostic
+```
+
+The CUDA comparison is diagnostic only for this CPU lane. It must not be used to
+claim GPU proof or server readiness from a 9950X3D CPU receipt.
 
 ## Receipt Fields
 
@@ -78,9 +117,25 @@ Minimum CPU proof receipt:
     "avx512_detected": true,
     "tdp_watts": 170
   },
+  "cpu_topology": {
+    "ccd_count": 2,
+    "x3d_cache_domain": "...",
+    "core_affinity": "...",
+    "scheduler_policy": "...",
+    "smt_enabled": true
+  },
   "power": {
     "mode": "...",
-    "sustained_run": true
+    "sustained_run": true,
+    "duration_seconds": 600
+  },
+  "qk256_hot_path": {
+    "f32_scalar_invocations": 0,
+    "f32_avx2_invocations": 0,
+    "f32_avx512_invocations": 0,
+    "i8s_scaled_scalar_invocations": 0,
+    "i8s_scaled_avx2_invocations": 0,
+    "i8s_scaled_avx512_invocations": 0
   }
 }
 ```
@@ -97,7 +152,11 @@ Collect OS, CPU flags, topology, scheduler/core placement context, memory, gover
 
 ### AMD9950X3D-003 - Scalar, AVX2, and AVX-512 Dispatch Proof
 
-Prove scalar, AVX2, and AVX-512 paths can be forced independently and receipts record selected CPU kernel path.
+Prove scalar, AVX2, and AVX-512 paths can be forced independently and receipts
+record requested kernel, selected kernel, fallback status, fallback reason, CPU
+features required/used, and AVX-512 hot-path invocation counters. Strict
+requested AVX-512 must fail if the required AVX-512 subfeatures or compiled
+kernel are unavailable.
 
 ### AMD9950X3D-004 - Strict CPU Proof Run
 
@@ -133,3 +192,5 @@ How does the CPU-first path behave on a modern high-end AVX-512 and large-cache 
 - Do not ignore cache-domain or scheduler context for X3D behavior.
 - Do not treat CPU proof as GPU/NPU proof.
 - Do not make performance claims without sustained-power receipts.
+- Do not promote auto AVX-512 selection from CPUID alone; promotion is
+  profile-scoped and receipt-gated.

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -10,6 +10,7 @@ end_state = [
   "Packed BitNet layout is canonical.",
   "Scalar truth kernels exist before SIMD performance work.",
   "AVX2 dispatch and decode work are parity checked.",
+  "AVX-512 work is separated into detection, dispatch, execution, parity, profile, and sustained proof before speed claims.",
   "Strict receipts record model, tokenizer, quantization, kernel family, selected backend, phase, and fallback status.",
 ]
 
@@ -20,6 +21,7 @@ hard_constraints = [
   "No coherent local-answer claim from an artifact that is not answer_ready under docs/model-artifacts/ANSWER_ARTIFACT_GATE.md.",
   "No performance claim without receipt artifacts.",
   "No helper-only SIMD work unless it is wired to real inference or explicitly scoped as preparation.",
+  "No AVX-512 speed or auto-selection claim from CPUID detection, receipt labels, or AVX2 proof alone.",
 ]
 
 [[work_item]]
@@ -800,4 +802,48 @@ must_not_claim = [
   "CUDA answer readiness is proven.",
   "GPU, NPU, or server inference is involved.",
   "A speedup or throughput claim is proven.",
+]
+
+
+[[work_item]]
+id = "CPU-AVX512-000"
+status = "in_progress"
+branch = "codex/cpu-avx512-kernel-contract"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU-ANSWER-007"]
+acceptance = "Add the AVX-512 kernel contract, strict CPU ISA selection rails, implementation plan, 9950X3D proof requirements, and kernel-matrix claim boundary before runtime AVX-512 implementation starts."
+commands = [
+  "git diff --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+]
+allowed_paths = [
+  "docs/specs/BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md",
+  "docs/specs/BITNET-SPEC-CPU-ISA-SELECTION.md",
+  "docs/specs/amd-9950x3d-cpu-roadmap.md",
+  "docs/specs/INDEX.md",
+  "docs/bitnet/BITNET_KERNEL_MATRIX.md",
+  "plans/cpu-avx512/implementation-plan.md",
+  "docs/tracking/campaigns/cpu-proof/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "ci/hardware/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "The AVX-512 CPU kernel contract and strict CPU ISA selection rails are documented after merge.",
+  "The 9950X3D AVX-512 lane now has a receipt-gated implementation sequence after merge.",
+]
+must_not_claim = [
+  "An AVX-512 optimized kernel is implemented.",
+  "AVX-512 is auto-selected.",
+  "AVX-512 speedup or sustained performance is proven.",
+  "CUDA, GPU, NPU, OpenCL, OpenVINO, Metal, WGPU, server, or answer-quality readiness is proven.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -28,6 +28,7 @@
 | CPU-ANSWER-005 | merged | #4003 | `codex/cpu-answer-005-tokenizer-authority` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Strict Rust CPU answer receipts record the MODEL-ARTIFACT-007 external Llama-BPE tokenizer/pre-tokenizer authority instead of `unknown` when an explicit or sibling Llama-3 tokenizer is used; failed answer-corpus artifacts remain diagnostic and no answer-quality, throughput, server, GPU, or NPU claim is made. |
 | CPU-ANSWER-006 | merged | #4005 | `codex/cpu-answer-006-reference-token-artifact` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | A Microsoft BitNet.cpp reference-divergence artifact records the MODEL-ARTIFACT-007 prompt envelope, BOS policy, external Llama-BPE tokenizer/pre-tokenizer authority, prompt token IDs, generated token IDs, decoded text, and first-step top-k/logit evidence where available, so strict Rust CPU failures can be classified as prompt/tokenizer divergence, shared decode/logits divergence, or backend-specific execution without claiming answer quality. |
 | CPU-ANSWER-007 | merged | #4019 | `codex/cpu-answer-007-bitnet-subnorms` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Strict Rust CPU answer-corpus runs pass the MODEL-ARTIFACT-007 official Microsoft I2_S answer-ready artifact by aligning BitNet B1.58 model math with BitNet.cpp: RMSNorm/ReLU^2 defaults, attention and FFN sub-layernorms, BitNet.cpp I2_S QK256 layout, inline scale and I8_S GEMV semantics, and GGML token-major F16 token embeddings. |
+| CPU-AVX512-000 | in_progress | TBD | `codex/cpu-avx512-kernel-contract` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the AVX-512 kernel contract, strict CPU ISA selection rails, implementation plan, 9950X3D proof requirements, and kernel-matrix claim boundary before runtime AVX-512 implementation starts. |
 
 ## Hard Constraints
 
@@ -37,3 +38,4 @@
 - No coherent local-answer claim from an artifact that is not answer_ready under docs/model-artifacts/ANSWER_ARTIFACT_GATE.md.
 - No performance claim without receipt artifacts.
 - No helper-only SIMD work unless it is wired to real inference or explicitly scoped as preparation.
+- No AVX-512 speed or auto-selection claim from CPUID detection, receipt labels, or AVX2 proof alone.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -220,6 +220,7 @@
 | cpu-proof | CPU-ANSWER-005 | CPU-ANSWER-004 | merged |
 | cpu-proof | CPU-ANSWER-006 | CPU-ANSWER-005 | merged |
 | cpu-proof | CPU-ANSWER-007 | CPU-ANSWER-006 | merged |
+| cpu-proof | CPU-AVX512-000 | CPU-ANSWER-007 | in_progress |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | merged |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | MB-AS-002 | TBD | blocked | MB-AS-004 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-ANSWER-007 | #4019 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
+| cpu-proof | CPU-AVX512-000 | TBD | in_progress | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -28,7 +28,7 @@
 | apple-m4-slm-performance | Apple M4 SLM performance | M4-SLM-PERF-007 | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | Apple Silicon MacBook cross-reference | MB-AS-002 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-ANSWER-007 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-AVX512-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |

--- a/plans/cpu-avx512/implementation-plan.md
+++ b/plans/cpu-avx512/implementation-plan.md
@@ -1,0 +1,134 @@
+# CPU AVX-512 Implementation Plan
+
+This plan sequences the CPU AVX-512 lane from documentation and strict dispatch
+rails to real QK256 execution, parity receipts, profile benchmarks, and
+profile-scoped auto-selection. It intentionally starts with documentation
+because AVX-512 detection or a receipt label is not optimized AVX-512 kernel
+proof.
+
+## Source Links
+
+- Spec: `docs/specs/BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md`
+- Spec: `docs/specs/BITNET-SPEC-CPU-ISA-SELECTION.md`
+- Roadmap: `docs/specs/amd-9950x3d-cpu-roadmap.md`
+- Matrix: `docs/bitnet/BITNET_KERNEL_MATRIX.md`
+- CPU path plan: `docs/bitnet/BITNET_CPU_PATH_PLAN.md`
+- Campaign: `docs/tracking/campaigns/cpu-proof/active.toml`
+
+## Work Item: CPU-AVX512-000
+
+Status: ready
+Campaign: `docs/tracking/campaigns/cpu-proof/active.toml`
+Blocked by: CPU-ANSWER-007
+Blocks: CPU-AVX512-001 through CPU-AVX512-013
+
+### Goal
+
+Add the AVX-512 kernel contract, strict CPU ISA selection rails, AVX-512 PR
+queue, 9950X3D proof requirements, and kernel-matrix claim boundary before any
+runtime AVX-512 implementation starts.
+
+### Production Delta
+
+No runtime delta. This item is documentation and planning only.
+
+### Non-Goals
+
+- Do not add AVX-512 target-feature code.
+- Do not add an `avx512` crate feature.
+- Do not change answer-corpus receipts.
+- Do not change CUDA, NPU, OpenCL, OpenVINO, Metal, WGPU, or server claims.
+- Do not claim AVX-512 speedup or auto-selection.
+
+### Acceptance
+
+- `docs/specs/BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md` exists and defines
+  detection, dispatch, execution, parity, performance, and sustained proof.
+- `docs/specs/BITNET-SPEC-CPU-ISA-SELECTION.md` exists and defines `auto`,
+  `scalar`, `avx2`, `avx512`, and `avx512-vnni` strict/fallback behavior.
+- `docs/bitnet/BITNET_KERNEL_MATRIX.md` lists the AVX-512 QK256 kernel IDs and
+  states that AVX-512 must inherit scalar parity and compare against AVX2 before
+  speed claims.
+- `docs/specs/amd-9950x3d-cpu-roadmap.md` names required AVX-512 profiles,
+  comparisons, hardware metadata, and proof boundaries.
+- The CPU proof active goal names this documentation work item and the follow-on
+  AVX-512 sequence.
+
+### Proof Commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+```
+
+### Rollback
+
+Revert the AVX-512 spec files, this plan, and the related documentation/tracker
+edits. No runtime migration is needed because this item has no runtime delta.
+
+## Follow-On PR Queue
+
+| Order | ID | Title | Scope | Acceptance summary |
+| --- | --- | --- | --- | --- |
+| 1 | CPU-AVX512-001 | `feat(cpu): expose AVX-512 subfeature detection` | `bitnet-cpu-detect` helpers only | Non-x86-safe helpers expose AVX-512F/BW/VL/VNNI and composite checks; no dispatch change. |
+| 2 | CPU-AVX512-002 | `feat(quant): add AVX-512 feature gates` | `bitnet-quantization` feature plumbing | `cpu`, `cpu,avx2`, and `cpu,avx512` checks compile without selecting AVX-512 automatically. |
+| 3 | CPU-AVX512-003 | `feat(cpu): add AVX-512 QK256 F32 GEMV` | No-scale F32-style QK256 GEMV | Scalar parity, repeated-run equality, and strict unavailable failure for `qk256-avx512-f32-gemv`. |
+| 4 | CPU-AVX512-004 | `feat(cpu): add AVX-512 QK256 kernel selection` | Selection metadata | Explicit AVX-512 strict requests fail when unavailable; non-strict fallback records `fallback_used=true`; auto remains unpromoted. |
+| 5 | CPU-AVX512-005 | `diag(cpu): record AVX-512 QK256 invocation counters` | Receipt counters | Answer-corpus and proof receipts distinguish scalar, AVX2, and AVX-512 hot-path invocations. |
+| 6 | CPU-AVX512-006 | `test(cpu): add scaled I2S-I8S AVX-512 fixtures` | Scalar oracle fixtures | Scaled I2_S × I8_S scalar expected values are locked for AVX-512 reuse. |
+| 7 | CPU-AVX512-007 | `feat(cpu): add AVX-512 scaled I2S-I8S QK256 GEMV` | Baseline scaled AVX-512 GEMV | `qk256-avx512-i8s-scaled-gemv` mirrors scalar semantics, covers tails, and passes parity. |
+| 8 | CPU-AVX512-008 | `feat(cpu): route inline-scale QK256 through AVX-512` | Transformer/QK256 dispatch | Explicit strict AVX-512 real BitNet runs show selected scaled AVX-512 kernel, counters > 0, and fallback false. |
+| 9 | CPU-AVX512-009 | `test(cpu): refresh strict AVX-512 answer corpus` | 9950X3D answer proof | Official Microsoft I2_S GGUF strict receipts record tokenizer, selected kernel, counters, and parity diagnostics; no speed claim. |
+| 10 | CPU-AVX512-010 | `bench(cpu): add QK256 AVX-512 microbench receipts` | Microbench receipts | Scalar, AVX2, AVX-512 F32, and AVX-512 scaled shapes emit median/p95 and feature context. |
+| 11 | CPU-AVX512-011 | `bench(cpu): add 9950X3D AVX-512 phase receipts` | Phase benchmark receipts | Prefill, first-token, decode, and warm-session receipts compare scalar, AVX2, AVX-512, and optional CUDA diagnostics. |
+| 12 | CPU-AVX512-012 | `bench(cpu): record sustained 9950X3D AVX-512 profile` | Sustained/cache-domain proof | Ten-minute decode or warm-session receipts record thermal/power/core/CCD context and AVX2 comparator behavior. |
+| 13 | CPU-AVX512-013 | `feat(cpu): promote AVX-512 auto-selection by profile` | Promotion ledger and selector | Auto selects AVX-512 only for profiles accepted by parity, answer, phase, sustained, fallback-free receipts. |
+
+## Default Validation Set For Runtime AVX-512 PRs
+
+Use the scoped subset that matches the changed files, and add receipt or
+benchmark commands when the work item introduces receipts:
+
+```bash
+cargo fmt --all -- --check
+cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx512
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx512 i2s_qk256
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx512 --test qk256_avx512_parity_tests
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2,avx512 --test qk256_avx2_parity_tests
+cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli
+cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+## 9950X3D Hardware Proof Commands
+
+These commands are for the 9950X3D hardware lane after the scaled kernel and
+receipt counters exist. They are not required for the documentation-only first
+PR.
+
+```bash
+cargo build --locked -p bitnet-cli --no-default-features --features cpu,full-cli,avx512 --release
+
+target/release/bitnet.exe answer-corpus \
+  --device cpu \
+  --cpu-kernel qk256-avx512-i8s-scaled-gemv \
+  --strict-loader \
+  --strict-tokenizer \
+  --model <official-bitnet-i2s-gguf> \
+  --tokenizer <tokenizer-json> \
+  --json-out ci/hardware/windows-9950x3d-rtx5070ti/<date>/cpu-avx512-answer-corpus.json
+
+target/release/bitnet.exe answer-parity \
+  --left <scalar receipt> \
+  --right <avx512 receipt> \
+  --json-out ci/hardware/windows-9950x3d-rtx5070ti/<date>/cpu-scalar-vs-avx512-answer-parity.json
+```
+
+## Rollback Guidance For Runtime PRs
+
+Runtime PRs must keep scalar and AVX2 behavior independently reversible. If an
+AVX-512 implementation regresses parity, revert that specific AVX-512 file,
+feature gate, selector branch, or promotion ledger without weakening strict
+fallback enforcement or scalar/AVX2 proofs.


### PR DESCRIPTION
### Motivation

- AVX-512 detection and AVX-512-labeled receipts are insufficient proof that an optimized AVX-512 QK256 kernel actually executed, so the repo needs a clear, staged contract for what counts as AVX-512 proof. 
- Prevent hidden fallback and accidental promotion by requiring strict request modes, runtime subfeature probes, distinct stable kernel IDs, invocation counters, and parity/benchmark receipts before any speed or auto-selection claims. 
- Establish a PR-by-PR implementation queue and campaign tracker so AVX-512 work proceeds from documentation/rails to conservative smoke kernels, scaled kernels, parity tests, phase benchmarks, and sustained-power proofs.

### Description

- Add `docs/specs/BITNET-SPEC-CPU-AVX512-KERNEL-CONTRACT.md` defining detection vs dispatch vs execution vs parity/performance/sustained proof and the required receipt fields and helper probes. 
- Add `docs/specs/BITNET-SPEC-CPU-ISA-SELECTION.md` defining request modes (`auto`, `scalar`, `avx2`, `avx512`, `avx512-vnni`), strict/fallback rules, and auto-selection rails. 
- Add `plans/cpu-avx512/implementation-plan.md`, update `docs/bitnet/BITNET_KERNEL_MATRIX.md` to include the AVX-512 kernel IDs (`qk256-avx512-f32-gemv`, `qk256-avx512-i8s-scaled-gemv`, `qk256-avx512-i8s-scaled-gemm`), and tighten `docs/specs/amd-9950x3d-cpu-roadmap.md` with required profiles/comparisons/topology/power fields. 
- Register the documentation work as a campaign work item in `docs/tracking/campaigns/cpu-proof/active.toml` and regenerate campaign dashboards under `docs/tracking/generated/` to reflect the new AVX-512 plan and constraints; this change is documentation-only and makes no runtime or crate-feature changes.

### Testing

- Ran the campaign tooling to validate and regenerate dashboards: `cargo run -p xtask --no-default-features -- campaign check cpu-proof` and `cargo run -p xtask --no-default-features -- campaign generate` succeeded and updated generated tracker artifacts. 
- Ran the contract/check invocation `cargo run -p xtask --no-default-features -- campaign generate --check` which reported generated dashboards are current. 
- Ran the repository checks referenced by the plan including the configured `git diff --check` validation and found no blocking issues. 
- All validation commands listed in the plan for this documentation-only PR completed successfully; no runtime tests were required because no code or feature gates were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaea86ab48333b485a1b8e285c59e)