### PR TITLE
docs(intel-gpu): add Intel GPU proof rails and specs

### DIFF
--- a/docs/intel-gpu/README.md
+++ b/docs/intel-gpu/README.md
@@ -1,0 +1,111 @@
+# Intel GPU source-of-truth map
+
+Intel GPU support in BitNet-rs is a vendor-specific accelerator family, not a
+single generic "GPU works" bucket. Every claim must name the selected device,
+runtime API, model family, proof family, fallback state, quality status,
+performance profile, and residency boundary.
+
+## Route families
+
+| Family | Hardware | Runtime | First target | Claim boundary |
+| --- | --- | --- | --- | --- |
+| A770 native OpenCL | Arc A770 16GB discrete GPU | OpenCL first, Level Zero only as a later candidate | BitNet I2_S/QK256 named-operation acceleration | `intel-arc-a770-opencl` |
+| A770 OpenVINO reference | Arc A770 16GB discrete GPU | OpenVINO GPU | Runtime/reference comparison only | not native OpenCL proof |
+| Arc 140V native OpenCL | Lunar Lake Arc 140V / Core Ultra 7 258V | OpenCL | Selected-device smoke/parity first | `arc140v-opencl` |
+| Arc 140V OpenVINO GPU | Lunar Lake Arc 140V / Core Ultra 7 258V | OpenVINO GPU / GenAI | Dense Qwen SLM candidate routing first | `openvino-gpu` |
+| Intel NPU | Lunar Lake Intel AI Boost NPU | OpenVINO NPU | Separate NPU proof lane | not GPU proof |
+| CPU reference plate | Host CPU | scalar/AVX2/AVX-512/native runtime | Comparator and fallback detector | not GPU proof |
+
+## Non-negotiable proof boundaries
+
+- A770 OpenCL proof is not Arc 140V proof.
+- Arc 140V OpenCL proof is not A770 proof.
+- OpenVINO GPU proof is not native OpenCL proof.
+- OpenVINO GPU proof is not NPU proof.
+- Intel GPU proof is not CUDA proof.
+- Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+- BitNet QK256 proof is not dense SLM proof.
+- CPU fallback cannot count as Intel GPU execution.
+- Generic OpenCL is not selected Intel GPU proof.
+- Generic GPU is not selected Intel GPU proof.
+
+## Claim ladder
+
+Intel GPU route documents, receipts, route matrices, status surfaces, and
+`receipts explain` output should use this ladder without collapsing adjacent
+levels:
+
+| Level | Meaning | Public claim |
+| --- | --- | --- |
+| `unsupported` | No valid route or proof. | none |
+| `runtime_detected` | Device is visible. | detection only |
+| `compile_smoke` | Kernel or graph compiles. | compile only |
+| `kernel_smoke` | Tiny kernel or graph executes. | smoke only |
+| `parity_tested` | CPU/GPU fixture parity exists. | fixture parity |
+| `answer_ready` | Strict answer corpus or bounded useful answers pass. | answer route |
+| `behavior_proven` | Prompt conditioning, stop/repetition, or long decode gates pass. | behavior route |
+| `benchmark_candidate` | Timing fields are recorded. | diagnostic performance |
+| `performance_proven` | Quality-gated profile beats a baseline with history. | exact-profile performance |
+| `resident_proven` | A named op or phase is resident. | named residency only |
+| `complete` | Required ops, residency, and server gates pass. | full route |
+
+`performance_proven`, `resident_proven`, and `complete` are separate outcomes.
+A route can have one without the others only when the matching receipts say so.
+
+## Required receipt shape
+
+Intel GPU receipts must make the proof family explicit. Fields may be nested to
+match a command-specific schema, but the same facts must be present:
+
+```json
+{
+  "requested_backend": "intel-arc-a770 | intel-arc-140v | openvino-gpu",
+  "selected_backend": "intel-arc-a770-opencl | intel-arc-140v-opencl | openvino-gpu",
+  "runtime_api": "opencl | openvino_genai | openvino_runtime | level_zero",
+  "runtime_device": "GPU.0 | GPU.1 | OpenCL platform/device index",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model_family": "bitnet | dense_slm | small_llm",
+  "proof_family": "bitnet_qk256_opencl | dense_slm_openvino_gpu | arc140v_opencl_smoke",
+  "device_identity": {
+    "name": "...",
+    "vendor": "Intel",
+    "pci_device_id": "0x56A0 | 0x64A0 | ...",
+    "driver_version": "...",
+    "vram_or_shared_memory_bytes": 0
+  },
+  "claim_boundary": {
+    "native_opencl_proof": true,
+    "openvino_gpu_proof": false,
+    "bitnet_qk256_proof": true,
+    "dense_slm_proof": false,
+    "full_residency_claim": false,
+    "speedup_claim": false
+  }
+}
+```
+
+## Current route posture
+
+- A770 native OpenCL is the discrete BitNet lane, but QK256, embedding, and
+  LM-head rows remain diagnostic until claim-grade committed receipts, quality
+  proof, benchmark/history proof, and residency boundaries are synchronized.
+- A770 OpenVINO GPU is a reference runtime lane and does not prove native
+  OpenCL kernels or BitNet QK256 execution.
+- Arc 140V OpenVINO GPU dense SLM evidence is promising but remains candidate
+  until corpus quality, profile timing applicability, direct-token limitations,
+  benchmark-qualified advantage, and telemetry context gates are satisfied.
+- Arc 140V native OpenCL currently belongs to selected-device smoke/parity work;
+  it is not A770 proof and not BitNet QK256 proof.
+- Intel NPU and CPU evidence remain separate proof families.
+
+## Source-of-truth stack
+
+- Proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`.
+- Shared plan: `plans/intel-gpu/implementation-plan.md`.
+- Existing A770 rails: `docs/specs/intel-arc-a770-gpu-roadmap.md` and
+  `docs/specs/a770-bitnet-claim-boundary.md`.
+- Existing Lunar Lake rails: `docs/tracking/campaigns/intel-258v-platform/` and
+  the Lunar Lake route/profile comparison receipts under `ci/hardware/intel-258v/`.
+- Forthcoming Intel GPU route contracts: `BITNET-SPEC-INTEL-GPU-*` specs listed
+  in `plans/intel-gpu/implementation-plan.md`.

--- a/docs/intel-gpu/README.md
+++ b/docs/intel-gpu/README.md
@@ -1,111 +1,79 @@
 # Intel GPU source-of-truth map
 
-Intel GPU support in BitNet-rs is a vendor-specific accelerator family, not a
-single generic "GPU works" bucket. Every claim must name the selected device,
-runtime API, model family, proof family, fallback state, quality status,
-performance profile, and residency boundary.
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Documentation only; no route promotion.
+Policy impact: Preserves existing proof-family and no-fallback boundaries.
 
-## Route families
+## Purpose
 
-| Family | Hardware | Runtime | First target | Claim boundary |
+Intel GPU support is a vendor-specific accelerator family, not a generic
+"GPU works" bucket. This map exists so users, maintainers, and agents can tell
+which Intel GPU lane is being discussed before any receipt, route matrix, status
+page, or benchmark claim is interpreted.
+
+This file does not promote a runtime route. It records the source-of-truth map
+that future receipts and status surfaces must follow.
+
+## Lanes
+
+| Lane | Hardware | Runtime | First serious target | Claim family |
 | --- | --- | --- | --- | --- |
-| A770 native OpenCL | Arc A770 16GB discrete GPU | OpenCL first, Level Zero only as a later candidate | BitNet I2_S/QK256 named-operation acceleration | `intel-arc-a770-opencl` |
-| A770 OpenVINO reference | Arc A770 16GB discrete GPU | OpenVINO GPU | Runtime/reference comparison only | not native OpenCL proof |
-| Arc 140V native OpenCL | Lunar Lake Arc 140V / Core Ultra 7 258V | OpenCL | Selected-device smoke/parity first | `arc140v-opencl` |
-| Arc 140V OpenVINO GPU | Lunar Lake Arc 140V / Core Ultra 7 258V | OpenVINO GPU / GenAI | Dense Qwen SLM candidate routing first | `openvino-gpu` |
-| Intel NPU | Lunar Lake Intel AI Boost NPU | OpenVINO NPU | Separate NPU proof lane | not GPU proof |
-| CPU reference plate | Host CPU | scalar/AVX2/AVX-512/native runtime | Comparator and fallback detector | not GPU proof |
+| A770 native GPU | Arc A770 16GB discrete GPU | OpenCL first; Level Zero candidate later | BitNet I2_S/QK256 trusted partial acceleration | `intel-arc-a770-opencl` |
+| Lunar Lake integrated GPU | Arc 140V / Core Ultra 7 258V | OpenVINO GPU and native OpenCL | Dense Qwen SLM candidate routing first; BitNet-adjacent parity later | `openvino-gpu` / `arc140v-opencl` |
 
-## Non-negotiable proof boundaries
+## Route-family map
 
-- A770 OpenCL proof is not Arc 140V proof.
-- Arc 140V OpenCL proof is not A770 proof.
-- OpenVINO GPU proof is not native OpenCL proof.
-- OpenVINO GPU proof is not NPU proof.
-- Intel GPU proof is not CUDA proof.
-- Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
-- BitNet QK256 proof is not dense SLM proof.
-- CPU fallback cannot count as Intel GPU execution.
-- Generic OpenCL is not selected Intel GPU proof.
-- Generic GPU is not selected Intel GPU proof.
-
-## Claim ladder
-
-Intel GPU route documents, receipts, route matrices, status surfaces, and
-`receipts explain` output should use this ladder without collapsing adjacent
-levels:
-
-| Level | Meaning | Public claim |
+| Route family | Meaning | Current posture |
 | --- | --- | --- |
-| `unsupported` | No valid route or proof. | none |
-| `runtime_detected` | Device is visible. | detection only |
-| `compile_smoke` | Kernel or graph compiles. | compile only |
-| `kernel_smoke` | Tiny kernel or graph executes. | smoke only |
-| `parity_tested` | CPU/GPU fixture parity exists. | fixture parity |
-| `answer_ready` | Strict answer corpus or bounded useful answers pass. | answer route |
-| `behavior_proven` | Prompt conditioning, stop/repetition, or long decode gates pass. | behavior route |
-| `benchmark_candidate` | Timing fields are recorded. | diagnostic performance |
-| `performance_proven` | Quality-gated profile beats a baseline with history. | exact-profile performance |
-| `resident_proven` | A named op or phase is resident. | named residency only |
-| `complete` | Required ops, residency, and server gates pass. | full route |
+| A770 native OpenCL | Discrete Arc A770 selected-device BitNet path. | OpenCL-first path for native BitNet QK256 proof; no generic Intel GPU claim. |
+| A770 OpenVINO GPU | A770 through OpenVINO GPU runtime or graph APIs. | Reference runtime path only; not native OpenCL proof. |
+| Arc 140V native OpenCL | Lunar Lake integrated GPU selected-device OpenCL lane. | Smoke/parity lane; not A770 proof and not BitNet QK256 support until fixtures and answer proof exist. |
+| Arc 140V OpenVINO GPU | Lunar Lake OpenVINO GPU `GPU.X` dense SLM route. | Dense SLM candidate route; promotion remains exact-profile and quality-gated. |
+| Intel NPU | OpenVINO NPU / Intel AI Boost lane. | Separate from every GPU lane. |
+| CPU | Reference and comparator plate. | CPU proof cannot count as Intel GPU execution. |
 
-`performance_proven`, `resident_proven`, and `complete` are separate outcomes.
-A route can have one without the others only when the matching receipts say so.
+## Non-interchangeable proof families
 
-## Required receipt shape
+These boundaries must appear in specs, receipts, model coverage, status pages,
+route matrices, and `receipts explain` output:
 
-Intel GPU receipts must make the proof family explicit. Fields may be nested to
-match a command-specific schema, but the same facts must be present:
-
-```json
-{
-  "requested_backend": "intel-arc-a770 | intel-arc-140v | openvino-gpu",
-  "selected_backend": "intel-arc-a770-opencl | intel-arc-140v-opencl | openvino-gpu",
-  "runtime_api": "opencl | openvino_genai | openvino_runtime | level_zero",
-  "runtime_device": "GPU.0 | GPU.1 | OpenCL platform/device index",
-  "fallback_used": false,
-  "fallback_reason": null,
-  "model_family": "bitnet | dense_slm | small_llm",
-  "proof_family": "bitnet_qk256_opencl | dense_slm_openvino_gpu | arc140v_opencl_smoke",
-  "device_identity": {
-    "name": "...",
-    "vendor": "Intel",
-    "pci_device_id": "0x56A0 | 0x64A0 | ...",
-    "driver_version": "...",
-    "vram_or_shared_memory_bytes": 0
-  },
-  "claim_boundary": {
-    "native_opencl_proof": true,
-    "openvino_gpu_proof": false,
-    "bitnet_qk256_proof": true,
-    "dense_slm_proof": false,
-    "full_residency_claim": false,
-    "speedup_claim": false
-  }
-}
+```text
+A770 OpenCL proof is not Arc 140V proof.
+Arc 140V OpenCL proof is not A770 proof.
+OpenVINO GPU proof is not native OpenCL proof.
+OpenVINO GPU proof is not NPU proof.
+Intel GPU proof is not CUDA proof.
+Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+BitNet QK256 proof is not dense SLM proof.
+CPU fallback cannot count as Intel GPU execution.
+Generic OpenCL is not selected Intel GPU proof.
+Generic GPU is not selected Intel GPU proof.
 ```
 
-## Current route posture
+## Current truth anchors
 
-- A770 native OpenCL is the discrete BitNet lane, but QK256, embedding, and
-  LM-head rows remain diagnostic until claim-grade committed receipts, quality
-  proof, benchmark/history proof, and residency boundaries are synchronized.
-- A770 OpenVINO GPU is a reference runtime lane and does not prove native
-  OpenCL kernels or BitNet QK256 execution.
-- Arc 140V OpenVINO GPU dense SLM evidence is promising but remains candidate
-  until corpus quality, profile timing applicability, direct-token limitations,
-  benchmark-qualified advantage, and telemetry context gates are satisfied.
-- Arc 140V native OpenCL currently belongs to selected-device smoke/parity work;
-  it is not A770 proof and not BitNet QK256 proof.
-- Intel NPU and CPU evidence remain separate proof families.
+- `docs/specs/intel-arc-a770-gpu-roadmap.md` defines A770 as the discrete
+  OpenCL-first Intel GPU lane and keeps OpenVINO GPU reference evidence
+  separate.
+- `docs/specs/a770-bitnet-claim-boundary.md` defines the first A770 product
+  claim as trusted partial BitNet I2_S acceleration, not full residency.
+- `ci/hardware/device-kernel-routing.toml` remains the route-matrix truth for
+  committed device/kernel proof; diagnostic rows must not be promoted without
+  claim-grade receipts.
+- `docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md` keeps Core Ultra 7
+  258V CPU, Arc 140V GPU, and NPU proof labels separate.
 
-## Source-of-truth stack
+## Documentation-only boundary
 
-- Proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`.
-- Shared plan: `plans/intel-gpu/implementation-plan.md`.
-- Existing A770 rails: `docs/specs/intel-arc-a770-gpu-roadmap.md` and
-  `docs/specs/a770-bitnet-claim-boundary.md`.
-- Existing Lunar Lake rails: `docs/tracking/campaigns/intel-258v-platform/` and
-  the Lunar Lake route/profile comparison receipts under `ci/hardware/intel-258v/`.
-- Forthcoming Intel GPU route contracts: `BITNET-SPEC-INTEL-GPU-*` specs listed
-  in `plans/intel-gpu/implementation-plan.md`.
+This source map adds no kernels, receipts, route promotions, model coverage
+claims, speed claims, or residency claims. Future implementation PRs must still
+produce selected-device receipts with `fallback_used=false` before claiming an
+Intel GPU route.

--- a/docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md
+++ b/docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md
@@ -1,0 +1,48 @@
+# BITNET-PROP-0006: Intel GPU productization
+
+## Status
+
+Proposed.
+
+## Thesis
+
+Intel GPU support gives BitNet-rs a vendor-diverse accelerator path: native
+OpenCL/Level-Zero-style kernels for packed BitNet on A770 and graph/runtime
+acceleration for dense SLMs on Lunar Lake Arc 140V through OpenVINO GPU. The
+value is not generic GPU detection; it is selected-device, selected-model,
+receipt-backed local inference.
+
+## Product lanes
+
+- A770 is the discrete native OpenCL BitNet lane. Its first product claim is
+  trusted partial BitNet I2_S/QK256 acceleration for named operations, not all
+  Intel GPUs and not full device residency.
+- Arc 140V is the integrated Lunar Lake GPU lane. Its near-term native OpenCL
+  role is smoke/parity; its first serious model route is dense SLM candidate
+  routing through OpenVINO GPU.
+- OpenVINO GPU is a runtime/graph lane, not native OpenCL proof.
+- Dense SLM proof and BitNet QK256/I2_S proof are separate model families.
+- Intel NPU proof is separate from OpenVINO GPU proof even when both use
+  OpenVINO tooling.
+- CPU evidence is the reference plate and fallback detector, not GPU execution.
+
+## User value
+
+Users should be able to ask which exact Intel route is available and receive an
+answer that names the hardware, runtime, model family, fallback state, quality
+result, timing profile, transfer/residency state, and not-claims. Maintainers
+should be able to reject overbroad GPU claims from receipts and route matrices.
+
+## Claim policy
+
+Performance is profile-specific. A speed claim requires quality passing,
+`fallback_used=false`, an applicable profile timing bundle, same-model and
+same-profile comparator evidence, same-device history, and an accepted claim.
+Full residency is named-phase only until every required phase is proven.
+
+## Non-goals
+
+This proposal does not promote any route, change kernels, change model coverage,
+or treat Microsoft BitNet.cpp GPU evidence as proof of native BitNet-rs Intel GPU
+execution. External BitNet.cpp material is context only unless BitNet-rs receipts
+prove the selected route.

--- a/docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md
+++ b/docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md
@@ -1,8 +1,16 @@
 # BITNET-PROP-0006: Intel GPU productization
 
-## Status
-
-Proposed.
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines rationale only; no support claim promotion.
+Policy impact: No exception.
 
 ## Thesis
 
@@ -14,35 +22,64 @@ receipt-backed local inference.
 
 ## Product lanes
 
-- A770 is the discrete native OpenCL BitNet lane. Its first product claim is
-  trusted partial BitNet I2_S/QK256 acceleration for named operations, not all
-  Intel GPUs and not full device residency.
-- Arc 140V is the integrated Lunar Lake GPU lane. Its near-term native OpenCL
-  role is smoke/parity; its first serious model route is dense SLM candidate
-  routing through OpenVINO GPU.
-- OpenVINO GPU is a runtime/graph lane, not native OpenCL proof.
-- Dense SLM proof and BitNet QK256/I2_S proof are separate model families.
-- Intel NPU proof is separate from OpenVINO GPU proof even when both use
-  OpenVINO tooling.
-- CPU evidence is the reference plate and fallback detector, not GPU execution.
+| Lane | Product purpose | First serious target |
+| --- | --- | --- |
+| A770 native OpenCL | Discrete Intel GPU path for packed BitNet kernels. | BitNet I2_S/QK256 trusted partial acceleration. |
+| Arc 140V OpenVINO GPU | Integrated Lunar Lake GPU graph/runtime path. | Dense Qwen SLM candidate routing and exact-profile promotion. |
+| Arc 140V native OpenCL | Integrated native-kernel smoke/parity path. | BitNet-adjacent parity evidence after A770 path is grounded. |
+| A770 OpenVINO GPU | Reference runtime comparison path. | Runtime/device comparison only unless separately specified. |
+
+OpenVINO GPU is a runtime/graph lane, not native OpenCL proof. Dense SLM proof
+and BitNet proof are separate. Performance is profile-specific. Full residency
+is named-phase only until every required phase is proven.
 
 ## User value
 
-Users should be able to ask which exact Intel route is available and receive an
-answer that names the hardware, runtime, model family, fallback state, quality
-result, timing profile, transfer/residency state, and not-claims. Maintainers
-should be able to reject overbroad GPU claims from receipts and route matrices.
+Users should eventually be able to ask for an Intel GPU route and receive an
+answer plus a receipt that explains:
 
-## Claim policy
+- exact selected backend and runtime API;
+- exact device identity;
+- model family and proof family;
+- whether fallback was used;
+- quality result and failure taxonomy when relevant;
+- timing profile and comparator boundary;
+- transfer and residency status;
+- not-claims and next proof needed.
 
-Performance is profile-specific. A speed claim requires quality passing,
-`fallback_used=false`, an applicable profile timing bundle, same-model and
-same-profile comparator evidence, same-device history, and an accepted claim.
-Full residency is named-phase only until every required phase is proven.
+## Non-interchangeable proof families
+
+Intel GPU productization must preserve these boundaries:
+
+```text
+A770 OpenCL proof is not Arc 140V proof.
+Arc 140V OpenCL proof is not A770 proof.
+OpenVINO GPU proof is not native OpenCL proof.
+OpenVINO GPU proof is not NPU proof.
+Intel GPU proof is not CUDA proof.
+Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+BitNet QK256 proof is not dense SLM proof.
+CPU fallback cannot count as Intel GPU execution.
+Generic OpenCL is not selected Intel GPU proof.
+Generic GPU is not selected Intel GPU proof.
+```
+
+## Product posture
+
+A usable Intel GPU product is not a one-off fast run. It is a route-specific,
+quality-gated, receipt-backed claim where maintainers can explain exactly what
+ran and what did not run. A770 should mature toward named BitNet partial
+acceleration. Arc 140V should mature first through dense OpenVINO GPU exact
+profiles and separately through native OpenCL smoke/parity evidence.
 
 ## Non-goals
 
-This proposal does not promote any route, change kernels, change model coverage,
-or treat Microsoft BitNet.cpp GPU evidence as proof of native BitNet-rs Intel GPU
-execution. External BitNet.cpp material is context only unless BitNet-rs receipts
-prove the selected route.
+This proposal does not:
+
+- promote any current route;
+- claim generic Intel GPU support;
+- claim speedup;
+- claim full device residency;
+- claim OpenVINO GPU as native OpenCL;
+- transfer A770 proof to Arc 140V, or Arc 140V proof to A770;
+- transfer dense SLM proof to BitNet QK256, or BitNet proof to dense SLMs.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md
@@ -1,0 +1,32 @@
+# BITNET-SPEC-INTEL-GPU-BITNET-QK256
+
+## Purpose
+
+Define native Intel GPU BitNet QK256/I2_S proof, starting with A770 OpenCL.
+
+## Required kernels and operations
+
+- `qk256_i2s_gemv_opencl`
+- `embedding_lookup_opencl`
+- `lm_head_tied_logits_opencl`
+- eventual `qk256_i2s_prefill_gemm_opencl`
+
+## Production semantics
+
+Claim-grade proof must match:
+
+- Official Microsoft I2_S/QK256 GGUF weights.
+- Canonical packed layout.
+- BitNet.cpp-aligned activation quantization.
+- I2_S by I8_S scaled math.
+- Weight scale handling.
+- Activation scale and sum correction.
+- Tail-column behavior.
+- Row-stride behavior.
+- Strict tokenizer/template authority.
+
+## Hard rule
+
+A diagnostic four-values-per-byte toy I2_S kernel cannot satisfy official QK256
+proof. Toy parity may support a smoke or fixture claim only when the route row
+and receipt say it is not official BitNet QK256 proof.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md
@@ -1,32 +1,66 @@
 # BITNET-SPEC-INTEL-GPU-BITNET-QK256
 
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines native BitNet route requirements; no promotion.
+Policy impact: No exception.
+
 ## Purpose
 
-Define native Intel GPU BitNet QK256/I2_S proof, starting with A770 OpenCL.
+Define the native Intel GPU BitNet route for official I2_S/QK256 artifacts. The
+first product lane is A770 OpenCL trusted partial acceleration for named
+operations; Arc 140V native OpenCL remains a candidate until separately proven.
 
 ## Required kernels and operations
 
-- `qk256_i2s_gemv_opencl`
-- `embedding_lookup_opencl`
-- `lm_head_tied_logits_opencl`
-- eventual `qk256_i2s_prefill_gemm_opencl`
+```text
+qk256_i2s_gemv_opencl
+embedding_lookup_opencl
+lm_head_tied_logits_opencl
+eventual qk256_i2s_prefill_gemm_opencl
+```
+
+A route may claim only the named operations it proves. QK256 linears alone are
+trusted partial acceleration, not full model residency.
 
 ## Production semantics
 
-Claim-grade proof must match:
+Production BitNet QK256 proof must match:
 
-- Official Microsoft I2_S/QK256 GGUF weights.
-- Canonical packed layout.
-- BitNet.cpp-aligned activation quantization.
-- I2_S by I8_S scaled math.
-- Weight scale handling.
-- Activation scale and sum correction.
-- Tail-column behavior.
-- Row-stride behavior.
-- Strict tokenizer/template authority.
+```text
+official Microsoft I2_S/QK256 GGUF
+canonical packed layout
+BitNet.cpp-aligned activation quantization
+I2_S × I8_S scaled math
+weight scale
+activation scale/sum correction
+tail-column behavior
+row stride behavior
+strict tokenizer/template authority
+```
 
 ## Hard rule
 
-A diagnostic four-values-per-byte toy I2_S kernel cannot satisfy official QK256
-proof. Toy parity may support a smoke or fixture claim only when the route row
-and receipt say it is not official BitNet QK256 proof.
+A diagnostic four-values-per-byte toy I2_S kernel cannot satisfy official
+QK256 proof. Toy kernels may remain smoke/parity evidence only when receipts and
+status surfaces say they are not official BitNet QK256 execution.
+
+## Required receipt evidence
+
+A claim-grade native BitNet OpenCL receipt must include:
+
+- selected backend and runtime API;
+- official model contract and artifact hashes;
+- tokenizer and prompt-template authority;
+- QK256 kernel invocation counts greater than zero for claimed operations;
+- CPU fallback count zero;
+- `fallback_used=false`;
+- quality gate result or explicit unpromoted status;
+- not-claims for dense SLM, generic Intel GPU, full residency, and speedup.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md
@@ -1,0 +1,36 @@
+# BITNET-SPEC-INTEL-GPU-DENSE-SLM
+
+## Purpose
+
+Define Arc/OpenVINO GPU dense SLM support without conflating it with BitNet
+QK256/I2_S, native OpenCL, A770, CPU, or NPU proof.
+
+## Initial target
+
+Qwen2.5 0.5B Instruct OpenVINO INT4 symmetric export on Lunar Lake Arc 140V
+`GPU.0`.
+
+## Proof ladder
+
+1. Export manifest.
+2. Runtime/device identity.
+3. OpenVINO GPU bounded smoke.
+4. Operator ask.
+5. Corpus v2.
+6. Phase timing.
+7. Profile comparison.
+8. Promotion review.
+9. Model status.
+10. Optional server exact-profile proof.
+
+## Promotion rule
+
+OpenVINO GPU can be promoted only per profile after `fallback=false`, quality
+passes for that profile, profile timing is applicable, benchmark-qualified
+advantage exists, telemetry context is present or explicitly unavailable, and
+generated-token limitations are recorded.
+
+Current known blockers include corpus quality failures, missing direct generated
+token IDs in some OpenVINO paths, missing prompt-token timing applicability,
+incomplete phase splits, missing profile regression bundle coverage, and no
+benchmark-qualified speed/power advantage for candidate GPU routes.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md
@@ -1,36 +1,67 @@
 # BITNET-SPEC-INTEL-GPU-DENSE-SLM
 
-## Purpose
-
-Define Arc/OpenVINO GPU dense SLM support without conflating it with BitNet
-QK256/I2_S, native OpenCL, A770, CPU, or NPU proof.
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines dense SLM OpenVINO GPU requirements; no promotion.
+Policy impact: No exception.
 
 ## Initial target
 
-Qwen2.5 0.5B Instruct OpenVINO INT4 symmetric export on Lunar Lake Arc 140V
-`GPU.0`.
+The initial dense SLM Intel GPU target is:
+
+```text
+Qwen2.5 0.5B Instruct OpenVINO INT4 symmetric export on Lunar Lake Arc 140V GPU.0
+```
+
+This is dense SLM OpenVINO GPU proof. It is not BitNet QK256 proof, native
+OpenCL proof, NPU proof, CUDA proof, or A770 proof.
 
 ## Proof ladder
 
-1. Export manifest.
-2. Runtime/device identity.
-3. OpenVINO GPU bounded smoke.
-4. Operator ask.
-5. Corpus v2.
-6. Phase timing.
-7. Profile comparison.
-8. Promotion review.
-9. Model status.
-10. Optional server exact-profile proof.
+Dense SLM OpenVINO GPU routes graduate through:
+
+```text
+export manifest
+runtime/device identity
+OpenVINO GPU bounded smoke
+operator ask
+corpus v2
+phase timing
+profile comparison
+promotion review
+model status
+server exact-profile optional
+```
 
 ## Promotion rule
 
-OpenVINO GPU can be promoted only per profile after `fallback=false`, quality
-passes for that profile, profile timing is applicable, benchmark-qualified
-advantage exists, telemetry context is present or explicitly unavailable, and
-generated-token limitations are recorded.
+OpenVINO GPU can be promoted only per profile after:
 
-Current known blockers include corpus quality failures, missing direct generated
-token IDs in some OpenVINO paths, missing prompt-token timing applicability,
-incomplete phase splits, missing profile regression bundle coverage, and no
-benchmark-qualified speed/power advantage for candidate GPU routes.
+- `fallback_used=false`;
+- quality passes for that profile;
+- profile timing is applicable;
+- benchmark-qualified advantage exists, or a reviewed UX/power advantage is
+  accepted for that exact profile;
+- telemetry context is present or explicitly unavailable;
+- generated-token limitation is recorded.
+
+## Known blocker classes to formalize
+
+Candidate route reviews must classify and preserve blockers such as:
+
+- corpus quality failures;
+- missing direct generated-token IDs;
+- missing prompt-token timing applicability;
+- incomplete phase splits;
+- missing profile regression bundle;
+- missing benchmark-qualified speed or power advantage.
+
+A bounded OpenVINO GPU answer receipt can be useful evidence while the route
+remains unpromoted.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md
@@ -1,31 +1,54 @@
 # BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY
 
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines identity fields; no promotion.
+Policy impact: No exception.
+
 ## Purpose
 
-Normalize device identity for A770, Arc 140V, OpenCL, Level Zero, OpenVINO GPU,
-and system telemetry so receipts can prove the selected Intel route.
+Normalize identity evidence across A770, Arc 140V, OpenCL, Level Zero,
+OpenVINO GPU, and system telemetry so proof receipts cannot inherit claims from
+another Intel device or runtime.
 
 ## Required identity fields
 
-Receipts must record, when available:
+Every Intel GPU proof receipt must record, or explicitly mark unavailable:
 
-- OS and kernel/build.
-- Native, WSL, container, or virtualized context.
-- GPU name and GPU family.
-- PCI ID.
-- Driver version.
-- OpenCL platform/device index.
-- Level Zero adapter identity.
-- OpenVINO available devices.
-- OpenVINO `GPU.X` full device name.
-- VRAM or shared-memory capacity.
-- ReBAR state for A770.
-- PCIe link width/generation for A770.
-- Linux render-node and permission context.
-- Power, thermal, and utilization tool availability.
+- OS and kernel/build;
+- native, WSL, container, or virtualized context;
+- GPU name;
+- GPU family;
+- PCI ID;
+- driver version;
+- OpenCL platform and device index;
+- Level Zero adapter identity;
+- OpenVINO available devices;
+- OpenVINO `GPU.X` full device name;
+- VRAM or shared memory;
+- ReBAR for A770;
+- PCIe link width and generation for A770;
+- Linux render-node and permission context;
+- power, thermal, and utilization tool availability.
 
-## Identity boundaries
+## Device-specific expectations
 
-A device name match alone is not enough for a promoted claim when PCI/runtime
-identity is available. Missing telemetry is allowed only when receipts explicitly
-record that the tool or permission was unavailable.
+| Device family | Required selected identity |
+| --- | --- |
+| A770 | Full Arc A770 device name, PCI ID `0x56A0` when exposed, discrete VRAM, OpenCL platform/device, and PCIe/ReBAR facts where available. |
+| Arc 140V | Full Arc 140V or Core Ultra 7 258V integrated GPU identity, PCI ID `0x64A0` when exposed, shared-memory context, and OpenVINO `GPU.X` mapping when OpenVINO is used. |
+| OpenVINO GPU | `GPU.X` selector, OpenVINO runtime or GenAI API version, available-device list, and resolved full device name. |
+| Level Zero | Adapter name, driver/runtime identity, and explicit candidate status unless promoted by a later spec. |
+
+## Unknown fields
+
+Unknown telemetry is acceptable only when the receipt records the attempted
+source and reason it is unavailable. Missing telemetry cannot silently become a
+performance, power, residency, or selected-device claim.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md
@@ -1,0 +1,31 @@
+# BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY
+
+## Purpose
+
+Normalize device identity for A770, Arc 140V, OpenCL, Level Zero, OpenVINO GPU,
+and system telemetry so receipts can prove the selected Intel route.
+
+## Required identity fields
+
+Receipts must record, when available:
+
+- OS and kernel/build.
+- Native, WSL, container, or virtualized context.
+- GPU name and GPU family.
+- PCI ID.
+- Driver version.
+- OpenCL platform/device index.
+- Level Zero adapter identity.
+- OpenVINO available devices.
+- OpenVINO `GPU.X` full device name.
+- VRAM or shared-memory capacity.
+- ReBAR state for A770.
+- PCIe link width/generation for A770.
+- Linux render-node and permission context.
+- Power, thermal, and utilization tool availability.
+
+## Identity boundaries
+
+A device name match alone is not enough for a promoted claim when PCI/runtime
+identity is available. Missing telemetry is allowed only when receipts explicitly
+record that the tool or permission was unavailable.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md
@@ -1,37 +1,73 @@
 # BITNET-SPEC-INTEL-GPU-PERFORMANCE
 
-## Purpose
-
-Define Intel GPU efficiency claims without overclaiming from a single timing or
-quality-free benchmark.
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines benchmark qualification; no speed claim.
+Policy impact: No exception.
 
 ## Profiles
 
-- `cold_load`
-- `warm_load`
-- `one_token`
-- `ask_short`
-- `ask_normal`
-- `prefill_128_decode_16`
-- `prefill_512_decode_32`
-- `decode_32`
-- `decode_128`
-- `warm_session_3_turns`
-- `warm_session_10_turns`
-- `resident_10x_ask_short`
-- `server_nonstream_exact_profile`
+Intel GPU performance evidence is profile-specific:
+
+```text
+cold_load
+warm_load
+one_token
+ask_short
+ask_normal
+prefill_128_decode_16
+prefill_512_decode_32
+decode_32
+decode_128
+warm_session_3_turns
+warm_session_10_turns
+resident_10x_ask_short
+server_nonstream_exact_profile
+```
 
 ## Required timing fields
 
-Receipts should record `model_load_ms`, `tokenizer_load_ms`, `prompt_render_ms`,
-`tokenize_ms`, `runtime_context_init_ms`, `kernel_or_graph_compile_ms`,
-`weight_upload_ms`, `prefill_ms`, `first_token_ms`, `decode_total_ms`,
-`steady_tok_per_s`, `kernel_or_graph_time_ms`, `launch_count`, H2D/D2H bytes and
-timing, VRAM/shared-memory high-water, and power/thermal context.
+Receipts used for performance claims must record, or explicitly mark
+not-applicable:
+
+```text
+model_load_ms
+tokenizer_load_ms
+prompt_render_ms
+tokenize_ms
+runtime_context_init_ms
+kernel_or_graph_compile_ms
+weight_upload_ms
+prefill_ms
+first_token_ms
+decode_total_ms
+steady_tok_per_s
+kernel_or_graph_time_ms
+launch_count
+H2D/D2H bytes and timing
+VRAM/shared-memory high-water
+power/thermal context
+```
 
 ## Promotion requirements
 
-Performance promotion requires `quality_passed=true`, `fallback_used=false`,
-`profile_timing_applicable=true`, same-model same-profile comparator evidence,
-two same-device history receipts for a performance claim, and an accepted claim
-review.
+A performance claim requires:
+
+```text
+quality_passed=true
+fallback_used=false
+profile_timing_applicable=true
+same-model same-profile comparator
+two same-device history receipts for performance claim
+claim reviewed and accepted
+```
+
+A single fast run is a benchmark candidate only. It cannot become a public
+speedup claim without the full gate above.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md
@@ -1,0 +1,37 @@
+# BITNET-SPEC-INTEL-GPU-PERFORMANCE
+
+## Purpose
+
+Define Intel GPU efficiency claims without overclaiming from a single timing or
+quality-free benchmark.
+
+## Profiles
+
+- `cold_load`
+- `warm_load`
+- `one_token`
+- `ask_short`
+- `ask_normal`
+- `prefill_128_decode_16`
+- `prefill_512_decode_32`
+- `decode_32`
+- `decode_128`
+- `warm_session_3_turns`
+- `warm_session_10_turns`
+- `resident_10x_ask_short`
+- `server_nonstream_exact_profile`
+
+## Required timing fields
+
+Receipts should record `model_load_ms`, `tokenizer_load_ms`, `prompt_render_ms`,
+`tokenize_ms`, `runtime_context_init_ms`, `kernel_or_graph_compile_ms`,
+`weight_upload_ms`, `prefill_ms`, `first_token_ms`, `decode_total_ms`,
+`steady_tok_per_s`, `kernel_or_graph_time_ms`, `launch_count`, H2D/D2H bytes and
+timing, VRAM/shared-memory high-water, and power/thermal context.
+
+## Promotion requirements
+
+Performance promotion requires `quality_passed=true`, `fallback_used=false`,
+`profile_timing_applicable=true`, same-model same-profile comparator evidence,
+two same-device history receipts for a performance claim, and an accepted claim
+review.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md
@@ -1,0 +1,36 @@
+# BITNET-SPEC-INTEL-GPU-QUALITY
+
+## Purpose
+
+Ensure Intel GPU "works" means intelligible, route-specific inference rather
+than only device visibility or isolated speed.
+
+## BitNet A770/OpenCL gates
+
+- Official answer corpus.
+- Prompt conditioning.
+- Paired context changes answer.
+- Copy/repeat.
+- Yes/no.
+- Format following.
+- Stop-token behavior.
+- Long decode.
+- CPU/A770 generated-token parity or first-divergence classification.
+
+## Dense SLM OpenVINO GPU gates
+
+- Lunar Lake answer corpus v2.
+- Profile summaries.
+- Category summaries.
+- Failure taxonomy.
+- Generation-budget sensitivity.
+- Stop/EOS diagnosis.
+- Retokenized-vs-direct-token-ID boundary.
+
+## Failure taxonomy
+
+Failures must use one or more of: `exact_answer_instruction_not_followed`,
+`exact_answer_overgenerated`, `missing_required_keyword`,
+`forbidden_token_observed`, `raw_special_token_seen`, `empty_answer`,
+`repetition`, `stop_policy_failed`, `context_sensitivity_failed`,
+`structured_output_failed`, `timeout`, or `runtime_error`.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md
@@ -1,36 +1,73 @@
 # BITNET-SPEC-INTEL-GPU-QUALITY
 
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines quality gates; no promotion.
+Policy impact: No exception.
+
 ## Purpose
 
-Ensure Intel GPU "works" means intelligible, route-specific inference rather
-than only device visibility or isolated speed.
+Intel GPU "up and running" means the route produces intelligible, useful,
+route-scoped answers. Kernel execution, graph execution, or fast timing alone
+is not answer readiness.
 
 ## BitNet A770/OpenCL gates
 
-- Official answer corpus.
-- Prompt conditioning.
-- Paired context changes answer.
-- Copy/repeat.
-- Yes/no.
-- Format following.
-- Stop-token behavior.
-- Long decode.
-- CPU/A770 generated-token parity or first-divergence classification.
+BitNet native OpenCL answer proof requires:
+
+```text
+official answer corpus
+prompt conditioning
+paired context changes answer
+copy/repeat
+yes/no
+format following
+stop-token behavior
+long decode
+CPU/A770 generated-token parity or first divergence classification
+```
 
 ## Dense SLM OpenVINO GPU gates
 
-- Lunar Lake answer corpus v2.
-- Profile summaries.
-- Category summaries.
-- Failure taxonomy.
-- Generation-budget sensitivity.
-- Stop/EOS diagnosis.
-- Retokenized-vs-direct-token-ID boundary.
+Dense SLM OpenVINO GPU proof requires:
+
+```text
+lunar-lake answer corpus v2
+profile summaries
+category summaries
+failure taxonomy
+generation-budget sensitivity
+stop/EOS diagnosis
+retokenized-vs-direct-token-ID boundary
+```
 
 ## Failure taxonomy
 
-Failures must use one or more of: `exact_answer_instruction_not_followed`,
-`exact_answer_overgenerated`, `missing_required_keyword`,
-`forbidden_token_observed`, `raw_special_token_seen`, `empty_answer`,
-`repetition`, `stop_policy_failed`, `context_sensitivity_failed`,
-`structured_output_failed`, `timeout`, or `runtime_error`.
+Failures must use one or more of:
+
+```text
+exact_answer_instruction_not_followed
+exact_answer_overgenerated
+missing_required_keyword
+forbidden_token_observed
+raw_special_token_seen
+empty_answer
+repetition
+stop_policy_failed
+context_sensitivity_failed
+structured_output_failed
+timeout
+runtime_error
+```
+
+## Promotion rule
+
+A route with unclassified quality failures cannot be promoted to
+`answer_ready`, `behavior_proven`, `performance_proven`, or `complete`.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md
@@ -1,0 +1,30 @@
+# BITNET-SPEC-INTEL-GPU-RESIDENCY
+
+## Purpose
+
+Stop partial acceleration from becoming an accidental "full GPU" or "full
+residency" claim.
+
+## Residency classes
+
+- `none`
+- `kernel_smoke`
+- `qk256_linears_only`
+- `bitnet_trusted_partial`
+- `dense_graph_runtime`
+- `support_ops_partial`
+- `decode_full`
+- `full_device_resident`
+
+## Phase table
+
+Receipts should include phase residency as `gpu`, `cpu`, `mixed`,
+`host_logits_only`, or `unknown` for weights, QK256 linears, dense linears,
+embedding, LM head, KV cache, RMSNorm, RoPE, attention scores, softmax,
+attention value mix, and sampling.
+
+## Hard rules
+
+QK256 linears on A770 are trusted partial acceleration, not full residency.
+OpenVINO GPU LLMPipeline output is dense graph/runtime proof, not native OpenCL
+residency.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md
@@ -1,30 +1,64 @@
 # BITNET-SPEC-INTEL-GPU-RESIDENCY
 
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines residency classes; no residency promotion.
+Policy impact: No exception.
+
 ## Purpose
 
-Stop partial acceleration from becoming an accidental "full GPU" or "full
-residency" claim.
+Partial acceleration must not become "full GPU" by implication. Residency is a
+named-phase claim and must be reported phase by phase.
 
 ## Residency classes
 
-- `none`
-- `kernel_smoke`
-- `qk256_linears_only`
-- `bitnet_trusted_partial`
-- `dense_graph_runtime`
-- `support_ops_partial`
-- `decode_full`
-- `full_device_resident`
+```text
+none
+kernel_smoke
+qk256_linears_only
+bitnet_trusted_partial
+dense_graph_runtime
+support_ops_partial
+decode_full
+full_device_resident
+```
 
 ## Phase table
 
-Receipts should include phase residency as `gpu`, `cpu`, `mixed`,
-`host_logits_only`, or `unknown` for weights, QK256 linears, dense linears,
-embedding, LM head, KV cache, RMSNorm, RoPE, attention scores, softmax,
-attention value mix, and sampling.
+Receipts that discuss residency must include this shape or an equivalent
+versioned table:
+
+```json
+{
+  "residency": {
+    "weights": "gpu|cpu|mixed|unknown",
+    "qk256_linears": "gpu|cpu|mixed|unknown",
+    "dense_linears": "gpu|cpu|mixed|unknown",
+    "embedding": "gpu|cpu|mixed|unknown",
+    "lm_head": "gpu|cpu|mixed|unknown",
+    "kv_cache": "gpu|cpu|mixed|unknown",
+    "rmsnorm": "gpu|cpu|mixed|unknown",
+    "rope": "gpu|cpu|mixed|unknown",
+    "attention_scores": "gpu|cpu|mixed|unknown",
+    "softmax": "gpu|cpu|mixed|unknown",
+    "attention_value_mix": "gpu|cpu|mixed|unknown",
+    "sampling": "gpu|cpu|host_logits_only|unknown"
+  }
+}
+```
 
 ## Hard rules
 
-QK256 linears on A770 are trusted partial acceleration, not full residency.
-OpenVINO GPU LLMPipeline output is dense graph/runtime proof, not native OpenCL
-residency.
+- QK256 linears on A770 are trusted partial acceleration, not full residency.
+- OpenVINO GPU LLMPipeline output is dense graph/runtime proof, not native
+  OpenCL residency.
+- `resident_proven` proves only the named phase or operation.
+- `complete` requires every required operation, residency phase, and server gate
+  for the selected route.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md
@@ -1,41 +1,87 @@
 # BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT
 
-## Purpose
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines labels; no promotion.
+Policy impact: No exception.
 
-Define concrete Intel GPU route identities so receipts, route matrices, status
-surfaces, and `receipts explain` cannot collapse A770, Arc 140V, OpenVINO GPU,
-OpenCL, Level Zero, CPU, NPU, CUDA, BitNet QK256, or dense SLM proof families.
+## Route identities
 
-## Route IDs
+Valid Intel GPU route IDs are concrete and model/runtime scoped:
 
-- `intel_arc_a770_opencl_bitnet_qk256`
-- `intel_arc_a770_opencl_embedding`
-- `intel_arc_a770_opencl_lm_head`
-- `intel_arc_a770_openvino_gpu_reference`
-- `intel_arc_140v_opencl_smoke`
-- `intel_arc_140v_opencl_bitnet_candidate`
-- `intel_arc_140v_openvino_gpu_dense_slm`
-- `intel_gpu_level_zero_candidate`
+```text
+intel_arc_a770_opencl_bitnet_qk256
+intel_arc_a770_opencl_embedding
+intel_arc_a770_opencl_lm_head
+intel_arc_a770_openvino_gpu_reference
+intel_arc_140v_opencl_smoke
+intel_arc_140v_opencl_bitnet_candidate
+intel_arc_140v_openvino_gpu_dense_slm
+intel_gpu_level_zero_candidate
+```
 
-## Backend and runtime rules
+## Backend labels
 
-- `selected_backend` must be concrete; generic `gpu`, `opencl`, or `intel` is
-  not a claim backend.
-- `runtime_api` must be concrete: `opencl`, `openvino_genai`,
-  `openvino_runtime`, or `level_zero`.
+- `selected_backend` must be concrete. Values such as `gpu`, `opencl`, or
+  `intel-gpu` are convenience selectors only and cannot appear as selected
+  proof backends.
+- Native A770 OpenCL proof uses `selected_backend=intel-arc-a770-opencl` and
+  `runtime_api=opencl`.
+- Native Arc 140V OpenCL proof uses `selected_backend=intel-arc-140v-opencl` and
+  `runtime_api=opencl`.
+- OpenVINO GPU proof uses `selected_backend=openvino-gpu` and
+  `runtime_api=openvino_genai` or `runtime_api=openvino_runtime`.
+- Level Zero evidence remains candidate evidence until a route-specific spec and
+  proof receipts promote it.
+
+## Claim rules
+
 - `fallback_used=false` is required for any Intel GPU route claim.
-- OpenVINO GPU receipts must record `GPU.X` and the full device name.
+- `fallback_reason` must be `null` when `fallback_used=false`.
+- OpenVINO GPU receipts must record `GPU.X` and full device name.
 - OpenCL receipts must record platform index, device index, and full device
   name.
 - A770 receipts must record PCI ID `0x56A0` when available.
 - Arc 140V receipts must record PCI ID `0x64A0` when available.
-- CPU fallback, CPU comparator evidence, and CPU reference results must be
-  labelled as CPU evidence and cannot satisfy Intel GPU execution.
+- CPU fallback, generic GPU selection, or generic OpenCL selection cannot
+  satisfy selected Intel GPU proof.
 
 ## Claim levels
 
-Routes use the common Intel GPU ladder: `unsupported`, `runtime_detected`,
-`compile_smoke`, `kernel_smoke`, `parity_tested`, `answer_ready`,
-`behavior_proven`, `benchmark_candidate`, `performance_proven`,
-`resident_proven`, and `complete`. `performance_proven`, `resident_proven`, and
-`complete` must not be collapsed.
+| Level | Meaning | Public claim |
+| --- | --- | --- |
+| `unsupported` | no valid route or proof | none |
+| `runtime_detected` | device visible | detection only |
+| `compile_smoke` | kernel/graph compiles | compile only |
+| `kernel_smoke` | tiny kernel/graph executes | smoke only |
+| `parity_tested` | CPU/GPU fixture parity | fixture parity |
+| `answer_ready` | strict answer corpus or bounded useful answers | answer route |
+| `behavior_proven` | prompt conditioning, stop/repetition, long decode | behavior route |
+| `benchmark_candidate` | timing fields recorded | diagnostic perf |
+| `performance_proven` | quality-gated profile beats baseline with history | exact-profile perf |
+| `resident_proven` | named op resident | named residency only |
+| `complete` | all required ops/residency/server gates pass | full route |
+
+`performance_proven`, `resident_proven`, and `complete` must never be collapsed.
+
+## Minimum route receipt shape
+
+```json
+{
+  "requested_backend": "intel-arc-a770 | intel-arc-140v | openvino-gpu",
+  "selected_backend": "intel-arc-a770-opencl | intel-arc-140v-opencl | openvino-gpu",
+  "runtime_api": "opencl | openvino_genai | openvino_runtime | level_zero",
+  "runtime_device": "GPU.0 | GPU.1 | OpenCL platform/device index",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model_family": "bitnet | dense_slm | small_llm",
+  "proof_family": "bitnet_qk256_opencl | dense_slm_openvino_gpu | arc140v_opencl_smoke"
+}
+```

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md
@@ -1,0 +1,41 @@
+# BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT
+
+## Purpose
+
+Define concrete Intel GPU route identities so receipts, route matrices, status
+surfaces, and `receipts explain` cannot collapse A770, Arc 140V, OpenVINO GPU,
+OpenCL, Level Zero, CPU, NPU, CUDA, BitNet QK256, or dense SLM proof families.
+
+## Route IDs
+
+- `intel_arc_a770_opencl_bitnet_qk256`
+- `intel_arc_a770_opencl_embedding`
+- `intel_arc_a770_opencl_lm_head`
+- `intel_arc_a770_openvino_gpu_reference`
+- `intel_arc_140v_opencl_smoke`
+- `intel_arc_140v_opencl_bitnet_candidate`
+- `intel_arc_140v_openvino_gpu_dense_slm`
+- `intel_gpu_level_zero_candidate`
+
+## Backend and runtime rules
+
+- `selected_backend` must be concrete; generic `gpu`, `opencl`, or `intel` is
+  not a claim backend.
+- `runtime_api` must be concrete: `opencl`, `openvino_genai`,
+  `openvino_runtime`, or `level_zero`.
+- `fallback_used=false` is required for any Intel GPU route claim.
+- OpenVINO GPU receipts must record `GPU.X` and the full device name.
+- OpenCL receipts must record platform index, device index, and full device
+  name.
+- A770 receipts must record PCI ID `0x56A0` when available.
+- Arc 140V receipts must record PCI ID `0x64A0` when available.
+- CPU fallback, CPU comparator evidence, and CPU reference results must be
+  labelled as CPU evidence and cannot satisfy Intel GPU execution.
+
+## Claim levels
+
+Routes use the common Intel GPU ladder: `unsupported`, `runtime_detected`,
+`compile_smoke`, `kernel_smoke`, `parity_tested`, `answer_ready`,
+`behavior_proven`, `benchmark_candidate`, `performance_proven`,
+`resident_proven`, and `complete`. `performance_proven`, `resident_proven`, and
+`complete` must not be collapsed.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md
@@ -1,12 +1,25 @@
 # BITNET-SPEC-INTEL-GPU-STATUS-SURFACE
 
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines future UX; no route promotion.
+Policy impact: No exception.
+
 ## Purpose
 
-Make Intel GPU route truth visible to users, maintainers, and agents.
+Intel GPU status surfaces must make proof-family truth visible to users and
+agents without requiring them to inspect raw receipts.
 
-## Target commands
+## Future commands
 
-Status and explanation surfaces should eventually include:
+Status surfaces should eventually include:
 
 ```bash
 bitnet model status --device intel-arc-a770-opencl
@@ -18,17 +31,38 @@ bitnet gpu doctor --vendor intel
 
 ## Required output fields
 
-Outputs should include route ID, proof family, claim level, selected backend,
-runtime API, quality status, performance status, residency status, server status,
-not-claims, and next required proof.
+Human and JSON output should include:
 
-## Explanation examples
+```text
+route id
+proof family
+claim level
+selected backend
+runtime API
+quality status
+performance status
+residency status
+server status
+not-claims
+next required proof
+```
 
-`receipts explain` must distinguish statements such as:
+## Required explanations
 
-- This is A770 native OpenCL BitNet proof.
-- This is Arc 140V OpenVINO GPU dense SLM proof.
-- This is Arc 140V native OpenCL smoke proof.
-- This is not NPU proof.
-- This is not CUDA proof.
-- This is not full residency.
+`receipts explain` and status pages must distinguish at least:
+
+- A770 native OpenCL BitNet proof;
+- A770 OpenVINO GPU reference proof;
+- Arc 140V OpenVINO GPU dense SLM proof;
+- Arc 140V native OpenCL smoke/parity proof;
+- Intel NPU proof;
+- CPU reference proof;
+- CUDA proof;
+- unsupported, candidate, exact-profile, and full-route states.
+
+## Not-claims
+
+Every Intel GPU status surface must say when a route is not generic Intel GPU
+support, not native OpenCL proof, not OpenVINO GPU proof, not NPU proof, not
+BitNet QK256 proof, not dense SLM proof, not a speedup claim, or not full
+residency.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md
@@ -1,0 +1,34 @@
+# BITNET-SPEC-INTEL-GPU-STATUS-SURFACE
+
+## Purpose
+
+Make Intel GPU route truth visible to users, maintainers, and agents.
+
+## Target commands
+
+Status and explanation surfaces should eventually include:
+
+```bash
+bitnet model status --device intel-arc-a770-opencl
+bitnet model status --device intel-arc-140v-openvino-gpu
+bitnet receipts explain <receipt>
+bitnet lunar-lake routes --format json
+bitnet gpu doctor --vendor intel
+```
+
+## Required output fields
+
+Outputs should include route ID, proof family, claim level, selected backend,
+runtime API, quality status, performance status, residency status, server status,
+not-claims, and next required proof.
+
+## Explanation examples
+
+`receipts explain` must distinguish statements such as:
+
+- This is A770 native OpenCL BitNet proof.
+- This is Arc 140V OpenVINO GPU dense SLM proof.
+- This is Arc 140V native OpenCL smoke proof.
+- This is not NPU proof.
+- This is not CUDA proof.
+- This is not full residency.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,6 +1,56 @@
 # Specs Index
 
 
+## Intel GPU productization
+
+Use these documents before implementing or claiming Intel GPU support:
+
+1. [Intel GPU source-of-truth map](../intel-gpu/README.md)
+   - Defines the A770 native OpenCL, A770 OpenVINO reference, Arc 140V
+     native OpenCL, Arc 140V OpenVINO GPU, NPU, and CPU proof-family
+     boundaries.
+2. [Intel GPU productization proposal](../proposals/BITNET-PROP-0006-intel-gpu-productization.md)
+   - Explains why Intel GPU exists as selected-device, selected-model,
+     receipt-backed local inference rather than generic GPU detection.
+3. [Intel GPU implementation plan](../../plans/intel-gpu/implementation-plan.md)
+   - Sequences documentation, specification, A770 native OpenCL, Lunar Lake
+     OpenVINO GPU, Arc 140V native OpenCL, and shared UX work.
+4. [Intel GPU Route Contract](BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md)
+   - Defines concrete route IDs, backend labels, fallback rules, and the common
+     claim ladder.
+5. [Intel GPU Device Identity](BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md)
+   - Normalizes OS, PCI, driver, OpenCL, Level Zero, OpenVINO GPU, memory,
+     ReBAR, PCIe, render-node, and telemetry identity fields.
+6. [Intel GPU BitNet QK256](BITNET-SPEC-INTEL-GPU-BITNET-QK256.md)
+   - Defines official BitNet QK256/I2_S semantics and rejects toy I2_S kernels
+     as official QK256 proof.
+7. [Intel GPU Dense SLM](BITNET-SPEC-INTEL-GPU-DENSE-SLM.md)
+   - Defines the Arc 140V OpenVINO GPU dense Qwen SLM candidate and profile
+     promotion ladder.
+8. [Intel GPU Quality](BITNET-SPEC-INTEL-GPU-QUALITY.md)
+   - Defines route-specific answer/behavior gates and failure taxonomy.
+9. [Intel GPU Performance](BITNET-SPEC-INTEL-GPU-PERFORMANCE.md)
+   - Defines exact profiles, timing fields, comparator requirements, and
+     history gates for performance claims.
+10. [Intel GPU Residency](BITNET-SPEC-INTEL-GPU-RESIDENCY.md)
+    - Defines residency classes and phase tables so partial acceleration does
+      not become full device residency.
+11. [Intel GPU Status Surface](BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md)
+    - Defines future model status, route, receipts explain, and gpu doctor
+      surfaces.
+12. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+    - Defines the first A770 product claim as trusted partial BitNet I2_S
+      acceleration, not all Intel GPUs or full device residency.
+13. [Intel Arc A770 GPU Roadmap](intel-arc-a770-gpu-roadmap.md)
+    - Defines the A770 hardware/runtime lane and OpenCL-first proof path.
+
+Do not proceed from generic GPU detection, OpenCL availability, OpenVINO GPU
+execution, CPU fallback, or dense SLM evidence to an Intel GPU product claim.
+Intel GPU claims must name the selected device, runtime API, model family, proof
+family, fallback state, quality result, performance profile, and residency
+boundary.
+
+
 ## CPU AVX-512 Kernel Proof
 
 Use these specs before implementing or claiming AVX-512 CPU kernel support:

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -9,12 +9,14 @@ end_state = [
   "258V CPU strict real-GGUF validation, scalar/AVX2 answer parity, and phase receipts provide the CPU reference plate.",
   "Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.",
   "Receipts record OS, drivers, memory, power, thermal, and WSL/native visibility context.",
+  "Shared Intel GPU source-of-truth map keeps Arc 140V OpenVINO GPU, Arc 140V native OpenCL, A770 native OpenCL, NPU, CPU, dense SLM, and BitNet QK256 proof labels separate.",
 ]
 
 hard_constraints = [
   "258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.",
   "Arc 140V OpenCL proof is not NPU proof.",
   "OpenVINO GPU smoke is not packed BitNet kernel proof.",
+  "OpenVINO GPU dense SLM evidence remains candidate-only until profile-specific quality, timing-applicability, comparator, telemetry, and claim-boundary gates pass.",
   "WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.",
 ]
 

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -127,4 +127,5 @@
 - 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.
+- OpenVINO GPU dense SLM evidence remains candidate-only until profile-specific quality, timing-applicability, comparator, telemetry, and claim-boundary gates pass.
 - WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -10,12 +10,14 @@ end_state = [
   "Tiny OpenCL smoke executes with fallback_used=false.",
   "CPU/OpenCL parity exists for one kernel or subgraph.",
   "Receipts preserve selected device identity before performance claims.",
+  "Shared Intel GPU source-of-truth map keeps A770 native OpenCL proof separate from Arc 140V, OpenVINO GPU, NPU, CPU, CUDA, dense SLM, and full-residency claims.",
 ]
 
 hard_constraints = [
   "OpenCL-first for native A770 proof.",
   "OpenVINO GPU is reference only.",
   "CPU fallback cannot count as A770 execution.",
+  "A770 route promotion requires claim-grade committed receipts; documentation-only Intel GPU PRs do not promote routes or change kernels.",
 ]
 
 [[work_item]]

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -16,3 +16,4 @@
 - OpenCL-first for native A770 proof.
 - OpenVINO GPU is reference only.
 - CPU fallback cannot count as A770 execution.
+- A770 route promotion requires claim-grade committed receipts; documentation-only Intel GPU PRs do not promote routes or change kernels.

--- a/plans/intel-gpu/README.md
+++ b/plans/intel-gpu/README.md
@@ -1,10 +1,20 @@
-# Intel GPU plans
+# Intel GPU productization plans
 
-This directory sequences Intel GPU productization without conflating A770 native
-OpenCL, Arc 140V native OpenCL, OpenVINO GPU, Intel NPU, CPU fallback, CUDA,
-BitNet QK256/I2_S, or dense SLM evidence.
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Documentation only; no support-tier promotion.
+Policy impact: Keeps A770, Arc 140V, OpenVINO GPU, NPU, CPU, and CUDA proof families separate.
 
-Start with `implementation-plan.md`. The first plan item is documentation-only:
-it adds the source-of-truth map, indexes the lane in the specs index, and links
-the A770 and Lunar Lake active campaign manifests to the shared proof-family
-boundary. It does not promote routes, alter kernels, or change model coverage.
+This directory sequences Intel GPU productization work. It spans the A770
+native OpenCL BitNet lane and the Lunar Lake Arc 140V OpenVINO/native OpenCL
+lanes while preserving strict proof-family boundaries.
+
+Start with `implementation-plan.md` for PR order, proof commands, non-goals,
+and rollback guidance.

--- a/plans/intel-gpu/README.md
+++ b/plans/intel-gpu/README.md
@@ -1,0 +1,10 @@
+# Intel GPU plans
+
+This directory sequences Intel GPU productization without conflating A770 native
+OpenCL, Arc 140V native OpenCL, OpenVINO GPU, Intel NPU, CPU fallback, CUDA,
+BitNet QK256/I2_S, or dense SLM evidence.
+
+Start with `implementation-plan.md`. The first plan item is documentation-only:
+it adds the source-of-truth map, indexes the lane in the specs index, and links
+the A770 and Lunar Lake active campaign manifests to the shared proof-family
+boundary. It does not promote routes, alter kernels, or change model coverage.

--- a/plans/intel-gpu/implementation-plan.md
+++ b/plans/intel-gpu/implementation-plan.md
@@ -1,0 +1,146 @@
+# Intel GPU implementation plan
+
+## Purpose
+
+Intel GPU support must become a receipt-backed family of exact routes rather
+than a generic GPU label. The plan keeps these lanes separate:
+
+- A770 native OpenCL for BitNet I2_S/QK256 named-operation acceleration.
+- A770 OpenVINO GPU as a reference runtime lane only.
+- Arc 140V native OpenCL for Lunar Lake selected-device smoke/parity work.
+- Arc 140V OpenVINO GPU for dense SLM candidate routing and profile-specific
+  promotion.
+- Intel NPU as a separate OpenVINO NPU proof family.
+- CPU as the reference plate and fallback detector, not GPU proof.
+
+## Global hard rules
+
+- Do not promote runtime claims in documentation/specification PRs.
+- Do not claim generic Intel GPU support.
+- Do not claim OpenVINO GPU is native OpenCL.
+- Do not claim Arc 140V proof is A770 proof.
+- Do not claim A770 proof is Arc 140V proof.
+- Do not claim dense SLM proof is BitNet QK256/I2_S proof.
+- Do not claim full device residency from linears, graph smoke, or LLMPipeline
+  output.
+- Do not claim speedup without quality-gated, profile-specific benchmark
+  receipts and same-device history.
+- Do not change QK256 kernels, OpenCL kernels, model coverage, or route
+  promotion state in documentation-only PRs.
+
+## PR sequence
+
+### PR 0: `docs(intel-gpu): add Intel GPU source-of-truth map`
+
+Scope:
+
+- Add `docs/intel-gpu/README.md`.
+- Add `plans/intel-gpu/README.md`.
+- Add `plans/intel-gpu/implementation-plan.md`.
+- Update `docs/specs/INDEX.md` with the Intel GPU map.
+- Update `docs/tracking/campaigns/intel-a770/active.toml` and
+  `docs/tracking/campaigns/intel-258v-platform/active.toml` so their campaign
+  constraints point to the shared Intel GPU proof-family boundary.
+
+Acceptance:
+
+- Documentation only.
+- No route promotion.
+- No receipt changes.
+- No kernel, QK256, OpenCL, model-coverage, or CLI behavior changes.
+- Campaign checks and generated campaign check pass, or any unavailable proof is
+  recorded with a reason.
+
+Proof commands:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check intel-a770
+cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+### PR 1: `docs(proposal): add Intel GPU productization proposal`
+
+Add `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md` explaining why
+Intel GPU exists as a product family and why selected-device, selected-model,
+receipt-backed local inference is the value rather than generic GPU detection.
+
+### PR 2: `docs(spec): add Intel GPU route contract`
+
+Add:
+
+- `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`.
+- `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`.
+
+Define concrete backend labels, runtime APIs, device identity requirements,
+OpenCL platform/device recording, OpenVINO `GPU.X` recording, PCI IDs, and
+fallback rules.
+
+### PR 3: `docs(spec): add Intel GPU BitNet QK256 contract`
+
+Add `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md` for the native Intel GPU
+BitNet route, including official I2_S/QK256 semantics, scalar oracle parity,
+OpenCL kernels, tail/stride behavior, tokenizer/template authority, and the rule
+that diagnostic toy I2_S kernels cannot satisfy official QK256 proof.
+
+### PR 4: `docs(spec): add Intel GPU dense SLM contract`
+
+Add `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md` for Qwen2.5 0.5B Instruct
+OpenVINO INT4 symmetric export on Lunar Lake Arc 140V GPU.0, including the
+promotion ladder from export manifest through profile comparison and optional
+server exact-profile proof.
+
+### PR 5: `docs(spec): add Intel GPU quality/performance/residency contracts`
+
+Add:
+
+- `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`.
+- `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`.
+- `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`.
+
+Define route-specific quality gates, failure taxonomy, exact performance
+profiles and timing fields, promotion requirements, residency classes, and phase
+residency tables.
+
+### PR 6: `docs(spec): add Intel GPU status surface contract`
+
+Add `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md` for status commands,
+route matrices, `receipts explain`, and `gpu doctor --vendor intel` output.
+
+### PR 7: `claims(a770): reconcile A770 proof state`
+
+Inspect committed A770 receipts, `verify-receipts.py`, the device-kernel routing
+matrix, and the A770 campaign. Keep routes diagnostic unless claim-grade receipts
+are committed and the route matrix can point to them.
+
+### PR 8: `receipts(a770): validate route matrix against receipts`
+
+Add a validator that rejects promoted A770 routes without proof receipts,
+strict selected backend identity, fallback-free receipts, not-claims, and
+accepted speed/residency claim evidence.
+
+### PR 9-14: A770 native OpenCL productization
+
+Refresh selected-device identity, lock official QK256 scalar/oracle parity,
+record claim-grade QK256 OpenCL receipts, add deterministic answer behavior
+proof, add quality-gated profile timings, and promote only trusted partial
+acceleration when all gates pass.
+
+### PR 15-17: Lunar Lake Arc 140V OpenVINO GPU route
+
+Classify corpus-v2 failures, fix profile-specific timing applicability, and
+promote only exact profiles that pass quality, fallback, profile-timing,
+comparator, telemetry, and claim-boundary gates.
+
+### PR 18-20: Arc 140V native OpenCL BitNet-adjacent lane
+
+Refresh selected-device OpenCL parity, add BitNet QK256 candidate fixtures, and
+record whether Arc 140V should pursue native BitNet QK256 before A770. The
+expected default is that A770 owns native BitNet OpenCL first.
+
+### PR 21-23: Shared Intel GPU UX
+
+Add route-family explanations to receipts, publish an Intel GPU capability
+matrix, and add `bitnet gpu doctor --vendor intel --format json` for route
+readiness and device/runtime diagnostics.

--- a/plans/intel-gpu/implementation-plan.md
+++ b/plans/intel-gpu/implementation-plan.md
@@ -1,55 +1,50 @@
 # Intel GPU implementation plan
 
-## Purpose
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Documentation only until a later runtime PR provides receipts.
+Policy impact: Adds no exceptions.
 
-Intel GPU support must become a receipt-backed family of exact routes rather
-than a generic GPU label. The plan keeps these lanes separate:
+## Goal
 
-- A770 native OpenCL for BitNet I2_S/QK256 named-operation acceleration.
-- A770 OpenVINO GPU as a reference runtime lane only.
-- Arc 140V native OpenCL for Lunar Lake selected-device smoke/parity work.
-- Arc 140V OpenVINO GPU for dense SLM candidate routing and profile-specific
-  promotion.
-- Intel NPU as a separate OpenVINO NPU proof family.
-- CPU as the reference plate and fallback detector, not GPU proof.
+Productize Intel GPU as a receipt-backed family of exact routes without
+conflating A770 native OpenCL, Arc 140V native OpenCL, OpenVINO GPU, Intel NPU,
+CPU, CUDA, BitNet QK256, and dense SLM proof.
 
-## Global hard rules
+## Phase 0: source-of-truth alignment
 
-- Do not promote runtime claims in documentation/specification PRs.
-- Do not claim generic Intel GPU support.
-- Do not claim OpenVINO GPU is native OpenCL.
-- Do not claim Arc 140V proof is A770 proof.
-- Do not claim A770 proof is Arc 140V proof.
-- Do not claim dense SLM proof is BitNet QK256/I2_S proof.
-- Do not claim full device residency from linears, graph smoke, or LLMPipeline
-  output.
-- Do not claim speedup without quality-gated, profile-specific benchmark
-  receipts and same-device history.
-- Do not change QK256 kernels, OpenCL kernels, model coverage, or route
-  promotion state in documentation-only PRs.
+### INTELGPU-DOCS-000: source map and contracts
 
-## PR sequence
+Add:
 
-### PR 0: `docs(intel-gpu): add Intel GPU source-of-truth map`
+- `docs/intel-gpu/README.md`
+- `plans/intel-gpu/README.md`
+- `plans/intel-gpu/implementation-plan.md`
+- `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+- Intel GPU route, identity, BitNet QK256, dense SLM, quality, performance,
+  residency, and status-surface specs.
 
-Scope:
+Update:
 
-- Add `docs/intel-gpu/README.md`.
-- Add `plans/intel-gpu/README.md`.
-- Add `plans/intel-gpu/implementation-plan.md`.
-- Update `docs/specs/INDEX.md` with the Intel GPU map.
-- Update `docs/tracking/campaigns/intel-a770/active.toml` and
-  `docs/tracking/campaigns/intel-258v-platform/active.toml` so their campaign
-  constraints point to the shared Intel GPU proof-family boundary.
+- `docs/specs/INDEX.md`
+- `docs/tracking/campaigns/intel-a770/active.toml`
+- `docs/tracking/campaigns/intel-258v-platform/active.toml`
+- generated campaign dashboards if required by `xtask`.
 
 Acceptance:
 
 - Documentation only.
 - No route promotion.
 - No receipt changes.
-- No kernel, QK256, OpenCL, model-coverage, or CLI behavior changes.
-- Campaign checks and generated campaign check pass, or any unavailable proof is
-  recorded with a reason.
+- No QK256/OpenCL kernel or model coverage changes.
+- Campaign checks and `git diff --check` pass.
 
 Proof commands:
 
@@ -60,87 +55,66 @@ cargo run --locked -p xtask --no-default-features -- campaign generate --check
 git diff --check
 ```
 
-### PR 1: `docs(proposal): add Intel GPU productization proposal`
+Rollback:
 
-Add `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md` explaining why
-Intel GPU exists as a product family and why selected-device, selected-model,
-receipt-backed local inference is the value rather than generic GPU detection.
+Revert the Intel GPU docs, specs, plan files, index update, campaign active
+manifest additions, and any generated dashboard changes from this plan item.
 
-### PR 2: `docs(spec): add Intel GPU route contract`
+## Phase 1: specs
 
-Add:
+1. `docs(proposal): add Intel GPU productization proposal`
+2. `docs(spec): add Intel GPU route contract`
+3. `docs(spec): add Intel GPU device identity contract`
+4. `docs(spec): add Intel GPU BitNet QK256 contract`
+5. `docs(spec): add Intel GPU dense SLM contract`
+6. `docs(spec): add Intel GPU quality/performance/residency contracts`
+7. `docs(spec): add Intel GPU status surface contract`
 
-- `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`.
-- `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`.
+These PRs must not promote runtime claims. They define the proof rules that
+later runtime and receipt PRs must satisfy.
 
-Define concrete backend labels, runtime APIs, device identity requirements,
-OpenCL platform/device recording, OpenVINO `GPU.X` recording, PCI IDs, and
-fallback rules.
+## Phase 2: A770 route truth and proof ledger
 
-### PR 3: `docs(spec): add Intel GPU BitNet QK256 contract`
+- Reconcile committed A770 proof receipts with `ci/hardware/device-kernel-routing.toml`.
+- Keep diagnostic rows diagnostic unless claim-grade receipts are committed.
+- Add validators that prevent promoted A770 rows without receipt paths,
+  `fallback_used=false`, selected backend `intel-arc-a770-opencl`, and explicit
+  not-claims.
 
-Add `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md` for the native Intel GPU
-BitNet route, including official I2_S/QK256 semantics, scalar oracle parity,
-OpenCL kernels, tail/stride behavior, tokenizer/template authority, and the rule
-that diagnostic toy I2_S kernels cannot satisfy official QK256 proof.
+## Phase 3: A770 native OpenCL productization
 
-### PR 4: `docs(spec): add Intel GPU dense SLM contract`
+- Refresh selected-device OpenCL/Level Zero identity.
+- Lock QK256 scaled I2S-I8S scalar oracle and OpenCL parity fixtures.
+- Record claim-grade QK256 OpenCL receipts.
+- Add deterministic BitNet answer behavior gates.
+- Add quality-gated profile timings.
+- Promote only named trusted partial acceleration after all gates pass.
 
-Add `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md` for Qwen2.5 0.5B Instruct
-OpenVINO INT4 symmetric export on Lunar Lake Arc 140V GPU.0, including the
-promotion ladder from export manifest through profile comparison and optional
-server exact-profile proof.
+## Phase 4: Lunar Lake Arc 140V OpenVINO GPU route
 
-### PR 5: `docs(spec): add Intel GPU quality/performance/residency contracts`
+- Classify OpenVINO GPU corpus-v2 failures.
+- Fix profile-specific timing applicability gaps.
+- Promote only exact OpenVINO GPU dense SLM profiles where quality,
+  fallback-free execution, comparator advantage, and telemetry rules pass.
 
-Add:
+## Phase 5: Arc 140V native OpenCL BitNet-adjacent lane
 
-- `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`.
-- `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`.
-- `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`.
+- Refresh selected-device native OpenCL parity.
+- Add BitNet QK256 candidate fixtures without claiming full BitNet support.
+- Decide whether Arc 140V native OpenCL should pursue BitNet QK256 before A770.
 
-Define route-specific quality gates, failure taxonomy, exact performance
-profiles and timing fields, promotion requirements, residency classes, and phase
-residency tables.
+## Phase 6: shared Intel GPU UX
 
-### PR 6: `docs(spec): add Intel GPU status surface contract`
+- Teach `receipts explain` to state proof families and not-claims.
+- Add an Intel GPU capability matrix.
+- Add `bitnet gpu doctor --vendor intel --format json` for route readiness and
+  driver/runtime identity.
 
-Add `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md` for status commands,
-route matrices, `receipts explain`, and `gpu doctor --vendor intel` output.
+## Non-goals for docs/spec PRs
 
-### PR 7: `claims(a770): reconcile A770 proof state`
-
-Inspect committed A770 receipts, `verify-receipts.py`, the device-kernel routing
-matrix, and the A770 campaign. Keep routes diagnostic unless claim-grade receipts
-are committed and the route matrix can point to them.
-
-### PR 8: `receipts(a770): validate route matrix against receipts`
-
-Add a validator that rejects promoted A770 routes without proof receipts,
-strict selected backend identity, fallback-free receipts, not-claims, and
-accepted speed/residency claim evidence.
-
-### PR 9-14: A770 native OpenCL productization
-
-Refresh selected-device identity, lock official QK256 scalar/oracle parity,
-record claim-grade QK256 OpenCL receipts, add deterministic answer behavior
-proof, add quality-gated profile timings, and promote only trusted partial
-acceleration when all gates pass.
-
-### PR 15-17: Lunar Lake Arc 140V OpenVINO GPU route
-
-Classify corpus-v2 failures, fix profile-specific timing applicability, and
-promote only exact profiles that pass quality, fallback, profile-timing,
-comparator, telemetry, and claim-boundary gates.
-
-### PR 18-20: Arc 140V native OpenCL BitNet-adjacent lane
-
-Refresh selected-device OpenCL parity, add BitNet QK256 candidate fixtures, and
-record whether Arc 140V should pursue native BitNet QK256 before A770. The
-expected default is that A770 owns native BitNet OpenCL first.
-
-### PR 21-23: Shared Intel GPU UX
-
-Add route-family explanations to receipts, publish an Intel GPU capability
-matrix, and add `bitnet gpu doctor --vendor intel --format json` for route
-readiness and device/runtime diagnostics.
+- Do not add or modify QK256 kernels.
+- Do not add or modify OpenCL kernels.
+- Do not promote route-matrix rows.
+- Do not change model coverage.
+- Do not claim generic Intel GPU support.
+- Do not claim speedup, full residency, or cross-family proof inheritance.


### PR DESCRIPTION
### Motivation

- Establish a clear, receipt-backed source-of-truth for Intel GPU work so A770 native OpenCL, Arc 140V native OpenCL, OpenVINO GPU, NPU, CPU, BitNet QK256, and dense SLM lanes are never conflated.
- Provide concrete route, identity, receipt, and contract rails so future route promotions require claim-grade receipts, quality gates, and profile-specific benchmarks.
- Consolidate the duplicate Intel GPU docs wave by using this PR as the canonical branch and porting the stronger source-of-truth metadata from #5596.

### Description

- Add a new source-of-truth map and plan: docs/intel-gpu/README.md, plans/intel-gpu/README.md, and plans/intel-gpu/implementation-plan.md.
- Add proposal and Intel GPU spec documents under docs/specs/ describing route contracts, device identity, BitNet QK256, dense SLM, quality, performance, residency, and status surface.
- Update docs/specs/INDEX.md and the intel-a770 and intel-258v-platform campaign manifests to reference the new Intel GPU rails, and refresh generated campaign status.
- Keep this documentation/spec-only: no runtime route promotion, model coverage change, kernel change, speed claim, full residency claim, or cross-family proof promotion.

### Testing

- git diff --check
- Hosted checks before consolidation were green, including Campaign Tracker, Docs Automation, CI Core, PR Plan, and PR Gate.
- After the consolidation commit, hosted checks are the merge gate. A local Windows run of cargo run --locked -p xtask --no-default-features -- campaign check intel-a770 timed out in the known xtask build path before producing campaign output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac74692d88333892aed66564d694c)
