### PR TITLE
docs(cuda): add CUDA route contract

### DIFF
--- a/docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md
+++ b/docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md
@@ -24,6 +24,7 @@ This spec relies on existing authorities instead of replacing them:
 - [Native Rust inference product proposal](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
 - [Source-of-truth and claim boundaries](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md)
 - [9950X3D + RTX 5070 Ti CUDA product contract](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- [CUDA route contract](BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
 - [Server readiness proof boundary](BITNET-SPEC-0010-server-readiness-proof-boundary.md)
 - [Answer Artifact Gate](../model-artifacts/ANSWER_ARTIFACT_GATE.md)
 - [Model Coverage Matrix](../model-artifacts/MODEL_COVERAGE_MATRIX.md)
@@ -139,7 +140,8 @@ route without fallback and with an accepted answer or diagnostic quality gate.
 Required evidence:
 
 - selected backend identity;
-- selected route identity;
+- selected route identity from the governed CUDA route vocabulary when the
+  accelerator is CUDA;
 - CPU/reference evidence from an earlier tier;
 - fallback rejection;
 - route-specific kernel or execution-plan evidence;
@@ -223,6 +225,9 @@ Must not claim:
 - A model must not skip `reference_good` or `cpu_answer_ready` before
   accelerator answer claims unless a later accepted spec defines a narrower
   substitute and updates the model coverage row.
+- CUDA route receipts must use the route IDs and proof-family booleans defined
+  by [BITNET-SPEC-CUDA-ROUTE-CONTRACT](BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
+  before promoting CUDA execution claims.
 - Dense CUDA evidence cannot satisfy BitNet I2_S/QK256 proof.
 - BitNet I2_S/QK256 evidence cannot satisfy dense SLM or small dense LLM proof.
 - Qwen2.5 evidence cannot satisfy Qwen3, SmolLM2, Llama, Gemma, or Phi rows.
@@ -255,9 +260,9 @@ machine-readable before user-facing status surfaces summarize them.
 
 | Family | Route examples | Separate proof required |
 | --- | --- | --- |
-| Official BitNet I2_S/QK256 | `bitnet_qk256_cuda`, CPU BitNet route | BitNet artifact, tokenizer, QK256 kernels, fallback rejection |
+| Official BitNet I2_S/QK256 | `bitnet_qk256_cuda`, CPU BitNet route | BitNet artifact, tokenizer, QK256 kernels, fallback rejection, route/proof-family receipt fields |
 | BitNet TL1/TL2/GPU-int2 | TL or int2 diagnostic routes | Own artifact and kernel proof; no inherited I2_S/QK256 proof |
-| Dense SLM | `dense_regular_llm_cuda` for Qwen/SmolLM rows | Own tokenizer, prompt, CPU, CUDA, benchmark, and server receipts |
+| Dense SLM | `dense_regular_llm_cuda` for Qwen/SmolLM rows | Own tokenizer, prompt, CPU, CUDA, benchmark, server receipts, and `bitnet_packed_i2s_qk256_proof=false` |
 | Small dense LLM | Llama, Gemma, Phi candidates | Own architecture, tokenizer, prompt, memory, and route proof |
 | Server readiness | `/v1/chat/completions` or later endpoints | Own endpoint/profile/readiness proof |
 

--- a/docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md
@@ -1,0 +1,172 @@
+# BITNET-SPEC-CUDA-ROUTE-CONTRACT: CUDA Route Contract
+
+Status: proposed
+Owner: cuda/product
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0002](../proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md), [BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs: [BITNET-SPEC-0007](BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md), [BITNET-SPEC-0010](BITNET-SPEC-0010-server-readiness-proof-boundary.md), [BITNET-SPEC-0013](BITNET-SPEC-0013-model-onboarding-proof-ladder.md), [BITNET-SPEC-0014](BITNET-SPEC-0014-runtime-performance-contract.md)
+Linked ADRs: [BITNET-ADR-0004](../adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
+Linked plan: [9950X3D + RTX 5070 Ti CUDA Productization Plan](../../plans/cuda-5070ti-productization/README.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines route and proof-family fields only; no tier or model-coverage promotion.
+Policy impact: No CI or policy exception change.
+
+## Purpose
+
+CUDA support must be explainable by route, model family, backend identity, and
+receipt evidence. A CUDA receipt that proves one route must not be reused to
+promote a different route, a different model family, speedup, server readiness,
+or full residency.
+
+This spec defines the minimum route vocabulary and receipt fields required
+before CUDA user-facing surfaces may say which CUDA path executed. It narrows
+and composes the existing 9950X3D + RTX 5070 Ti product contract,
+server-readiness boundary, model-onboarding ladder, and runtime-performance
+contract; it does not replace them.
+
+## Scope
+
+This contract applies to CUDA receipts, model coverage rows, model status,
+`ask`, `chat`, `bench`, `serve`, and `receipts explain` surfaces when they make
+or explain CUDA execution claims.
+
+It covers route identity and proof-family separation for:
+
+- official Microsoft BitNet 2B I2_S/QK256 CUDA;
+- dense SLM CUDA such as Qwen2.5 and Qwen3;
+- dense GGUF CUDA fixture and layer-plan proof;
+- shared-engine CUDA server profiles.
+
+## Required Route IDs
+
+CUDA proof receipts and explanations must use the narrowest applicable route
+identifier from this governed vocabulary:
+
+| Route ID | Meaning | May prove | Must not prove |
+| --- | --- | --- | --- |
+| `bitnet_qk256_cuda` | Official BitNet packed I2_S/QK256 route using CUDA QK256 execution evidence. | BitNet packed I2_S/QK256 CUDA for the exact artifact and profile. | Dense regular-LLM CUDA, TL1/TL2, GPU-int2 master-route, speedup, full residency, or broad server readiness. |
+| `dense_regular_llm_cuda` | Dense regular-LLM CUDA route for an exact dense SLM or small dense LLM artifact. | Dense CUDA execution for the exact model row and profile. | BitNet I2_S/QK256 proof or another dense model row's proof. |
+| `dense_gguf_linear_cuda_parity` | Dense GGUF single-linear or fixture parity route. | Narrow linear parity for the tested descriptor and fixture. | Whole-model dense CUDA readiness, BitNet proof, speedup, server readiness, or full residency. |
+| `dense_gguf_layer_plan` | Dense GGUF all-layer planning route with unsupported-op accounting. | Planning completeness or blockers for the exact artifact. | CUDA execution, answer readiness, speedup, server readiness, or full residency. |
+| `server_shared_engine_cuda` | Server request used the shared CUDA inference engine for an exact endpoint/profile. | Server readiness only for the exact model, endpoint, streaming mode, and profile when the route also names the model-family proof. | Broad serving readiness, streaming/concurrency readiness without matching proof, speedup, full residency, or cross-family proof. |
+
+New CUDA route IDs require a later spec or an update to this spec before a
+model coverage row or receipt explanation may promote them.
+
+## Required CUDA Receipt Fields
+
+Every CUDA receipt that supports an execution claim must include these fields or
+an equivalent machine-readable representation with the same meaning:
+
+```json
+{
+  "requested_backend": "cuda | nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "selected_route": "bitnet_qk256_cuda | dense_regular_llm_cuda | dense_gguf_linear_cuda_parity | dense_gguf_layer_plan | server_shared_engine_cuda",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "execution_plan": {
+    "route": "...",
+    "bitnet_qk256_cuda_ops": 0,
+    "dense_regular_llm_cuda_ops": 0,
+    "cpu_fallback_ops": 0,
+    "unsupported_ops": 0
+  },
+  "proof_family": {
+    "bitnet_packed_i2s_qk256_proof": true,
+    "dense_regular_llm_cuda_proof": false
+  }
+}
+```
+
+The selected route and proof-family booleans must agree. For example,
+`bitnet_qk256_cuda` receipts that claim BitNet proof must keep
+`dense_regular_llm_cuda_proof=false`, and dense CUDA receipts must keep
+`bitnet_packed_i2s_qk256_proof=false`.
+
+## Backend Resolution
+
+`cuda` may be accepted as a user convenience selector. It is not a strict proof
+identity until the receipt resolves it to the selected backend.
+
+For the current CUDA product bench, strict execution claims require:
+
+```text
+requested_backend = cuda | nvidia-rtx-5070-ti-cuda
+selected_backend = nvidia-rtx-5070-ti-cuda
+runtime_api = cuda
+fallback_used = false
+```
+
+A receipt whose selected backend remains generic `cuda` cannot promote RTX 5070
+Ti CUDA proof.
+
+## Proof-Family Rails
+
+CUDA proof families are non-interchangeable:
+
+- dense CUDA can never satisfy BitNet packed I2_S/QK256 proof;
+- BitNet QK256 CUDA can never satisfy dense regular-LLM CUDA proof;
+- CPU AVX-512 can provide reference evidence but not CUDA execution proof;
+- WGPU, Vulkan, D3D12, OpenCL, Metal, NPU, generic GPU, or hardware-visibility
+  receipts cannot satisfy CUDA proof;
+- a CUDA receipt with no execution plan cannot promote a CUDA execution claim;
+- fallback to CPU under strict CUDA is a hard failure, not a successful CUDA
+  result.
+
+## Claim Boundaries
+
+A valid route receipt may support only the claim family it proves:
+
+| Receipt evidence | May claim | Must not claim |
+| --- | --- | --- |
+| `bitnet_qk256_cuda` with QK256 kernel evidence and fallback rejection | Official BitNet I2_S/QK256 CUDA execution for the exact artifact/profile. | Dense CUDA, global speedup, full residency, broad server readiness, broad chat quality. |
+| `dense_regular_llm_cuda` with exact artifact evidence and fallback rejection | Dense regular-LLM CUDA execution for that exact model/profile. | BitNet packed I2_S/QK256, another dense model, global speedup, full residency. |
+| `dense_gguf_linear_cuda_parity` | Linear fixture parity only. | Whole-model answer readiness or product CLI readiness. |
+| `dense_gguf_layer_plan` | Layer-plan completeness and unsupported-op counts. | CUDA execution or answer quality. |
+| `server_shared_engine_cuda` with endpoint/profile fields | Exact-profile server route evidence for the same model-family proof. | Streaming, concurrency, long-context, broad production, speedup, or full residency without separate proof. |
+
+Speedup, server readiness, and full residency remain separate claim families.
+They require the governing benchmark, server, or residency fields before status
+surfaces or model coverage rows may promote them.
+
+## User-Facing Explanation Requirements
+
+`bitnet receipts explain`, `bitnet model status`, status docs, and model
+coverage summaries must expose enough route information to answer:
+
+- what backend was requested and what backend was selected;
+- which CUDA route executed;
+- which proof family is true and which proof families are false;
+- whether fallback was rejected;
+- which execution-plan counters support the route;
+- which claims remain forbidden for this receipt.
+
+If a receipt lacks the model coverage matrix row or a route cannot be matched,
+the explanation must degrade to a narrower diagnostic claim instead of
+promoting CUDA readiness.
+
+## Validation
+
+This is a documentation-only spec. Validation for changes to this spec is:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+```
+
+Runtime PRs that implement validators or receipt explanations must add their
+own crate-level tests and fixture checks for the route and proof-family rails in
+this spec.
+
+## Non-Goals
+
+- Do not implement runtime CUDA routing in this spec.
+- Do not modify existing receipts in this spec.
+- Do not promote any model coverage row in this spec.
+- Do not claim CUDA speedup, full residency, server readiness, or broad chat
+  quality from route identity alone.
+- Do not make CUDA hardware proof part of ordinary PR CI.

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -22,6 +22,7 @@ bitnet receipts explain --latest
 | Human-readable model coverage | `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md` |
 | RTX 5070 Ti campaign state | `docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md` |
 | Strict CUDA product contract | `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md` |
+| CUDA route contract | `docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md` |
 | Server readiness boundary | `docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md` |
 | User quickstart | `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md` |
 | BitNet CUDA guide | `docs/tutorials/rtx5070ti-bitnet-cuda.md` |
@@ -47,11 +48,16 @@ bitnet receipts explain --latest
 - `accelerator_answer_ready` means strict accelerator receipts exist for the
   scoped model and route. It does not imply broad product UX readiness.
 - Qwen3 proof receipts are not yet a product CLI readiness claim.
+- CUDA route claims use the governed route IDs from the CUDA route contract:
+  `bitnet_qk256_cuda`, `dense_regular_llm_cuda`,
+  `dense_gguf_linear_cuda_parity`, `dense_gguf_layer_plan`, and
+  `server_shared_engine_cuda`.
 - Dense SLM CUDA proof is first-class CUDA product evidence, but it never proves
   BitNet packed I2_S/QK256 behavior.
 - BitNet QK256 CUDA proof never proves dense regular-LLM CUDA behavior.
 - Generic `cuda`, WGPU, Vulkan, CPU fallback, or hardware visibility is not
-  strict RTX 5070 Ti CUDA proof.
+  strict RTX 5070 Ti CUDA proof; generic `cuda` must resolve to
+  `nvidia-rtx-5070-ti-cuda` in the receipt before any RTX 5070 Ti proof claim.
 - `speedup_claim=false` remains correct until a governed benchmark
   qualification receipt accepts an exact model/profile.
 - `server_ready=true` is exact-profile only. The dense Qwen row is ready only

--- a/plans/cuda-5070ti-productization/README.md
+++ b/plans/cuda-5070ti-productization/README.md
@@ -18,6 +18,8 @@ CUDA target:  nvidia-rtx-5070-ti-cuda
   [`BITNET-PROP-0002`](../../docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
 - Contract spec:
   [`BITNET-SPEC-0007`](../../docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- CUDA route contract:
+  [`BITNET-SPEC-CUDA-ROUTE-CONTRACT`](../../docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md)
 - Server readiness spec:
   [`BITNET-SPEC-0010`](../../docs/specs/BITNET-SPEC-0010-server-readiness-proof-boundary.md)
 - Bench ADR:
@@ -53,6 +55,7 @@ Do not use this plan to claim:
 
 - dense Qwen proof as BitNet proof;
 - BitNet QK256 proof as dense SLM proof;
+- route IDs without matching receipt execution-plan and proof-family fields;
 - generic `cuda` as RTX 5070 Ti proof;
 - hardware execution as answer quality;
 - benchmark baselines as accepted speedup;


### PR DESCRIPTION
### Motivation

- Define a governed CUDA route vocabulary and receipt fields so CUDA execution claims are precise, non-interchangeable, and auditable across BitNet QK256, dense SLM, fixture/plan, and server routes.
- Prevent silent resolution of generic `cuda` into hardware proof and stop cross-family claim conflation (dense CUDA ≠ BitNet QK256; CPU/WGPU/etc. are only reference evidence).

### Description

- Add `docs/specs/BITNET-SPEC-CUDA-ROUTE-CONTRACT.md` to declare route IDs (`bitnet_qk256_cuda`, `dense_regular_llm_cuda`, `dense_gguf_linear_cuda_parity`, `dense_gguf_layer_plan`, `server_shared_engine_cuda`), required receipt fields (backend resolution, `selected_route`, `execution_plan`, proof-family booleans, fallback fields), proof-family rails, claim boundaries, and user-facing explanation requirements.
- Update `docs/specs/BITNET-SPEC-0013-model-onboarding-proof-ladder.md` to reference the new CUDA route contract and require governed CUDA route identity and proof-family booleans for accelerator promotion.
- Update `docs/status/CUDA_CAPABILITY_MATRIX.md` to link the new route contract and to surface the governed route IDs and the rule that generic `cuda` must resolve to `nvidia-rtx-5070-ti-cuda` in receipts before claiming RTX 5070 Ti proof.
- Update `plans/cuda-5070ti-productization/README.md` to include the route contract as a source-of-truth and to forbid promoting route IDs without matching execution-plan/proof-family receipt fields.

### Testing

- Ran `git diff --check` which reported no issues and passed.
- Ran `cargo run --locked -p xtask --no-default-features -- check-model-coverage` which passed and validated the model coverage matrix.
- Ran `cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti` which passed and validated the campaign rules for the NVIDIA lane.
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check` which passed and confirmed generated dashboards are current.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab9b0529083339d68e4386d0ef189)