### PR TITLE
docs(opencl): reconcile A770 proof state

### DIFF
--- a/ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
+++ b/ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
@@ -18,7 +18,7 @@
       "status": "diagnostic",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
-      "reason": "Trusted-path A770 QK256 receipts are local/target evidence until a clean claim-grade rerun lands."
+      "reason": "No committed claim-grade A770 QK256 receipts prove the stronger transcript/full-inference state; a clean rerun must land before promotion."
     },
     {
       "kernel": "embedding_lookup",
@@ -26,7 +26,7 @@
       "status": "diagnostic",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
-      "reason": "A770 embedding route is explicit, but claim-grade receipts are not committed yet."
+      "reason": "A770 embedding route is explicit, but no committed claim-grade receipts prove A770 embedding execution yet."
     },
     {
       "kernel": "lm_head_tied_logits",
@@ -34,7 +34,7 @@
       "status": "diagnostic",
       "fallback_allowed_when_claimed": false,
       "proof_receipts": [],
-      "reason": "A770 lm_head/tied-logits route is explicit, but claim-grade receipts are not committed yet."
+      "reason": "A770 lm_head/tied-logits route is explicit, but no committed claim-grade receipts prove A770 tied-logits execution yet."
     },
     {
       "kernel": "dense_f16_gemv",

--- a/ci/hardware/device-kernel-routing.toml
+++ b/ci/hardware/device-kernel-routing.toml
@@ -17,7 +17,7 @@ kernel_variant = "a770_opencl_qk256_i2s_route_pending_claim_receipts"
 claim_level = "diagnostic"
 fallback_allowed = false
 proof_receipts = []
-reason = "A770 route is explicit, but claim-grade A770 QK256 receipts are not committed yet."
+reason = "A770 route is explicit, but no committed claim-grade A770 QK256 receipts prove the stronger transcript/full-inference state yet."
 not_claims = [
   "selected_attention_residency",
   "resident_kv_decode",
@@ -43,7 +43,7 @@ kernel_variant = "a770_opencl_embedding_route_pending_claim_receipts"
 claim_level = "diagnostic"
 fallback_allowed = false
 proof_receipts = []
-reason = "A770 embedding route is explicit, but claim-grade receipts are not committed yet."
+reason = "A770 embedding route is explicit, but no committed claim-grade receipts prove A770 embedding execution yet."
 not_claims = [
   "selected_attention_residency",
   "resident_kv_decode",
@@ -69,7 +69,7 @@ kernel_variant = "a770_opencl_lm_head_route_pending_claim_receipts"
 claim_level = "diagnostic"
 fallback_allowed = false
 proof_receipts = []
-reason = "A770 lm_head route is explicit, but claim-grade receipts are not committed yet."
+reason = "A770 lm_head route is explicit, but no committed claim-grade receipts prove A770 tied-logits execution yet."
 not_claims = [
   "selected_attention_residency",
   "resident_kv_decode",

--- a/docs/reports/A770_OPENCL_TRUTH_RECONCILIATION.md
+++ b/docs/reports/A770_OPENCL_TRUTH_RECONCILIATION.md
@@ -1,0 +1,79 @@
+# A770 OpenCL truth reconciliation
+
+Status: diagnostic reconciliation
+Owner: Codex
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs:
+- `docs/specs/intel-arc-a770-gpu-roadmap.md`
+- `docs/specs/a770-bitnet-claim-boundary.md`
+Linked ADRs: n/a
+Linked plan: `plans/a770-bitnet-claim-boundary-implementation.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no promotion
+Policy impact: none
+
+## Decision
+
+Keep the A770 OpenCL BitNet route at `diagnostic` until claim-grade receipts are
+committed and validated. This reconciliation PR does not land kernels, dispatch
+changes, benchmark data, or model-inference receipts.
+
+The current repository contains route and capability declarations for the A770
+OpenCL lane, but it does not contain committed proof artifacts that justify a
+full-inference, trusted-partial, performance, or residency promotion.
+
+## Evidence inventory
+
+| Surface | Current committed state | Reconciliation result |
+|---|---|---|
+| Campaign active goal | A770 lane objective is OpenCL-first validation with selected-device receipts; A770 backend identity remains a prerequisite. | Add a dedicated truth-reconciliation item before follow-on A770 execution work. |
+| Campaign narrative | A770-003 was the only ready item and A770-004 through A770-007 were future proposed work. | Record that proof inventory must agree with route and capability matrices before promotion. |
+| Route matrix | A770 BitNet QK256, embedding, and tied LM-head routes are present but `claim_level = "diagnostic"` with empty `proof_receipts`. | Keep them diagnostic and explicitly tie the reason to missing committed claim-grade receipts. |
+| Kernel capability matrix | QK256, embedding, and tied LM-head are `diagnostic`; dense, support-op, KV, attention, and full-residency rows remain missing. | Keep diagnostic/missing status and clarify that no full-inference route is proved. |
+| Receipt paths | No A770 proof receipts were found under `ci/hardware/amd-5700x-intel-a770/`, `ci/hardware/intel-arc-a770/`, or `docs/reports/` beyond non-proof reconciliation notes; campaign events contain tracker state only. | Do not promote the uploaded/transcript proof state. |
+| Runtime dispatch | No reconciliation change is made to dispatch. | Future PRs must add strict OpenCL dispatch and receipts before route promotion. |
+
+## Claim boundary after reconciliation
+
+Allowed claim for this PR:
+
+```text
+The A770 OpenCL proof state is reconciled as diagnostic-only in committed repo
+state until claim-grade receipts are present.
+```
+
+Not claimed by this PR:
+
+```text
+A770 OpenCL execution works
+BitNet inference works on A770 OpenCL
+trusted partial A770 acceleration is claim-ready
+full A770 inference is proved
+QK256 linears, embedding, or LM-head are production-routed through A770 OpenCL
+attention, KV, softmax, RMSNorm, RoPE, support-op, or full-device residency
+dense SLM, Gemma, or small-LLM support on A770 OpenCL
+performance or speedup
+server readiness
+```
+
+## Follow-up gates
+
+The next OpenCL PRs should prove, in order:
+
+1. selected-device A770 OpenCL smoke with fallback false;
+2. OpenCL kernel compile smoke with build logs;
+3. official QK256 scalar fixtures for grouped layout and scaled I2_S × I8_S math;
+4. A770 OpenCL QK256 parity;
+5. strict dispatch routing with fail-closed fallback semantics;
+6. one-token and answer-corpus quality receipts;
+7. long-decode behavior receipts;
+8. phase timing and same-device history receipts;
+9. a separate promotion PR if and only if the preceding receipts pass.
+
+## Rollback plan
+
+Revert this documentation/tracker reconciliation if claim-grade A770 receipts are
+landed in the same branch and the route matrix, capability matrix, campaign
+tracker, and generated dashboards are updated to point to those receipts.

--- a/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
@@ -15,6 +15,7 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 - Tiny OpenCL smoke executes with fallback=false.
 - CPU/OpenCL parity exists for one kernel or subgraph.
 - Receipts preserve selected device identity before performance claims.
+- Tracker, route matrix, capability matrix, and committed receipt inventory agree before route promotion.
 
 ## Hard Constraints
 
@@ -22,12 +23,14 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 - OpenVINO GPU is reference only.
 - CPU fallback cannot count as A770 execution.
 - Performance claims require driver, PCIe, ReBAR, VRAM, power, and thermal context.
+- Full inference, trusted partial acceleration, support-op residency, and dense-model claims require committed claim-grade receipts before promotion.
 
 ## Work Items
 
 | Work item | Status | Notes |
 |---|---|---|
-| A770-003 | ready | Preserve selected-device identity. |
+| A770-OPENCL-TRUTH-001 | in_progress | Reconcile tracker, route matrix, kernel matrix, and committed proof inventory before any A770 OpenCL claim promotion. |
+| A770-003 | ready | Preserve selected-device identity after truth reconciliation. |
 | A770-004 | proposed | Add runtime probe. |
 | A770-005 | proposed | Run OpenCL smoke. |
 | A770-006 | proposed | Add CPU/OpenCL parity. |
@@ -36,3 +39,18 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 ## Review Policy
 
 A770 runtime PRs are non-stackable. Do not combine A770 with Intel NPU, Arc 140V, or CPU proof changes unless the campaign manifest explicitly allows it.
+
+## Current Evidence Reconciliation
+
+As of 2026-05-18, the committed repository does not contain claim-grade A770
+OpenCL proof receipts under `ci/hardware/amd-5700x-intel-a770/`,
+`ci/hardware/intel-arc-a770/`, or `docs/reports/` beyond non-proof
+reconciliation notes; the A770 campaign event log contains tracker state only. Therefore the campaign remains diagnostic-only for A770 BitNet QK256,
+embedding, and tied LM-head routes. The uploaded or local transcript state that
+mentions full inference, all QK256 linears on A770, and CPU/A770 greedy-token
+parity is not promoted unless those artifacts are committed and pass the
+claim-boundary gates.
+
+The next runtime-facing steps remain selected-device OpenCL smoke, kernel
+compile smoke, official QK256 scalar/OpenCL parity, strict dispatch routing,
+quality-gated answer receipts, phase timing, and same-device history receipts.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -10,12 +10,53 @@ end_state = [
   "Tiny OpenCL smoke executes with fallback_used=false.",
   "CPU/OpenCL parity exists for one kernel or subgraph.",
   "Receipts preserve selected device identity before performance claims.",
+  "Current tracker, route matrix, capability matrix, and committed receipt inventory agree before any A770 promotion.",
 ]
 
 hard_constraints = [
   "OpenCL-first for native A770 proof.",
   "OpenVINO GPU is reference only.",
   "CPU fallback cannot count as A770 execution.",
+  "No full-inference, trusted-partial, performance, or residency claim may appear without committed claim-grade receipts.",
+]
+
+[[work_item]]
+id = "A770-OPENCL-TRUTH-001"
+status = "in_progress"
+branch = "work"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Reconcile the A770 tracker, route matrix, kernel matrix, and committed proof inventory so no full-inference or trusted-partial OpenCL claim is implied without claim-grade receipts."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check intel-a770",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/device-kernel-routing.toml",
+  "ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json",
+  "docs/reports/**",
+  "docs/tracking/campaigns/intel-a770/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/src/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "A770 OpenCL proof state is reconciled as diagnostic-only unless committed claim-grade receipts are present.",
+]
+must_not_claim = [
+  "A770 OpenCL execution works.",
+  "BitNet inference works on A770 OpenCL.",
+  "Trusted partial A770 acceleration is claim-ready.",
+  "Full A770 inference or full device residency is proved.",
+  "Dense SLM, Gemma, or small LLM support inherits BitNet A770 proof.",
 ]
 
 [[work_item]]
@@ -26,8 +67,8 @@ stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
-blocked_by = []
-acceptance = "Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims."
+blocked_by = ["A770-OPENCL-TRUTH-001"]
+acceptance = "Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims after truth reconciliation confirms the committed A770 OpenCL proof level."
 commands = [
   "cargo fmt --all -- --check",
   "cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu",

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-18T000000Z-A770-OPENCL-TRUTH-001-in-progress.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-18T000000Z-A770-OPENCL-TRUTH-001-in-progress.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-18T00:00:00Z"
+campaign = "intel-a770"
+item = "A770-OPENCL-TRUTH-001"
+event = "in_progress"
+actor = "codex"
+branch = "work"
+
+notes = [
+  "Started the A770 OpenCL truth-reconciliation item before route or kernel promotion.",
+  "Scope is docs, tracker, route matrix, and capability matrix evidence alignment only; no kernel, dispatch, inference, or benchmark behavior changes are introduced.",
+  "The item keeps A770 QK256, embedding, and tied LM-head routes diagnostic unless committed claim-grade receipts prove the stronger transcript state.",
+]

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -9,10 +9,12 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| A770-003 | ready | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-OPENCL-TRUTH-001 | in_progress | TBD | `work` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Reconcile the A770 tracker, route matrix, kernel matrix, and committed proof inventory so no full-inference or trusted-partial OpenCL claim is implied without claim-grade receipts. |
+| A770-003 | ready | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims after truth reconciliation confirms the committed A770 OpenCL proof level. |
 
 ## Hard Constraints
 
 - OpenCL-first for native A770 proof.
 - OpenVINO GPU is reference only.
 - CPU fallback cannot count as A770 execution.
+- No full-inference, trusted-partial, performance, or residency claim may appear without committed claim-grade receipts.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -329,6 +329,7 @@
 | intel-258v-platform | LNL258V-ROUTE-008 | LNL258V-ROUTE-007 | merged |
 | intel-258v-platform | LNL258V-ROUTE-009 | LNL258V-ROUTE-008 | merged |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | LNL258V-OV-QUAL-004 | merged |
+| intel-a770 | A770-003 | A770-OPENCL-TRUTH-001 | ready |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-OPENCL-TRUTH-001 | TBD | in_progress | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-a770 | Intel Arc A770 validation | A770-OPENCL-TRUTH-001 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
### Motivation
- Reconcile a mismatch between uploaded/local A770 OpenCL transcript claims and the committed repository evidence so the repo does not promote unvalidated OpenCL/A770 inference claims. 
- Ensure the route matrix, kernel capability matrix, campaign tracker, and committed receipt inventory remain consistent before any promotion of A770 OpenCL routes. 
- Provide a scoped, machine-readable work item so follow-on runtime PRs must land claim-grade receipts and pass the defined gates before changing claim levels. 

### Description
- Add a truth-reconciliation report at `docs/reports/A770_OPENCL_TRUTH_RECONCILIATION.md` that records the decision to keep A770 BitNet OpenCL routes diagnostic until claim-grade receipts are committed. 
- Add a campaign work item `A770-OPENCL-TRUTH-001` and event under `docs/tracking/campaigns/intel-a770/active.toml` and `events/` to enforce a reconciliation step before route promotion. 
- Update campaign narrative and generated dashboards (`docs/tracking/campaigns/intel-a770/CAMPAIGN.md` and generated files) to require tracker/route/capability/receipt agreement before promotion. 
- Clarify routing/capability reasons and keep QK256/embedding/LM-head routes `diagnostic` with empty `proof_receipts` by editing `ci/hardware/device-kernel-routing.toml` and `ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json`. 

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign check intel-a770` and it reported `campaign check passed: intel-a770`. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check` and it reported `generated dashboards are current`. 
- Ran `git diff --check` and fixed the only whitespace/EOF issue; all validation checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc5ce3c48333ada6bd0490348e1d)