### PR TITLE
docs(opencl): reconcile A770 proof state

### DIFF
--- a/ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
+++ b/ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
@@ -9,36 +9,47 @@
     "no_model_family_claim_without_required_kernels": true,
     "no_benchmark_claim_without_quality_passed": true,
     "no_fallback_for_claimed_kernels": true,
-    "device_route_must_be_concrete": true
+    "device_route_must_be_concrete": true,
+    "no_transcript_or_local_claim_without_committed_receipt": true
   },
   "kernels": [
     {
       "kernel": "qk256_i2s_gemv",
-      "model_families": ["bitnet"],
+      "model_families": [
+        "bitnet"
+      ],
       "status": "diagnostic",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
-      "reason": "Trusted-path A770 QK256 receipts are local/target evidence until a clean claim-grade rerun lands."
+      "reason": "A770 QK256 remains diagnostic: no committed claim-grade strict selected-device OpenCL QK256 receipt exists."
     },
     {
       "kernel": "embedding_lookup",
-      "model_families": ["bitnet"],
+      "model_families": [
+        "bitnet"
+      ],
       "status": "diagnostic",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
-      "reason": "A770 embedding route is explicit, but claim-grade receipts are not committed yet."
+      "reason": "A770 embedding remains diagnostic: no committed claim-grade strict selected-device OpenCL embedding receipt exists."
     },
     {
       "kernel": "lm_head_tied_logits",
-      "model_families": ["bitnet"],
+      "model_families": [
+        "bitnet"
+      ],
       "status": "diagnostic",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
-      "reason": "A770 lm_head/tied-logits route is explicit, but claim-grade receipts are not committed yet."
+      "reason": "A770 LM-head/tied-logits remains diagnostic: no committed claim-grade strict selected-device OpenCL receipt exists."
     },
     {
       "kernel": "dense_f16_gemv",
-      "model_families": ["gemma", "llama", "qwen"],
+      "model_families": [
+        "gemma",
+        "llama",
+        "qwen"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -46,7 +57,12 @@
     },
     {
       "kernel": "q4_q5_q8_dequant_gemv",
-      "model_families": ["slm", "llama", "qwen", "gemma"],
+      "model_families": [
+        "slm",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -54,7 +70,12 @@
     },
     {
       "kernel": "rmsnorm",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -62,7 +83,12 @@
     },
     {
       "kernel": "rope",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -70,7 +96,9 @@
     },
     {
       "kernel": "selected_attention_scores",
-      "model_families": ["bitnet"],
+      "model_families": [
+        "bitnet"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -78,7 +106,12 @@
     },
     {
       "kernel": "softmax",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -86,7 +119,12 @@
     },
     {
       "kernel": "attention_value_mix",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -94,7 +132,12 @@
     },
     {
       "kernel": "resident_kv_cache",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -102,7 +145,12 @@
     },
     {
       "kernel": "full_support_residency",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
@@ -110,7 +158,12 @@
     },
     {
       "kernel": "full_device_residency",
-      "model_families": ["bitnet", "llama", "qwen", "gemma"],
+      "model_families": [
+        "bitnet",
+        "llama",
+        "qwen",
+        "gemma"
+      ],
       "status": "missing",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],

--- a/ci/hardware/device-kernel-routing.toml
+++ b/ci/hardware/device-kernel-routing.toml
@@ -17,7 +17,7 @@ kernel_variant = "a770_opencl_qk256_i2s_route_pending_claim_receipts"
 claim_level = "diagnostic"
 fallback_allowed = false
 proof_receipts = []
-reason = "A770 route is explicit, but claim-grade A770 QK256 receipts are not committed yet."
+reason = "A770 route is explicit and remains diagnostic because no committed claim-grade strict A770 OpenCL QK256 receipts exist."
 not_claims = [
   "selected_attention_residency",
   "resident_kv_decode",
@@ -43,7 +43,7 @@ kernel_variant = "a770_opencl_embedding_route_pending_claim_receipts"
 claim_level = "diagnostic"
 fallback_allowed = false
 proof_receipts = []
-reason = "A770 embedding route is explicit, but claim-grade receipts are not committed yet."
+reason = "A770 embedding route is explicit and remains diagnostic because no committed claim-grade strict A770 OpenCL embedding receipts exist."
 not_claims = [
   "selected_attention_residency",
   "resident_kv_decode",
@@ -69,7 +69,7 @@ kernel_variant = "a770_opencl_lm_head_route_pending_claim_receipts"
 claim_level = "diagnostic"
 fallback_allowed = false
 proof_receipts = []
-reason = "A770 lm_head route is explicit, but claim-grade receipts are not committed yet."
+reason = "A770 lm_head route is explicit and remains diagnostic because no committed claim-grade strict A770 OpenCL LM-head receipts exist."
 not_claims = [
   "selected_attention_residency",
   "resident_kv_decode",

--- a/docs/hardware/HARDWARE_MATRIX.md
+++ b/docs/hardware/HARDWARE_MATRIX.md
@@ -49,7 +49,10 @@ Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, or O
 
 ## Required Identity Fields
 
-Every receipt or hardware artifact should preserve separate identity fields:
+Every receipt or hardware artifact should preserve separate identity fields.
+The example path below is a required shape, not a claim that the artifact already
+exists; A770 OpenCL claims require a committed receipt linked from the route and
+capability matrices.
 
 ```json
 {
@@ -61,7 +64,7 @@ Every receipt or hardware artifact should preserve separate identity fields:
     "pci_device_id": "0x56A0"
   },
   "fallback_used": false,
-  "artifact_path": "ci/hardware/intel-arc-a770/2026-05-05/opencl-smoke.json"
+  "artifact_path": "ci/hardware/amd-5700x-intel-a770/<date>/opencl-smoke.json"
 }
 ```
 

--- a/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
+++ b/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
@@ -33,12 +33,16 @@ cpu:
   quality_gate: required
 
 a770:
-  support: trusted_partial
+  support: diagnostic
+  target_support: trusted_partial
+  claim_status: diagnostic_pending_claim_grade_receipts
   selected_backend: intel-arc-a770-opencl
+  receipt_requirement: "Commit strict selected-device OpenCL receipts before promoting qk256_linears, embedding, or lm_head_tied_logits."
   required_claimed_ops:
     - qk256_linears
     - embedding
     - lm_head_tied_logits
+  claim_ready_required_ops: []
   not_claims:
     - selected_attention_residency
     - resident_kv_decode

--- a/docs/reports/2026-05-18-a770-opencl-truth-reconciliation.md
+++ b/docs/reports/2026-05-18-a770-opencl-truth-reconciliation.md
@@ -1,0 +1,55 @@
+# A770 OpenCL Truth Reconciliation
+
+Status: diagnostic
+Owner: Codex
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs:
+- `docs/specs/intel-arc-a770-gpu-roadmap.md`
+- `docs/specs/a770-bitnet-claim-boundary.md`
+Linked ADRs:
+- `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Linked plan:
+- `plans/a770-bitnet-claim-boundary-implementation.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no promotion
+Policy impact: none
+
+## Finding
+
+No committed claim-grade A770 OpenCL BitNet inference receipt was found in the
+repository for the transcript-level state that described full inference or all
+QK256 linears running on A770. Repository evidence remains limited to explicit
+A770 route declarations and diagnostic capability rows with empty proof receipt
+lists.
+
+## Reconciled Source of Truth
+
+| Surface | Reconciled state |
+|---|---|
+| Active campaign | `A770-OPENCL-TRUTH-000` is the current ready item; backend-identity work follows after this reconciliation. |
+| Route matrix | A770 BitNet QK256, embedding, and LM-head routes remain `diagnostic` with empty proof receipts. |
+| Kernel capability matrix | A770 BitNet QK256, embedding, and LM-head capabilities remain `diagnostic`; support ops, dense SLM, Gemma, and full residency remain missing or unsupported. |
+| Model contract | A770 is `diagnostic` with `target_support: trusted_partial`; the target is not claim-ready until receipts land. |
+| Claim ledger | `a770.bitnet.trusted_partial_experience` remains `diagnostic` with no evidence. |
+
+## Claim Boundary
+
+This reconciliation may claim only that the repository truth has been narrowed to
+diagnostic A770 OpenCL BitNet status pending committed proof. It must not claim:
+
+- A770 OpenCL BitNet execution works.
+- Full inference is proven on A770.
+- CPU, CUDA, OpenVINO GPU, generic OpenCL, or Arc 140V evidence proves native
+  A770 OpenCL execution.
+- QK256-only or route declaration evidence proves full residency, attention/KV
+  residency, dense SLM support, Gemma support, server readiness, or speedup.
+
+## Next Required Evidence
+
+A later runtime PR may promote A770 status only after it commits strict
+selected-device OpenCL receipts under `ci/hardware/amd-5700x-intel-a770/<date>/`,
+links those receipts from the route and capability matrices, and records quality,
+fallback, route identity, model identity, and timing evidence required by the
+A770 claim-boundary plan.

--- a/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
@@ -23,11 +23,22 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 - CPU fallback cannot count as A770 execution.
 - Performance claims require driver, PCIe, ReBAR, VRAM, power, and thermal context.
 
+## Current Reconciliation
+
+The current repository has no committed claim-grade A770 OpenCL BitNet inference
+receipt. The route matrix, kernel capability matrix, claim ledger, and model
+contract therefore remain at `diagnostic` for A770 BitNet until a later PR lands
+strict selected-device OpenCL execution receipts. Local or uploaded transcript
+claims are not product claims unless their receipt artifacts are committed under
+`ci/hardware/amd-5700x-intel-a770/<date>/`, summarized in `docs/reports/`, and
+linked from the matrices.
+
 ## Work Items
 
 | Work item | Status | Notes |
 |---|---|---|
-| A770-003 | ready | Preserve selected-device identity. |
+| A770-OPENCL-TRUTH-000 | ready | Reconcile tracker, route, capability, claim, and contract state before runtime work. |
+| A770-003 | proposed | Preserve selected-device identity after reconciliation lands. |
 | A770-004 | proposed | Add runtime probe. |
 | A770-005 | proposed | Run OpenCL smoke. |
 | A770-006 | proposed | Add CPU/OpenCL parity. |

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -19,14 +19,57 @@ hard_constraints = [
 ]
 
 [[work_item]]
-id = "A770-003"
+id = "A770-OPENCL-TRUTH-000"
 status = "ready"
-branch = "codex/intel-a770/A770-003-backend-identity"
+branch = "codex/intel-a770/opencl-truth-reconciliation"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
 blocked_by = []
+acceptance = [
+  "Inspect committed A770 proof artifacts and record whether claim-grade OpenCL inference receipts exist.",
+  "Keep A770 BitNet routes diagnostic unless committed receipts prove strict selected-device OpenCL execution.",
+  "Make active.toml, CAMPAIGN.md, route matrix, kernel matrix, model contract, and reconciliation report agree on the same claim level.",
+  "Do not change OpenCL kernels or QK256 dispatch in this reconciliation PR.",
+]
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check intel-a770",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/claims/claim-ledger.json",
+  "ci/hardware/device-kernel-routing.toml",
+  "ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json",
+  "docs/hardware/HARDWARE_MATRIX.md",
+  "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
+  "docs/reports/**",
+  "docs/tracking/campaigns/intel-a770/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "ci/hardware/amd-5700x-intel-a770/*/*.json",
+]
+may_claim = [
+  "A770 OpenCL BitNet route state is reconciled as diagnostic pending committed claim-grade receipts.",
+]
+must_not_claim = [
+  "A770 OpenCL execution works.",
+  "OpenVINO GPU proves native OpenCL kernels.",
+  "BitNet inference works on A770.",
+  "Full A770 inference or full device residency is proven.",
+]
+
+[[work_item]]
+id = "A770-003"
+status = "proposed"
+branch = "codex/intel-a770/A770-003-backend-identity"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["A770-OPENCL-TRUTH-000"]
 acceptance = "Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims."
 commands = [
   "cargo fmt --all -- --check",
@@ -45,11 +88,5 @@ forbidden_paths = [
   "crates/bitnet-qk256-dispatch/**",
   "crates/bitnet-server/**",
 ]
-may_claim = [
-  "A770 backend identity is preserved through config and logging surfaces.",
-]
-must_not_claim = [
-  "A770 OpenCL execution works.",
-  "OpenVINO GPU proves native OpenCL kernels.",
-  "BitNet inference works on A770.",
-]
+may_claim = []
+must_not_claim = []

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -9,7 +9,8 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| A770-003 | ready | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-OPENCL-TRUTH-000 | ready | TBD | `codex/intel-a770/opencl-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Inspect committed A770 proof artifacts and record whether claim-grade OpenCL inference receipts exist.; Keep A770 BitNet routes diagnostic unless committed receipts prove strict selected-device OpenCL execution.; Make active.toml, CAMPAIGN.md, route matrix, kernel matrix, model contract, and reconciliation report agree on the same claim level.; Do not change OpenCL kernels or QK256 dispatch in this reconciliation PR. |
+| A770-003 | proposed | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -336,6 +336,7 @@
 | intel-258v-platform | LNL258V-ROUTE-008 | LNL258V-ROUTE-007 | merged |
 | intel-258v-platform | LNL258V-ROUTE-009 | LNL258V-ROUTE-008 | merged |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | LNL258V-OV-QUAL-004 | merged |
+| intel-a770 | A770-003 | A770-OPENCL-TRUTH-000 | proposed |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-OPENCL-TRUTH-000 | TBD | ready | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-a770 | Intel Arc A770 validation | A770-OPENCL-TRUTH-000 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
### Motivation

- There is a mismatch between local/uploaded A770 transcript claims and the repository source-of-truth surfaces which could result in overclaiming native A770 OpenCL BitNet inference. 
- This PR narrows the public claim surface to diagnostic until claim-grade, committed selected-device OpenCL receipts exist. 
- The reconciliation keeps runtime/kernels unchanged while aligning the campaign, route/capability matrices, and model contract with committed evidence requirements.

### Description

- Add a new ready work item `A770-OPENCL-TRUTH-000` to `docs/tracking/campaigns/intel-a770/active.toml` and surface it in `CAMPAIGN.md` to make reconciliation the prerequisite for backend identity work. 
- Downgrade the `a770` entry in `docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml` from `support: trusted_partial` to `support: diagnostic` and add `target_support`, `claim_status`, and a `receipt_requirement` that requires committed selected-device OpenCL receipts before promotion. 
- Update `ci/hardware/device-kernel-routing.toml` and `ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json` to keep QK256/embedding/LM-head routes and kernels `diagnostic`, tighten reasons, and add a capability policy flag preventing transcript/local claims without committed receipts. 
- Clarify `docs/hardware/HARDWARE_MATRIX.md` to treat the A770 receipt example path as a required artifact shape rather than evidence already present, add a reconciliation report at `docs/reports/2026-05-18-a770-opencl-truth-reconciliation.md`, and regenerate campaign dashboards under `docs/tracking/generated/` so the tracker reflects the reconciliation item. 
- This is a docs/tracker-only PR and does not change runtime code, kernels, or dispatch logic.

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- campaign check intel-a770` which passed. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check` and regenerated dashboards successfully. 
- Ran `cargo run --locked -p xtask --no-default-features -- model-contract lint --format json --allow-missing-assets` which passed (assets are allowed missing in CI). 
- Ran repository hygiene checks `git diff --check` and `cargo fmt --all -- --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc5ce3c48333ada6bd0490348e1d)