### PR TITLE
docs(cuda): add CUDA route contract

### DIFF
--- a/docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md
+++ b/docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md
@@ -24,6 +24,7 @@ This spec relies on existing authorities instead of replacing them:
 - [Native Rust inference product proposal](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
 - [Source-of-truth and claim boundaries](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md)
 - [9950X3D + RTX 5070 Ti CUDA product contract](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- [CUDA Route Contract](BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
 - [Server readiness proof boundary](BITNET-SPEC-0010-server-readiness-proof-boundary.md)
 - [Answer Artifact Gate](../model-artifacts/ANSWER_ARTIFACT_GATE.md)
 - [Model Coverage Matrix](../model-artifacts/MODEL_COVERAGE_MATRIX.md)
@@ -218,6 +219,14 @@ Must not claim:
 - concurrency readiness without concurrency proof;
 - speedup or full residency without separate proof.
 
+## CUDA Route Contract
+
+CUDA model rows and receipts that claim CUDA execution must follow the narrower
+[BITNET-SPEC-CUDA-ROUTE-CONTRACT](BITNET-SPEC-CUDA-ROUTE-CONTRACT.md).
+In particular, generic `cuda` must resolve to the strict backend before proof,
+`selected_route` must use the documented CUDA route IDs, strict CUDA fallback is
+a hard failure, and proof-family booleans must stay non-interchangeable.
+
 ## Promotion Rules
 
 - A model must not skip `reference_good` or `cpu_answer_ready` before
@@ -225,6 +234,8 @@ Must not claim:
   substitute and updates the model coverage row.
 - Dense CUDA evidence cannot satisfy BitNet I2_S/QK256 proof.
 - BitNet I2_S/QK256 evidence cannot satisfy dense SLM or small dense LLM proof.
+- CUDA receipts without a selected route and execution plan cannot promote
+  accelerator, product, server, speed, or residency claims.
 - Qwen2.5 evidence cannot satisfy Qwen3, SmolLM2, Llama, Gemma, or Phi rows.
 - Structural validity cannot satisfy answer readiness.
 - Hardware detection cannot satisfy selected-backend execution proof.

--- a/docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md
@@ -1,0 +1,229 @@
+# BITNET-SPEC-CUDA-ROUTE-CONTRACT: CUDA Route Contract
+
+Status: Draft
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0002](../proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md),
+  [BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs: [BITNET-SPEC-0007](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md),
+  [BITNET-SPEC-0013](BITNET-SPEC-0013-model-onboarding-proof-ladder.md),
+  [BITNET-SPEC-0014](BITNET-SPEC-0014-runtime-performance-contract.md)
+Linked ADRs: [BITNET-ADR-0004](../adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
+Linked plan: [CUDA 5070 Ti productization](../../plans/cuda-5070ti-productization/README.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines route and proof-family fields required before
+  CUDA receipts can promote accelerator, product, server, speed, or residency
+  claims.
+Policy impact: No CI policy change; CUDA hardware proof remains outside
+  ordinary PR CI.
+
+## Purpose
+
+This spec defines the route vocabulary and receipt fields that make CUDA claims
+machine-checkable for BitNet-rs. It narrows the existing CUDA product contract
+under BITNET-SPEC-0007 and the model proof ladder under BITNET-SPEC-0013 so
+users and maintainers can tell which CUDA route actually executed and which
+proof family, if any, the receipt can support.
+
+A CUDA receipt must never let these proof families look interchangeable:
+
+- official BitNet I2_S/QK256 CUDA;
+- dense regular-LLM CUDA for dense SLMs or small dense LLMs;
+- dense GGUF diagnostic parity fixtures;
+- dense GGUF layer-planning evidence;
+- server shared-engine CUDA execution;
+- CPU reference execution.
+
+## Scope
+
+This spec applies to CUDA receipts, CUDA model coverage rows, and user-facing
+surfaces that summarize CUDA receipts, including:
+
+```text
+bitnet model status --device nvidia-rtx-5070-ti-cuda
+bitnet model verify <model>
+bitnet ask --device cuda --model <model> "..."
+bitnet chat --device cuda --model <model>
+bitnet bench --device cuda --model <model>
+bitnet serve --device cuda --model <model>
+bitnet receipts explain --latest --format json
+```
+
+It is a documentation and receipt contract. It does not implement runtime
+routing, kernels, CLI behavior, server behavior, or benchmark promotion.
+
+## Route IDs
+
+CUDA receipts and status explanations must use one of these route IDs when the
+receipt is claiming or evaluating CUDA execution:
+
+| Route ID | Meaning | May prove | Must not prove |
+| --- | --- | --- | --- |
+| `bitnet_qk256_cuda` | Official BitNet I2_S/QK256 route that executes packed QK256 BitNet linear work through CUDA kernels. | BitNet packed I2_S/QK256 CUDA for the exact artifact, backend, and profile. | Dense regular-LLM CUDA, TL1/TL2, GPU-int2 master routes, speedup, full residency, or broad server readiness. |
+| `dense_regular_llm_cuda` | Dense SLM or small dense LLM route that executes dense regular-LLM model work through CUDA. | Dense regular-LLM CUDA for the exact model family, artifact, backend, and profile. | BitNet I2_S/QK256, 1-bit packed-kernel proof, or another dense model family's proof. |
+| `dense_gguf_linear_cuda_parity` | Diagnostic dense GGUF single-linear or role-sweep parity fixture. | The scoped parity fixture only. | Whole-model CUDA execution, answer readiness, product CLI readiness, server readiness, speedup, or full residency. |
+| `dense_gguf_layer_plan` | Dense GGUF all-layer route-planning descriptor with supported and unsupported op counts. | Planning readiness and missing-op accounting. | CUDA execution, answer quality, product CLI readiness, server readiness, speedup, or residency. |
+| `server_shared_engine_cuda` | Server path using a shared CUDA engine for a named endpoint/profile. | Exact-profile server readiness only when paired with endpoint, profile, model row, fallback, and response-quality proof. | CLI readiness, streaming/concurrency/long-context readiness outside the proven profile, speedup, full residency, or other model-family proof. |
+
+Receipts may include narrower sub-route or kernel fields, but those fields must
+not replace the route ID above when promoting a CUDA support claim.
+
+## Required CUDA Receipt Fields
+
+Every CUDA receipt that can be used for accelerator, product, server,
+benchmark, speed, or residency claims must include enough structured data to
+explain backend selection, fallback, route identity, execution-plan counts, and
+proof-family booleans.
+
+Minimum shape:
+
+```json
+{
+  "requested_backend": "cuda | nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "selected_route": "bitnet_qk256_cuda | dense_regular_llm_cuda | dense_gguf_linear_cuda_parity | dense_gguf_layer_plan | server_shared_engine_cuda",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "execution_plan": {
+    "route": "bitnet_qk256_cuda",
+    "bitnet_qk256_cuda_ops": 0,
+    "dense_regular_llm_cuda_ops": 0,
+    "cpu_fallback_ops": 0,
+    "unsupported_ops": 0
+  },
+  "proof_family": {
+    "bitnet_packed_i2s_qk256_proof": true,
+    "dense_regular_llm_cuda_proof": false
+  }
+}
+```
+
+A route-specific receipt may add fields such as kernel invocation counts,
+server request IDs, timing data, transfer counters, or residency phase tables.
+Those fields refine the claim but do not remove the minimum fields above.
+
+## Backend Selection Rules
+
+- `requested_backend="cuda"` is a convenience selector only. A CUDA proof
+  receipt must resolve it to `selected_backend="nvidia-rtx-5070-ti-cuda"`
+  before claiming RTX 5070 Ti CUDA execution.
+- `selected_backend="cuda"` is not a strict product proof value.
+- `runtime_api="cuda"` is required for CUDA proof. WGPU, Vulkan, D3D12,
+  OpenCL, ROCm, Metal, and CPU receipts must keep their own API identities.
+- Hardware visibility, device enumeration, NVML presence, and a tiny kernel
+  smoke are not whole-route execution proof unless paired with a route and
+  execution plan.
+
+## Execution Plan Rules
+
+A CUDA execution plan must make hidden fallback and unsupported work visible.
+At minimum it must report:
+
+- the route being evaluated;
+- BitNet QK256 CUDA op count;
+- dense regular-LLM CUDA op count;
+- CPU fallback op count;
+- unsupported op count.
+
+For strict CUDA product claims:
+
+- `fallback_used` must be `false`;
+- `fallback_reason` must be `null`;
+- `cpu_fallback_ops` must be `0`;
+- the route-relevant CUDA op count must be greater than `0` for execution
+  claims;
+- a receipt with no execution plan cannot promote a CUDA claim.
+
+## Proof Family Rules
+
+Proof family booleans must stay explicit and non-interchangeable:
+
+| Claim boolean | May be true when | Must be false when |
+| --- | --- | --- |
+| `bitnet_packed_i2s_qk256_proof` | The exact official BitNet I2_S/QK256 artifact executed the `bitnet_qk256_cuda` route with route-specific proof and fallback rejected. | The route is dense regular-LLM, dense parity-only, planning-only, server-only without BitNet route proof, CPU, WGPU, Vulkan, or generic hardware smoke. |
+| `dense_regular_llm_cuda_proof` | The exact dense model artifact executed the `dense_regular_llm_cuda` route with model-family proof and fallback rejected. | The route is BitNet QK256, dense parity-only, planning-only, CPU, WGPU, Vulkan, or another dense model's proof. |
+
+A receipt may set both booleans to `false` for diagnostic, planning,
+benchmark-review, or server receipts that do not independently prove either
+family. A receipt must not set both to `true` unless a later spec defines an
+explicit composite route and its independent evidence requirements.
+
+## Claim Rails
+
+CUDA route receipts must enforce these rails:
+
+- Dense CUDA can never satisfy BitNet packed I2_S/QK256 proof.
+- BitNet QK256 CUDA can never satisfy dense regular-LLM CUDA proof.
+- CPU AVX-512 receipts are same-box reference evidence, not CUDA execution.
+- Generic `cuda` without strict backend resolution is not RTX 5070 Ti proof.
+- Strict CUDA with CPU fallback is a hard failure for CUDA execution claims.
+- Dense GGUF parity fixtures are diagnostics, not product route proof.
+- Dense GGUF layer plans are route-planning evidence, not execution proof.
+- Exact-profile server readiness does not imply CLI readiness, streaming
+  readiness, concurrency readiness, speedup, or full residency.
+- Benchmark qualification is exact-profile only and requires the runtime
+  performance contract fields before any speed claim.
+- Upload-once weights, kernel invocation counts, or CUDA linears alone do not
+  prove full model residency.
+
+## Status And Receipt Explanation Requirements
+
+`model status` and `receipts explain` summaries for CUDA claims should expose:
+
+- model coverage row;
+- current support tier;
+- requested backend;
+- selected backend;
+- runtime API;
+- selected route;
+- proof family booleans;
+- fallback status;
+- execution-plan counts;
+- server readiness and scope when applicable;
+- speedup claim status;
+- full-residency claim status;
+- forbidden claims that remain false.
+
+Missing model coverage rows or missing optional detail should degrade to an
+honest unknown or unsupported explanation. They must not silently promote the
+receipt to CUDA product support.
+
+## Acceptance
+
+This spec is accepted when:
+
+- the route IDs above are documented and linked from the model proof ladder,
+  CUDA capability matrix, and CUDA productization plan;
+- receipt fields and proof-family booleans are defined;
+- hard rails prevent dense/BitNet proof-family conflation;
+- no runtime behavior changes are made;
+- no model coverage row is promoted.
+
+## Proof Commands
+
+Docs-only validation for this spec:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+```
+
+If a status page with its own validation block is edited in the same PR, also
+run its listed checker or record why it is unavailable.
+
+## Non-Goals
+
+- Do not implement CUDA kernels or runtime dispatch in this spec.
+- Do not change model coverage tiers or claim booleans in this spec.
+- Do not add or edit hardware proof receipts in this spec.
+- Do not define BitNet QK256 kernel semantics; a narrower BitNet CUDA spec owns
+  that contract.
+- Do not define dense model-family onboarding details; a narrower dense CUDA
+  spec owns that contract.
+- Do not define full residency phase proof; a narrower residency spec owns that
+  contract.
+- Do not define exact-profile server readiness; a narrower server spec owns
+  that contract.

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -22,6 +22,7 @@ bitnet receipts explain --latest
 | Human-readable model coverage | `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md` |
 | RTX 5070 Ti campaign state | `docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md` |
 | Strict CUDA product contract | `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md` |
+| CUDA route/proof-family contract | `docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md` |
 | Server readiness boundary | `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` |
 | User quickstart | `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md` |
 | BitNet CUDA guide | `docs/tutorials/rtx5070ti-bitnet-cuda.md` |
@@ -50,6 +51,8 @@ bitnet receipts explain --latest
 - Dense SLM CUDA proof is first-class CUDA product evidence, but it never proves
   BitNet packed I2_S/QK256 behavior.
 - BitNet QK256 CUDA proof never proves dense regular-LLM CUDA behavior.
+- CUDA receipts must name a route from the CUDA route contract and include an
+  execution plan before they can promote a CUDA claim.
 - Generic `cuda`, WGPU, Vulkan, CPU fallback, or hardware visibility is not
   strict RTX 5070 Ti CUDA proof.
 - `speedup_claim=false` remains correct until a governed benchmark

--- a/plans/cuda-5070ti-productization/README.md
+++ b/plans/cuda-5070ti-productization/README.md
@@ -18,6 +18,8 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
   [`BITNET-PROP-0002`](../../docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
 - Contract spec:
   [`BITNET-SPEC-0007`](../../docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- CUDA route contract:
+  [`BITNET-SPEC-CUDA-ROUTE-CONTRACT`](../../docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
 - Server readiness spec:
   [`BITNET-SPEC-0010`](../../docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md)
 - Bench ADR:
@@ -47,13 +49,18 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
 ## Claim Boundary
 
 This plan does not claim new runtime behavior. It only defines the order,
-acceptance, receipts, and rollback paths for future PRs.
+acceptance, receipts, and rollback paths for future PRs. CUDA-route proof now
+flows through the narrower route contract so future receipts can distinguish
+BitNet QK256 CUDA, dense regular-LLM CUDA, diagnostics, layer planning, and
+server shared-engine profiles without proof-family conflation.
 
 Do not use this plan to claim:
 
 - dense Qwen proof as BitNet proof;
 - BitNet QK256 proof as dense SLM proof;
 - generic `cuda` as RTX 5070 Ti proof;
+- CUDA receipts without a selected route, execution plan, and proof-family
+  booleans as promotable product proof;
 - hardware execution as answer quality;
 - benchmark baselines as accepted speedup;
 - server readiness from CLI receipts.


### PR DESCRIPTION
### Motivation

- Define a narrow, machine-checkable contract for CUDA receipts so proof families (BitNet QK256, dense regular-LLM, parity/plan fixtures, server shared-engine, CPU reference) cannot be conflated. 
- Make receipts and status surfaces require explicit `selected_route`, execution-plan counts, and proof-family booleans before promoting accelerator/product/server/speed/residency claims. 

### Description

- Add `docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md` which defines route IDs (`bitnet_qk256_cuda`, `dense_regular_llm_cuda`, `dense_gguf_linear_cuda_parity`, `dense_gguf_layer_plan`, `server_shared_engine_cuda`), the minimum receipt JSON shape (backend selection, `selected_route`, `execution_plan`, `proof_family` booleans), backend selection rules, execution-plan rules, claim rails, and status/`receipts explain` expectations. 
- Link the new CUDA route contract from the model onboarding ladder by updating `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md`. 
- Surface the route contract in the CUDA status and plan by updating `docs/status/CUDA_CAPABILITY_MATRIX.md` and `plans/cuda-5070ti-productization/README.md` so user-facing matrices and the productization plan reference the new contract. 
- This is docs-only scope: no runtime, kernel, or model-coverage promotions were made. 

### Testing

- Ran `git diff --check` and it reported no issues. 
- Ran `cargo run --locked -p xtask --no-default-features -- check-model-coverage` and it passed the model coverage checks. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti` and it passed the campaign check. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check` and generated dashboards were current.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab9b0529083339d68e4386d0ef189)