### PR TITLE
docs(apple): add Apple Silicon source-of-truth map and rollout plan

### DIFF
--- a/docs/apple-silicon/README.md
+++ b/docs/apple-silicon/README.md
@@ -1,0 +1,128 @@
+# Apple Silicon Source-of-Truth Map
+
+This page is the navigation contract for Apple Silicon work in BitNet-rs. It
+prevents one successful Mac run from becoming an unsupported claim about every
+Apple machine, backend, model family, or acceleration path.
+
+It is intentionally a map, not a new proof source. The linked roadmap, matrix,
+campaign, receipts, and future specs remain the authorities for their own
+layers. Historical campaign pages stay in place for auditability.
+
+## Product Target
+
+The first Apple Silicon product target is a Mac-native local inference appliance
+for the M4 Mac mini:
+
+```text
+M4 Mac mini local appliance:
+  dense SLMs: product path on apple-m4-cpu-neon first
+  BitNet: accepted artifact on apple-m4-cpu-neon first
+  Metal: phase-scoped acceleration proof only
+  MPSGraph: reference/graph lane only
+  Neural Engine: not claimed unless explicitly receipt-proven
+```
+
+This target does not claim full `apple-m4-metal` inference, Neural Engine
+execution, MPSGraph model inference, broad Apple Silicon support, or MacBook
+proof for M4 Mac mini runtime behavior.
+
+## Proof Families
+
+Apple proof families are separated by machine, model family, backend, runtime
+API, and fallback state:
+
+| Proof family | Machine | Model family | Backend/runtime scope | Current role |
+| --- | --- | --- | --- | --- |
+| `apple_m4_cpu_neon_dense_slm` | `apple-m4-mac-mini` | dense SLM | `apple-m4-cpu-neon` / CPU | Product appliance path for supported Qwen-class dense SLMs. |
+| `apple_m4_cpu_neon_bitnet` | `apple-m4-mac-mini` | BitNet | `apple-m4-cpu-neon` / CPU | Productization path for the accepted BitNet artifact. |
+| `apple_m4_metal_phase` | `apple-m4-mac-mini` | dense SLM or BitNet phase fixtures | `apple-m4-metal` / Metal | Phase-scoped acceleration research and parity proof only. |
+| `apple_m4_mpsgraph_reference` | `apple-m4-mac-mini` | graph/reference fixtures | MPSGraph | Graph/reference lane; not native Metal proof. |
+| `apple_m4_neural_engine_research` | `apple-m4-mac-mini` | receipt-proven only | resolved Neural Engine target only if proven | Research lane with no current product claim. |
+| `apple_macbook_cpu_neon_bitnet` | `apple-silicon-macbook` | BitNet | CPU/NEON | Auxiliary larger-artifact and longer-soak lane; not M4 proof. |
+| `apple_macbook_metal_phase` | `apple-silicon-macbook` | phase fixtures | Metal | Auxiliary parity experiments; not M4 proof. |
+
+Every receipt that contributes to one family must identify its `machine_id`,
+`model_family`, `requested_backend`, `selected_backend`, `runtime_api`,
+`fallback_used`, and `proof_family` so dashboard and operator claims cannot mix
+families.
+
+## Authority Table
+
+| Layer | Source of truth | Notes |
+| --- | --- | --- |
+| Apple Silicon route semantics | Future `docs/specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md` | Contractual labels, fallback rules, and proof-family receipt fields. Until it lands, this map is only routing guidance. |
+| M4 Mac mini hardware facts | [`docs/specs/apple-m4-mac-mini-roadmap.md`](../specs/apple-m4-mac-mini-roadmap.md) | Defines the M4 lane as Metal-first, MPSGraph reference, and CPU/NEON fallback/parity. |
+| Supported dense SLM models | [`docs/slm/apple-m4-dense-slm-model-support-matrix.md`](../slm/apple-m4-dense-slm-model-support-matrix.md) | Defines the supported/default/candidate dense SLM matrix and promotion gates. |
+| Current M4 excellence state | [`docs/tracking/campaigns/apple-m4-inference-excellence/active.toml`](../tracking/campaigns/apple-m4-inference-excellence/active.toml) | Machine-readable active campaign queue and proof commands. |
+| Operator-facing narrative | [`docs/slm/apple-m4-inference-excellence.md`](../slm/apple-m4-inference-excellence.md) | Human-readable M4 appliance status, dashboards, and claim boundaries. |
+| Historical proof campaigns | Existing `docs/tracking/campaigns/apple-m4-*` folders | Historical proof surfaces remain audit records and must not be deleted during cleanup. |
+| MacBook auxiliary lane | Future Apple MacBook campaign/docs | MacBook can aid larger artifacts and longer soaks, but must not replace M4 Mac mini proof. |
+| Machine artifacts | `ci/hardware/apple-m4-mac-mini/**` and future MacBook paths | Receipt evidence, not source-of-truth prose. No model binaries. |
+| General Apple Metal/MPS/NEON policy | Future Apple Silicon specs | Contractual docs added by the Apple Silicon docs rollout. |
+
+## Current Mature Lane: Dense SLM on M4 CPU/NEON
+
+The dense SLM lane is the most mature Apple product path. The support matrix
+keeps it separate from BitNet, QK256, full Metal inference, MPSGraph, and Neural
+Engine work.
+
+Current supported dense M4 models are:
+
+```text
+qwen2.5-0.5b-instruct-q8_0       default
+qwen2.5-0.5b-instruct-q4_k_m     supported, storage-conscious
+qwen2.5-1.5b-instruct-q4_k_m     supported, non-default
+```
+
+These rows are M4 Mac mini, Apple CPU/NEON, supported dense model identity
+claims only. They are not broad Apple Silicon, BitNet, Metal, MPSGraph, Neural
+Engine, or MacBook claims.
+
+## BitNet Lane: M4 CPU/NEON First
+
+BitNet Apple work is productized on `apple-m4-cpu-neon` before any full Metal
+route claim. Accepted BitNet evidence must stay BitNet-specific and must not use
+dense Qwen receipts as substitute proof. Metal, MPSGraph, Neural Engine, and
+QK256 acceleration claims require separate receipt-backed proof families.
+
+## Metal Lane: Phase-Scoped Proof Only
+
+Metal is a useful proof lane when each kernel or subgraph has explicit CPU
+reference parity and fallback-free receipts. The current source-of-truth cleanup
+does not promote full Metal inference. In particular:
+
+- Metal visibility is not Metal execution.
+- CPU fallback is not Metal execution.
+- Metal subgraph parity is not full autoregressive inference.
+- MPSGraph smoke is not native Metal proof.
+- Phase-local timing is not a broad speedup claim.
+
+## Claim Rails
+
+These rails apply across Apple specs, plans, active manifests, status docs, and
+operator-facing pages:
+
+```text
+Dense Qwen SLM evidence is not BitNet evidence.
+BitNet CPU/NEON evidence is not Metal evidence.
+Metal visibility is not Metal execution.
+Metal subgraph parity is not full Metal inference.
+MPSGraph smoke is not native Metal proof.
+MPSGraph smoke is not Neural Engine proof unless the resolved target is receipt-backed.
+CPU fallback cannot count as Metal execution.
+MacBook evidence is not M4 Mac Mini runtime proof.
+M4 Mac Mini evidence is not broad Apple Silicon proof.
+QK256-on-x86/CUDA/A770 evidence is not QK256-on-Metal evidence.
+Supported dense SLMs must be artifact-pinned and tokenizer-authoritative.
+No model binaries are committed.
+Live hardware/model timing is never required in ordinary generic PR CI.
+```
+
+## Cleanup Rules
+
+- Do not delete old campaign docs.
+- Do not create another competing “current truth” page.
+- Add Apple Silicon specs as contractual rails, not as runtime promotions.
+- Keep source-of-truth roles separated: proposals explain why, specs define
+  behavior, plans sequence work, active goals describe current execution, and
+  receipts prove exact runs.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,5 +1,28 @@
 # Specs Index
 
+## Apple Silicon Source-of-Truth
+
+Use these maps before implementing or claiming Apple Silicon product support:
+
+1. [Apple Silicon Source-of-Truth Map](../apple-silicon/README.md)
+   - Identifies the proof-family boundaries for M4 dense SLM, M4 BitNet,
+     phase-scoped Metal, MPSGraph reference work, Neural Engine research, and
+     MacBook auxiliary evidence.
+2. [Apple Silicon Implementation Plan](../../plans/apple-silicon/implementation-plan.md)
+   - Defines the documentation-first PR sequence for adding Apple Silicon
+     proposal/spec rails without promoting runtime claims.
+3. [Apple M4 Mac mini Roadmap](apple-m4-mac-mini-roadmap.md)
+   - Defines the M4 hardware lane, current Metal/MPSGraph/CPU labels, and
+     claim boundaries.
+4. [Apple M4 Dense SLM Support Matrix](../slm/apple-m4-dense-slm-model-support-matrix.md)
+   - Defines the supported dense Qwen-class M4 model identities and promotion
+     gates.
+
+Do not proceed from one Mac run, Metal visibility, MPSGraph smoke, CPU fallback,
+MacBook evidence, or dense SLM receipts to broad Apple Silicon, BitNet, Metal,
+Neural Engine, or QK256 claims. The Apple Silicon specs added by this rollout
+are contractual rails, not runtime promotions.
+
 ## A770 BitNet Productization
 
 Use these specs before implementing or claiming A770 BitNet product support:

--- a/docs/tracking/campaigns/apple-m4-inference-excellence/active.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-excellence/active.toml
@@ -18,6 +18,7 @@ end_state = [
   "Release gates state exactly which eval, benchmark, stability, service, and operator checks must pass before updating the public M4 expectation envelope.",
   "Operator UX exposes supported models, cache/disk health, last dense and BitNet reports, current regressions, unsupported claim boundaries, and recommended next commands.",
   "Metal work remains phase-scoped with CPU parity, fallback-free phase receipts, and explicit CPU/NEON remainder until a full route is separately proven.",
+  "Apple Silicon source-of-truth docs point dense SLM, BitNet, Metal, MPSGraph, Neural Engine, MacBook, machine artifacts, and historical campaigns to their own authorities without creating new runtime claims.",
 ]
 
 hard_constraints = [
@@ -30,6 +31,7 @@ hard_constraints = [
   "Do not add live model downloads, hardware timing runs, BitNet runtime runs, or long resident soaks to generic required PR CI.",
   "Never commit model binaries.",
   "Do not let eval, benchmark, serve, or status commands contact external services except for explicit model fetch commands.",
+  "Do not treat Apple Silicon docs/spec rails as model, backend, performance, or service promotions without matching receipt-backed work items.",
 ]
 
 [[work_item]]
@@ -2615,4 +2617,43 @@ must_not_claim = [
   "Full apple-m4-metal inference works.",
   "The phase proves end-to-end speedup.",
   "QK256, Neural Engine, or MPSGraph inference is supported.",
+]
+
+[[work_item]]
+id = "M4-APPLE-RAILS-000"
+status = "proposed"
+branch = "codex/apple-silicon/source-of-truth-map"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add the Apple Silicon source-of-truth map and docs rollout plan so M4 dense SLM, BitNet CPU/NEON, Metal phase, MPSGraph reference, Neural Engine research, MacBook auxiliary, machine artifact, and historical campaign authorities are explicit without promoting runtime claims."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-excellence",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/apple-silicon/**",
+  "plans/apple-silicon/**",
+  "docs/specs/INDEX.md",
+  "docs/tracking/campaigns/apple-m4-inference-excellence/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Apple Silicon source-of-truth docs identify separate authorities and proof families for M4 dense SLM, M4 BitNet, Metal phase, MPSGraph reference, Neural Engine research, MacBook auxiliary, and machine-artifact evidence.",
+]
+must_not_claim = [
+  "The source-of-truth map proves a new model, backend, service, speed, or broad Apple Silicon claim.",
+  "MacBook evidence proves M4 Mac mini runtime behavior.",
+  "Dense SLM evidence proves BitNet behavior.",
+  "BitNet CPU/NEON evidence proves Metal execution.",
 ]

--- a/docs/tracking/campaigns/apple-m4-inference-excellence/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-inference-excellence/generated/status.md
@@ -75,6 +75,7 @@
 | M4-RELEASE-001 | proposed | TBD | `codex/apple-m4-inference-excellence/M4-RELEASE-001-go-no-go` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish the M4 inference release go/no-go matrix that states which dense SLM, BitNet, benchmark, stability, service, operator, and claim-boundary gates must pass before updating the public M4 expectation envelope or marking a model family route excellent. |
 | M4-METAL-EX-001 | proposed | TBD | `codex/apple-m4-inference-excellence/M4-METAL-EX-001-phase-choice` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Choose one named future Apple M4 Metal phase from existing proof boundaries, document CPU reference parity requirements, fallback=false receipt fields, phase-local timing, and explicit CPU/NEON remainder before any code route changes. |
 | M4-METAL-EX-002 | proposed | TBD | `codex/apple-m4-inference-excellence/M4-METAL-EX-002-phase-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Implement the selected Metal phase fixture with CPU reference parity, same generated token IDs/text where required by the phase, fallback=false phase receipts, and phase-local timing only. |
+| M4-APPLE-RAILS-000 | proposed | TBD | `codex/apple-silicon/source-of-truth-map` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the Apple Silicon source-of-truth map and docs rollout plan so M4 dense SLM, BitNet CPU/NEON, Metal phase, MPSGraph reference, Neural Engine research, MacBook auxiliary, machine artifact, and historical campaign authorities are explicit without promoting runtime claims. |
 
 ## Hard Constraints
 
@@ -87,3 +88,4 @@
 - Do not add live model downloads, hardware timing runs, BitNet runtime runs, or long resident soaks to generic required PR CI.
 - Never commit model binaries.
 - Do not let eval, benchmark, serve, or status commands contact external services except for explicit model fetch commands.
+- Do not treat Apple Silicon docs/spec rails as model, backend, performance, or service promotions without matching receipt-backed work items.

--- a/plans/apple-silicon/README.md
+++ b/plans/apple-silicon/README.md
@@ -1,0 +1,11 @@
+# Apple Silicon Plans
+
+This directory sequences Apple Silicon docs and rails work. The first rollout is
+source-of-truth cleanup: it adds a map and then contracts that prevent dense
+SLM, BitNet, Metal, MPSGraph, Neural Engine, MacBook, and M4 Mac mini evidence
+from being conflated.
+
+Start with [`implementation-plan.md`](implementation-plan.md). The plan is
+intentionally documentation-first and does not authorize runtime backend changes,
+model binary commits, full Metal inference claims, Neural Engine claims, or live
+hardware/model timing in ordinary generic PR CI.

--- a/plans/apple-silicon/implementation-plan.md
+++ b/plans/apple-silicon/implementation-plan.md
@@ -1,0 +1,200 @@
+# Apple Silicon Source-of-Truth Implementation Plan
+
+## Purpose
+
+Lay down Apple Silicon docs/specs/rails so future Codex agents can continue M4
+Mac mini, MacBook, dense SLM, BitNet CPU/NEON, and Metal phase work without
+mixing proof families or broadening support claims.
+
+This plan is a documentation rollout. It does not promote runtime support and it
+does not authorize touching model binaries, QK256 kernels, Metal kernels, server
+runtime code, or live hardware timing paths.
+
+## Current Authority Inputs
+
+- `docs/specs/apple-m4-mac-mini-roadmap.md` defines the M4 lane as Metal-first,
+  with MPSGraph as a graph/reference lane and CPU/NEON as fallback/parity.
+- `docs/slm/apple-m4-dense-slm-model-support-matrix.md` defines supported dense
+  M4 SLM models and promotion gates.
+- `docs/slm/apple-m4-inference-excellence.md` is the operator-facing narrative
+  for the active M4 inference-excellence campaign.
+- `docs/tracking/campaigns/apple-m4-inference-excellence/active.toml` is the
+  machine-readable current M4 excellence campaign state.
+- `ci/hardware/apple-m4-mac-mini/**` contains committed machine evidence; those
+  artifacts are receipts, not broad Apple Silicon claims.
+
+## Global Rails
+
+Every PR in this rollout must preserve these boundaries:
+
+- Dense Qwen SLM evidence is not BitNet evidence.
+- BitNet CPU/NEON evidence is not Metal evidence.
+- Metal visibility is not Metal execution.
+- Metal subgraph parity is not full Metal inference.
+- MPSGraph smoke is not native Metal proof.
+- MPSGraph smoke is not Neural Engine proof unless the resolved target is
+  receipt-backed.
+- CPU fallback cannot count as Metal execution.
+- MacBook evidence is not M4 Mac mini runtime proof.
+- M4 Mac mini evidence is not broad Apple Silicon proof.
+- QK256-on-x86/CUDA/A770 evidence is not QK256-on-Metal evidence.
+- Supported dense SLMs must be artifact-pinned and tokenizer-authoritative.
+- No model binaries are committed.
+- Live hardware/model timing is never required in ordinary generic PR CI.
+
+## PR Rollout
+
+### PR 0 — Apple Silicon source-of-truth map
+
+Title: `docs(apple): add Apple Silicon source-of-truth map`
+
+Add:
+
+- `docs/apple-silicon/README.md`
+- `plans/apple-silicon/README.md`
+- `plans/apple-silicon/implementation-plan.md`
+
+Update:
+
+- `docs/specs/INDEX.md`
+- `docs/tracking/campaigns/apple-m4-inference-excellence/active.toml`
+- generated campaign docs if required by `xtask`
+
+Acceptance:
+
+- lists Apple proof families;
+- identifies current source of truth for M4 dense SLM, BitNet, Metal, and
+  MacBook work;
+- explains which older campaign/docs surfaces are historical audit records;
+- defines that future Apple Silicon specs are contractual rails, not runtime
+  promotions.
+
+Validation:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-excellence
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+### PR 1 — Apple Silicon proposal
+
+Title: `docs(proposal): add Apple Silicon productization proposal`
+
+Add `docs/proposals/BITNET-PROP-0005-apple-silicon-productization.md`.
+
+Acceptance:
+
+- explains dense SLM-first product path;
+- explains BitNet CPU/NEON path;
+- explains phase-scoped Metal;
+- explains MacBook auxiliary lane;
+- makes no model/status/claim changes.
+
+### PR 2 — Route contract
+
+Title: `docs(spec): add Apple Silicon route contract`
+
+Add `docs/specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md`.
+
+Acceptance:
+
+- defines `apple-m4-cpu-neon`, `apple-m4-metal`, `apple-m4-mpsgraph`, and
+  MacBook labels;
+- defines strict fallback failure rules and receipt fields;
+- keeps proof families separated.
+
+### PR 3 — Dense SLM appliance spec
+
+Title: `docs(spec): define Apple M4 dense SLM appliance path`
+
+Add `docs/specs/BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md`.
+
+Acceptance:
+
+- codifies default, supported, candidate, diagnostic-only, and rejected states;
+- imports support matrix gates contractually;
+- keeps Qwen support separate from BitNet.
+
+### PR 4 — BitNet CPU/NEON spec
+
+Title: `docs(spec): define Apple M4 BitNet CPU/NEON path`
+
+Add `docs/specs/BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md`.
+
+Acceptance:
+
+- codifies the accepted Microsoft I2_S artifact path;
+- requires strict tokenizer/loader proof;
+- defines one-shot, warm, chat, and serve gates;
+- prevents Metal, QK256, Neural Engine, MPSGraph, and dense SLM claim leakage.
+
+### PR 5 — Metal phase-scoped acceleration spec
+
+Title: `docs(spec): define phase-scoped Apple Metal acceleration`
+
+Add `docs/specs/BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION.md`.
+
+Acceptance:
+
+- defines tiny smoke to parity to phase-contribution to generation-contribution
+  ladder;
+- requires CPU reference parity;
+- blocks full Metal inference claims until a full route is proven separately.
+
+### PR 6 — Quality and benchmark envelope specs
+
+Title: `docs(spec): add Apple quality and benchmark envelope contracts`
+
+Add:
+
+- `docs/specs/BITNET-SPEC-APPLE-QUALITY-CORPUS.md`
+- `docs/specs/BITNET-SPEC-APPLE-BENCHMARK-ENVELOPE.md`
+
+Acceptance:
+
+- keeps dense and BitNet corpora separate;
+- documents benchmark fields and profile list;
+- requires p50/p90/p99/min/max and repeatability rules where profiles claim
+  comparable timing.
+
+### PR 7 — Reproducible identity and MacBook auxiliary specs
+
+Title: `docs(spec): add Apple reproducibility and MacBook auxiliary lane specs`
+
+Add:
+
+- `docs/specs/BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md`
+- `docs/specs/BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md`
+
+Acceptance:
+
+- makes Apple run identity fields contractual;
+- states MacBook proof cannot promote M4 Mac mini proof;
+- explains the storage/larger-artifact auxiliary role.
+
+### PR 8 — Service surface spec
+
+Title: `docs(spec): define Apple ask chat serve readiness`
+
+Add `docs/specs/BITNET-SPEC-APPLE-SERVICE-SURFACE.md`.
+
+Acceptance:
+
+- defines doctor, evidence, ask, chat, serve, receipts-check, regression,
+  report-refresh, and benchmark semantics;
+- requires per-request receipts and exact-profile serve scope;
+- avoids production-hosting overclaims.
+
+## Proof Commands
+
+For documentation PRs in this rollout, run:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-excellence
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+If a command cannot run in the environment, record the command, the reason, any
+substitute evidence, and whether it blocks merge.


### PR DESCRIPTION
### Motivation

- Prevent conflation of Apple proof families by establishing a single navigation contract that separates dense SLM, BitNet, Metal phase, MPSGraph, Neural Engine, MacBook auxiliary, and machine-artifact evidence. 
- Provide a documentation-first rollout so follow-on proposal/spec PRs can add contractual rails without promoting runtime claims or touching model binaries or runtime kernels. 
- Make the active M4 campaign explicitly point to the new docs/plan so agent workflows and operator-facing pages can reference authoritative sources of truth.

### Description

- Added `docs/apple-silicon/README.md` as the Apple Silicon source-of-truth map that enumerates proof families, claim rails, and receipt identity fields. 
- Added `plans/apple-silicon/README.md` and `plans/apple-silicon/implementation-plan.md` to sequence a documentation-first PR rollout and enumerate PR-by-PR acceptance criteria and validation commands. 
- Updated `docs/specs/INDEX.md` to register the Apple Silicon map and plan in the specs index and to warn against broad claims from single runs. 
- Updated the `apple-m4-inference-excellence` active manifest to add the new end-state/hard-constraint text and a new work item `M4-APPLE-RAILS-000`, and regenerated the campaign status dashboard under `docs/tracking/campaigns/apple-m4-inference-excellence/generated/status.md` so operator dashboards and xtask generators remain current.

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-excellence` and it passed. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check` and then `cargo run --locked -p xtask --no-default-features -- campaign generate` to refresh generated dashboards, and the generated dashboards are current. 
- Ran `git diff --check` as the final validation command and it reported no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac4a9c5148333a45aea6223587251)