### PR TITLE
docs(intel-gpu): add source-of-truth map and implementation plan

### DIFF
--- a/docs/intel-gpu/README.md
+++ b/docs/intel-gpu/README.md
@@ -1,0 +1,127 @@
+# Intel GPU source-of-truth map
+
+## Purpose
+
+Intel GPU support in BitNet-rs is a vendor-specific accelerator family, not a
+single generic `gpu` bucket. This map keeps the discrete A770 lane, Lunar Lake
+Arc 140V lane, OpenVINO GPU graph/runtime lane, Intel NPU lane, CPU reference
+lane, CUDA lane, BitNet QK256 proof, and dense SLM proof separate until a
+route-specific receipt proves otherwise.
+
+This document is intentionally a source-of-truth alignment map only. It does
+not promote a runtime route, add receipt requirements beyond the linked specs,
+or change model coverage.
+
+## Route-family boundaries
+
+| Route family | Hardware | Runtime/API | First target | Current claim posture |
+| --- | --- | --- | --- | --- |
+| A770 native OpenCL | Arc A770 discrete GPU | OpenCL first; Level Zero may follow later | BitNet I2_S/QK256 named-op acceleration | Discrete BitNet lane governed by the A770 roadmap and claim-boundary spec. |
+| A770 OpenVINO GPU reference | Arc A770 discrete GPU | OpenVINO GPU | Reference runtime comparison only | Reference evidence only; not native OpenCL proof. |
+| Arc 140V native OpenCL | Lunar Lake Arc 140V integrated GPU | OpenCL | Native smoke/parity lane before BitNet-adjacent work | Integrated-GPU proof only; not A770 proof and not OpenVINO proof. |
+| Arc 140V OpenVINO GPU | Lunar Lake Arc 140V integrated GPU | OpenVINO GPU / OpenVINO GenAI | Dense Qwen SLM candidate routing | Dense SLM candidate route; not BitNet QK256 proof and not NPU proof. |
+| Intel NPU | Lunar Lake Intel AI Boost NPU | OpenVINO NPU | Separate NPU candidate evidence | NPU proof only; not GPU proof. |
+| CPU reference plate | Host CPU | Scalar/AVX2/AVX-512/CPU OpenVINO as applicable | Reference correctness and comparison | Comparator evidence only; CPU fallback cannot satisfy GPU proof. |
+
+## Non-conflation rules
+
+These rules apply to specifications, receipts, status pages, route matrices,
+model coverage, and future `receipts explain` output:
+
+- A770 OpenCL proof is not Arc 140V proof.
+- Arc 140V OpenCL proof is not A770 proof.
+- OpenVINO GPU proof is not native OpenCL proof.
+- OpenVINO GPU proof is not NPU proof.
+- Intel GPU proof is not CUDA proof.
+- Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+- BitNet QK256 proof is not dense SLM proof.
+- CPU fallback cannot count as Intel GPU execution.
+- Generic OpenCL is not selected Intel GPU proof.
+- Generic GPU is not selected Intel GPU proof.
+
+## Shared claim-level ladder
+
+Intel GPU routes use the following ladder unless a stricter route-specific spec
+supersedes it:
+
+| Level | Meaning | Public claim |
+| --- | --- | --- |
+| `unsupported` | No valid route or proof. | None. |
+| `runtime_detected` | Device is visible. | Detection only. |
+| `compile_smoke` | Kernel or graph compiles. | Compile only. |
+| `kernel_smoke` | Tiny kernel or graph executes. | Smoke only. |
+| `parity_tested` | CPU/GPU fixture parity exists. | Fixture parity. |
+| `answer_ready` | Strict answer corpus or bounded useful answers pass. | Answer route. |
+| `behavior_proven` | Prompt conditioning, stop/repetition, and long decode pass. | Behavior route. |
+| `benchmark_candidate` | Timing fields are recorded. | Diagnostic performance. |
+| `performance_proven` | Quality-gated profile beats a baseline with history. | Exact-profile performance. |
+| `resident_proven` | A named operation or phase is resident. | Named residency only. |
+| `complete` | All required ops, residency, and server gates pass. | Full route. |
+
+`performance_proven`, `resident_proven`, and `complete` must remain separate.
+A route may be performance-proven for one profile without being resident or
+complete, and a named residency proof does not imply profile speedup.
+
+## Receipt identity baseline
+
+Every Intel GPU receipt should make the selected lane explicit enough for a
+reader to reject generic GPU claims. At minimum, route-specific receipts should
+record:
+
+```json
+{
+  "requested_backend": "intel-arc-a770 | intel-arc-140v | openvino-gpu",
+  "selected_backend": "intel-arc-a770-opencl | intel-arc-140v-opencl | openvino-gpu",
+  "runtime_api": "opencl | openvino_genai | openvino_runtime | level_zero",
+  "runtime_device": "GPU.0 | GPU.1 | OpenCL platform/device index",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model_family": "bitnet | dense_slm | small_llm",
+  "proof_family": "bitnet_qk256_opencl | dense_slm_openvino_gpu | arc140v_opencl_smoke",
+  "device_identity": {
+    "name": "...",
+    "vendor": "Intel",
+    "pci_device_id": "0x56A0 | 0x64A0 | ...",
+    "driver_version": "...",
+    "vram_or_shared_memory_bytes": 0
+  },
+  "claim_boundary": {
+    "native_opencl_proof": true,
+    "openvino_gpu_proof": false,
+    "bitnet_qk256_proof": true,
+    "dense_slm_proof": false,
+    "full_residency_claim": false,
+    "speedup_claim": false
+  }
+}
+```
+
+A route-specific spec may require more fields, stricter enums, or a different
+claim-boundary shape, but it must preserve the same non-conflation semantics.
+
+## Current source-of-truth stack
+
+- A770 route identity and proof rails are defined by
+  `docs/specs/intel-arc-a770-gpu-roadmap.md`.
+- The first A770 BitNet product claim is bounded by
+  `docs/specs/a770-bitnet-claim-boundary.md`.
+- Lunar Lake CPU, Arc 140V GPU, and NPU proof labels are kept separate by
+  `docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md` and its active
+  goal.
+- The shared Intel GPU rollout sequence starts in
+  `plans/intel-gpu/implementation-plan.md`.
+
+## Current route posture
+
+- A770 native OpenCL is the discrete BitNet path. It must not be promoted from
+  diagnostic or smoke evidence to answer/performance/residency claims without
+  committed selected-device receipts and the A770 claim-boundary gates.
+- A770 OpenVINO GPU is a reference runtime path. It does not prove native
+  OpenCL QK256 execution.
+- Arc 140V OpenCL is the integrated-GPU native smoke/parity path. It does not
+  prove A770 behavior, OpenVINO GPU behavior, or BitNet inference.
+- Arc 140V OpenVINO GPU is a dense SLM candidate route. It can become promoted
+  only per exact profile after fallback-free quality, timing applicability,
+  comparator, telemetry, and benchmark-history gates pass.
+- Intel NPU evidence remains a separate OpenVINO NPU lane.
+- CPU evidence remains the reference plate and comparator, not GPU proof.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,6 +1,31 @@
 # Specs Index
 
 
+
+## Intel GPU Source-of-Truth Map
+
+Use this map before implementing or claiming Intel GPU support across A770,
+Arc 140V, OpenVINO GPU, Intel NPU, CPU, CUDA, BitNet QK256, and dense SLM
+routes:
+
+1. [Intel GPU Source-of-Truth Map](../intel-gpu/README.md)
+   - Defines shared route-family boundaries, non-conflation rules, claim-level
+     ladder, and receipt identity baseline for Intel GPU routes.
+2. [Intel GPU Implementation Plan](../../plans/intel-gpu/implementation-plan.md)
+   - Defines the documentation-first rollout from source-of-truth alignment to
+     shared specs, A770 proof synchronization, Arc 140V OpenVINO GPU profiles,
+     and user-facing status surfaces.
+3. [Intel Arc A770 GPU Roadmap](intel-arc-a770-gpu-roadmap.md)
+   - Defines the A770 discrete GPU hardware/runtime lane and native OpenCL proof
+     path.
+4. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+   - Defines the first trusted partial A770 BitNet claim boundary and the
+     not-claims that block full-residency or generic-GPU overclaims.
+
+Do not proceed from generic Intel GPU detection, generic OpenCL execution,
+OpenVINO GPU graph execution, or CPU fallback to a route claim. Intel GPU claims
+require selected-device, selected-runtime, model-family-specific receipts.
+
 ## CPU AVX-512 Kernel Proof
 
 Use these specs before implementing or claiming AVX-512 CPU kernel support:

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -5,6 +5,7 @@ status = "active"
 objective = "Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate."
 
 end_state = [
+  "Shared Intel GPU source-of-truth map keeps Arc 140V OpenCL, Arc 140V OpenVINO GPU, A770 OpenCL, NPU, CPU, CUDA, BitNet QK256, and dense SLM proof separate.",
   "Same-machine CPU, GPU, and NPU facts are captured.",
   "258V CPU strict real-GGUF validation, scalar/AVX2 answer parity, and phase receipts provide the CPU reference plate.",
   "Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.",
@@ -12,6 +13,7 @@ end_state = [
 ]
 
 hard_constraints = [
+  "Follow docs/intel-gpu/README.md before any Arc 140V GPU route claim promotion.",
   "258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.",
   "Arc 140V OpenCL proof is not NPU proof.",
   "OpenVINO GPU smoke is not packed BitNet kernel proof.",

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -124,6 +124,7 @@
 
 ## Hard Constraints
 
+- Follow docs/intel-gpu/README.md before any Arc 140V GPU route claim promotion.
 - 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -5,6 +5,7 @@ status = "active"
 objective = "Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, or OpenVINO GPU conflation."
 
 end_state = [
+  "Shared Intel GPU source-of-truth map keeps A770 native OpenCL separate from Arc 140V, OpenVINO GPU, NPU, CPU, CUDA, and dense SLM proof.",
   "A770 backend identity is distinct from generic OpenCL and Intel NPU.",
   "Runtime probe records OpenCL, Level Zero, OpenVINO GPU, PCI, VRAM, ReBAR, and render-node facts.",
   "Tiny OpenCL smoke executes with fallback_used=false.",
@@ -13,6 +14,7 @@ end_state = [
 ]
 
 hard_constraints = [
+  "Follow docs/intel-gpu/README.md before any A770 route claim promotion.",
   "OpenCL-first for native A770 proof.",
   "OpenVINO GPU is reference only.",
   "CPU fallback cannot count as A770 execution.",

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -13,6 +13,7 @@
 
 ## Hard Constraints
 
+- Follow docs/intel-gpu/README.md before any A770 route claim promotion.
 - OpenCL-first for native A770 proof.
 - OpenVINO GPU is reference only.
 - CPU fallback cannot count as A770 execution.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -31,8 +31,8 @@
 | cpu-proof | CPU-AVX512-000 | TBD | in_progress | CPU-SCALAR-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
+| intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | Follow docs/intel-gpu/README.md before any Arc 140V GPU route claim promotion. |
+| intel-a770 | A770-003 | TBD | ready | none | Follow docs/intel-gpu/README.md before any A770 route claim promotion. |
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -31,8 +31,8 @@
 | cpu-proof | BitNet CPU proof | CPU-AVX512-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | Follow docs/intel-gpu/README.md before any Arc 140V GPU route claim promotion. |
+| intel-a770 | Intel Arc A770 validation | A770-003 | Follow docs/intel-gpu/README.md before any A770 route claim promotion. |
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |

--- a/plans/intel-gpu/README.md
+++ b/plans/intel-gpu/README.md
@@ -1,0 +1,8 @@
+# Intel GPU plans
+
+This directory sequences Intel GPU source-of-truth work across the A770 native
+OpenCL BitNet lane and the Lunar Lake Arc 140V OpenVINO/native OpenCL lanes.
+The plan is documentation-first: establish route boundaries before any runtime
+claim, receipt promotion, kernel change, or status-surface expansion.
+
+Start with `implementation-plan.md`.

--- a/plans/intel-gpu/implementation-plan.md
+++ b/plans/intel-gpu/implementation-plan.md
@@ -1,0 +1,115 @@
+# Intel GPU implementation plan
+
+## Purpose
+
+This plan lays down the PR sequence for making Intel GPU support a first-class,
+receipt-backed inference family without conflating A770 native OpenCL, Arc 140V
+native OpenCL, OpenVINO GPU, Intel NPU, CPU, CUDA, BitNet QK256, or dense SLM
+proof families.
+
+## Authorities
+
+- Source-of-truth map: `docs/intel-gpu/README.md`
+- A770 hardware/runtime lane: `docs/specs/intel-arc-a770-gpu-roadmap.md`
+- A770 BitNet claim boundary: `docs/specs/a770-bitnet-claim-boundary.md`
+- Lunar Lake platform campaign: `docs/tracking/campaigns/intel-258v-platform/`
+- A770 campaign: `docs/tracking/campaigns/intel-a770/`
+
+## Phase 0: source-of-truth alignment
+
+### INTEL-GPU-DOCS-000: add Intel GPU source-of-truth map
+
+Scope:
+
+- Add `docs/intel-gpu/README.md`.
+- Add `plans/intel-gpu/README.md`.
+- Add this implementation plan.
+- Update `docs/specs/INDEX.md`.
+- Update the Intel A770 and Intel 258V active goals to point at the shared map
+  without changing runtime claims.
+
+Acceptance:
+
+- Documentation only.
+- No route promotion.
+- No receipt changes.
+- No QK256, OpenCL, OpenVINO, model-coverage, or server-code changes.
+- Campaign checks and generation checks pass, or any environment limitation is
+  recorded.
+
+Proof commands:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check intel-a770
+cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+## Phase 1: shared Intel GPU specifications
+
+Add one semantic spec PR at a time:
+
+1. Productization proposal: why Intel GPU exists as a product family.
+2. Route contract and device identity specs.
+3. Native Intel GPU BitNet QK256 contract.
+4. Dense SLM OpenVINO GPU contract.
+5. Quality, performance, and residency contracts.
+6. Status-surface contract.
+
+Each spec PR must preserve the non-conflation rules from
+`docs/intel-gpu/README.md` and must not promote runtime routes.
+
+## Phase 2: A770 route truth and proof ledger
+
+Reconcile `ci/hardware/device-kernel-routing.toml`, committed A770 receipts,
+A770 verification tooling, and the A770 campaign. If claim-grade receipts are
+not committed, diagnostic rows remain diagnostic and the missing artifacts are
+listed explicitly.
+
+## Phase 3: A770 native OpenCL productization
+
+Proceed from selected-device identity through QK256 scalar-oracle fixtures,
+claim-grade OpenCL receipts, deterministic answer behavior, quality-gated
+profile timings, and only then trusted partial acceleration promotion for named
+operations.
+
+Allowed end claim after all gates pass:
+
+```text
+Official BitNet b1.58 I2_S/QK256 has trusted partial A770 OpenCL acceleration
+for named operations.
+```
+
+This is not a full-device-residency, generic Intel GPU, dense SLM, OpenVINO GPU,
+CUDA, NPU, or all-OpenCL-device claim.
+
+## Phase 4: Lunar Lake Arc 140V OpenVINO GPU route
+
+Classify OpenVINO GPU corpus-v2 failures, fix profile-timing applicability, add
+profile comparisons, and promote only exact profiles that pass quality,
+fallback, comparator, telemetry, generated-token-boundary, and accepted
+advantage gates.
+
+OpenVINO GPU proof is dense graph/runtime proof; it is not native OpenCL proof,
+NPU proof, or BitNet QK256 proof.
+
+## Phase 5: Arc 140V native OpenCL BitNet-adjacent lane
+
+Refresh selected-device native OpenCL smoke/parity, add QK256 candidate fixtures
+only after layout and scaled I2_S-I8_S parity are proven, and decide whether Arc
+140V should pursue native BitNet before or after A770. Until evidence says
+otherwise, A770 owns native BitNet OpenCL first and Arc 140V remains
+smoke/parity plus dense OpenVINO GPU candidate.
+
+## Phase 6: shared Intel GPU UX
+
+Add user-facing route-family explanations after the proof contracts exist:
+
+- `receipts explain` route-family boundaries.
+- Intel GPU capability matrix.
+- `bitnet gpu doctor --vendor intel --format json`.
+
+These surfaces must show route ID, proof family, claim level, selected backend,
+runtime API, quality status, performance status, residency status, server
+status, not-claims, and next required proof.


### PR DESCRIPTION
### Motivation

- Establish an explicit, docs-first source-of-truth for Intel GPU work so A770 native OpenCL, Arc 140V native OpenCL, OpenVINO GPU, NPU, CPU, CUDA, BitNet QK256, and dense SLM proof families are never conflated. 
- Provide a clear rollout plan and claim-level ladder to prevent premature or ambiguous runtime/residency/performance claims. 
- Make receipts and campaign goals reference the shared map so route promotions must follow the documented proof gates.

### Description

- Add `docs/intel-gpu/README.md` with route-family boundaries, non-conflation rules, a shared claim-level ladder, and a baseline receipt identity shape. 
- Add `plans/intel-gpu/README.md` and `plans/intel-gpu/implementation-plan.md` with a documentation-first PR sequence and proof commands for the A770 and Arc 140V lanes. 
- Update `docs/specs/INDEX.md` to reference the Intel GPU map and plan, and update the Intel A770 and Intel 258V active goals to reference the shared map and require it before any route-claim promotion. 
- Regenerate campaign dashboards so generated status surfaces reflect the new guidance and inserted constraints into campaign status artifacts.

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- campaign check intel-a770`, which completed successfully and reported the campaign check passed. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform`, which completed successfully and reported the campaign check passed (existing campaign warnings about missing event metadata were surfaced). 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check` (and `campaign generate`) to refresh generated dashboards, and the generation/check completed with generated dashboards current. 
- Ran `git diff --check` as part of validation and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac74692d88333892aed66564d694c)