### PR TITLE
cpu(avx2): audit qk256 hot-path execution

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -5010,6 +5010,14 @@ async fn run_simple_generation(
         let runtime_api = backend_identity.runtime_api.as_str();
         let apple_machine = apple_machine_receipt_json(requested_backend, selected_backend);
         let bitnet_linear_coverage = bitnet_qk256_dispatch::qk256_dispatch_coverage();
+        let qk256_kernel_observed = bitnet_linear_coverage.selected_kernel != "qk256-not-observed";
+        let receipt_requested_kernel =
+            bitnet_linear_coverage.requested_kernel.unwrap_or(selected_kernel.as_str());
+        let receipt_selected_kernel = if qk256_kernel_observed {
+            bitnet_linear_coverage.selected_kernel
+        } else {
+            selected_kernel.as_str()
+        };
         let strict_cuda_selected_artifact = strict_backend
             && canonical_bitnet_model
             && selected_backend == "nvidia-rtx-5070-ti-cuda"
@@ -5344,6 +5352,34 @@ async fn run_simple_generation(
                 "bitnet_linear_layers_on_cuda": bitnet_linear_coverage.bitnet_linear_layers_on_cuda,
                 "bitnet_linear_layers_cpu_fallback": bitnet_linear_coverage.bitnet_linear_layers_cpu_fallback,
                 "unsupported_ops": bitnet_linear_coverage.unsupported_ops.clone(),
+                "requested_kernel": bitnet_linear_coverage.requested_kernel,
+                "selected_kernel": bitnet_linear_coverage.selected_kernel,
+                "scaled_i8s_path_exercised": bitnet_linear_coverage.qk256_i8s_scaled_path_exercised,
+                "qk256_hot_path": {
+                    "requested_kernel": bitnet_linear_coverage.requested_kernel,
+                    "selected_kernel": bitnet_linear_coverage.selected_kernel,
+                    "scaled_i8s_path_exercised": bitnet_linear_coverage.qk256_i8s_scaled_path_exercised,
+                    "fallback_used": bitnet_linear_coverage.qk256_i8s_scaled_avx2_requested_invocations
+                        > bitnet_linear_coverage.qk256_i8s_scaled_avx2_invocations,
+                    "fallback_reason": if bitnet_linear_coverage.qk256_i8s_scaled_avx2_requested_invocations
+                        > bitnet_linear_coverage.qk256_i8s_scaled_avx2_invocations {
+                        Some("qk256_i8s_scaled_avx2_not_implemented")
+                    } else {
+                        None
+                    },
+                },
+                "qk256_kernel_invocations": {
+                    "qk256_f32_scalar_gemv_invocations": bitnet_linear_coverage.qk256_f32_scalar_gemv_invocations,
+                    "qk256_f32_avx2_gemv_invocations": bitnet_linear_coverage.qk256_f32_avx2_gemv_invocations,
+                    "qk256_i8s_scaled_scalar_invocations": bitnet_linear_coverage.qk256_i8s_scaled_scalar_invocations,
+                    "qk256_i8s_scaled_avx2_invocations": bitnet_linear_coverage.qk256_i8s_scaled_avx2_invocations,
+                    "qk256_i8s_scaled_avx2_requested_invocations": bitnet_linear_coverage.qk256_i8s_scaled_avx2_requested_invocations,
+                },
+                "qk256_materialization_counts": {
+                    "qk256_flat_bytes_extracted_count": bitnet_linear_coverage.qk256_flat_bytes_extracted_count,
+                    "input_rows_materialized_count": bitnet_linear_coverage.input_rows_materialized_count,
+                    "output_rows_allocated_count": bitnet_linear_coverage.output_rows_allocated_count,
+                },
                 "execution_claim": bitnet_linear_coverage.execution_claim,
             },
             "kernel": {
@@ -5352,6 +5388,8 @@ async fn run_simple_generation(
                 "layout": kernel_layout,
                 "dequantizes_before_compute": dequantizes_before_compute,
                 "kernel_id": selected_kernel.as_str(),
+                "requested_kernel": receipt_requested_kernel,
+                "selected_kernel": receipt_selected_kernel,
             },
             "cpu": {
                 "model": cpu_model.as_str(),
@@ -5362,8 +5400,8 @@ async fn run_simple_generation(
             "strict_provenance": {
                 "requested_backend": requested_backend,
                 "selected_backend": selected_backend,
-                "requested_kernel": selected_kernel.as_str(),
-                "selected_kernel": selected_kernel.as_str(),
+                "requested_kernel": receipt_requested_kernel,
+                "selected_kernel": receipt_selected_kernel,
                 "loader_mode": loader_mode,
                 "tokenizer_source": tokenizer_source_str,
                 "tokenizer_strict": tokenizer_strict,
@@ -7483,6 +7521,35 @@ fn qk256_dispatch_coverage_delta(
             .difference(&unsupported_before)
             .cloned()
             .collect::<Vec<_>>(),
+        requested_kernel: after.requested_kernel,
+        selected_kernel: after.selected_kernel,
+        qk256_i8s_scaled_path_exercised: after.qk256_i8s_scaled_scalar_invocations
+            > before.qk256_i8s_scaled_scalar_invocations
+            || after.qk256_i8s_scaled_avx2_invocations > before.qk256_i8s_scaled_avx2_invocations,
+        qk256_f32_scalar_gemv_invocations: after
+            .qk256_f32_scalar_gemv_invocations
+            .saturating_sub(before.qk256_f32_scalar_gemv_invocations),
+        qk256_f32_avx2_gemv_invocations: after
+            .qk256_f32_avx2_gemv_invocations
+            .saturating_sub(before.qk256_f32_avx2_gemv_invocations),
+        qk256_i8s_scaled_scalar_invocations: after
+            .qk256_i8s_scaled_scalar_invocations
+            .saturating_sub(before.qk256_i8s_scaled_scalar_invocations),
+        qk256_i8s_scaled_avx2_invocations: after
+            .qk256_i8s_scaled_avx2_invocations
+            .saturating_sub(before.qk256_i8s_scaled_avx2_invocations),
+        qk256_i8s_scaled_avx2_requested_invocations: after
+            .qk256_i8s_scaled_avx2_requested_invocations
+            .saturating_sub(before.qk256_i8s_scaled_avx2_requested_invocations),
+        qk256_flat_bytes_extracted_count: after
+            .qk256_flat_bytes_extracted_count
+            .saturating_sub(before.qk256_flat_bytes_extracted_count),
+        input_rows_materialized_count: after
+            .input_rows_materialized_count
+            .saturating_sub(before.input_rows_materialized_count),
+        output_rows_allocated_count: after
+            .output_rows_allocated_count
+            .saturating_sub(before.output_rows_allocated_count),
         execution_claim: if after.bitnet_linear_layers_on_cuda > before.bitnet_linear_layers_on_cuda
         {
             "cuda_inference_contribution"
@@ -7501,6 +7568,34 @@ fn qk256_dispatch_coverage_receipt(
         "bitnet_linear_layers_on_cuda": coverage.bitnet_linear_layers_on_cuda,
         "bitnet_linear_layers_cpu_fallback": coverage.bitnet_linear_layers_cpu_fallback,
         "unsupported_ops": coverage.unsupported_ops,
+        "requested_kernel": coverage.requested_kernel,
+        "selected_kernel": coverage.selected_kernel,
+        "scaled_i8s_path_exercised": coverage.qk256_i8s_scaled_path_exercised,
+        "qk256_hot_path": {
+            "requested_kernel": coverage.requested_kernel,
+            "selected_kernel": coverage.selected_kernel,
+            "scaled_i8s_path_exercised": coverage.qk256_i8s_scaled_path_exercised,
+            "fallback_used": coverage.qk256_i8s_scaled_avx2_requested_invocations
+                > coverage.qk256_i8s_scaled_avx2_invocations,
+            "fallback_reason": if coverage.qk256_i8s_scaled_avx2_requested_invocations
+                > coverage.qk256_i8s_scaled_avx2_invocations {
+                Some("qk256_i8s_scaled_avx2_not_implemented")
+            } else {
+                None
+            },
+        },
+        "qk256_kernel_invocations": {
+            "qk256_f32_scalar_gemv_invocations": coverage.qk256_f32_scalar_gemv_invocations,
+            "qk256_f32_avx2_gemv_invocations": coverage.qk256_f32_avx2_gemv_invocations,
+            "qk256_i8s_scaled_scalar_invocations": coverage.qk256_i8s_scaled_scalar_invocations,
+            "qk256_i8s_scaled_avx2_invocations": coverage.qk256_i8s_scaled_avx2_invocations,
+            "qk256_i8s_scaled_avx2_requested_invocations": coverage.qk256_i8s_scaled_avx2_requested_invocations,
+        },
+        "qk256_materialization_counts": {
+            "qk256_flat_bytes_extracted_count": coverage.qk256_flat_bytes_extracted_count,
+            "input_rows_materialized_count": coverage.input_rows_materialized_count,
+            "output_rows_allocated_count": coverage.output_rows_allocated_count,
+        },
         "execution_claim": coverage.execution_claim,
     })
 }
@@ -12505,15 +12600,35 @@ mod tests {
         assert!(!uses_report_only_cuda_benchmark_receipt(None));
     }
 
+    fn qk256_test_coverage(
+        total: u64,
+        on_cuda: u64,
+        cpu_fallback: u64,
+        unsupported_ops: Vec<String>,
+    ) -> bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
+        bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
+            bitnet_linear_layers_total: total,
+            bitnet_linear_layers_on_cuda: on_cuda,
+            bitnet_linear_layers_cpu_fallback: cpu_fallback,
+            unsupported_ops,
+            requested_kernel: None,
+            selected_kernel: "qk256-not-observed",
+            qk256_i8s_scaled_path_exercised: false,
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_i8s_scaled_avx2_requested_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
+            execution_claim: "cuda_inference_contribution",
+        }
+    }
+
     #[test]
     fn cuda_execution_residency_receipt_preserves_claim_boundary() {
-        let coverage = bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
-            bitnet_linear_layers_total: 42,
-            bitnet_linear_layers_on_cuda: 42,
-            bitnet_linear_layers_cpu_fallback: 0,
-            unsupported_ops: Vec::new(),
-            execution_claim: "cuda_inference_contribution",
-        };
+        let coverage = qk256_test_coverage(42, 42, 0, Vec::new());
         let residency = bitnet_qk256_dispatch::Qk256CudaWeightResidency {
             weight_handle_count: 21,
             weights_uploaded_once: true,
@@ -12550,13 +12665,7 @@ mod tests {
 
     #[test]
     fn cuda_execution_residency_receipt_marks_non_linear_phases_not_resident() {
-        let coverage = bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
-            bitnet_linear_layers_total: 2,
-            bitnet_linear_layers_on_cuda: 1,
-            bitnet_linear_layers_cpu_fallback: 1,
-            unsupported_ops: vec!["qk256_cpu_fallback".to_string()],
-            execution_claim: "cuda_inference_contribution",
-        };
+        let coverage = qk256_test_coverage(2, 1, 1, vec!["qk256_cpu_fallback".to_string()]);
 
         let receipt = cuda_execution_residency_receipt(CudaExecutionResidencyReceiptInput {
             coverage: &coverage,
@@ -12592,13 +12701,7 @@ mod tests {
 
     #[test]
     fn qk256_kernel_stats_receipt_records_measured_cuda_accounting() {
-        let coverage = bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
-            bitnet_linear_layers_total: 4,
-            bitnet_linear_layers_on_cuda: 4,
-            bitnet_linear_layers_cpu_fallback: 0,
-            unsupported_ops: Vec::new(),
-            execution_claim: "cuda_inference_contribution",
-        };
+        let coverage = qk256_test_coverage(4, 4, 0, Vec::new());
         let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
             host_to_device_bytes: 4096,
             device_to_host_bytes: 2048,
@@ -12619,13 +12722,7 @@ mod tests {
 
     #[test]
     fn cuda_execution_residency_receipt_records_measured_qk256_accounting() {
-        let coverage = bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
-            bitnet_linear_layers_total: 4,
-            bitnet_linear_layers_on_cuda: 4,
-            bitnet_linear_layers_cpu_fallback: 0,
-            unsupported_ops: Vec::new(),
-            execution_claim: "cuda_inference_contribution",
-        };
+        let coverage = qk256_test_coverage(4, 4, 0, Vec::new());
         let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
             host_to_device_bytes: 4096,
             device_to_host_bytes: 2048,

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -26,6 +26,19 @@ static CUDA_QK256_HOST_TO_DEVICE_BYTES: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_DEVICE_TO_HOST_BYTES: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_KERNEL_TIME_MICROS: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_KERNEL_TIME_SAMPLES: AtomicU64 = AtomicU64::new(0);
+static QK256_F32_SCALAR_GEMV_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_F32_AVX2_GEMV_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_I8S_SCALED_SCALAR_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_I8S_SCALED_AVX2_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_SCALED_I8S_AVX2_REQUESTS: AtomicU64 = AtomicU64::new(0);
+static QK256_FLAT_BYTES_EXTRACTED_COUNT: AtomicU64 = AtomicU64::new(0);
+static QK256_INPUT_ROWS_MATERIALIZED_COUNT: AtomicU64 = AtomicU64::new(0);
+static QK256_OUTPUT_ROWS_ALLOCATED_COUNT: AtomicU64 = AtomicU64::new(0);
+
+const QK256_I8S_SCALED_SCALAR_GEMV_KERNEL_ID: &str = "qk256-i2s-i8s-scaled-scalar-gemv";
+const QK256_I8S_SCALED_AVX2_GEMV_KERNEL_ID: &str = "qk256-i2s-i8s-scaled-avx2-gemv";
+const QK256_MIXED_GEMV_KERNEL_ID: &str = "qk256-mixed-gemv";
+const QK256_NOT_OBSERVED_KERNEL_ID: &str = "qk256-not-observed";
 
 #[cfg(feature = "cuda")]
 thread_local! {
@@ -43,6 +56,28 @@ pub struct Qk256DispatchCoverageCounters {
     pub bitnet_linear_layers_cpu_fallback: u64,
     /// Unsupported operations that prevent a full CUDA inference claim.
     pub unsupported_ops: Vec<String>,
+    /// Requested QK256 kernel label inferred from CPU-kernel controls, when explicit.
+    pub requested_kernel: Option<&'static str>,
+    /// Selected QK256 kernel label inferred from observed dispatch counters.
+    pub selected_kernel: &'static str,
+    /// True when the inline-scaled BitNet I2_S × I8_S path ran.
+    pub qk256_i8s_scaled_path_exercised: bool,
+    /// No-scale F32 QK256 GEMV calls that selected the scalar kernel.
+    pub qk256_f32_scalar_gemv_invocations: u64,
+    /// No-scale F32 QK256 GEMV calls that selected the AVX2/FMA kernel.
+    pub qk256_f32_avx2_gemv_invocations: u64,
+    /// Inline-scaled BitNet I2_S × I8_S GEMV calls that used the scalar oracle.
+    pub qk256_i8s_scaled_scalar_invocations: u64,
+    /// Inline-scaled BitNet I2_S × I8_S GEMV calls that used a scaled AVX2 implementation.
+    pub qk256_i8s_scaled_avx2_invocations: u64,
+    /// Inline-scaled BitNet I2_S × I8_S calls made while AVX2 was requested.
+    pub qk256_i8s_scaled_avx2_requested_invocations: u64,
+    /// Number of QK256 tensor-to-flat-byte materializations observed.
+    pub qk256_flat_bytes_extracted_count: u64,
+    /// Number of activation rows materialized through Tensor-to-Vec conversion.
+    pub input_rows_materialized_count: u64,
+    /// Number of output row Vecs allocated for QK256 CPU forwarding.
+    pub output_rows_allocated_count: u64,
     /// Human-readable claim boundary for partial routing.
     pub execution_claim: &'static str,
 }
@@ -71,6 +106,54 @@ pub struct Qk256CudaRuntimeStats {
     pub kernel_time_samples: u64,
 }
 
+fn selected_qk256_kernel_label(
+    f32_scalar: u64,
+    f32_avx2: u64,
+    scaled_scalar: u64,
+    scaled_avx2: u64,
+) -> &'static str {
+    let observed = [f32_scalar > 0, f32_avx2 > 0, scaled_scalar > 0, scaled_avx2 > 0]
+        .into_iter()
+        .filter(|value| *value)
+        .count();
+    if observed > 1 {
+        QK256_MIXED_GEMV_KERNEL_ID
+    } else if scaled_avx2 > 0 {
+        QK256_I8S_SCALED_AVX2_GEMV_KERNEL_ID
+    } else if scaled_scalar > 0 {
+        QK256_I8S_SCALED_SCALAR_GEMV_KERNEL_ID
+    } else if f32_avx2 > 0 {
+        bitnet_quantization::i2s_qk256::QK256_AVX2_GEMV_KERNEL_ID
+    } else if f32_scalar > 0 {
+        bitnet_quantization::i2s_qk256::QK256_SCALAR_GEMV_KERNEL_ID
+    } else {
+        QK256_NOT_OBSERVED_KERNEL_ID
+    }
+}
+
+fn requested_qk256_kernel_label(scaled_path_observed: bool) -> Option<&'static str> {
+    if std::env::var("BITNET_FORCE_SCALAR").as_deref() == Ok("1") {
+        return Some(if scaled_path_observed {
+            QK256_I8S_SCALED_SCALAR_GEMV_KERNEL_ID
+        } else {
+            bitnet_quantization::i2s_qk256::QK256_SCALAR_GEMV_KERNEL_ID
+        });
+    }
+    match std::env::var("BITNET_CPU_KERNEL").ok().as_deref() {
+        Some("scalar") => Some(if scaled_path_observed {
+            QK256_I8S_SCALED_SCALAR_GEMV_KERNEL_ID
+        } else {
+            bitnet_quantization::i2s_qk256::QK256_SCALAR_GEMV_KERNEL_ID
+        }),
+        Some("avx2") => Some(if scaled_path_observed {
+            QK256_I8S_SCALED_AVX2_GEMV_KERNEL_ID
+        } else {
+            bitnet_quantization::i2s_qk256::QK256_AVX2_GEMV_KERNEL_ID
+        }),
+        _ => None,
+    }
+}
+
 /// Snapshot the current QK256 dispatch coverage counters.
 pub fn qk256_dispatch_coverage() -> Qk256DispatchCoverageCounters {
     let cpu_fallback = BITNET_LINEAR_CPU_FALLBACK.load(Ordering::Relaxed);
@@ -83,12 +166,37 @@ pub fn qk256_dispatch_coverage() -> Qk256DispatchCoverageCounters {
     if unsupported > 0 {
         unsupported_ops.push("qk256_strict_cuda_unsupported".to_string());
     }
+    let scaled_avx2_requests = QK256_SCALED_I8S_AVX2_REQUESTS.load(Ordering::Relaxed);
+    let f32_scalar = QK256_F32_SCALAR_GEMV_INVOCATIONS.load(Ordering::Relaxed);
+    let f32_avx2 = QK256_F32_AVX2_GEMV_INVOCATIONS.load(Ordering::Relaxed);
+    let scaled_scalar = QK256_I8S_SCALED_SCALAR_INVOCATIONS.load(Ordering::Relaxed);
+    let scaled_avx2_invocations = QK256_I8S_SCALED_AVX2_INVOCATIONS.load(Ordering::Relaxed);
+    let scaled_path_observed = scaled_scalar > 0 || scaled_avx2_invocations > 0;
+    if scaled_avx2_requests > scaled_avx2_invocations {
+        unsupported_ops.push("qk256_i8s_scaled_avx2_not_implemented".to_string());
+    }
 
     Qk256DispatchCoverageCounters {
         bitnet_linear_layers_total: BITNET_LINEAR_TOTAL.load(Ordering::Relaxed),
         bitnet_linear_layers_on_cuda: on_cuda,
         bitnet_linear_layers_cpu_fallback: cpu_fallback,
         unsupported_ops,
+        requested_kernel: requested_qk256_kernel_label(scaled_path_observed),
+        selected_kernel: selected_qk256_kernel_label(
+            f32_scalar,
+            f32_avx2,
+            scaled_scalar,
+            scaled_avx2_invocations,
+        ),
+        qk256_i8s_scaled_path_exercised: scaled_path_observed,
+        qk256_f32_scalar_gemv_invocations: f32_scalar,
+        qk256_f32_avx2_gemv_invocations: f32_avx2,
+        qk256_i8s_scaled_scalar_invocations: scaled_scalar,
+        qk256_i8s_scaled_avx2_invocations: scaled_avx2_invocations,
+        qk256_i8s_scaled_avx2_requested_invocations: scaled_avx2_requests,
+        qk256_flat_bytes_extracted_count: QK256_FLAT_BYTES_EXTRACTED_COUNT.load(Ordering::Relaxed),
+        input_rows_materialized_count: QK256_INPUT_ROWS_MATERIALIZED_COUNT.load(Ordering::Relaxed),
+        output_rows_allocated_count: QK256_OUTPUT_ROWS_ALLOCATED_COUNT.load(Ordering::Relaxed),
         execution_claim: if on_cuda > 0 {
             "cuda_inference_contribution"
         } else if cuda_bitnet_backend_requested() {
@@ -112,6 +220,14 @@ pub fn reset_qk256_dispatch_coverage() {
     CUDA_QK256_DEVICE_TO_HOST_BYTES.store(0, Ordering::Relaxed);
     CUDA_QK256_KERNEL_TIME_MICROS.store(0, Ordering::Relaxed);
     CUDA_QK256_KERNEL_TIME_SAMPLES.store(0, Ordering::Relaxed);
+    QK256_F32_SCALAR_GEMV_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_F32_AVX2_GEMV_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_I8S_SCALED_SCALAR_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_I8S_SCALED_AVX2_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_SCALED_I8S_AVX2_REQUESTS.store(0, Ordering::Relaxed);
+    QK256_FLAT_BYTES_EXTRACTED_COUNT.store(0, Ordering::Relaxed);
+    QK256_INPUT_ROWS_MATERIALIZED_COUNT.store(0, Ordering::Relaxed);
+    QK256_OUTPUT_ROWS_ALLOCATED_COUNT.store(0, Ordering::Relaxed);
     reset_cuda_qk256_context();
 }
 
@@ -211,19 +327,39 @@ pub fn forward_qk256_with_scale(
     forward_qk256_cpu(input, qk256_tensor, weight_name, inline_scale)
 }
 
+fn requested_qk256_f32_kernel() -> Option<&'static str> {
+    match std::env::var("BITNET_CPU_KERNEL").ok().as_deref() {
+        Some("scalar") => Some(bitnet_quantization::i2s_qk256::QK256_SCALAR_GEMV_KERNEL_ID),
+        Some("avx2") => Some(bitnet_quantization::i2s_qk256::QK256_AVX2_GEMV_KERNEL_ID),
+        _ => None,
+    }
+}
+
+fn scaled_i8s_avx2_requested() -> bool {
+    std::env::var("BITNET_CPU_KERNEL").as_deref() == Ok("avx2")
+        && std::env::var("BITNET_FORCE_SCALAR").as_deref() != Ok("1")
+}
+
+fn strict_cpu_kernel_requested() -> bool {
+    env_truthy("BITNET_STRICT_MODE") || std::env::var("BITNET_CPU_KERNEL").is_ok()
+}
+
 fn forward_qk256_cpu(
     input: &Tensor,
     qk256_tensor: &Tensor,
     weight_name: &str,
     inline_scale: Option<f32>,
 ) -> Result<Tensor> {
-    use bitnet_quantization::i2s_qk256::{gemv_qk256, gemv_qk256_bitnet_i8s_scaled};
+    use bitnet_quantization::i2s_qk256::{
+        QK256_AVX2_GEMV_KERNEL_ID, gemv_qk256_bitnet_i8s_scaled, gemv_qk256_with_kernel_selection,
+    };
 
     let prepared = prepare_qk256_forward(input, qk256_tensor, weight_name)?;
     let mut output_rows = vec![
         vec![0.0f32; prepared.layout.rows];
         prepared.shape.batch_size * prepared.shape.seq_len
     ];
+    QK256_OUTPUT_ROWS_ALLOCATED_COUNT.fetch_add(output_rows.len() as u64, Ordering::Relaxed);
 
     if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && weight_name.contains("layers.0.")
     {
@@ -242,6 +378,10 @@ fn forward_qk256_cpu(
 
     for (row_index, input_row) in prepared.input_rows.iter().enumerate() {
         let gemv_result = if let Some(scale) = inline_scale {
+            if scaled_i8s_avx2_requested() {
+                QK256_SCALED_I8S_AVX2_REQUESTS.fetch_add(1, Ordering::Relaxed);
+            }
+            QK256_I8S_SCALED_SCALAR_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
             gemv_qk256_bitnet_i8s_scaled(
                 &prepared.flat_bytes,
                 input_row,
@@ -252,14 +392,23 @@ fn forward_qk256_cpu(
                 scale,
             )
         } else {
-            gemv_qk256(
+            gemv_qk256_with_kernel_selection(
                 &prepared.flat_bytes,
                 input_row,
                 &mut output_rows[row_index],
                 prepared.layout.rows,
                 prepared.layout.cols,
                 prepared.layout.row_stride_bytes,
+                requested_qk256_f32_kernel(),
+                strict_cpu_kernel_requested(),
             )
+            .map(|selection| {
+                if selection.selected_kernel == QK256_AVX2_GEMV_KERNEL_ID {
+                    QK256_F32_AVX2_GEMV_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    QK256_F32_SCALAR_GEMV_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                }
+            })
         };
         gemv_result.map_err(|e| {
             BitNetError::Validation(format!(
@@ -437,6 +586,7 @@ fn prepare_qk256_activation(
             weight_name, e
         ))
     })?;
+    QK256_INPUT_ROWS_MATERIALIZED_COUNT.fetch_add(input_rows.len() as u64, Ordering::Relaxed);
 
     Ok(PreparedQk256Activation { layout, shape, input_rows })
 }
@@ -446,6 +596,7 @@ fn extract_qk256_flat_bytes(
     layout: &Qk256Layout,
     weight_name: &str,
 ) -> Result<Vec<u8>> {
+    QK256_FLAT_BYTES_EXTRACTED_COUNT.fetch_add(1, Ordering::Relaxed);
     let bytes_2d = qk256_tensor.to_vec2::<u8>().map_err(|e| {
         BitNetError::Validation(format!("Failed to extract QK256 bytes for {}: {}", weight_name, e))
     })?;


### PR DESCRIPTION
### Motivation

- Provide unambiguous, receipt-backed evidence for which QK256 hot path actually runs (no-scale F32 path vs inline-scaled BitNet I2_S×I8_S path) so we can tell whether AVX2 is the true scaled I2_S hot path or only a no-scale F32 reference.
- Surface obvious runtime allocation/copy materialization counts (flat bytes, input rows, output rows) to quantify and then eliminate per-token allocation/copy overhead on the QK256 forward path.
- Emit diagnostics that make it explicit when an AVX2 scaled implementation was requested but not observed so the team can plan the dedicated scaled AVX2 kernel work without changing model math.

### Description

- Added QK256 dispatch counters and materialization counters in `crates/bitnet-qk256-dispatch/src/lib.rs`: counters for no-scale F32 scalar/AVX2 GEMV invocations, inline-scaled I2_S×I8_S scalar/AVX2 invocations, AVX2 scaled-path requests, and counts for flat-byte extraction, input-row materialization, and output-row allocations.
- Added logic to infer `requested_kernel` and `selected_kernel` from observed counters and kernel-selection controls, plus small helpers to classify observed hot-path labels and detect mixed or not-observed cases, without changing any model math.
- Instrumented the CPU forward path so no-scale calls go through the existing kernel selection path while inline-scale calls continue to call the scalar scaled oracle; all relevant counters are incremented (including a counter for scaled-AVX2 requests when `--cpu-kernel=avx2` is set).
- Extended the CLI receipt generation in `crates/bitnet-cli/src/main.rs` to include the new coverage fields in `execution_coverage` and `kernel` sections (requested/selected kernel, scaled-path diagnostics, invocation counts, and materialization counts), and to choose honest requested/selected-kernel values when QK256 is not observed.

### Testing

- Ran QK256 parity unit tests: `cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests` — 17 tests passed (all OK).
- Ran CLI answer-corpus tests: `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus` — 40 tests passed (all OK).
- Static checks and builds: `cargo check` for `bitnet-qk256-dispatch` and `bitnet-cli`, `cargo fmt --all -- --check` — succeeded.
- Campaign check: `cargo run -p xtask --no-default-features -- campaign check cpu-proof` — succeeded (campaign check passed).

Note: strict official Microsoft I2_S runs that produce strict receipts on a designated 258V proof host were not executed here because the container lacks the official GGUF/tokenizer artifacts and target hardware; those are out-of-band validation steps and remain to be run on the designated proof lane.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab06d45c8833391b85965dca2c4bf)