### PR TITLE
docs(opencl): reconcile A770 tracker and proof state

### DIFF
--- a/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
+++ b/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
@@ -33,8 +33,12 @@ cpu:
   quality_gate: required
 
 a770:
-  support: trusted_partial
+  support: diagnostic
+  target_support: trusted_partial
   selected_backend: intel-arc-a770-opencl
+  evidence_state: no_claim_grade_receipts_committed
+  proof_receipts: []
+  promotion_blocker: claim-grade A770 OpenCL BitNet receipts are not committed yet
   required_claimed_ops:
     - qk256_linears
     - embedding

--- a/docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md
+++ b/docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md
@@ -1,0 +1,87 @@
+# OPENCL_A770_000 Truth Reconciliation
+
+Status: diagnostic-current-state preserved
+Owner: Codex
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: `docs/specs/intel-arc-a770-gpu-roadmap.md`, `docs/specs/a770-bitnet-claim-boundary.md`
+Linked ADRs: n/a
+Linked plan: `plans/a770-bitnet-claim-boundary-implementation.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no promotion
+Policy impact: n/a
+
+## Decision
+
+The current repository does not contain claim-grade A770 OpenCL BitNet proof
+artifacts matching the transcript-level state described in the handoff. The
+committed truth therefore remains diagnostic for BitNet QK256, embedding, and
+LM-head A770 OpenCL routes, and unsupported for selected attention, dense SLM,
+Gemma-class, support-op residency, and full-device residency routes.
+
+No full-inference, full-residency, dense-model, server-readiness, or speedup
+claim is made by this reconciliation.
+
+## Inspection Summary
+
+- `ci/hardware/amd-5700x-intel-a770/` contains the A770 kernel capability
+  matrix but no dated claim-grade receipt directory.
+- `docs/tracking/campaigns/intel-a770/events/` contains no A770 proof event
+  beyond the placeholder.
+- `docs/reports/` contains no A770 OpenCL BitNet proof report with committed
+  receipt paths.
+- `ci/hardware/device-kernel-routing.toml` already classifies A770 BitNet
+  QK256, embedding, and LM-head routes as `diagnostic` with empty
+  `proof_receipts`.
+- `ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json` already
+  classifies A770 BitNet QK256, embedding, and LM-head kernels as `diagnostic`
+  with empty `proof_receipts`.
+- `ci/claims/claim-ledger.json` and generated `docs/claims.md` keep the
+  trusted-partial experience claim at `diagnostic`.
+- The model contract now records `support: diagnostic` and
+  `target_support: trusted_partial` so target intent cannot be mistaken for a
+  current public support claim.
+
+## Reconciled Current State
+
+| Surface | Current state | Reconciled action |
+|---|---|---|
+| Campaign active item | Truth reconciliation is first | Added `A770-000` as the ready item and made `A770-003` depend on it. |
+| Campaign narrative | A770-003 was previously first ready item | Added an explicit diagnostic-current-state note. |
+| Model contract | Target support was encoded as current support | Split current `support: diagnostic` from `target_support: trusted_partial`. |
+| Route matrix | QK256 / embedding / LM-head diagnostic | Kept diagnostic with empty proof receipts. |
+| Kernel matrix | QK256 / embedding / LM-head diagnostic | Kept diagnostic with empty proof receipts. |
+| Claim ledger | Trusted partial experience diagnostic | Kept diagnostic. |
+| Receipts | No claim-grade A770 BitNet receipts committed | No route promotion. |
+
+## Claim Boundary
+
+Allowed claim for this PR:
+
+```text
+The committed A770 OpenCL BitNet source-of-truth files agree that current route
+state is diagnostic or unsupported until claim-grade receipts land.
+```
+
+Not claimed:
+
+```text
+A770 OpenCL execution works
+BitNet inference works on A770
+QK256 linears ran on A770
+embedding ran on A770
+LM-head logits ran on A770
+fallback_used=false for a BitNet A770 run
+full inference
+full device residency
+performance speedup
+server readiness
+dense SLM/Gemma/small LLM support
+```
+
+## Rollback Plan
+
+Revert this report, the campaign manifest/dashboard updates, and the model
+contract support split. Because no runtime code or kernels changed, rollback is
+limited to source-of-truth documentation and tracking files.

--- a/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
@@ -27,7 +27,8 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 
 | Work item | Status | Notes |
 |---|---|---|
-| A770-003 | ready | Preserve selected-device identity. |
+| A770-000 | ready | Reconcile tracker, route, capability, claim, model-contract, and receipt truth before runtime work. |
+| A770-003 | proposed | Preserve selected-device identity after reconciliation. |
 | A770-004 | proposed | Add runtime probe. |
 | A770-005 | proposed | Run OpenCL smoke. |
 | A770-006 | proposed | Add CPU/OpenCL parity. |
@@ -35,4 +36,4 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 
 ## Review Policy
 
-A770 runtime PRs are non-stackable. Do not combine A770 with Intel NPU, Arc 140V, or CPU proof changes unless the campaign manifest explicitly allows it.
+A770 runtime PRs are non-stackable. Do not combine A770 with Intel NPU, Arc 140V, or CPU proof changes unless the campaign manifest explicitly allows it. The current committed A770 BitNet route state is diagnostic/unsupported until claim-grade receipts are committed; transcript-only or local target evidence must not promote the route, model contract, or campaign status.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -16,17 +16,62 @@ hard_constraints = [
   "OpenCL-first for native A770 proof.",
   "OpenVINO GPU is reference only.",
   "CPU fallback cannot count as A770 execution.",
+  "Diagnostic A770 route rows and model-contract targets do not promote to trusted partial until claim-grade receipts are committed.",
 ]
 
 [[work_item]]
-id = "A770-003"
+id = "A770-000"
 status = "ready"
-branch = "codex/intel-a770/A770-003-backend-identity"
+branch = "codex/intel-a770/A770-000-truth-reconciliation"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
 blocked_by = []
+acceptance = "Reconcile the A770 campaign, model contract, route matrix, kernel matrix, claims ledger, and committed receipts so they all preserve diagnostic current state and no full-inference claim appears without claim-grade evidence."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- hardware a770 kernel-capability-check --format json",
+  "cargo run --locked -p xtask --no-default-features -- hardware route resolve --format json",
+  "cargo run --locked -p xtask --no-default-features -- claims verify --format json",
+  "cargo run --locked -p xtask --no-default-features -- campaign check intel-a770",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+]
+allowed_paths = [
+  "ci/claims/claim-ledger.json",
+  "ci/hardware/amd-5700x-intel-a770/**",
+  "ci/hardware/device-kernel-routing.toml",
+  "docs/claims.md",
+  "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
+  "docs/reports/**",
+  "docs/specs/a770-bitnet-claim-boundary.md",
+  "docs/specs/intel-arc-a770-gpu-roadmap.md",
+  "docs/tracking/campaigns/intel-a770/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/src/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "The committed A770 source-of-truth files agree that current A770 OpenCL BitNet routes are diagnostic or unsupported until claim-grade receipts land.",
+]
+must_not_claim = [
+  "A770 OpenCL execution works.",
+  "OpenVINO GPU proves native OpenCL kernels.",
+  "BitNet inference works on A770.",
+  "A770 full inference, full residency, or performance is proven.",
+]
+
+[[work_item]]
+id = "A770-003"
+status = "proposed"
+branch = "codex/intel-a770/A770-003-backend-identity"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["A770-000"]
 acceptance = "Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims."
 commands = [
   "cargo fmt --all -- --check",

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -9,10 +9,12 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| A770-003 | ready | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-000 | ready | TBD | `codex/intel-a770/A770-000-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Reconcile the A770 campaign, model contract, route matrix, kernel matrix, claims ledger, and committed receipts so they all preserve diagnostic current state and no full-inference claim appears without claim-grade evidence. |
+| A770-003 | proposed | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
 
 ## Hard Constraints
 
 - OpenCL-first for native A770 proof.
 - OpenVINO GPU is reference only.
 - CPU fallback cannot count as A770 execution.
+- Diagnostic A770 route rows and model-contract targets do not promote to trusted partial until claim-grade receipts are committed.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -329,6 +329,7 @@
 | intel-258v-platform | LNL258V-ROUTE-008 | LNL258V-ROUTE-007 | merged |
 | intel-258v-platform | LNL258V-ROUTE-009 | LNL258V-ROUTE-008 | merged |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | LNL258V-OV-QUAL-004 | merged |
+| intel-a770 | A770-003 | A770-000 | proposed |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-000 | TBD | ready | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-a770 | Intel Arc A770 validation | A770-000 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
### Motivation
- Reconcile a mismatch between local/transcript A770 proof artifacts and the committed repo state so the source-of-truth files do not promote claim-grade A770 OpenCL BitNet support prematurely.
- Preserve the repo rails that require concrete, receipt-backed evidence before promoting any trusted partial, performance, or residency claims for A770 OpenCL.

### Description
- Add `docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md` documenting that no claim-grade A770 BitNet OpenCL receipts are committed and enumerating the inspection and rollback plan.
- Insert a new campaign work item `A770-000` (truth reconciliation) in `docs/tracking/campaigns/intel-a770/active.toml` with validation commands, allowed/forbidden paths, and explicit may/must-not claims, and make `A770-003` depend on it.
- Update `docs/tracking/campaigns/intel-a770/CAMPAIGN.md` and regenerate campaign dashboards to surface `A770-000` as the ready item and to warn that transcript/local evidence cannot promote claims.
- Split the BitNet model contract A770 entry in `docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml` from `support: trusted_partial` to `support: diagnostic` plus `target_support: trusted_partial` and add `evidence_state`, empty `proof_receipts`, and a `promotion_blocker` note; do not change runtime/kernel/dispatch code.

### Testing
- Ran `xtask hardware a770 kernel-capability-check --format json` and it passed, reporting no claimable kernels for A770.
- Ran `xtask hardware route resolve --format json`, `xtask claims verify --format json`, `xtask campaign check intel-a770`, and `xtask campaign generate --check`, and all checks passed.
- Ran repository hygiene and build/tests: `cargo fmt --all -- --check`, `cargo check -p bitnet-kernels --features opencl`, `cargo test -p bitnet-device-probe --features opencl`, `cargo test -p bitnet-kernels --features opencl --test opencl_fuzz_targets`, and `xtask model-contract lint --allow-missing-assets`; all succeeded.
- Performed `git diff --check` and validated generated dashboards; no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abc5ce3c48333ada6bd0490348e1d)