### PR TITLE
cpu(avx2): add QK256 execution counters and expose them in receipts/coverage

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -5343,6 +5343,20 @@ async fn run_simple_generation(
                 "bitnet_linear_layers_total": bitnet_linear_coverage.bitnet_linear_layers_total,
                 "bitnet_linear_layers_on_cuda": bitnet_linear_coverage.bitnet_linear_layers_on_cuda,
                 "bitnet_linear_layers_cpu_fallback": bitnet_linear_coverage.bitnet_linear_layers_cpu_fallback,
+                "qk256_f32_avx2_gemv_invocations": bitnet_linear_coverage.qk256_f32_avx2_gemv_invocations,
+                "qk256_f32_scalar_gemv_invocations": bitnet_linear_coverage.qk256_f32_scalar_gemv_invocations,
+                "qk256_i8s_scaled_scalar_invocations": bitnet_linear_coverage.qk256_i8s_scaled_scalar_invocations,
+                "qk256_i8s_scaled_avx2_invocations": bitnet_linear_coverage.qk256_i8s_scaled_avx2_invocations,
+                "qk256_flat_bytes_extracted_count": bitnet_linear_coverage.qk256_flat_bytes_extracted_count,
+                "input_rows_materialized_count": bitnet_linear_coverage.input_rows_materialized_count,
+                "output_rows_allocated_count": bitnet_linear_coverage.output_rows_allocated_count,
+                "scaled_vs_no_scale_path": if bitnet_linear_coverage.qk256_i8s_scaled_scalar_invocations + bitnet_linear_coverage.qk256_i8s_scaled_avx2_invocations > 0 {
+                    "scaled_i2s_i8s"
+                } else if bitnet_linear_coverage.qk256_f32_scalar_gemv_invocations + bitnet_linear_coverage.qk256_f32_avx2_gemv_invocations > 0 {
+                    "no_scale_f32"
+                } else {
+                    "not_observed"
+                },
                 "unsupported_ops": bitnet_linear_coverage.unsupported_ops.clone(),
                 "execution_claim": bitnet_linear_coverage.execution_claim,
             },
@@ -5837,6 +5851,7 @@ struct CpuPhasePromptRun {
     token_decode_step_ms: Vec<f64>,
     decode_step_ms: Vec<f64>,
     prefill_step_ms: Vec<f64>,
+    qk256_coverage: bitnet_qk256_dispatch::Qk256DispatchCoverageCounters,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -6172,6 +6187,7 @@ async fn run_cpu_phase_warm_session(
         }));
     }
 
+    let total_qk256_coverage = bitnet_qk256_dispatch::qk256_dispatch_coverage();
     let aggregate_artifact_kind =
         if dense_slm_model { "dense_slm_cpu_phase_warm_session" } else { "cpu_phase_warm_session" };
     let aggregate = serde_json::json!({
@@ -6258,6 +6274,7 @@ async fn run_cpu_phase_warm_session(
             "total_session_ms": rounded_ms(elapsed_ms(session_start)),
         },
         "profiles": profile_summaries,
+        "execution_coverage": qk256_dispatch_coverage_receipt(&total_qk256_coverage),
         "claim_boundary": {
             "cpu_phase_timing_only": true,
             "dense_slm_cpu_phase_timing_only": dense_slm_model,
@@ -6301,6 +6318,7 @@ fn run_cpu_phase_prompt(
     let prompt_token_count = tokens.len();
     let prompt_token_ids = tokens.clone();
 
+    let qk256_coverage_before = bitnet_qk256_dispatch::qk256_dispatch_coverage();
     let cache = KVCache::new(config, 1, &candle_core::Device::Cpu)?;
     let mut any_cache: Box<dyn std::any::Any> = Box::new(cache);
     let mut sampler = SamplingStrategy::new(SamplingConfig {
@@ -6374,6 +6392,9 @@ fn run_cpu_phase_prompt(
     }
 
     let generated_text = tokenizer.decode(&generated_token_ids)?;
+    let qk256_coverage_after = bitnet_qk256_dispatch::qk256_dispatch_coverage();
+    let qk256_coverage =
+        qk256_dispatch_coverage_delta(&qk256_coverage_before, &qk256_coverage_after);
     Ok(CpuPhasePromptRun {
         profile_id: plan.profile_id,
         phase: plan.phase,
@@ -6400,6 +6421,7 @@ fn run_cpu_phase_prompt(
         token_decode_step_ms,
         decode_step_ms,
         prefill_step_ms,
+        qk256_coverage,
     })
 }
 
@@ -6592,6 +6614,7 @@ fn cpu_phase_strict_profile_receipt(
             "fallback_used": false,
             "fallback_reason": serde_json::Value::Null,
         },
+        "execution_coverage": qk256_dispatch_coverage_receipt(&run.qk256_coverage),
         "kernel": {
             "family": kernel_family,
             "implementation": kernel_implementation,
@@ -7483,6 +7506,27 @@ fn qk256_dispatch_coverage_delta(
             .difference(&unsupported_before)
             .cloned()
             .collect::<Vec<_>>(),
+        qk256_f32_avx2_gemv_invocations: after
+            .qk256_f32_avx2_gemv_invocations
+            .saturating_sub(before.qk256_f32_avx2_gemv_invocations),
+        qk256_f32_scalar_gemv_invocations: after
+            .qk256_f32_scalar_gemv_invocations
+            .saturating_sub(before.qk256_f32_scalar_gemv_invocations),
+        qk256_i8s_scaled_scalar_invocations: after
+            .qk256_i8s_scaled_scalar_invocations
+            .saturating_sub(before.qk256_i8s_scaled_scalar_invocations),
+        qk256_i8s_scaled_avx2_invocations: after
+            .qk256_i8s_scaled_avx2_invocations
+            .saturating_sub(before.qk256_i8s_scaled_avx2_invocations),
+        qk256_flat_bytes_extracted_count: after
+            .qk256_flat_bytes_extracted_count
+            .saturating_sub(before.qk256_flat_bytes_extracted_count),
+        input_rows_materialized_count: after
+            .input_rows_materialized_count
+            .saturating_sub(before.input_rows_materialized_count),
+        output_rows_allocated_count: after
+            .output_rows_allocated_count
+            .saturating_sub(before.output_rows_allocated_count),
         execution_claim: if after.bitnet_linear_layers_on_cuda > before.bitnet_linear_layers_on_cuda
         {
             "cuda_inference_contribution"
@@ -7500,6 +7544,20 @@ fn qk256_dispatch_coverage_receipt(
         "bitnet_linear_layers_total": coverage.bitnet_linear_layers_total,
         "bitnet_linear_layers_on_cuda": coverage.bitnet_linear_layers_on_cuda,
         "bitnet_linear_layers_cpu_fallback": coverage.bitnet_linear_layers_cpu_fallback,
+        "qk256_f32_avx2_gemv_invocations": coverage.qk256_f32_avx2_gemv_invocations,
+        "qk256_f32_scalar_gemv_invocations": coverage.qk256_f32_scalar_gemv_invocations,
+        "qk256_i8s_scaled_scalar_invocations": coverage.qk256_i8s_scaled_scalar_invocations,
+        "qk256_i8s_scaled_avx2_invocations": coverage.qk256_i8s_scaled_avx2_invocations,
+        "qk256_flat_bytes_extracted_count": coverage.qk256_flat_bytes_extracted_count,
+        "input_rows_materialized_count": coverage.input_rows_materialized_count,
+        "output_rows_allocated_count": coverage.output_rows_allocated_count,
+        "scaled_vs_no_scale_path": if coverage.qk256_i8s_scaled_scalar_invocations + coverage.qk256_i8s_scaled_avx2_invocations > 0 {
+            "scaled_i2s_i8s"
+        } else if coverage.qk256_f32_scalar_gemv_invocations + coverage.qk256_f32_avx2_gemv_invocations > 0 {
+            "no_scale_f32"
+        } else {
+            "not_observed"
+        },
         "unsupported_ops": coverage.unsupported_ops,
         "execution_claim": coverage.execution_claim,
     })
@@ -12512,6 +12570,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 42,
             bitnet_linear_layers_cpu_fallback: 0,
             unsupported_ops: Vec::new(),
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
         let residency = bitnet_qk256_dispatch::Qk256CudaWeightResidency {
@@ -12555,6 +12620,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 1,
             bitnet_linear_layers_cpu_fallback: 1,
             unsupported_ops: vec!["qk256_cpu_fallback".to_string()],
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
 
@@ -12597,6 +12669,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 4,
             bitnet_linear_layers_cpu_fallback: 0,
             unsupported_ops: Vec::new(),
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
         let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
@@ -12624,6 +12703,13 @@ mod tests {
             bitnet_linear_layers_on_cuda: 4,
             bitnet_linear_layers_cpu_fallback: 0,
             unsupported_ops: Vec::new(),
+            qk256_f32_avx2_gemv_invocations: 0,
+            qk256_f32_scalar_gemv_invocations: 0,
+            qk256_i8s_scaled_scalar_invocations: 0,
+            qk256_i8s_scaled_avx2_invocations: 0,
+            qk256_flat_bytes_extracted_count: 0,
+            input_rows_materialized_count: 0,
+            output_rows_allocated_count: 0,
             execution_claim: "cuda_inference_contribution",
         };
         let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -26,6 +26,13 @@ static CUDA_QK256_HOST_TO_DEVICE_BYTES: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_DEVICE_TO_HOST_BYTES: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_KERNEL_TIME_MICROS: AtomicU64 = AtomicU64::new(0);
 static CUDA_QK256_KERNEL_TIME_SAMPLES: AtomicU64 = AtomicU64::new(0);
+static QK256_F32_AVX2_GEMV_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_F32_SCALAR_GEMV_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_I8S_SCALED_SCALAR_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_I8S_SCALED_AVX2_INVOCATIONS: AtomicU64 = AtomicU64::new(0);
+static QK256_FLAT_BYTES_EXTRACTED_COUNT: AtomicU64 = AtomicU64::new(0);
+static QK256_INPUT_ROWS_MATERIALIZED_COUNT: AtomicU64 = AtomicU64::new(0);
+static QK256_OUTPUT_ROWS_ALLOCATED_COUNT: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(feature = "cuda")]
 thread_local! {
@@ -43,6 +50,20 @@ pub struct Qk256DispatchCoverageCounters {
     pub bitnet_linear_layers_cpu_fallback: u64,
     /// Unsupported operations that prevent a full CUDA inference claim.
     pub unsupported_ops: Vec<String>,
+    /// No-scale F32 QK256 GEMV calls that selected the AVX2/FMA kernel.
+    pub qk256_f32_avx2_gemv_invocations: u64,
+    /// No-scale F32 QK256 GEMV calls that selected the scalar kernel.
+    pub qk256_f32_scalar_gemv_invocations: u64,
+    /// Inline-scaled BitNet I2_S × I8_S calls that used the scalar oracle.
+    pub qk256_i8s_scaled_scalar_invocations: u64,
+    /// Inline-scaled BitNet I2_S × I8_S calls that used an AVX2 implementation.
+    pub qk256_i8s_scaled_avx2_invocations: u64,
+    /// Number of QK256 tensor-to-flat-byte materializations.
+    pub qk256_flat_bytes_extracted_count: u64,
+    /// Number of input tensor row materializations.
+    pub input_rows_materialized_count: u64,
+    /// Number of output row-buffer allocations.
+    pub output_rows_allocated_count: u64,
     /// Human-readable claim boundary for partial routing.
     pub execution_claim: &'static str,
 }
@@ -89,6 +110,16 @@ pub fn qk256_dispatch_coverage() -> Qk256DispatchCoverageCounters {
         bitnet_linear_layers_on_cuda: on_cuda,
         bitnet_linear_layers_cpu_fallback: cpu_fallback,
         unsupported_ops,
+        qk256_f32_avx2_gemv_invocations: QK256_F32_AVX2_GEMV_INVOCATIONS.load(Ordering::Relaxed),
+        qk256_f32_scalar_gemv_invocations: QK256_F32_SCALAR_GEMV_INVOCATIONS
+            .load(Ordering::Relaxed),
+        qk256_i8s_scaled_scalar_invocations: QK256_I8S_SCALED_SCALAR_INVOCATIONS
+            .load(Ordering::Relaxed),
+        qk256_i8s_scaled_avx2_invocations: QK256_I8S_SCALED_AVX2_INVOCATIONS
+            .load(Ordering::Relaxed),
+        qk256_flat_bytes_extracted_count: QK256_FLAT_BYTES_EXTRACTED_COUNT.load(Ordering::Relaxed),
+        input_rows_materialized_count: QK256_INPUT_ROWS_MATERIALIZED_COUNT.load(Ordering::Relaxed),
+        output_rows_allocated_count: QK256_OUTPUT_ROWS_ALLOCATED_COUNT.load(Ordering::Relaxed),
         execution_claim: if on_cuda > 0 {
             "cuda_inference_contribution"
         } else if cuda_bitnet_backend_requested() {
@@ -112,6 +143,13 @@ pub fn reset_qk256_dispatch_coverage() {
     CUDA_QK256_DEVICE_TO_HOST_BYTES.store(0, Ordering::Relaxed);
     CUDA_QK256_KERNEL_TIME_MICROS.store(0, Ordering::Relaxed);
     CUDA_QK256_KERNEL_TIME_SAMPLES.store(0, Ordering::Relaxed);
+    QK256_F32_AVX2_GEMV_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_F32_SCALAR_GEMV_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_I8S_SCALED_SCALAR_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_I8S_SCALED_AVX2_INVOCATIONS.store(0, Ordering::Relaxed);
+    QK256_FLAT_BYTES_EXTRACTED_COUNT.store(0, Ordering::Relaxed);
+    QK256_INPUT_ROWS_MATERIALIZED_COUNT.store(0, Ordering::Relaxed);
+    QK256_OUTPUT_ROWS_ALLOCATED_COUNT.store(0, Ordering::Relaxed);
     reset_cuda_qk256_context();
 }
 
@@ -217,13 +255,17 @@ fn forward_qk256_cpu(
     weight_name: &str,
     inline_scale: Option<f32>,
 ) -> Result<Tensor> {
-    use bitnet_quantization::i2s_qk256::{gemv_qk256, gemv_qk256_bitnet_i8s_scaled};
+    use bitnet_quantization::i2s_qk256::{
+        QK256_AVX2_GEMV_KERNEL_ID, gemv_qk256, gemv_qk256_bitnet_i8s_scaled,
+        select_qk256_gemv_kernel,
+    };
 
     let prepared = prepare_qk256_forward(input, qk256_tensor, weight_name)?;
     let mut output_rows = vec![
         vec![0.0f32; prepared.layout.rows];
         prepared.shape.batch_size * prepared.shape.seq_len
     ];
+    QK256_OUTPUT_ROWS_ALLOCATED_COUNT.fetch_add(1, Ordering::Relaxed);
 
     if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && weight_name.contains("layers.0.")
     {
@@ -242,6 +284,7 @@ fn forward_qk256_cpu(
 
     for (row_index, input_row) in prepared.input_rows.iter().enumerate() {
         let gemv_result = if let Some(scale) = inline_scale {
+            QK256_I8S_SCALED_SCALAR_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
             gemv_qk256_bitnet_i8s_scaled(
                 &prepared.flat_bytes,
                 input_row,
@@ -252,6 +295,14 @@ fn forward_qk256_cpu(
                 scale,
             )
         } else {
+            match select_qk256_gemv_kernel(None, false) {
+                Ok(selection) if selection.selected_kernel == QK256_AVX2_GEMV_KERNEL_ID => {
+                    QK256_F32_AVX2_GEMV_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                }
+                _ => {
+                    QK256_F32_SCALAR_GEMV_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+                }
+            }
             gemv_qk256(
                 &prepared.flat_bytes,
                 input_row,
@@ -437,6 +488,7 @@ fn prepare_qk256_activation(
             weight_name, e
         ))
     })?;
+    QK256_INPUT_ROWS_MATERIALIZED_COUNT.fetch_add(1, Ordering::Relaxed);
 
     Ok(PreparedQk256Activation { layout, shape, input_rows })
 }
@@ -446,6 +498,7 @@ fn extract_qk256_flat_bytes(
     layout: &Qk256Layout,
     weight_name: &str,
 ) -> Result<Vec<u8>> {
+    QK256_FLAT_BYTES_EXTRACTED_COUNT.fetch_add(1, Ordering::Relaxed);
     let bytes_2d = qk256_tensor.to_vec2::<u8>().map_err(|e| {
         BitNetError::Validation(format!("Failed to extract QK256 bytes for {}: {}", weight_name, e))
     })?;

--- a/crates/bitnet-qk256-dispatch/tests/cuda_coverage.rs
+++ b/crates/bitnet-qk256-dispatch/tests/cuda_coverage.rs
@@ -45,6 +45,56 @@ fn cpu_selected_qk256_forward_records_total_without_fallback() {
 }
 
 #[test]
+fn cpu_qk256_forward_records_materialization_and_no_scale_kernel_counters() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+    let device = Device::Cpu;
+    let input = Tensor::ones(&[1, 1, 256], DType::F32, &device).unwrap();
+    let qk256 = qk256_tensor(2, 256, &device);
+
+    let _ = forward_qk256(&input, &qk256, "layers.0.attention.q_proj.weight.qk256_qs").unwrap();
+    let coverage = qk256_dispatch_coverage();
+
+    assert_eq!(coverage.qk256_flat_bytes_extracted_count, 1);
+    assert_eq!(coverage.input_rows_materialized_count, 1);
+    assert_eq!(coverage.output_rows_allocated_count, 1);
+    assert_eq!(
+        coverage.qk256_f32_avx2_gemv_invocations + coverage.qk256_f32_scalar_gemv_invocations,
+        1
+    );
+    assert_eq!(coverage.qk256_i8s_scaled_scalar_invocations, 0);
+    assert_eq!(coverage.qk256_i8s_scaled_avx2_invocations, 0);
+}
+
+#[test]
+fn cpu_qk256_forward_with_inline_scale_records_scaled_scalar_hot_path() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+    let device = Device::Cpu;
+    let input = Tensor::ones(&[1, 1, 256], DType::F32, &device).unwrap();
+    let qk256 = qk256_tensor(2, 256, &device);
+
+    let _ = bitnet_qk256_dispatch::forward_qk256_with_scale(
+        &input,
+        &qk256,
+        "layers.0.attention.q_proj.weight.qk256_qs",
+        Some(1.0),
+    )
+    .unwrap();
+    let coverage = qk256_dispatch_coverage();
+
+    assert_eq!(coverage.qk256_i8s_scaled_scalar_invocations, 1);
+    assert_eq!(coverage.qk256_i8s_scaled_avx2_invocations, 0);
+    assert_eq!(coverage.qk256_f32_avx2_gemv_invocations, 0);
+    assert_eq!(coverage.qk256_f32_scalar_gemv_invocations, 0);
+    assert_eq!(coverage.qk256_flat_bytes_extracted_count, 1);
+    assert_eq!(coverage.input_rows_materialized_count, 1);
+    assert_eq!(coverage.output_rows_allocated_count, 1);
+}
+
+#[test]
 fn missing_qk256_tensor_fallback_counter_is_backend_aware() {
     let _guard = ENV_LOCK.lock().unwrap();
     clear_backend_env();

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -1168,6 +1168,27 @@ fn qk256_dispatch_coverage_delta(
         bitnet_linear_layers_on_cuda,
         bitnet_linear_layers_cpu_fallback,
         unsupported_ops: unsupported_delta,
+        qk256_f32_avx2_gemv_invocations: after
+            .qk256_f32_avx2_gemv_invocations
+            .saturating_sub(before.qk256_f32_avx2_gemv_invocations),
+        qk256_f32_scalar_gemv_invocations: after
+            .qk256_f32_scalar_gemv_invocations
+            .saturating_sub(before.qk256_f32_scalar_gemv_invocations),
+        qk256_i8s_scaled_scalar_invocations: after
+            .qk256_i8s_scaled_scalar_invocations
+            .saturating_sub(before.qk256_i8s_scaled_scalar_invocations),
+        qk256_i8s_scaled_avx2_invocations: after
+            .qk256_i8s_scaled_avx2_invocations
+            .saturating_sub(before.qk256_i8s_scaled_avx2_invocations),
+        qk256_flat_bytes_extracted_count: after
+            .qk256_flat_bytes_extracted_count
+            .saturating_sub(before.qk256_flat_bytes_extracted_count),
+        input_rows_materialized_count: after
+            .input_rows_materialized_count
+            .saturating_sub(before.input_rows_materialized_count),
+        output_rows_allocated_count: after
+            .output_rows_allocated_count
+            .saturating_sub(before.output_rows_allocated_count),
         execution_claim: if bitnet_linear_layers_on_cuda > 0 {
             "cuda_inference_contribution"
         } else {


### PR DESCRIPTION
### Motivation

- Add unambiguous, per-run diagnostics to prove which QK256 GEMV path actually executed (no-scale F32 AVX2 vs F32 scalar vs BitNet I2_S×I8_S scaled) and to count obvious allocation/materialization costs that mask kernel speedups.
- Surface those counters in the CLI/server receipts and dispatch coverage so strict CPU/CUDA proof artifacts can report whether the real scaled AVX2 hot path ran and whether per-token copies/allocation occurred.

### Description

- Added atomic coverage counters in `bitnet-qk256-dispatch`: `QK256_F32_AVX2_GEMV_INVOCATIONS`, `QK256_F32_SCALAR_GEMV_INVOCATIONS`, `QK256_I8S_SCALED_SCALAR_INVOCATIONS`, `QK256_I8S_SCALED_AVX2_INVOCATIONS`, `QK256_FLAT_BYTES_EXTRACTED_COUNT`, `QK256_INPUT_ROWS_MATERIALIZED_COUNT`, and `QK256_OUTPUT_ROWS_ALLOCATED_COUNT`, and reset logic to zero them in `reset_qk256_dispatch_coverage`.
- Extended `Qk256DispatchCoverageCounters` to include the new invocation and materialization fields and return them from `qk256_dispatch_coverage` and related delta/receipt helpers.
- Instrumented hot paths: increment `QK256_INPUT_ROWS_MATERIALIZED_COUNT` when input rows are materialized, `QK256_FLAT_BYTES_EXTRACTED_COUNT` when tensor bytes are flattened, `QK256_OUTPUT_ROWS_ALLOCATED_COUNT` when output row buffers are allocated, and increment per-call invocation counters immediately before dispatching to the selected GEMV implementation (AVX2 vs scalar) or when calling the BitNet-scaled scalar path.
- Updated `bitnet-cli` and server/planner receipt builders to include the new coverage fields and to propagate per-run deltas into per-profile receipts and execution-plan evidence so receipts can prove which kernel family/implementation and how many invocations were observed.

### Testing

- No automated tests were executed during this change; existing unit and integration test suites remain and will be run by CI (suggested local smoke commands: `cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2`, `cargo test -p bitnet-qk256-dispatch`, and `cargo test -p bitnet-cli`).
- Repository already contains targeted parity and coverage tests (e.g., `qk256_avx2_parity_tests`, `bitnet-qk256-dispatch` coverage tests) which should be run by CI to validate selection and that receipts still validate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab06d45c8833391b85965dca2c4bf)