### PR TITLE
docs(cuda): add CUDA route contract

### DIFF
--- a/docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md
+++ b/docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md
@@ -24,6 +24,7 @@ This spec relies on existing authorities instead of replacing them:
 - [Native Rust inference product proposal](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
 - [Source-of-truth and claim boundaries](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md)
 - [9950X3D + RTX 5070 Ti CUDA product contract](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- [CUDA route contract](BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
 - [Server readiness proof boundary](BITNET-SPEC-0010-server-readiness-proof-boundary.md)
 - [Answer Artifact Gate](../model-artifacts/ANSWER_ARTIFACT_GATE.md)
 - [Model Coverage Matrix](../model-artifacts/MODEL_COVERAGE_MATRIX.md)
@@ -232,6 +233,25 @@ Must not claim:
 - Speedup is exact-profile only.
 - Server readiness is exact-profile unless a later spec explicitly promotes a
   broader scope.
+
+## CUDA Route Claim Boundary
+
+CUDA accelerator rows must name a selected route before promotion. The common
+route IDs are defined by
+[BITNET-SPEC-CUDA-ROUTE-CONTRACT](BITNET-SPEC-CUDA-ROUTE-CONTRACT.md):
+
+```text
+bitnet_qk256_cuda
+dense_regular_llm_cuda
+dense_gguf_linear_cuda_parity
+dense_gguf_layer_plan
+server_shared_engine_cuda
+```
+
+A receipt with generic `cuda` but no resolved selected backend cannot promote a
+strict RTX 5070 Ti claim. Dense regular-LLM CUDA and BitNet packed I2_S/QK256
+CUDA remain separate proof families, and planning or fixture routes cannot be
+used as full-model execution proof.
 
 ## Required Claim Booleans
 

--- a/docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md
@@ -1,0 +1,202 @@
+# BITNET-SPEC-CUDA-ROUTE-CONTRACT: CUDA Route Contract
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal:
+[BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md),
+[BITNET-PROP-0002](../proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
+Linked specs:
+[BITNET-SPEC-0013](BITNET-SPEC-0013-model-onboarding-proof-ladder.md),
+[BITNET-SPEC-0014](BITNET-SPEC-0014-runtime-performance-contract.md),
+[BITNET-SPEC-0007](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+Linked ADRs:
+[BITNET-ADR-0004](../adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md),
+[BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan:
+[9950X3D + RTX 5070 Ti CUDA Productization Plan](../../plans/cuda-5070ti-productization/README.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines CUDA route receipt fields and proof-family rails;
+does not promote any model coverage row.
+Policy impact: n/a
+
+## Purpose
+
+CUDA support in BitNet-rs is not one interchangeable proof family. A receipt
+must identify the selected backend, runtime API, route, execution plan,
+fallback status, and proof family before it can support a CUDA claim.
+
+This spec defines the narrow route vocabulary and receipt contract used by CUDA
+model-status, ask/chat, bench, server, and receipt-explanation surfaces. It is a
+child contract under the model onboarding proof ladder and runtime performance
+contract; it does not add new runtime behavior or promote any model.
+
+## Route IDs
+
+CUDA receipts that make route claims must use one of these route IDs.
+
+| Route ID | Meaning | Claim boundary |
+| --- | --- | --- |
+| `bitnet_qk256_cuda` | Official BitNet I2_S/QK256 packed route using CUDA QK256 model math evidence. | Proves only the scoped BitNet packed I2_S/QK256 route for the named artifact/backend/profile. |
+| `dense_regular_llm_cuda` | Dense SLM or small dense LLM CUDA inference route for a named model family and artifact. | Proves only that dense model row and profile; it is not BitNet proof. |
+| `dense_gguf_linear_cuda_parity` | Dense GGUF single-linear or boundary parity fixture. | Fixture evidence only; it is not full model CUDA readiness. |
+| `dense_gguf_layer_plan` | Dense GGUF all-layer execution-plan or unsupported-op accounting. | Planning evidence only; it is not CUDA execution proof. |
+| `server_shared_engine_cuda` | Shared-engine CUDA server route for a named endpoint/profile. | Server-profile evidence only; it does not imply broad serving, speedup, or full residency. |
+
+Future CUDA routes must be added to this table before receipts use them for
+promotion.
+
+## Required CUDA Receipt Fields
+
+Every CUDA receipt that supports a user-facing claim must include these fields
+or an explicitly documented equivalent path in the receipt schema:
+
+```json
+{
+  "requested_backend": "cuda | nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "selected_route": "bitnet_qk256_cuda | dense_regular_llm_cuda",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "execution_plan": {
+    "route": "...",
+    "bitnet_qk256_cuda_ops": 0,
+    "dense_regular_llm_cuda_ops": 0,
+    "cpu_fallback_ops": 0,
+    "unsupported_ops": 0
+  },
+  "proof_family": {
+    "bitnet_packed_i2s_qk256_proof": true,
+    "dense_regular_llm_cuda_proof": false
+  }
+}
+```
+
+Receipts may include additional route-specific fields, but these common fields
+are the minimum needed to prevent hidden fallback and proof-family conflation.
+
+## Backend Resolution
+
+`cuda` is a user convenience selector, not proof by itself. A CUDA receipt may
+record `requested_backend = "cuda"` only if it resolves the actual selected
+backend before making any proof claim.
+
+For the 9950X3D + RTX 5070 Ti lane, strict proof receipts must resolve to:
+
+```text
+selected_backend = nvidia-rtx-5070-ti-cuda
+runtime_api = cuda
+fallback_used = false
+```
+
+A receipt that leaves `selected_backend` as generic `cuda` cannot promote RTX
+5070 Ti CUDA status.
+
+## Proof-Family Rules
+
+CUDA proof families are non-interchangeable:
+
+- Dense regular-LLM CUDA proof never satisfies BitNet packed I2_S/QK256 proof.
+- BitNet packed I2_S/QK256 proof never satisfies dense regular-LLM CUDA proof.
+- Dense linear parity fixtures do not prove dense full-model CUDA readiness.
+- Dense all-layer plans do not prove CUDA execution.
+- Server shared-engine CUDA receipts prove only the named server endpoint,
+  streaming mode, request profile, model row, backend, route, and readiness
+  scope.
+- CPU AVX-512, WGPU, OpenCL, Vulkan, Metal, NPU, hardware visibility, and CUDA
+  probe receipts do not prove CUDA model execution.
+
+## Fallback Rules
+
+Strict CUDA receipts must reject hidden fallback:
+
+- `fallback_used = true` is a hard failure for strict CUDA proof.
+- `cpu_fallback_ops > 0` is a hard failure for strict CUDA proof unless the
+  receipt is explicitly a diagnostic non-promotion receipt.
+- `unsupported_ops > 0` may be valid planning evidence, but it blocks route
+  promotion until the unsupported operations are resolved or scoped out by an
+  accepted spec.
+- A missing fallback field cannot be interpreted as fallback-free.
+
+## Execution-Plan Rules
+
+A CUDA receipt with no execution plan cannot promote a CUDA claim. The execution
+plan must state the route and route-family operation counters so reviewers can
+answer which CUDA route actually executed.
+
+For BitNet QK256 receipts, `bitnet_qk256_cuda_ops` or route-specific QK256
+kernel counters must be greater than zero for execution proof.
+
+For dense regular-LLM CUDA receipts, `dense_regular_llm_cuda_ops` or equivalent
+dense route counters must be greater than zero for execution proof.
+
+## Claim Booleans
+
+CUDA model coverage rows and receipt explanations must keep proof booleans
+separate:
+
+```json
+{
+  "bitnet_packed_i2s_qk256_proof": false,
+  "dense_regular_llm_cuda_proof": true,
+  "server_ready": false,
+  "speedup_claim": false,
+  "full_residency_claim": false
+}
+```
+
+A row may set only the proof booleans supported by matching receipts. Speedup,
+server readiness, and full residency remain separate claims even when CUDA
+execution and answer quality are proven.
+
+## Required Explanation Surface
+
+`bitnet receipts explain` and `bitnet model status` should expose enough route
+contract information for users to distinguish:
+
+- requested backend versus selected backend;
+- generic CUDA selector versus strict RTX 5070 Ti proof;
+- BitNet QK256 CUDA versus dense regular-LLM CUDA;
+- execution proof versus planning or fixture evidence;
+- fallback-free execution versus rejected fallback;
+- product CLI readiness versus server readiness;
+- benchmark qualification versus unqualified speed;
+- upload-once or linear residency versus full model residency.
+
+## Acceptance
+
+This spec is accepted when:
+
+- CUDA route IDs are explicit and reusable by later receipt validators;
+- required common receipt fields are defined;
+- proof-family boundaries are stated as hard rails;
+- strict CUDA fallback rules are documented;
+- no runtime behavior changes are introduced by this docs PR;
+- no model coverage row is promoted by this docs PR.
+
+## Non-Goals
+
+This spec does not prove or implement:
+
+- a new CUDA kernel;
+- a new BitNet QK256 answer receipt;
+- a new dense SLM answer receipt;
+- speedup;
+- full CUDA residency;
+- server readiness;
+- broad chat quality;
+- support for a GPU other than the selected proof backend named in a receipt.
+
+## Validation
+
+For docs-only edits to this route contract and linked status surfaces, run:
+
+```bash
+git diff --check
+```
+
+When this contract is wired into generated model coverage or receipt validators,
+those later PRs must also run the relevant generator or checker named by the
+plan item.

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -22,11 +22,34 @@ bitnet receipts explain --latest
 | Human-readable model coverage | `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md` |
 | RTX 5070 Ti campaign state | `docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md` |
 | Strict CUDA product contract | `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md` |
+| CUDA route contract | `docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md` |
 | Server readiness boundary | `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` |
 | User quickstart | `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md` |
 | BitNet CUDA guide | `docs/tutorials/rtx5070ti-bitnet-cuda.md` |
 | Dense Qwen CUDA guide | `docs/tutorials/rtx5070ti-dense-qwen-cuda.md` |
 | Receipt triage guide | `docs/tutorials/cuda-receipt-triage.md` |
+
+## Route Contract
+
+CUDA status rows use the route IDs and proof-family booleans defined by
+[BITNET-SPEC-CUDA-ROUTE-CONTRACT](../specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md).
+A row may not treat generic `cuda` as strict RTX 5070 Ti proof unless the
+receipt resolves `selected_backend = nvidia-rtx-5070-ti-cuda`, records
+`runtime_api = cuda`, rejects fallback, and includes an execution plan for the
+selected route.
+
+The current first-class route IDs are:
+
+```text
+bitnet_qk256_cuda
+dense_regular_llm_cuda
+dense_gguf_linear_cuda_parity
+dense_gguf_layer_plan
+server_shared_engine_cuda
+```
+
+Dense CUDA proof, BitNet QK256 proof, fixture parity, layer planning, server
+readiness, speedup, and full residency are separate claims.
 
 ## Current CUDA Rows
 

--- a/plans/cuda-5070ti-productization/README.md
+++ b/plans/cuda-5070ti-productization/README.md
@@ -20,6 +20,8 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
   [`BITNET-SPEC-0007`](../../docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
 - Server readiness spec:
   [`BITNET-SPEC-0010`](../../docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md)
+- CUDA route contract:
+  [`BITNET-SPEC-CUDA-ROUTE-CONTRACT`](../../docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
 - Bench ADR:
   [`BITNET-ADR-0004`](../../docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
 - CUDA campaign:
@@ -34,6 +36,7 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
 ## Files
 
 - [`implementation-plan.md`](implementation-plan.md) lists the PR-sized queue.
+- [`BITNET-SPEC-CUDA-ROUTE-CONTRACT`](../../docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md) defines route IDs, common CUDA receipt fields, and proof-family rails for this plan.
 - [`bitnet-official-i2s.md`](bitnet-official-i2s.md) owns the official BitNet
   2B I2_S/QK256 product path.
 - [`dense-qwen.md`](dense-qwen.md) owns the Qwen2.5 0.5B Q8_0 dense CUDA lane.
@@ -43,6 +46,15 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
   profile-specific speed decisions.
 - [`server-readiness.md`](server-readiness.md) owns exact-profile server
   readiness promotion rules.
+
+## Phase 0 Spec Rails
+
+The first CUDA end-state PR adds the route contract before any runtime change.
+That contract makes `bitnet_qk256_cuda`, `dense_regular_llm_cuda`,
+`dense_gguf_linear_cuda_parity`, `dense_gguf_layer_plan`, and
+`server_shared_engine_cuda` explicit, requires selected-backend resolution and
+execution-plan fields in promotion receipts, and keeps proof families
+non-interchangeable.
 
 ## Claim Boundary
 


### PR DESCRIPTION
### Motivation

- Make CUDA route identities and receipt contract explicit so proof families cannot be conflated and generic `cuda` cannot silently promote RTX 5070 Ti claims. 
- Ensure `bitnet receipts explain`, model status, plans, and model-onboarding ladders can rely on a shared route vocabulary and common receipt fields. 

### Description

- Add `docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md` which defines route IDs (`bitnet_qk256_cuda`, `dense_regular_llm_cuda`, `dense_gguf_linear_cuda_parity`, `dense_gguf_layer_plan`, `server_shared_engine_cuda`), required common receipt fields, backend resolution rules, fallback rails, execution-plan expectations, proof-family separation, claim booleans, and non-goals. 
- Link the new CUDA route contract from the model onboarding spec by updating `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md` and add a CUDA route claim-boundary section there. 
- Update `docs/status/CUDA_CAPABILITY_MATRIX.md` to include the route contract in its sources and surface the route IDs and claim-boundary guidance. 
- Update `plans/cuda-5070ti-productization/README.md` to reference the route contract and document Phase 0 spec rails (route contract is added before runtime changes). 

### Testing

- Ran the model-coverage validation with `xtask` using `cargo run --locked -p xtask --no-default-features -- check-model-coverage` which completed successfully. 
- Ran the campaign checks with `cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti` which passed. 
- Ran the campaign generation validation with `cargo run --locked -p xtask --no-default-features -- campaign generate --check` which reported generated dashboards are current. 
- Ran `git diff --check` as the docs validation step which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab9b0529083339d68e4386d0ef189)