### PR TITLE
fix(ci): format BDD grid feature fallback

### DIFF
--- a/crates/bitnet-bdd-grid/src/features.rs
+++ b/crates/bitnet-bdd-grid/src/features.rs
@@ -2,10 +2,7 @@ use crate::{FeatureSet, feature_set_from_names, try_feature_set_from_names};
 
 pub(crate) fn curated_features(features: &[&str]) -> FeatureSet {
     try_feature_set_from_names(features).unwrap_or_else(|unknown| {
-        eprintln!(
-            "curated BDD grid contains unknown feature names: {}",
-            unknown.join(", ")
-        );
+        eprintln!("curated BDD grid contains unknown feature names: {}", unknown.join(", "));
         feature_set_from_names(features)
     })
 }


### PR DESCRIPTION
Formats the BDD grid curated-feature fallback so rustfmt/macOS format gates stop failing after the SRP queue merges. Validation: rtk proxy cargo fmt -p bitnet-bdd-grid -- --check; rtk cargo check --locked -p bitnet-bdd-grid --no-default-features; rtk git diff --check.