### PR TITLE
CUDA-UX-013: lock status and receipt JSON contracts

### DIFF
--- a/crates/bitnet-cli/src/commands/receipts.rs
+++ b/crates/bitnet-cli/src/commands/receipts.rs
@@ -62,7 +62,9 @@ pub struct ReceiptExplanation {
     pub selected_backend: Option<String>,
     pub selected_route: Option<String>,
     pub fallback_used: Option<bool>,
+    pub product_cli_ready: Option<bool>,
     pub server_ready: Option<bool>,
+    pub server_ready_scope: Option<String>,
     pub speedup_claim: Option<bool>,
     pub full_residency_claim: Option<bool>,
     pub bitnet_packed_i2s_qk256_proof: Option<bool>,
@@ -88,9 +90,11 @@ pub struct ModelCoverageExplanation {
     pub current_tier: Option<String>,
     pub status: Option<String>,
     pub route: Option<String>,
+    pub product_cli_ready: Option<bool>,
     pub speedup_claim: Option<bool>,
     pub benchmark_qualified: Option<bool>,
     pub server_ready: Option<bool>,
+    pub server_ready_scope: Option<String>,
     pub full_residency_claim: Option<bool>,
     pub bitnet_packed_i2s_qk256_proof: Option<bool>,
     pub dense_regular_llm_cuda_proof: Option<bool>,
@@ -213,6 +217,7 @@ struct ModelCoverageEntry {
 #[derive(Debug, Clone, Deserialize)]
 struct ModelCoverageClaims {
     benchmark_qualified: bool,
+    product_cli_ready: bool,
     server_ready: bool,
     speedup_claim: bool,
     full_residency_claim: bool,
@@ -311,7 +316,9 @@ pub fn explain_receipt(path: &Path, receipt: &Value) -> ReceiptExplanation {
         selected_backend: None,
         selected_route: None,
         fallback_used: None,
+        product_cli_ready: None,
         server_ready: None,
+        server_ready_scope: None,
         speedup_claim: None,
         full_residency_claim: None,
         bitnet_packed_i2s_qk256_proof: None,
@@ -344,7 +351,9 @@ fn apply_receipt_json_contract_aliases(explanation: &mut ReceiptExplanation) {
         .clone()
         .or_else(|| explanation.model_coverage.route.clone());
     explanation.fallback_used = explanation.backend.fallback_used;
+    explanation.product_cli_ready = explanation.model_coverage.product_cli_ready;
     explanation.server_ready = explanation.model_coverage.server_ready;
+    explanation.server_ready_scope = explanation.model_coverage.server_ready_scope.clone();
     explanation.speedup_claim =
         explanation.model_coverage.speedup_claim.or(explanation.claim_limits.speedup_claim);
     explanation.full_residency_claim = explanation
@@ -654,9 +663,11 @@ fn model_coverage_explanation(
             .selected_route
             .clone()
             .or_else(|| entry.accelerator_routes.first().cloned());
+        coverage.product_cli_ready = Some(entry.claims.product_cli_ready);
         coverage.speedup_claim = Some(entry.claims.speedup_claim);
         coverage.benchmark_qualified = Some(entry.claims.benchmark_qualified);
         coverage.server_ready = Some(entry.claims.server_ready);
+        coverage.server_ready_scope = model_coverage_server_ready_scope(entry);
         coverage.full_residency_claim = Some(entry.claims.full_residency_claim);
         coverage.bitnet_packed_i2s_qk256_proof = Some(entry.claims.bitnet_packed_i2s_qk256_proof);
         coverage.dense_regular_llm_cuda_proof = Some(entry.claims.dense_regular_llm_cuda_proof);
@@ -667,6 +678,10 @@ fn model_coverage_explanation(
     }
 
     coverage
+}
+
+fn model_coverage_server_ready_scope(entry: &ModelCoverageEntry) -> Option<String> {
+    entry.claims.server_ready.then(|| "exact_profile".to_string())
 }
 
 fn find_model_coverage_matrix() -> Option<PathBuf> {
@@ -1036,9 +1051,14 @@ fn print_receipt_explanation(explanation: &ReceiptExplanation) {
         print_option_indented("current_tier", explanation.model_coverage.current_tier.as_deref());
         print_option_indented("status", explanation.model_coverage.status.as_deref());
         print_option_indented("route", explanation.model_coverage.route.as_deref());
+        print_bool_indented("product_cli_ready", explanation.model_coverage.product_cli_ready);
         print_bool_indented("speedup_claim", explanation.model_coverage.speedup_claim);
         print_bool_indented("benchmark_qualified", explanation.model_coverage.benchmark_qualified);
         print_bool_indented("server_ready", explanation.model_coverage.server_ready);
+        print_option_indented(
+            "server_ready_scope",
+            explanation.model_coverage.server_ready_scope.as_deref(),
+        );
         print_bool_indented(
             "bitnet_packed_i2s_qk256_proof",
             explanation.model_coverage.bitnet_packed_i2s_qk256_proof,
@@ -1340,9 +1360,11 @@ fn has_model_coverage(coverage: &ModelCoverageExplanation) -> bool {
         || coverage.current_tier.is_some()
         || coverage.status.is_some()
         || coverage.route.is_some()
+        || coverage.product_cli_ready.is_some()
         || coverage.speedup_claim.is_some()
         || coverage.benchmark_qualified.is_some()
         || coverage.server_ready.is_some()
+        || coverage.server_ready_scope.is_some()
         || coverage.bitnet_packed_i2s_qk256_proof.is_some()
         || coverage.dense_regular_llm_cuda_proof.is_some()
         || coverage.claim_boundary.is_some()
@@ -1592,8 +1614,10 @@ mod tests {
         assert_eq!(explanation.model_coverage.row.as_deref(), Some("bitnet_official_2b_i2s_qk256"));
         assert_eq!(explanation.model_coverage.current_tier.as_deref(), Some("product_cli_ready"));
         assert_eq!(explanation.model_coverage.route.as_deref(), Some("bitnet_qk256_cuda"));
+        assert_eq!(explanation.model_coverage.product_cli_ready, Some(true));
         assert_eq!(explanation.model_coverage.speedup_claim, Some(false));
         assert_eq!(explanation.model_coverage.server_ready, Some(false));
+        assert_eq!(explanation.model_coverage.server_ready_scope, None);
         assert_eq!(explanation.server_ready, Some(false));
         assert_eq!(explanation.model_coverage.bitnet_packed_i2s_qk256_proof, Some(true));
         assert_eq!(explanation.model_coverage.dense_regular_llm_cuda_proof, Some(false));
@@ -1602,6 +1626,8 @@ mod tests {
         assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
         assert_eq!(explanation.selected_route.as_deref(), Some("bitnet_qk256_cuda"));
         assert_eq!(explanation.fallback_used, Some(false));
+        assert_eq!(explanation.product_cli_ready, Some(true));
+        assert_eq!(explanation.server_ready_scope, None);
         assert_eq!(explanation.speedup_claim, Some(false));
         assert_eq!(explanation.full_residency_claim, Some(false));
         assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(true));
@@ -1613,6 +1639,20 @@ mod tests {
                 .iter()
                 .any(|warning| warning.contains("not dense SLM CUDA proof"))
         );
+
+        let value = serde_json::to_value(&explanation).expect("serialize receipt explanation");
+        assert_eq!(value["model_coverage_row"], "bitnet_official_2b_i2s_qk256");
+        assert_eq!(value["current_tier"], "product_cli_ready");
+        assert_eq!(value["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(value["selected_route"], "bitnet_qk256_cuda");
+        assert_eq!(value["fallback_used"], false);
+        assert_eq!(value["product_cli_ready"], true);
+        assert_eq!(value["server_ready"], false);
+        assert!(value["server_ready_scope"].is_null());
+        assert_eq!(value["speedup_claim"], false);
+        assert_eq!(value["full_residency_claim"], false);
+        assert_eq!(value["bitnet_packed_i2s_qk256_proof"], true);
+        assert_eq!(value["dense_regular_llm_cuda_proof"], false);
     }
 
     #[test]
@@ -1645,8 +1685,10 @@ mod tests {
         assert_eq!(explanation.model_coverage.row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
         assert_eq!(explanation.model_coverage.current_tier.as_deref(), Some("product_cli_ready"));
         assert_eq!(explanation.model_coverage.route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert_eq!(explanation.model_coverage.product_cli_ready, Some(true));
         assert_eq!(explanation.model_coverage.speedup_claim, Some(false));
         assert_eq!(explanation.model_coverage.server_ready, Some(true));
+        assert_eq!(explanation.model_coverage.server_ready_scope.as_deref(), Some("exact_profile"));
         assert_eq!(explanation.model_coverage.bitnet_packed_i2s_qk256_proof, Some(false));
         assert_eq!(explanation.model_coverage.dense_regular_llm_cuda_proof, Some(true));
         assert_eq!(explanation.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
@@ -1654,7 +1696,9 @@ mod tests {
         assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
         assert_eq!(explanation.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
         assert_eq!(explanation.fallback_used, Some(false));
+        assert_eq!(explanation.product_cli_ready, Some(true));
         assert_eq!(explanation.server_ready, Some(true));
+        assert_eq!(explanation.server_ready_scope.as_deref(), Some("exact_profile"));
         assert_eq!(explanation.speedup_claim, Some(false));
         assert_eq!(explanation.full_residency_claim, Some(false));
         assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(false));
@@ -1666,6 +1710,20 @@ mod tests {
                 .iter()
                 .any(|warning| warning.contains("not BitNet packed I2_S/QK256 proof"))
         );
+
+        let value = serde_json::to_value(&explanation).expect("serialize receipt explanation");
+        assert_eq!(value["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
+        assert_eq!(value["current_tier"], "product_cli_ready");
+        assert_eq!(value["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(value["selected_route"], "dense_regular_llm_cuda");
+        assert_eq!(value["fallback_used"], false);
+        assert_eq!(value["product_cli_ready"], true);
+        assert_eq!(value["server_ready"], true);
+        assert_eq!(value["server_ready_scope"], "exact_profile");
+        assert_eq!(value["speedup_claim"], false);
+        assert_eq!(value["full_residency_claim"], false);
+        assert_eq!(value["bitnet_packed_i2s_qk256_proof"], false);
+        assert_eq!(value["dense_regular_llm_cuda_proof"], true);
     }
 
     #[test]
@@ -1704,7 +1762,9 @@ mod tests {
             Some("accelerator_answer_ready")
         );
         assert_eq!(explanation.model_coverage.route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert_eq!(explanation.model_coverage.product_cli_ready, Some(false));
         assert_eq!(explanation.model_coverage.server_ready, Some(false));
+        assert_eq!(explanation.model_coverage.server_ready_scope, None);
         assert_eq!(explanation.model_coverage.speedup_claim, Some(false));
         assert_eq!(explanation.model_coverage.full_residency_claim, Some(false));
         assert_eq!(explanation.model_coverage.bitnet_packed_i2s_qk256_proof, Some(false));
@@ -1714,11 +1774,27 @@ mod tests {
         assert_eq!(explanation.selected_backend.as_deref(), Some("nvidia-rtx-5070-ti-cuda"));
         assert_eq!(explanation.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
         assert_eq!(explanation.fallback_used, Some(false));
+        assert_eq!(explanation.product_cli_ready, Some(false));
         assert_eq!(explanation.server_ready, Some(false));
+        assert_eq!(explanation.server_ready_scope, None);
         assert_eq!(explanation.speedup_claim, Some(false));
         assert_eq!(explanation.full_residency_claim, Some(false));
         assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(false));
         assert_eq!(explanation.dense_regular_llm_cuda_proof, Some(true));
+
+        let value = serde_json::to_value(&explanation).expect("serialize receipt explanation");
+        assert_eq!(value["model_coverage_row"], "dense_qwen3_06b_q8_candidate");
+        assert_eq!(value["current_tier"], "accelerator_answer_ready");
+        assert_eq!(value["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(value["selected_route"], "dense_regular_llm_cuda");
+        assert_eq!(value["fallback_used"], false);
+        assert_eq!(value["product_cli_ready"], false);
+        assert_eq!(value["server_ready"], false);
+        assert!(value["server_ready_scope"].is_null());
+        assert_eq!(value["speedup_claim"], false);
+        assert_eq!(value["full_residency_claim"], false);
+        assert_eq!(value["bitnet_packed_i2s_qk256_proof"], false);
+        assert_eq!(value["dense_regular_llm_cuda_proof"], true);
     }
 
     #[test]

--- a/crates/bitnet-cli/src/commands/receipts.rs
+++ b/crates/bitnet-cli/src/commands/receipts.rs
@@ -1586,7 +1586,7 @@ mod tests {
     }
 
     #[test]
-    fn receipts_explain_links_bitnet_receipt_to_model_coverage() {
+    fn receipts_explain_links_bitnet_receipt_to_model_coverage() -> Result<()> {
         let receipt = json!({
             "artifact_kind": "bitnet_cuda_answer",
             "model": {
@@ -1640,7 +1640,7 @@ mod tests {
                 .any(|warning| warning.contains("not dense SLM CUDA proof"))
         );
 
-        let value = serde_json::to_value(&explanation).expect("serialize receipt explanation");
+        let value = serde_json::to_value(&explanation)?;
         assert_eq!(value["model_coverage_row"], "bitnet_official_2b_i2s_qk256");
         assert_eq!(value["current_tier"], "product_cli_ready");
         assert_eq!(value["selected_backend"], "nvidia-rtx-5070-ti-cuda");
@@ -1653,10 +1653,11 @@ mod tests {
         assert_eq!(value["full_residency_claim"], false);
         assert_eq!(value["bitnet_packed_i2s_qk256_proof"], true);
         assert_eq!(value["dense_regular_llm_cuda_proof"], false);
+        Ok(())
     }
 
     #[test]
-    fn receipts_explain_links_dense_qwen_receipt_to_model_coverage() {
+    fn receipts_explain_links_dense_qwen_receipt_to_model_coverage() -> Result<()> {
         let receipt = json!({
             "artifact_kind": "dense_gguf_qwen_warm_session_strict_cuda_proof",
             "claim": "dense_gguf_qwen_warm_session_strict_cuda_proof_recorded",
@@ -1711,7 +1712,7 @@ mod tests {
                 .any(|warning| warning.contains("not BitNet packed I2_S/QK256 proof"))
         );
 
-        let value = serde_json::to_value(&explanation).expect("serialize receipt explanation");
+        let value = serde_json::to_value(&explanation)?;
         assert_eq!(value["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
         assert_eq!(value["current_tier"], "product_cli_ready");
         assert_eq!(value["selected_backend"], "nvidia-rtx-5070-ti-cuda");
@@ -1724,10 +1725,11 @@ mod tests {
         assert_eq!(value["full_residency_claim"], false);
         assert_eq!(value["bitnet_packed_i2s_qk256_proof"], false);
         assert_eq!(value["dense_regular_llm_cuda_proof"], true);
+        Ok(())
     }
 
     #[test]
-    fn receipts_explain_links_qwen3_dense_receipt_to_candidate_coverage() {
+    fn receipts_explain_links_qwen3_dense_receipt_to_candidate_coverage() -> Result<()> {
         let receipt = json!({
             "artifact_kind": "dense_gguf_qwen_ask_strict_cuda_proof",
             "claim": "dense_gguf_qwen_ask_strict_cuda_proof_recorded",
@@ -1782,7 +1784,7 @@ mod tests {
         assert_eq!(explanation.bitnet_packed_i2s_qk256_proof, Some(false));
         assert_eq!(explanation.dense_regular_llm_cuda_proof, Some(true));
 
-        let value = serde_json::to_value(&explanation).expect("serialize receipt explanation");
+        let value = serde_json::to_value(&explanation)?;
         assert_eq!(value["model_coverage_row"], "dense_qwen3_06b_q8_candidate");
         assert_eq!(value["current_tier"], "accelerator_answer_ready");
         assert_eq!(value["selected_backend"], "nvidia-rtx-5070-ti-cuda");
@@ -1795,6 +1797,7 @@ mod tests {
         assert_eq!(value["full_residency_claim"], false);
         assert_eq!(value["bitnet_packed_i2s_qk256_proof"], false);
         assert_eq!(value["dense_regular_llm_cuda_proof"], true);
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -542,6 +542,7 @@ struct ModelStatusRow {
     cpu_answer_ready: bool,
     accelerator_answer_ready: bool,
     benchmark_qualified: bool,
+    product_cli_ready: bool,
     speedup_claim: bool,
     server_ready: bool,
     full_residency_claim: bool,
@@ -553,6 +554,7 @@ struct ModelStatusRow {
     warm_session: String,
     benchmark: String,
     server: String,
+    server_ready_scope: Option<String>,
     server_scope: Option<String>,
     server_endpoint: Option<String>,
     server_streaming: Option<bool>,
@@ -1323,8 +1325,11 @@ fn model_status_includes_entry(device: &str, entry: &ModelCoverageEntry) -> bool
         return true;
     }
 
+    let actionable_candidate = entry.status.contains("candidate")
+        || entry.status.contains("blocked")
+        || entry.id.ends_with("_candidate");
     !entry.claims.product_cli_ready
-        && entry.status.contains("candidate")
+        && actionable_candidate
         && matches!(entry.model_class.as_str(), "dense_slm" | "small_llm")
 }
 
@@ -1355,6 +1360,7 @@ fn model_status_row(device: &str, entry: &ModelCoverageEntry) -> ModelStatusRow 
         cpu_answer_ready: entry.claims.cpu_answer_ready,
         accelerator_answer_ready: entry.claims.accelerator_answer_ready,
         benchmark_qualified: entry.claims.benchmark_qualified,
+        product_cli_ready: entry.claims.product_cli_ready,
         speedup_claim: entry.claims.speedup_claim,
         server_ready: entry.claims.server_ready,
         full_residency_claim: entry.claims.full_residency_claim,
@@ -1366,6 +1372,7 @@ fn model_status_row(device: &str, entry: &ModelCoverageEntry) -> ModelStatusRow 
         warm_session,
         benchmark,
         server: server.label,
+        server_ready_scope: server.scope.clone(),
         server_scope: server.scope,
         server_endpoint: server.endpoint,
         server_streaming: server.streaming,
@@ -3118,12 +3125,14 @@ mod tests {
         assert_eq!(bitnet.route.as_deref(), Some("bitnet_qk256_cuda"));
         assert!(bitnet.cpu_answer_ready);
         assert!(bitnet.accelerator_answer_ready);
+        assert!(bitnet.product_cli_ready);
         assert!(bitnet.bitnet_packed_i2s_qk256_proof);
         assert!(!bitnet.dense_regular_llm_cuda_proof);
         assert!(!bitnet.benchmark_qualified);
         assert!(!bitnet.speedup_claim);
         assert!(!bitnet.server_ready);
         assert_eq!(bitnet.server, "smoke only, not broad-ready");
+        assert_eq!(bitnet.server_ready_scope, None);
         assert_eq!(bitnet.server_scope, None);
         assert_eq!(bitnet.server_endpoint.as_deref(), Some("/v1/chat/completions"));
         assert_eq!(bitnet.server_streaming, Some(false));
@@ -3152,12 +3161,14 @@ mod tests {
         assert_eq!(dense.route.as_deref(), Some("dense_regular_llm_cuda"));
         assert!(dense.cpu_answer_ready);
         assert!(dense.accelerator_answer_ready);
+        assert!(dense.product_cli_ready);
         assert!(dense.dense_regular_llm_cuda_proof);
         assert!(!dense.bitnet_packed_i2s_qk256_proof);
         assert!(!dense.benchmark_qualified);
         assert!(!dense.speedup_claim);
         assert!(dense.server_ready);
         assert_eq!(dense.server, "exact-profile ready (/v1/chat/completions, streaming=false)");
+        assert_eq!(dense.server_ready_scope.as_deref(), Some("exact_profile"));
         assert_eq!(dense.server_scope.as_deref(), Some("exact_profile"));
         assert_eq!(dense.server_endpoint.as_deref(), Some("/v1/chat/completions"));
         assert_eq!(dense.server_streaming, Some(false));
@@ -3184,6 +3195,7 @@ mod tests {
         assert_eq!(qwen3.route.as_deref(), Some("dense_regular_llm_cuda"));
         assert!(qwen3.cpu_answer_ready);
         assert!(qwen3.accelerator_answer_ready);
+        assert!(!qwen3.product_cli_ready);
         assert!(qwen3.dense_regular_llm_cuda_proof);
         assert!(!qwen3.bitnet_packed_i2s_qk256_proof);
         assert!(!qwen3.speedup_claim);
@@ -3198,6 +3210,33 @@ mod tests {
         assert!(qwen3.next_proof.contains("user-facing ask/chat product UX"));
         assert!(qwen3.claim_boundary.contains("dense_regular_llm_cuda RTX 5070 Ti route"));
         assert!(qwen3.claim_boundary.contains("does not inherit Qwen2.5 CUDA receipts"));
+        Ok(())
+    }
+
+    #[test]
+    fn model_status_dashboard_lists_smollm2_structural_blocker() -> Result<()> {
+        let matrix_path = workspace_model_coverage_matrix_path();
+        let matrix = read_model_coverage_matrix(&matrix_path)?;
+        let dashboard = model_status_dashboard("nvidia-rtx-5070-ti-cuda", &matrix_path, &matrix);
+
+        let smollm2 = model_status_row_for(&dashboard, "dense_smollm2_360m_candidate")?;
+        assert_eq!(smollm2.display_name, "smollm2-360m-instruct");
+        assert_eq!(smollm2.current_tier, "structurally_valid");
+        assert_eq!(smollm2.category, "candidate");
+        assert_eq!(smollm2.selected_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(smollm2.selected_route, None);
+        assert_eq!(smollm2.fallback_used, None);
+        assert!(!smollm2.product_cli_ready);
+        assert!(!smollm2.cpu_answer_ready);
+        assert!(!smollm2.accelerator_answer_ready);
+        assert!(!smollm2.dense_regular_llm_cuda_proof);
+        assert!(!smollm2.bitnet_packed_i2s_qk256_proof);
+        assert!(!smollm2.speedup_claim);
+        assert!(!smollm2.server_ready);
+        assert_eq!(smollm2.server_ready_scope, None);
+        assert!(!smollm2.full_residency_claim);
+        assert!(smollm2.next_proof.contains("same-prompt SmolLM2"));
+        assert!(smollm2.claim_boundary.contains("no CPU answer readiness"));
         Ok(())
     }
 
@@ -3229,10 +3268,13 @@ mod tests {
                     && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
                     && model["selected_route"] == "dense_regular_llm_cuda"
                     && model["fallback_used"] == false
+                    && model["product_cli_ready"] == true
                     && model["route"] == "dense_regular_llm_cuda"
                     && model["speedup_claim"] == false
                     && model["server_ready"] == true
+                    && model["server_ready_scope"] == "exact_profile"
                     && model["server_scope"] == "exact_profile"
+                    && model["full_residency_claim"] == false
                     && model["server_endpoint"] == "/v1/chat/completions"
                     && model["server_streaming"] == false
                     && model["server_smoke"] == true
@@ -3251,10 +3293,13 @@ mod tests {
                     && model["selected_route"] == "dense_regular_llm_cuda"
                     && model["fallback_used"] == false
                     && model["tier"] == "accelerator_answer_ready"
+                    && model["product_cli_ready"] == false
                     && model["route"] == "dense_regular_llm_cuda"
                     && model["accelerator_answer_ready"] == true
                     && model["speedup_claim"] == false
                     && model["server_ready"] == false
+                    && model["server_ready_scope"].is_null()
+                    && model["full_residency_claim"] == false
                     && model["server_smoke"] == false
                     && model["bitnet_packed_i2s_qk256_proof"] == false
                     && model["dense_regular_llm_cuda_proof"] == true
@@ -3264,12 +3309,33 @@ mod tests {
             models.iter().any(|model| {
                 model["id"] == "bitnet_official_2b_i2s_qk256"
                     && model["selected_route"] == "bitnet_qk256_cuda"
+                    && model["product_cli_ready"] == true
                     && model["server_ready"] == false
+                    && model["server_ready_scope"].is_null()
                     && model["server_scope"].is_null()
+                    && model["full_residency_claim"] == false
                     && model["server_endpoint"] == "/v1/chat/completions"
                     && model["server_streaming"] == false
                     && model["server_smoke"] == true
                     && model["server_reason"] == "broad production readiness not qualified"
+            })
+        }));
+        assert!(value["models"].as_array().is_some_and(|models| {
+            models.iter().any(|model| {
+                model["id"] == "dense_smollm2_360m_candidate"
+                    && model["model_coverage_row"] == "dense_smollm2_360m_candidate"
+                    && model["category"] == "candidate"
+                    && model["current_tier"] == "structurally_valid"
+                    && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
+                    && model["selected_route"].is_null()
+                    && model["fallback_used"].is_null()
+                    && model["product_cli_ready"] == false
+                    && model["speedup_claim"] == false
+                    && model["server_ready"] == false
+                    && model["server_ready_scope"].is_null()
+                    && model["full_residency_claim"] == false
+                    && model["bitnet_packed_i2s_qk256_proof"] == false
+                    && model["dense_regular_llm_cuda_proof"] == false
             })
         }));
         Ok(())


### PR DESCRIPTION
## Summary
- add stable product_cli_ready and server_ready_scope aliases to model status JSON
- expose the same coverage-derived aliases from receipts explain JSON
- lock official BitNet, Qwen2.5, Qwen3, and SmolLM2 status/receipt claim boundaries with tests

## Validation
- rtk cargo fmt -p bitnet-cli -- --check
- rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
- rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
- rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_coverage_matrix
- rtk git diff --check

## Validation gap
- rtk cargo run --locked -p xtask --no-default-features -- check-model-coverage was attempted, but timed out before running the verifier while compiling native sentencepiece-sys in this Windows environment.