### PR TITLE
fix(policy): remove new no-panic debt

### DIFF
--- a/crates/bitnet-models/src/model_kernel_compat/claims.rs
+++ b/crates/bitnet-models/src/model_kernel_compat/claims.rs
@@ -114,8 +114,13 @@ fn decision_reason(
             kernel.as_str(),
             claim.as_str()
         ),
-        ModelKernelSupport::SupportedReference | ModelKernelSupport::Supported => {
-            unreachable!("supported routes are allowed at the compatibility layer")
-        }
+        ModelKernelSupport::SupportedReference | ModelKernelSupport::Supported => format!(
+            "{} {} {} is {}; compatibility allowance was denied before {}",
+            model_id,
+            arch.as_str(),
+            kernel.as_str(),
+            support.as_str(),
+            claim.as_str()
+        ),
     }
 }

--- a/crates/bitnet-tool-use-core/src/parsing.rs
+++ b/crates/bitnet-tool-use-core/src/parsing.rs
@@ -54,12 +54,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_tool_call_valid() {
+    fn parse_tool_call_valid() -> Result<(), &'static str> {
         let text =
             r#"<tool_call>{"name":"get_weather","arguments":{"location":"London"}}</tool_call>"#;
-        let call = parse_tool_call(text, &ToolUseFormat::ChatMLTools).expect("valid tool call");
+        let call = parse_tool_call(text, &ToolUseFormat::ChatMLTools).ok_or("valid tool call")?;
         assert_eq!(call.name, "get_weather");
         assert!(call.arguments.contains("London"));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Clears the two no-panic-family findings currently blocking refreshed PRs: replaces the supported-route unreachable! fallback with a conservative reason string, and rewrites the tool-call parser test to avoid expect(). Validation: rtk proxy cargo fmt -p bitnet-models -p bitnet-tool-use-core -- --check; rtk cargo test --locked -p bitnet-models --no-default-features model_kernel_compat; rtk cargo test --locked -p bitnet-tool-use-core --no-default-features parsing; rtk git diff --check. Local xtask check-no-panic-family timed out on Windows while building sentencepiece-sys; GitHub Policy is the authoritative gate.