### PR TITLE
docs(intel-gpu): add Intel GPU source-of-truth map and implementation plan

### DIFF
--- a/docs/intel-gpu/README.md
+++ b/docs/intel-gpu/README.md
@@ -1,0 +1,143 @@
+# Intel GPU source-of-truth map
+
+Intel GPU support in BitNet-rs is a vendor-specific accelerator family, not a
+single generic "GPU works" claim. The family is split into receipt-backed lanes
+that preserve the exact device, runtime, model family, route, fallback status,
+quality state, timing profile, residency boundary, and not-claims.
+
+This map aligns the existing A770 and Lunar Lake 258V campaigns before any new
+route promotion or receipt schema changes. It is documentation-only: it does not
+promote runtime support, alter model coverage, or change kernel behavior.
+
+## Lane boundaries
+
+| Lane | Hardware | Runtime | First target | Claim family |
+| --- | --- | --- | --- | --- |
+| A770 native GPU | Intel Arc A770, especially 16GB boards | OpenCL first; Level Zero only as a candidate later | BitNet I2_S/QK256 trusted partial acceleration | `intel-arc-a770-opencl` |
+| A770 OpenVINO GPU reference | Intel Arc A770 | OpenVINO GPU `GPU.X` | Reference graph/runtime comparison only | `intel-arc-a770-openvino-gpu` |
+| Lunar Lake Arc 140V OpenVINO GPU | Arc 140V on Core Ultra 7 258V class systems | OpenVINO GPU `GPU.0` when it resolves to Arc 140V | Dense SLM candidate routing, initially Qwen-family OpenVINO exports | `openvino-gpu` |
+| Lunar Lake Arc 140V native OpenCL | Arc 140V on Core Ultra 7 258V class systems | Native OpenCL selected device | Smoke/parity first; BitNet-adjacent fixtures later | `arc140v-opencl` |
+| Lunar Lake NPU | Intel AI Boost NPU | OpenVINO NPU | Separate NPU evidence lane | `openvino-npu` |
+| CPU reference plate | Host CPU, including 258V CPU routes | CPU scalar/SIMD | Comparator and correctness baseline | not GPU proof |
+
+## Non-conflation rules
+
+These boundaries apply to specs, plans, receipts, route matrices, status pages,
+and future `receipts explain` output:
+
+- A770 OpenCL proof is not Arc 140V proof.
+- Arc 140V OpenCL proof is not A770 proof.
+- OpenVINO GPU proof is not native OpenCL proof.
+- OpenVINO GPU proof is not NPU proof.
+- Intel GPU proof is not CUDA proof.
+- Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+- BitNet QK256 proof is not dense SLM proof.
+- CPU fallback cannot count as Intel GPU execution.
+- Generic OpenCL is not selected Intel GPU proof.
+- Generic GPU is not selected Intel GPU proof.
+
+## Current source-of-truth stack
+
+| Artifact | Role |
+| --- | --- |
+| `docs/specs/intel-arc-a770-gpu-roadmap.md` | Existing A770 hardware/runtime lane; identifies native OpenCL as primary and OpenVINO GPU as reference. |
+| `docs/specs/a770-bitnet-claim-boundary.md` | Existing A770 BitNet product claim boundary; limits the first claim to trusted partial BitNet I2_S acceleration with explicit not-claims. |
+| `docs/tracking/campaigns/intel-a770/active.toml` | Active A770 campaign execution state. |
+| `docs/specs/intel-lunar-lake-gpu-roadmap.md` | Existing Arc 140V GPU roadmap; separates OpenVINO GPU and native OpenCL evidence. |
+| `docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md` | Generated 258V campaign state; keeps CPU, Arc 140V GPU, and NPU proof labels separate. |
+| `docs/tracking/campaigns/intel-258v-platform/active.toml` | Active 258V platform execution state. |
+| `plans/intel-gpu/implementation-plan.md` | Shared Intel GPU documentation/spec rollout plan. |
+
+## Route truth before promotion
+
+The shared Intel GPU work starts from this posture:
+
+- A770 native OpenCL is the discrete BitNet path, but A770 QK256, embedding,
+  and LM-head rows remain diagnostic until committed claim-grade receipts prove
+  selected-device execution, fallback-free operation, quality, timing, and
+  not-claims.
+- A770 OpenVINO GPU is a reference runtime path, not native OpenCL proof.
+- Arc 140V OpenVINO GPU is a dense SLM candidate route; promising timings do not
+  promote it until exact-profile quality, timing applicability, comparator, and
+  telemetry gates pass.
+- Arc 140V native OpenCL is an integrated GPU smoke/parity lane; it does not
+  imply A770 support or BitNet QK256 support.
+- NPU evidence remains a separate OpenVINO NPU lane.
+- CPU evidence is the reference plate and never satisfies Intel GPU execution.
+
+## Shared claim ladder
+
+Intel GPU routes use a common claim ladder so detection, execution, answer
+quality, performance, and residency are not collapsed:
+
+| Level | Meaning | Public claim |
+| --- | --- | --- |
+| `unsupported` | no valid route or proof | none |
+| `runtime_detected` | device visible | detection only |
+| `compile_smoke` | kernel/graph compiles | compile only |
+| `kernel_smoke` | tiny kernel/graph executes | smoke only |
+| `parity_tested` | CPU/GPU fixture parity | fixture parity |
+| `answer_ready` | strict answer corpus or bounded useful answers | answer route |
+| `behavior_proven` | prompt conditioning, stop/repetition, long decode | behavior route |
+| `benchmark_candidate` | timing fields recorded | diagnostic performance |
+| `performance_proven` | quality-gated profile beats baseline with history | exact-profile performance |
+| `resident_proven` | named op or phase resident | named residency only |
+| `complete` | all required ops, residency, and server gates pass | full route |
+
+`performance_proven`, `resident_proven`, and `complete` are separate states.
+Named QK256 linears, embedding, LM-head, dense graph runtime, KV cache, attention
+scores, softmax, sampling, and server paths must each carry their own proof.
+
+## Receipt identity minimum
+
+Every Intel GPU route receipt should converge on these fields as specs and code
+catch up:
+
+```json
+{
+  "requested_backend": "intel-arc-a770 | intel-arc-140v | openvino-gpu",
+  "selected_backend": "intel-arc-a770-opencl | intel-arc-140v-opencl | openvino-gpu",
+  "runtime_api": "opencl | openvino_genai | openvino_runtime | level_zero",
+  "runtime_device": "GPU.0 | GPU.1 | OpenCL platform/device index",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model_family": "bitnet | dense_slm | small_llm",
+  "proof_family": "bitnet_qk256_opencl | dense_slm_openvino_gpu | arc140v_opencl_smoke",
+  "device_identity": {
+    "name": "...",
+    "vendor": "Intel",
+    "pci_device_id": "0x56A0 | 0x64A0 | ...",
+    "driver_version": "...",
+    "vram_or_shared_memory_bytes": 0
+  },
+  "claim_boundary": {
+    "native_opencl_proof": true,
+    "openvino_gpu_proof": false,
+    "bitnet_qk256_proof": true,
+    "dense_slm_proof": false,
+    "full_residency_claim": false,
+    "speedup_claim": false
+  }
+}
+```
+
+Route-specific specs may add stricter fields; they must not weaken selected
+backend identity or fallback truth.
+
+## Immediate rollout
+
+The shared rollout is staged in `plans/intel-gpu/implementation-plan.md`:
+
+1. Add this source-of-truth map and the shared implementation plan.
+2. Add Intel GPU proposal/spec documents for route identity, device identity,
+   BitNet QK256, dense SLM, quality, performance, residency, and status
+   surfaces.
+3. Reconcile A770 route truth against committed claim-grade receipts.
+4. Productize A770 native OpenCL only through selected-device, answer-quality,
+   timing, and named-residency receipts.
+5. Productize Arc 140V OpenVINO GPU only per dense-SLM exact profile after
+   quality and timing blockers are closed.
+6. Keep Arc 140V native OpenCL as smoke/parity until BitNet-adjacent fixtures and
+   answer proof exist.
+7. Add shared UX surfaces such as capability matrices, `receipts explain`, and
+   `gpu doctor` without broadening claims.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,6 +1,35 @@
 # Specs Index
 
 
+## Intel GPU Productization
+
+Use this source-of-truth map before implementing, validating, or claiming Intel
+GPU support across A770, Lunar Lake Arc 140V, OpenVINO GPU, native OpenCL, NPU,
+CPU, CUDA, BitNet QK256, or dense SLM lanes:
+
+1. [Intel GPU Source-of-Truth Map](../intel-gpu/README.md)
+   - Defines the shared lane boundaries, non-conflation rules, claim ladder,
+     and receipt identity minimum for Intel GPU routes.
+2. [Intel GPU Implementation Plan](../../plans/intel-gpu/implementation-plan.md)
+   - Defines the PR-by-PR rollout from documentation alignment through specs,
+     A770 proof reconciliation, A770 OpenCL productization, Arc 140V OpenVINO
+     GPU profile promotion, Arc 140V OpenCL parity, and shared UX surfaces.
+3. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+   - Defines the existing A770 trusted-partial BitNet claim boundary and
+     not-claims.
+4. [Intel Arc A770 GPU Roadmap](intel-arc-a770-gpu-roadmap.md)
+   - Defines the discrete A770 OpenCL-first lane and OpenVINO GPU reference
+     path.
+5. [Intel Lunar Lake GPU Roadmap](intel-lunar-lake-gpu-roadmap.md)
+   - Defines the integrated Arc 140V GPU lane and separates OpenVINO GPU from
+     native OpenCL evidence.
+
+Do not claim generic Intel GPU support. A770 OpenCL proof is not Arc 140V proof;
+Arc 140V OpenCL proof is not A770 proof; OpenVINO GPU proof is not native OpenCL
+proof or NPU proof; dense SLM proof is not BitNet QK256 proof; CPU fallback is
+not Intel GPU execution.
+
+
 ## CPU AVX-512 Kernel Proof
 
 Use these specs before implementing or claiming AVX-512 CPU kernel support:

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -5,6 +5,7 @@ status = "active"
 objective = "Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate."
 
 end_state = [
+  "Shared Intel GPU source-of-truth keeps Arc 140V OpenVINO GPU, Arc 140V native OpenCL, A770 OpenCL, NPU, CPU, CUDA, dense SLM, and BitNet QK256 proof labels separate.",
   "Same-machine CPU, GPU, and NPU facts are captured.",
   "258V CPU strict real-GGUF validation, scalar/AVX2 answer parity, and phase receipts provide the CPU reference plate.",
   "Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.",
@@ -12,6 +13,7 @@ end_state = [
 ]
 
 hard_constraints = [
+  "Shared Intel GPU docs/spec work must not promote Arc 140V OpenVINO GPU or native OpenCL routes without exact-profile quality, timing, fallback, and receipt gates.",
   "258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.",
   "Arc 140V OpenCL proof is not NPU proof.",
   "OpenVINO GPU smoke is not packed BitNet kernel proof.",

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -124,6 +124,7 @@
 
 ## Hard Constraints
 
+- Shared Intel GPU docs/spec work must not promote Arc 140V OpenVINO GPU or native OpenCL routes without exact-profile quality, timing, fallback, and receipt gates.
 - 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -5,6 +5,7 @@ status = "active"
 objective = "Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, or OpenVINO GPU conflation."
 
 end_state = [
+  "Shared Intel GPU source-of-truth keeps A770 native OpenCL separate from Arc 140V OpenCL, OpenVINO GPU, NPU, CPU, CUDA, dense SLM, and generic GPU proof.",
   "A770 backend identity is distinct from generic OpenCL and Intel NPU.",
   "Runtime probe records OpenCL, Level Zero, OpenVINO GPU, PCI, VRAM, ReBAR, and render-node facts.",
   "Tiny OpenCL smoke executes with fallback_used=false.",
@@ -13,6 +14,7 @@ end_state = [
 ]
 
 hard_constraints = [
+  "Shared Intel GPU docs/spec work must not promote A770 routes without committed claim-grade receipts.",
   "OpenCL-first for native A770 proof.",
   "OpenVINO GPU is reference only.",
   "CPU fallback cannot count as A770 execution.",

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -13,6 +13,7 @@
 
 ## Hard Constraints
 
+- Shared Intel GPU docs/spec work must not promote A770 routes without committed claim-grade receipts.
 - OpenCL-first for native A770 proof.
 - OpenVINO GPU is reference only.
 - CPU fallback cannot count as A770 execution.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -31,8 +31,8 @@
 | cpu-proof | CPU-AVX512-000 | TBD | in_progress | CPU-SCALAR-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
+| intel-258v-platform | LNL258V-OV-QUAL-005 | #5526 | merged | none | Shared Intel GPU docs/spec work must not promote Arc 140V OpenVINO GPU or native OpenCL routes without exact-profile quality, timing, fallback, and receipt gates. |
+| intel-a770 | A770-003 | TBD | ready | none | Shared Intel GPU docs/spec work must not promote A770 routes without committed claim-grade receipts. |
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -31,8 +31,8 @@
 | cpu-proof | BitNet CPU proof | CPU-AVX512-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-OV-QUAL-005 | Shared Intel GPU docs/spec work must not promote Arc 140V OpenVINO GPU or native OpenCL routes without exact-profile quality, timing, fallback, and receipt gates. |
+| intel-a770 | Intel Arc A770 validation | A770-003 | Shared Intel GPU docs/spec work must not promote A770 routes without committed claim-grade receipts. |
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |

--- a/plans/intel-gpu/README.md
+++ b/plans/intel-gpu/README.md
@@ -1,0 +1,20 @@
+# Intel GPU plan index
+
+This directory sequences the shared Intel GPU documentation, proof, and UX work.
+It coordinates the existing A770 and Lunar Lake 258V campaigns without merging
+their claim families.
+
+Start with:
+
+- `implementation-plan.md` for the PR-by-PR rollout.
+- `docs/intel-gpu/README.md` for the source-of-truth map.
+
+Hard boundaries for every plan item:
+
+- A770 native OpenCL proof is not Arc 140V proof.
+- Arc 140V OpenCL proof is not A770 proof.
+- OpenVINO GPU proof is not native OpenCL proof or NPU proof.
+- Dense SLM proof is not BitNet QK256/I2_S proof.
+- CPU fallback cannot satisfy Intel GPU execution.
+- No performance or residency claim is valid without profile-specific,
+  quality-gated receipts and explicit not-claims.

--- a/plans/intel-gpu/implementation-plan.md
+++ b/plans/intel-gpu/implementation-plan.md
@@ -1,0 +1,163 @@
+# Intel GPU implementation plan
+
+## Purpose
+
+Lay down the Intel GPU source-of-truth, specs, proof rails, and user-visible
+status surfaces so BitNet-rs can productize Intel GPU support without conflating
+A770 native OpenCL, Arc 140V native OpenCL, OpenVINO GPU, Intel NPU, CPU, CUDA,
+BitNet QK256, and dense SLM proof families.
+
+## Scope controls
+
+- Documentation/spec PRs do not promote runtime claims.
+- Documentation/spec PRs do not change QK256 kernels, OpenCL kernels, model
+  coverage, route matrix support levels, or receipt validation behavior unless a
+  specific later work item says so.
+- Runtime PRs must link to the relevant route spec and preserve selected backend
+  identity, runtime API, fallback truth, proof family, quality state, timing
+  profile, residency boundary, and not-claims.
+- A770 OpenCL, Arc 140V OpenCL, OpenVINO GPU, OpenVINO NPU, CPU, and CUDA remain
+  separate proof families.
+
+## Phase 0: source-of-truth alignment
+
+### PR 0: `docs(intel-gpu): add Intel GPU source-of-truth map`
+
+Add:
+
+- `docs/intel-gpu/README.md`
+- `plans/intel-gpu/README.md`
+- `plans/intel-gpu/implementation-plan.md`
+
+Update:
+
+- `docs/specs/INDEX.md`
+- `docs/tracking/campaigns/intel-a770/active.toml`
+- `docs/tracking/campaigns/intel-258v-platform/active.toml`
+- generated campaign docs if the campaign generator requires it
+
+Acceptance:
+
+- Docs only.
+- No route promotion.
+- No receipt schema or receipt artifact changes.
+- A770 native OpenCL is documented as the discrete BitNet path.
+- A770 OpenVINO GPU is documented as reference runtime evidence only.
+- Arc 140V OpenVINO GPU is documented as the dense SLM candidate route.
+- Arc 140V native OpenCL is documented as smoke/parity first.
+- NPU remains a separate OpenVINO NPU lane.
+- CPU remains a reference plate, not GPU proof.
+
+Proof commands:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check intel-a770
+cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+## Phase 1: Intel GPU specs
+
+Add proposal/spec artifacts without runtime promotion:
+
+1. `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+2. `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`
+3. `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`
+4. `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`
+5. `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`
+6. `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`
+7. `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`
+8. `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+9. `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+
+Acceptance:
+
+- Backend labels and route IDs are concrete.
+- Receipt identity fields are normalized across A770, Arc 140V, OpenCL, Level
+  Zero, OpenVINO GPU, and telemetry contexts.
+- The BitNet QK256 spec rejects toy I2_S kernels as official QK256 proof.
+- Dense SLM OpenVINO GPU promotion is exact-profile only.
+- Quality, performance, and residency are separate gates.
+- Status surfaces expose not-claims and next required proof.
+
+## Phase 2: A770 route truth and proof ledger
+
+Reconcile `ci/hardware/amd-5700x-intel-a770/**`,
+`ci/hardware/amd-5700x-intel-a770/verify-receipts.py`,
+`ci/hardware/device-kernel-routing.toml`, and the A770 campaign.
+
+Acceptance:
+
+- If claim-grade receipts are committed, route rows list them and use the
+  correct claim level.
+- If claim-grade receipts are absent, route rows remain diagnostic and document
+  missing artifacts.
+- Strict A770 claims require `selected_backend=intel-arc-a770-opencl`,
+  `fallback_used=false`, proof receipts, and preserved not-claims.
+- Speedup or full residency claims fail validation unless accepted gates exist.
+
+## Phase 3: A770 native OpenCL productization
+
+Sequence selected-device identity refresh, QK256 scaled I2_S/I8_S parity
+fixtures, claim-grade QK256 OpenCL receipts, deterministic BitNet answer
+behavior, quality-gated profile timings, and trusted partial-acceleration
+promotion.
+
+Allowed first product claim, only after gates pass:
+
+```text
+Official BitNet b1.58 I2_S/QK256 has trusted partial A770 OpenCL acceleration
+for named operations.
+```
+
+Not allowed:
+
+- all Intel GPUs
+- all OpenCL devices
+- dense SLM/Gemma support
+- selected-attention residency
+- KV residency
+- full support-op residency
+- full device residency
+- speedup without quality-gated same-device profile history
+
+## Phase 4: Lunar Lake Arc 140V OpenVINO GPU route
+
+Classify OpenVINO GPU corpus-v2 failures, add profile-specific timing, then
+promote only exact profiles where quality passes, fallback is false, profile
+timing is applicable, and a benchmark-qualified CPU/UX/power advantage is
+accepted.
+
+Not allowed:
+
+- native OpenCL proof from OpenVINO GPU
+- NPU proof from OpenVINO GPU
+- BitNet QK256 proof from dense SLM OpenVINO GPU
+- broad Arc 140V GPU support claims
+
+## Phase 5: Arc 140V native OpenCL BitNet-adjacent lane
+
+Refresh selected-device native OpenCL parity, add BitNet QK256 candidate
+fixtures, and decide whether Arc 140V should pursue a native BitNet route before
+A770 reaches trusted partial acceleration.
+
+Default posture:
+
+```text
+A770 owns native BitNet OpenCL first; Arc 140V remains smoke/parity and dense
+OpenVINO GPU candidate unless evidence says otherwise.
+```
+
+## Phase 6: shared Intel GPU UX
+
+Add user-visible status and explanation surfaces only after the route contracts
+exist:
+
+- `bitnet receipts explain <receipt>` route-family explanation.
+- `docs/status/INTEL_GPU_CAPABILITY_MATRIX.md`.
+- `bitnet gpu doctor --vendor intel --format json`.
+
+Each surface must show route ID, proof family, claim level, selected backend,
+runtime API, quality status, performance status, residency status, server status,
+not-claims, and next required proof.


### PR DESCRIPTION
### Motivation

- Establish a concrete, repository-level source-of-truth for Intel GPU work so A770 native OpenCL, Arc 140V OpenCL, OpenVINO GPU, NPU, CPU, and dense-SLM proof families are never conflated. 
- Provide a staged rollout plan and scope controls so documentation/spec PRs do not prematurely promote runtime claims or change kernel/model proof artifacts. 
- Normalize receipt/route identity expectations and a claim ladder to make future route promotions and receipts auditable and machine-checkable. 

### Description

- Add a new source-of-truth document at `docs/intel-gpu/README.md` that defines lane boundaries, non-conflation rules, a shared claim ladder, and minimum receipt identity fields. 
- Add a plan index and PR-by-PR implementation plan in `plans/intel-gpu/README.md` and `plans/intel-gpu/implementation-plan.md` to sequence docs/spec, proof reconciliation, productization, and UX surface work. 
- Register the Intel GPU docs in the specs index by updating `docs/specs/INDEX.md` and add shared end-state/hard-constraints to the active campaign manifests at `docs/tracking/campaigns/intel-a770/active.toml` and `docs/tracking/campaigns/intel-258v-platform/active.toml`. 
- Regenerated campaign dashboards and supporting generated tracking docs so the new constraints and index entries appear in `docs/tracking/generated/*` and campaign `generated/status.md` outputs. 

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- campaign check intel-a770` and it passed. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform` and it passed (the run emitted a few pre-existing campaign event warnings but did not fail). 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate` and `cargo run --locked -p xtask --no-default-features -- campaign generate --check` to refresh and validate generated dashboards, and the generated dashboards are current. 
- Ran `git diff --check` (as the repo proof command) and there were no blocking check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac74692d88333892aed66564d694c)