### PR TITLE
CUDA-UX-014: add support bundle command

### DIFF
--- a/crates/bitnet-cli/src/commands/mod.rs
+++ b/crates/bitnet-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod output_head_logits_audit;
 pub mod receipts;
 pub mod reference_compare;
 pub mod serve;
+pub mod support;
 pub mod template_util;
 pub mod transformer_layer_parity;
 
@@ -49,4 +50,5 @@ pub use output_head_logits_audit::OutputHeadLogitsAuditCommand;
 pub use receipts::ReceiptsCommand;
 pub use reference_compare::ReferenceCompareCommand;
 pub use serve::ServeCommand;
+pub use support::SupportCommand;
 pub use transformer_layer_parity::TransformerLayerParityCommand;

--- a/crates/bitnet-cli/src/commands/receipts.rs
+++ b/crates/bitnet-cli/src/commands/receipts.rs
@@ -244,7 +244,7 @@ impl ReceiptsCommand {
     }
 }
 
-fn resolve_receipt_path(path: Option<&Path>, latest: bool) -> Result<PathBuf> {
+pub(crate) fn resolve_receipt_path(path: Option<&Path>, latest: bool) -> Result<PathBuf> {
     if latest {
         let search_root = path.unwrap_or_else(|| Path::new(DEFAULT_RECEIPTS_DIR));
         return latest_receipt_under(search_root);
@@ -257,7 +257,7 @@ fn resolve_receipt_path(path: Option<&Path>, latest: bool) -> Result<PathBuf> {
     Ok(path.to_path_buf())
 }
 
-fn read_receipt_json(path: &Path) -> Result<Value> {
+pub(crate) fn read_receipt_json(path: &Path) -> Result<Value> {
     let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
     serde_json::from_slice(&bytes)
         .with_context(|| format!("failed to parse receipt JSON {}", path.display()))

--- a/crates/bitnet-cli/src/commands/support.rs
+++ b/crates/bitnet-cli/src/commands/support.rs
@@ -1,0 +1,447 @@
+//! Support bundle command for receipt-backed issue reports.
+
+use crate::model_cache::{self, ModelStatusDashboard};
+
+use super::receipts::{self, ReceiptExplanation};
+use anyhow::Result;
+use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+/// Collect model status and latest receipt evidence into one pasteable artifact.
+#[derive(Args, Debug, Clone)]
+pub struct SupportCommand {
+    #[command(subcommand)]
+    pub action: SupportAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum SupportAction {
+    /// Emit a support bundle from model status and a receipt explanation.
+    Bundle {
+        /// Receipt file to explain. With --latest, this may be a directory to search.
+        #[arg(value_name = "PATH")]
+        path: Option<PathBuf>,
+
+        /// Use the newest JSON receipt under the path or default receipt directory.
+        #[arg(long, default_value_t = false)]
+        latest: bool,
+
+        /// Device label to summarize, for example nvidia-rtx-5070-ti-cuda.
+        #[arg(long, value_name = "DEVICE")]
+        device: String,
+
+        /// Override the coverage matrix path. Defaults to ci/model-artifacts/model-coverage-matrix.toml when run from this repo.
+        #[arg(long, value_name = "PATH", env = "BITNET_MODEL_COVERAGE_MATRIX")]
+        matrix: Option<PathBuf>,
+
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = SupportBundleFormat::Json)]
+        format: SupportBundleFormat,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SupportBundleFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Serialize)]
+struct SupportBundle {
+    schema_version: u32,
+    kind: &'static str,
+    created_utc: String,
+    device: String,
+    summary: SupportBundleSummary,
+    binary: SupportBinaryIdentity,
+    runtime: SupportRuntimeInfo,
+    model_status: ModelStatusDashboard,
+    latest_receipt: ReceiptExplanation,
+}
+
+#[derive(Debug, Serialize)]
+struct SupportBundleSummary {
+    model_coverage_row: Option<String>,
+    current_tier: Option<String>,
+    selected_backend: Option<String>,
+    selected_route: Option<String>,
+    fallback_used: Option<bool>,
+    quality_gate: String,
+    server_ready: Option<bool>,
+    server_ready_scope: Option<String>,
+    speedup_claim: Option<bool>,
+    full_residency_claim: Option<bool>,
+    bitnet_packed_i2s_qk256_proof: Option<bool>,
+    dense_regular_llm_cuda_proof: Option<bool>,
+    next_proof: Option<String>,
+    receipt_path: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SupportBinaryIdentity {
+    name: &'static str,
+    crate_version: &'static str,
+    git_commit: Option<String>,
+    git_commit_source: Option<&'static str>,
+    build_timestamp: Option<&'static str>,
+    rustc_version: Option<&'static str>,
+    target_triple: Option<&'static str>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct SupportRuntimeInfo {
+    selected_backend: Option<String>,
+    runtime_api: Option<String>,
+    device_name: Option<String>,
+    driver_version: Option<String>,
+    cuda_runtime_version: Option<String>,
+    cuda_driver_version: Option<String>,
+    source: Option<&'static str>,
+}
+
+impl SupportCommand {
+    pub async fn execute(&self) -> Result<()> {
+        match &self.action {
+            SupportAction::Bundle { path, latest, device, matrix, format } => {
+                let bundle = support_bundle(
+                    path.as_deref(),
+                    *latest,
+                    device,
+                    matrix.clone(),
+                    current_timestamp_utc(),
+                )?;
+                match format {
+                    SupportBundleFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&bundle)?);
+                    }
+                    SupportBundleFormat::Text => print_support_bundle_text(&bundle),
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn support_bundle(
+    receipt_path: Option<&Path>,
+    latest: bool,
+    device: &str,
+    matrix: Option<PathBuf>,
+    created_utc: String,
+) -> Result<SupportBundle> {
+    let model_status = model_cache::model_status_dashboard_for_device(device, matrix)?;
+    let receipt_path = receipts::resolve_receipt_path(receipt_path, latest)?;
+    let receipt = receipts::read_receipt_json(&receipt_path)?;
+    let latest_receipt = receipts::explain_receipt(&receipt_path, &receipt);
+    let summary = support_summary(&latest_receipt, &model_status);
+    let runtime = runtime_info(&latest_receipt, &receipt);
+
+    Ok(SupportBundle {
+        schema_version: 1,
+        kind: "bitnet_support_bundle",
+        created_utc,
+        device: device.to_string(),
+        summary,
+        binary: binary_identity(),
+        runtime,
+        model_status,
+        latest_receipt,
+    })
+}
+
+fn support_summary(
+    receipt: &ReceiptExplanation,
+    model_status: &ModelStatusDashboard,
+) -> SupportBundleSummary {
+    let next_proof = receipt
+        .model_coverage_row
+        .as_deref()
+        .and_then(|row| model_status.next_proof_for_row(row))
+        .map(ToOwned::to_owned)
+        .or_else(|| receipt.model_coverage.claim_boundary.clone());
+
+    SupportBundleSummary {
+        model_coverage_row: receipt.model_coverage_row.clone(),
+        current_tier: receipt.current_tier.clone(),
+        selected_backend: receipt.selected_backend.clone(),
+        selected_route: receipt.selected_route.clone(),
+        fallback_used: receipt.fallback_used,
+        quality_gate: quality_gate_status(receipt).to_string(),
+        server_ready: receipt.server_ready,
+        server_ready_scope: receipt.server_ready_scope.clone(),
+        speedup_claim: receipt.speedup_claim,
+        full_residency_claim: receipt.full_residency_claim,
+        bitnet_packed_i2s_qk256_proof: receipt.bitnet_packed_i2s_qk256_proof,
+        dense_regular_llm_cuda_proof: receipt.dense_regular_llm_cuda_proof,
+        next_proof,
+        receipt_path: receipt.path.clone(),
+    }
+}
+
+fn quality_gate_status(receipt: &ReceiptExplanation) -> &'static str {
+    let gates = [
+        receipt.quality.answer_quality_passed,
+        receipt.quality.benchmark_quality_passed,
+        receipt.quality.parity_passed,
+    ];
+    if gates.iter().any(|gate| *gate == Some(false)) {
+        "blocked"
+    } else if gates.iter().any(|gate| *gate == Some(true)) {
+        "passed"
+    } else {
+        "not_available"
+    }
+}
+
+fn runtime_info(explanation: &ReceiptExplanation, receipt: &Value) -> SupportRuntimeInfo {
+    let info = SupportRuntimeInfo {
+        selected_backend: explanation.selected_backend.clone(),
+        runtime_api: explanation.backend.runtime_api.clone(),
+        device_name: string_at_any(
+            receipt,
+            &[
+                &["backend", "device_name"],
+                &["backend_runtime", "device_name"],
+                &["hardware", "device_name"],
+                &["device", "name"],
+            ],
+        ),
+        driver_version: string_at_any(
+            receipt,
+            &[
+                &["backend", "driver_version"],
+                &["backend_runtime", "driver_version"],
+                &["hardware", "driver_version"],
+                &["driver_version"],
+            ],
+        ),
+        cuda_runtime_version: string_at_any(
+            receipt,
+            &[
+                &["backend", "cuda_runtime_version"],
+                &["backend_runtime", "cuda_runtime_version"],
+                &["hardware", "cuda_runtime_version"],
+                &["cuda_runtime_version"],
+            ],
+        ),
+        cuda_driver_version: string_at_any(
+            receipt,
+            &[
+                &["backend", "cuda_driver_version"],
+                &["backend_runtime", "cuda_driver_version"],
+                &["hardware", "cuda_driver_version"],
+                &["cuda_driver_version"],
+            ],
+        ),
+        source: None,
+    };
+
+    if info.selected_backend.is_some()
+        || info.runtime_api.is_some()
+        || info.device_name.is_some()
+        || info.driver_version.is_some()
+        || info.cuda_runtime_version.is_some()
+        || info.cuda_driver_version.is_some()
+    {
+        SupportRuntimeInfo { source: Some("latest_receipt"), ..info }
+    } else {
+        info
+    }
+}
+
+fn binary_identity() -> SupportBinaryIdentity {
+    let git_commit = option_env!("GITHUB_SHA")
+        .filter(|sha| !sha.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            option_env!("VERGEN_GIT_SHA")
+                .filter(|sha| !sha.trim().is_empty())
+                .map(ToOwned::to_owned)
+        });
+    let git_commit_source = if option_env!("GITHUB_SHA").is_some_and(|sha| !sha.trim().is_empty()) {
+        Some("GITHUB_SHA")
+    } else if option_env!("VERGEN_GIT_SHA").is_some_and(|sha| !sha.trim().is_empty()) {
+        Some("VERGEN_GIT_SHA")
+    } else {
+        None
+    };
+
+    SupportBinaryIdentity {
+        name: env!("CARGO_PKG_NAME"),
+        crate_version: env!("CARGO_PKG_VERSION"),
+        git_commit,
+        git_commit_source,
+        build_timestamp: option_env!("BITNET_BUILD_TS").or(option_env!("VERGEN_BUILD_TIMESTAMP")),
+        rustc_version: option_env!("VERGEN_RUSTC_SEMVER"),
+        target_triple: option_env!("VERGEN_CARGO_TARGET_TRIPLE"),
+    }
+}
+
+fn current_timestamp_utc() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn print_support_bundle_text(bundle: &SupportBundle) {
+    println!("BitNet support bundle");
+    println!("  device: {}", bundle.device);
+    println!("  receipt: {}", bundle.summary.receipt_path);
+    if let Some(row) = &bundle.summary.model_coverage_row {
+        println!("  model_coverage_row: {row}");
+    }
+    if let Some(route) = &bundle.summary.selected_route {
+        println!("  selected_route: {route}");
+    }
+    if let Some(backend) = &bundle.summary.selected_backend {
+        println!("  selected_backend: {backend}");
+    }
+    if let Some(fallback) = bundle.summary.fallback_used {
+        println!("  fallback_used: {fallback}");
+    }
+    println!("  quality_gate: {}", bundle.summary.quality_gate);
+    println!("  binary: {} {}", bundle.binary.name, bundle.binary.crate_version);
+}
+
+fn string_at_any(value: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths.iter().find_map(|path| string_at(value, path))
+}
+
+fn string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for segment in path {
+        current = current.get(*segment)?;
+    }
+    current.as_str().map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Context;
+    use clap::Parser;
+    use serde_json::json;
+    use std::fs;
+
+    #[derive(Parser, Debug)]
+    struct SupportActionParser {
+        #[command(subcommand)]
+        action: SupportAction,
+    }
+
+    fn model_matrix_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("ci")
+            .join("model-artifacts")
+            .join("model-coverage-matrix.toml")
+    }
+
+    #[test]
+    fn support_bundle_accepts_latest_device_and_format_json() -> Result<()> {
+        let parsed = SupportActionParser::try_parse_from([
+            "support",
+            "bundle",
+            "--latest",
+            "--device",
+            "nvidia-rtx-5070-ti-cuda",
+            "--format",
+            "json",
+        ])?;
+
+        let SupportAction::Bundle { latest, device, format, .. } = parsed.action;
+        assert!(latest);
+        assert_eq!(device, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(format, SupportBundleFormat::Json);
+        Ok(())
+    }
+
+    #[test]
+    fn support_bundle_combines_model_status_latest_receipt_and_summary() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let receipt_path = dir.path().join("qwen25-receipt.json");
+        let receipt = json!({
+            "artifact_kind": "dense_gguf_qwen_warm_session_strict_cuda_proof",
+            "claim": "dense_gguf_qwen_warm_session_strict_cuda_proof_recorded",
+            "model": {
+                "id": "qwen2.5-0.5b-instruct-q8_0"
+            },
+            "backend": {
+                "selected_backend": "nvidia-rtx-5070-ti-cuda",
+                "runtime_api": "cuda",
+                "fallback_used": false,
+                "device_name": "NVIDIA GeForce RTX 5070 Ti",
+                "driver_version": "test-driver",
+                "cuda_runtime_version": "test-cuda-runtime"
+            },
+            "execution_plan": {
+                "selected_route": "dense_regular_llm_cuda",
+                "model_family": "qwen",
+                "requested_backend": "nvidia-rtx-5070-ti-cuda",
+                "speedup_claim": false
+            },
+            "quality_gate": {
+                "passed": true
+            },
+            "claim_boundary": {
+                "bitnet_packed_i2s_qk256_proof": false,
+                "dense_regular_llm_cuda_claimed": true,
+                "speedup_claim": false,
+                "full_cuda_residency_claimed": false
+            }
+        });
+        fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt)?)?;
+
+        let bundle = support_bundle(
+            Some(dir.path()),
+            true,
+            "nvidia-rtx-5070-ti-cuda",
+            Some(model_matrix_path()),
+            "2026-05-18T00:00:00Z".to_string(),
+        )?;
+        let value = serde_json::to_value(&bundle)?;
+
+        assert_eq!(value["kind"], "bitnet_support_bundle");
+        assert_eq!(value["device"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(value["summary"]["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
+        assert_eq!(value["summary"]["current_tier"], "product_cli_ready");
+        assert_eq!(value["summary"]["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(value["summary"]["selected_route"], "dense_regular_llm_cuda");
+        assert_eq!(value["summary"]["fallback_used"], false);
+        assert_eq!(value["summary"]["quality_gate"], "passed");
+        assert_eq!(value["summary"]["server_ready"], true);
+        assert_eq!(value["summary"]["server_ready_scope"], "exact_profile");
+        assert_eq!(value["summary"]["speedup_claim"], false);
+        assert_eq!(value["summary"]["full_residency_claim"], false);
+        assert_eq!(value["summary"]["bitnet_packed_i2s_qk256_proof"], false);
+        assert_eq!(value["summary"]["dense_regular_llm_cuda_proof"], true);
+        assert!(
+            value["summary"]["next_proof"]
+                .as_str()
+                .context("support summary next_proof must be a string")?
+                .contains("exact-profile dense Qwen server readiness")
+        );
+        assert_eq!(value["runtime"]["runtime_api"], "cuda");
+        assert_eq!(value["runtime"]["driver_version"], "test-driver");
+        assert_eq!(value["runtime"]["cuda_runtime_version"], "test-cuda-runtime");
+        assert_eq!(value["runtime"]["source"], "latest_receipt");
+        assert_eq!(value["latest_receipt"]["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
+        assert_eq!(value["latest_receipt"]["server_ready_scope"], "exact_profile");
+
+        let models = value["model_status"]["models"]
+            .as_array()
+            .context("support bundle model_status.models must be an array")?;
+        assert!(models.iter().any(|model| {
+            model["model_coverage_row"] == "bitnet_official_2b_i2s_qk256"
+                && model["bitnet_packed_i2s_qk256_proof"] == true
+                && model["dense_regular_llm_cuda_proof"] == false
+        }));
+        assert!(models.iter().any(|model| {
+            model["model_coverage_row"] == "dense_qwen25_05b_q8_cuda"
+                && model["dense_regular_llm_cuda_proof"] == true
+                && model["bitnet_packed_i2s_qk256_proof"] == false
+        }));
+        Ok(())
+    }
+}

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -129,8 +129,8 @@ use commands::{
     DenseGgufSamplingPolicyCommand, DenseQwenCudaAskOptions,
     ExternalReferenceInstrumentationCommand, FirstTokenDivergenceCommand, InferenceCommand,
     InspectCommand, LunarLakeAction, LunarLakeCommand, OutputHeadLogitsAuditCommand,
-    ReceiptsCommand, ReferenceCompareCommand, ServeCommand, TransformerLayerParityCommand,
-    run_dense_qwen_cuda_ask,
+    ReceiptsCommand, ReferenceCompareCommand, ServeCommand, SupportCommand,
+    TransformerLayerParityCommand, run_dense_qwen_cuda_ask,
 };
 use config::{CliConfig, ConfigBuilder, DEVICE_HELP};
 #[cfg(feature = "full-cli")]
@@ -477,6 +477,10 @@ enum Commands {
 
     /// Fetch, verify, list, and prune supported local model artifacts
     Model(ModelCommand),
+
+    #[cfg(feature = "full-cli")]
+    /// Collect model status and receipt evidence for support
+    Support(SupportCommand),
 
     /// RTX 5070 Ti CUDA proof-lane utilities
     Cuda {
@@ -1509,6 +1513,8 @@ async fn async_main() -> Result<()> {
             .await
         }
         Some(Commands::Model(cmd)) => cmd.execute().await,
+        #[cfg(feature = "full-cli")]
+        Some(Commands::Support(cmd)) => cmd.execute().await,
         Some(Commands::Cuda { action }) => {
             handle_cuda_command(action, explicit_device_label.as_deref())
         }
@@ -10510,13 +10516,17 @@ fn default_log_level_for_command(command: Option<&Commands>) -> Option<&'static 
         #[cfg(feature = "full-cli")]
         Some(Commands::Receipts(_)) => Some("warn"),
         #[cfg(feature = "full-cli")]
+        Some(Commands::Support(_)) => Some("warn"),
+        #[cfg(feature = "full-cli")]
         Some(Commands::Mac(cmd)) => cmd.default_log_level(),
         _ => None,
     }
 }
 
 fn skips_startup_backend_selection(command: Option<&Commands>) -> bool {
-    uses_report_only_cuda_benchmark_receipt(command) || uses_read_only_model_status(command)
+    uses_report_only_cuda_benchmark_receipt(command)
+        || uses_read_only_model_status(command)
+        || uses_read_only_support_bundle(command)
 }
 
 fn uses_report_only_cuda_benchmark_receipt(command: Option<&Commands>) -> bool {
@@ -10534,6 +10544,18 @@ fn uses_read_only_model_status(command: Option<&Commands>) -> bool {
         command,
         Some(Commands::Model(ModelCommand { action: model_cache::ModelAction::Status { .. } }))
     )
+}
+
+fn uses_read_only_support_bundle(command: Option<&Commands>) -> bool {
+    #[cfg(feature = "full-cli")]
+    {
+        matches!(command, Some(Commands::Support(_)))
+    }
+    #[cfg(not(feature = "full-cli"))]
+    {
+        let _ = command;
+        false
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -12537,6 +12559,18 @@ mod tests {
             Some("warn")
         );
         assert_eq!(
+            default_log_level_for_command(Some(&Commands::Support(SupportCommand {
+                action: commands::support::SupportAction::Bundle {
+                    path: None,
+                    latest: true,
+                    device: "nvidia-rtx-5070-ti-cuda".to_string(),
+                    matrix: None,
+                    format: commands::support::SupportBundleFormat::Json,
+                },
+            }))),
+            Some("warn")
+        );
+        assert_eq!(
             default_log_level_for_command(Some(&Commands::Chat(Box::default()))),
             Some("warn")
         );
@@ -12553,6 +12587,24 @@ mod tests {
         });
 
         assert!(uses_read_only_model_status(Some(&command)));
+        assert!(skips_startup_backend_selection(Some(&command)));
+        assert_eq!(default_log_level_for_command(Some(&command)), Some("warn"));
+    }
+
+    #[test]
+    #[cfg(feature = "full-cli")]
+    fn support_bundle_skips_startup_backend_selection() {
+        let command = Commands::Support(SupportCommand {
+            action: commands::support::SupportAction::Bundle {
+                path: None,
+                latest: true,
+                device: "nvidia-rtx-5070-ti-cuda".to_string(),
+                matrix: None,
+                format: commands::support::SupportBundleFormat::Json,
+            },
+        });
+
+        assert!(uses_read_only_support_bundle(Some(&command)));
         assert!(skips_startup_backend_selection(Some(&command)));
         assert_eq!(default_log_level_for_command(Some(&command)), Some("warn"));
     }

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -610,7 +610,7 @@ struct ModelCoverageEntryOutput<'a> {
 }
 
 #[derive(Debug, Serialize)]
-struct ModelStatusDashboard {
+pub(crate) struct ModelStatusDashboard {
     schema_version: u32,
     device: String,
     source: PathBuf,
@@ -618,8 +618,17 @@ struct ModelStatusDashboard {
     models: Vec<ModelStatusRow>,
 }
 
+impl ModelStatusDashboard {
+    pub(crate) fn next_proof_for_row(&self, row: &str) -> Option<&str> {
+        self.models
+            .iter()
+            .find(|model| model.model_coverage_row == row)
+            .map(|model| model.next_proof.as_str())
+    }
+}
+
 #[derive(Debug, Serialize)]
-struct ModelStatusRow {
+pub(crate) struct ModelStatusRow {
     id: String,
     model_coverage_row: String,
     display_name: String,
@@ -1443,6 +1452,15 @@ fn print_model_status(
     }
 
     Ok(())
+}
+
+pub(crate) fn model_status_dashboard_for_device(
+    device: &str,
+    matrix: Option<PathBuf>,
+) -> Result<ModelStatusDashboard> {
+    let matrix_path = resolve_model_coverage_matrix_path(matrix)?;
+    let matrix = read_model_coverage_matrix(&matrix_path)?;
+    Ok(model_status_dashboard(device, &matrix_path, &matrix))
 }
 
 fn model_status_dashboard(

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -619,6 +619,7 @@ pub(crate) struct ModelStatusDashboard {
 }
 
 impl ModelStatusDashboard {
+    #[cfg(feature = "full-cli")]
     pub(crate) fn next_proof_for_row(&self, row: &str) -> Option<&str> {
         self.models
             .iter()
@@ -1454,6 +1455,7 @@ fn print_model_status(
     Ok(())
 }
 
+#[cfg(feature = "full-cli")]
 pub(crate) fn model_status_dashboard_for_device(
     device: &str,
     matrix: Option<PathBuf>,


### PR DESCRIPTION
## Summary
- add itnet support bundle --latest --device <device> --format json to compose model-status JSON with latest receipt-explain JSON
- include support summary fields for backend, route, fallback, quality, server scope, speed/residency claim booleans, proof-family booleans, next proof, binary identity, and receipt runtime info
- keep support bundle read-only: no inference, no hardware probing, no claim promotion

## Validation
- PASS cargo fmt -p bitnet-cli -- --check
- PASS cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli support_bundle
- PASS cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
- PASS cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
- PASS cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_and_receipts_default_to_warn_logging_for_user_facing_output
- PASS git diff --check
- GAP cargo run --locked -p xtask --no-default-features -- check-model-coverage failed before checker execution while compiling sentencepiece-sys locally