### PR TITLE
docs(apple): consolidate silicon proof rails

### DIFF
--- a/docs/apple-silicon/README.md
+++ b/docs/apple-silicon/README.md
@@ -1,0 +1,76 @@
+# Apple Silicon source-of-truth map
+
+Status: active
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](../specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md), [Apple M4 dense SLM appliance](../specs/BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md), [Apple M4 BitNet CPU/NEON](../specs/BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md), [Apple Metal phased acceleration](../specs/BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION.md), [Apple quality corpus](../specs/BITNET-SPEC-APPLE-QUALITY-CORPUS.md), [Apple benchmark envelope](../specs/BITNET-SPEC-APPLE-BENCHMARK-ENVELOPE.md), [Apple reproducible run identity](../specs/BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md), [Apple MacBook auxiliary lane](../specs/BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md), [Apple service surface](../specs/BITNET-SPEC-APPLE-SERVICE-SURFACE.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; this map only routes proof families to existing authorities and new contracts
+Policy impact: no policy exception
+
+Apple Silicon work is split into proof families so one successful Mac run cannot
+become an unsupported claim about every Apple backend, model family, or
+acceleration path. This page is a navigation contract, not a new runtime claim
+or a replacement for campaign receipts.
+
+## Current product target
+
+The first Apple Silicon product target is the M4 Mac Mini local appliance:
+
+- supported dense SLMs run first on `apple-m4-cpu-neon`;
+- the accepted BitNet artifact runs first on `apple-m4-cpu-neon`;
+- Metal remains a phase-scoped acceleration proof lane;
+- MPSGraph remains a graph/reference lane;
+- Neural Engine execution is not claimed unless a future receipt proves it.
+
+## Source-of-truth hierarchy
+
+| Layer | Source of truth | Notes |
+| --- | --- | --- |
+| Apple Silicon route semantics | [`BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md`](../specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md) | Backend labels, proof families, receipt fields, and fallback rules. |
+| M4 Mac Mini hardware facts | [`docs/specs/apple-m4-mac-mini-roadmap.md`](../specs/apple-m4-mac-mini-roadmap.md) | Existing M4 roadmap and hardware/backend lane framing. |
+| Supported dense SLM models | [`docs/slm/apple-m4-dense-slm-model-support-matrix.md`](../slm/apple-m4-dense-slm-model-support-matrix.md) | Artifact-pinned model states and promotion gates. |
+| Current M4 excellence state | [`docs/tracking/campaigns/apple-m4-inference-excellence/active.toml`](../tracking/campaigns/apple-m4-inference-excellence/active.toml) | Active campaign work items and proof commands. |
+| Operator-facing narrative | [`docs/slm/apple-m4-inference-excellence.md`](../slm/apple-m4-inference-excellence.md) | Human-readable current M4 evidence narrative. |
+| Historical proof campaigns | Existing `docs/tracking/campaigns/apple-m4-*` folders | Keep as historical evidence; do not delete or rewrite as current truth. |
+| MacBook auxiliary lane | Apple Silicon MacBook campaign/docs and [`BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md`](../specs/BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md) | Separate machine and proof family; never substitutes for M4 Mac Mini proof. |
+| Machine artifacts | `ci/hardware/apple-m4-mac-mini/**` and future MacBook paths | Receipt inputs/outputs, not broad claims by themselves. |
+| General Apple Metal/MPS/NEON policy | New Apple Silicon specs linked above | Contractual rails for future work. |
+
+## Proof families
+
+| Proof family | Route label | Counts as | Does not count as |
+| --- | --- | --- | --- |
+| `apple_m4_cpu_neon_dense_slm` | `apple-m4-cpu-neon` | Supported dense Qwen-class M4 CPU/NEON evidence. | BitNet, Metal, MPSGraph, Neural Engine, MacBook, or broad Apple Silicon proof. |
+| `apple_m4_cpu_neon_bitnet` | `apple-m4-cpu-neon` | Accepted BitNet artifact on M4 CPU/NEON with strict receipts. | Dense SLM, Metal, QK256 acceleration, Neural Engine, MPSGraph, or broad Apple Silicon proof. |
+| `apple_m4_metal_phase` | `apple-m4-metal` | Named Metal kernel/subgraph phase with CPU parity and fallback-free receipts. | Full autoregressive Metal inference until a full route is proven. |
+| `apple_m4_mpsgraph_reference` | `apple-m4-mpsgraph` | Reference/graph-lane experiments with explicit target receipts. | Native Metal or Neural Engine proof. |
+| `apple_m4_neural_engine_research` | future explicit route | Research only until receipt-proven. | Any current product claim. |
+| `apple_macbook_cpu_neon_bitnet` | MacBook CPU/NEON route | MacBook-specific larger-artifact or longer-soak evidence. | M4 Mac Mini runtime proof. |
+| `apple_macbook_metal_phase` | MacBook Metal route | MacBook-specific Metal phase evidence. | M4 Mac Mini Metal proof or broad Apple Silicon proof. |
+
+## Hard claim rails
+
+- Dense Qwen SLM evidence is not BitNet evidence.
+- BitNet CPU/NEON evidence is not Metal evidence.
+- Metal visibility is not Metal execution.
+- Metal subgraph parity is not full Metal inference.
+- MPSGraph smoke is not native Metal proof.
+- MPSGraph smoke is not Neural Engine proof unless the resolved target is receipt-backed.
+- CPU fallback cannot count as Metal execution.
+- MacBook evidence is not M4 Mac Mini runtime proof.
+- M4 Mac Mini evidence is not broad Apple Silicon proof.
+- QK256-on-x86/CUDA/A770 evidence is not QK256-on-Metal evidence.
+- Supported dense SLMs must be artifact-pinned and tokenizer-authoritative.
+- No model binaries are committed.
+- Live hardware/model timing is never required in ordinary generic PR CI.
+
+## Historical campaign rule
+
+Do not delete old Apple campaign docs and do not create a competing "current
+truth" page. New specs are contractual rails; current execution remains owned
+by the active campaign manifest and proof receipts.

--- a/docs/proposals/BITNET-PROP-0005-apple-silicon-productization.md
+++ b/docs/proposals/BITNET-PROP-0005-apple-silicon-productization.md
@@ -1,0 +1,72 @@
+# BITNET-PROP-0005: Apple Silicon productization
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: [Apple Silicon route contract](../specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md), [Apple M4 dense SLM appliance](../specs/BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md), [Apple M4 BitNet CPU/NEON](../specs/BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md), [Apple Metal phased acceleration](../specs/BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion by this proposal
+Policy impact: no policy exception
+
+## Thesis
+
+Apple Silicon gives BitNet-rs a Mac-native local inference appliance path:
+supported dense SLMs and accepted BitNet artifacts can run on widely available
+unified-memory Macs with strict receipts, useful local-answer behavior,
+operator health checks, and phase-scoped Metal acceleration work.
+
+## Motivation
+
+The M4 Mac Mini lane already has strong local inference foundations, but Apple
+Silicon claims are easy to over-broaden. A dense Qwen-class CPU/NEON result does
+not prove BitNet; a BitNet CPU/NEON result does not prove Metal; a MacBook run
+does not prove M4 Mac Mini behavior; and a Metal smoke test does not prove full
+autoregressive Metal inference. This proposal creates a product lane that is
+useful now while preserving those boundaries.
+
+## Product order
+
+1. **Dense SLM appliance path first.** Supported, artifact-pinned Qwen-class
+   dense SLMs are the first Mac-native user path. They must keep tokenizer,
+   prompt-template, backend, fallback, quality, and timing receipts.
+2. **BitNet CPU/NEON path second.** The accepted BitNet artifact should run on
+   Apple CPU/NEON before any acceleration claim expands.
+3. **Metal acceleration is phase-scoped.** Metal work remains explicit kernels
+   or subgraphs with CPU parity and receipt boundaries until a full route proof
+   exists.
+4. **MPSGraph is a reference/graph lane.** MPSGraph can inform graph experiments
+   but does not count as native Metal proof.
+5. **Neural Engine is not claimed.** No ANE or Neural Engine claim exists until
+   a future route records the selected target and proves it with receipts.
+6. **MacBook is auxiliary.** A MacBook can help with larger artifacts, external
+   reference comparisons, and longer soaks, but MacBook proof never counts as
+   M4 Mac Mini proof.
+
+## Non-goals
+
+- Full Metal BitNet inference.
+- QK256-on-Metal proof.
+- Neural Engine execution.
+- Broad Apple Silicon support or performance from one M4 Mac Mini profile.
+- Runtime, kernel, server, or model-binary changes in proposal/spec PRs.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| A successful dense SLM run is treated as BitNet evidence. | Route contract requires `model_family` and `proof_family` receipts. |
+| CPU fallback is counted as Metal execution. | Metal specs require `runtime_api = "metal"` and `fallback_used = false`. |
+| MacBook storage solves are mistaken for M4 runtime proof. | MacBook receipts must record `counts_as_m4_mac_mini_proof = false`. |
+| Hardware-only timing becomes generic CI. | Plans keep live hardware/model timing out of ordinary PR CI. |
+
+## Acceptance
+
+This proposal is accepted when linked specs define backend labels, proof
+families, dense SLM gates, BitNet CPU/NEON gates, phase-scoped Metal promotion,
+quality corpus separation, benchmark envelopes, reproducible identity, MacBook
+auxiliary boundaries, and Mac service-surface readiness without promoting new
+runtime claims.

--- a/docs/specs/BITNET-SPEC-APPLE-BENCHMARK-ENVELOPE.md
+++ b/docs/specs/BITNET-SPEC-APPLE-BENCHMARK-ENVELOPE.md
@@ -1,0 +1,70 @@
+# BITNET-SPEC-APPLE-BENCHMARK-ENVELOPE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple reproducible run identity](BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; benchmark contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define Apple benchmark envelopes that are useful to operators without
+claiming broad Apple Silicon performance from one machine, backend, or profile.
+
+## Required metrics
+
+Benchmark receipts and summaries must record, where supported by the profile:
+
+- cold load;
+- tokenizer load;
+- prompt render;
+- prompt tokenization;
+- prefill/input tok/s;
+- TTFT;
+- first streamed chunk;
+- decode/output tok/s;
+- sampling overhead;
+- total wall time;
+- peak memory;
+- memory drift;
+- disk/cache context;
+- thermal pressure where available;
+- power state where available;
+- p50/p90/p99/min/max;
+- repeat count;
+- outlier policy;
+- matching identity context.
+
+## Required profiles
+
+Apple benchmark profiles include:
+
+- `short_prompt_16_out`;
+- `short_prompt_64_out`;
+- `long_prompt_16_out`;
+- `long_prompt_128_out`;
+- `context_1k`;
+- `context_4k`;
+- `resident_25`;
+- `resident_50`;
+- `resident_100`;
+- `mixed_model_switch`;
+- `bitnet_one_shot`;
+- `bitnet_warm`.
+
+## Envelope rules
+
+- Every benchmark comparison must include reproducible run identity.
+- Dense SLM and BitNet benchmark envelopes remain separate.
+- Profiles with different model, tokenizer, prompt, backend, fallback, machine,
+  OS, binary/build, corpus/profile, or seed identity are not matching-history
+  comparisons.
+- No broad Apple Silicon benchmark claim may be made from one M4 Mac Mini
+  profile.
+- Live hardware/model timing is not required in ordinary generic PR CI.

--- a/docs/specs/BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md
+++ b/docs/specs/BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md
@@ -1,0 +1,59 @@
+# BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; defines proof ladder for accepted BitNet artifact
+Policy impact: no policy exception
+
+## Purpose
+
+Define the accepted BitNet artifact path on Apple M4 CPU/NEON. This is the
+first BitNet productization target for M4 and is deliberately separate from
+dense SLM, Metal, MPSGraph, Neural Engine, QK256, and broad Apple Silicon
+claims.
+
+## Required proof ladder
+
+The `apple_m4_cpu_neon_bitnet` proof family advances only through this ladder:
+
+1. model verify;
+2. tokenizer authority;
+3. strict one-shot ask;
+4. 100-case BitNet corpus;
+5. reference-vs-Rust comparison;
+6. one-shot benchmark;
+7. variable warm-session;
+8. 25/50/100 prompt warm soaks;
+9. progress/timeout/failure receipts;
+10. chat gate;
+11. serve gate;
+12. task-family taxonomy;
+13. 250-case corpus;
+14. 500-case decision.
+
+Each rung must preserve model identity, tokenizer identity, prompt/template
+identity, requested backend, selected backend, runtime API, fallback status,
+proof family, generated token/text receipts where applicable, and timing or
+failure taxonomy appropriate to the rung.
+
+## Not-claims
+
+BitNet CPU/NEON receipts are:
+
+- not Metal;
+- not QK256 acceleration;
+- not Neural Engine;
+- not MPSGraph;
+- not broad Apple Silicon;
+- not dense SLM.
+
+Scalar fallback cannot count as Apple CPU/NEON proof if fallback is selected.
+Fallback behavior may be tested, but such tests must be labeled as fallback
+behavior, not as product route proof.

--- a/docs/specs/BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md
+++ b/docs/specs/BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md
@@ -1,0 +1,65 @@
+# BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; codifies existing supported dense SLM states
+Policy impact: no policy exception
+
+## Purpose
+
+Define the Apple M4 dense SLM appliance path. This spec inherits the current
+M4 dense SLM support matrix and makes its promotion gates contractual for the
+`apple_m4_cpu_neon_dense_slm` proof family.
+
+## Supported states
+
+| State | Meaning |
+| --- | --- |
+| `default` | The default dense M4 SLM for normal Mac appliance paths. |
+| `supported` | Explicitly supported non-default model with all required gates. |
+| `candidate` | Exact artifact may be evaluated but is not supported. |
+| `diagnostic-only` | Useful for loader/tokenizer/debug work but not product support. |
+| `rejected` | Outside the lane until a separate architecture/artifact campaign reopens it. |
+
+## Current model states
+
+| Model ID | State | Notes |
+| --- | --- | --- |
+| `qwen2.5-0.5b-instruct-q8_0` | `default` | Remains default unless a promotion review changes it. |
+| `qwen2.5-0.5b-instruct-q4_k_m` | `supported` | Storage-conscious supported non-default row. |
+| `qwen2.5-1.5b-instruct-q4_k_m` | `supported` | Larger supported non-default row. |
+| Qwen3, SmolLM, Gemma, Phi candidates | `candidate` or `diagnostic-only` | Must pass exact gates before support. |
+| Qwen3.5, hybrid, vision, MoE, state-space, random unpinned GGUFs | `rejected` unless reopened by a separate campaign | Not automatically supported. |
+
+## Required model gates
+
+A dense SLM may be `default` or `supported` only when receipts record:
+
+- source repository and revision;
+- file name, byte size, and SHA256;
+- GGUF architecture;
+- quantization;
+- tokenizer model and pre-tokenizer authority;
+- prompt-template authority;
+- strict cache verification;
+- reference-runner sanity;
+- Rust M4 quality;
+- generated text, prompt token IDs, and generated token IDs;
+- timing;
+- `fallback_used = false`;
+- unsupported-backend failure behavior;
+- 500-case deterministic corpus where promoted;
+- matching-history receipts for operator envelope.
+
+## Claim boundary
+
+Dense SLM evidence is dense SLM evidence only. It does not prove BitNet,
+QK256, full Apple Metal inference, Neural Engine execution, MPSGraph model
+inference, MacBook behavior, CUDA, x86, or broad Apple Silicon performance.

--- a/docs/specs/BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md
+++ b/docs/specs/BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md
@@ -1,0 +1,49 @@
+# BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md), [Apple reproducible run identity](BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; MacBook lane is auxiliary
+Policy impact: no policy exception
+
+## Purpose
+
+Use MacBook hardware for larger-artifact and longer-soak Apple work without
+corrupting M4 Mac Mini proof.
+
+## MacBook lane can do
+
+- larger BitNet artifact storage;
+- larger dense/SLM artifact storage;
+- external reference comparisons;
+- longer soaks;
+- BitNet model exploration;
+- Metal/CPU parity experiments.
+
+## MacBook lane cannot do
+
+- prove M4 Mac Mini runtime behavior;
+- replace M4 evidence;
+- promote broad Apple Silicon support;
+- silently change M4 defaults.
+
+## Receipt distinction
+
+MacBook receipts must distinguish themselves from M4 Mac Mini receipts:
+
+```json
+{
+  "machine_id": "apple-silicon-macbook",
+  "proof_family": "apple_macbook_cpu_neon_bitnet",
+  "counts_as_m4_mac_mini_proof": false
+}
+```
+
+MacBook evidence may inform future work, but promotion of M4 Mac Mini support
+requires M4 Mac Mini receipts under the relevant M4 proof family.

--- a/docs/specs/BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION.md
+++ b/docs/specs/BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION.md
@@ -1,0 +1,64 @@
+# BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; phase-scoped Metal proof only
+Policy impact: no policy exception
+
+## Purpose
+
+Keep Apple Metal work honest and useful by proving explicit kernels/subgraphs
+with CPU reference parity and receipts before any generation contribution or
+full route claim.
+
+## Phases
+
+1. `metal_visibility`;
+2. `tiny_compute_smoke`;
+3. `tiny_add_cpu_parity`;
+4. `i2s_packed_parity`;
+5. `i2s_prefill_projection_fixture`;
+6. `i2s_projection_residual_subgraph`;
+7. `dense_prefill_linear_fixture`;
+8. `dense_prefill_qkv_fixture`;
+9. `real_generation_contribution_candidate`;
+10. `full_route_candidate`.
+
+## Required phase receipt fields
+
+```json
+{
+  "requested_backend": "apple-m4-metal",
+  "selected_backend": "apple-m4-metal",
+  "runtime_api": "metal",
+  "fallback_used": false,
+  "kernel_id": "tiny_metal_i2s_prefill_contribution",
+  "phase_scope": "prefill_projection_fixture",
+  "full_autoregressive_decode": false,
+  "cpu_reference_tokens_match": true,
+  "decoded_text_match": true,
+  "full_metal_inference_claimed": false,
+  "speedup_claim": false
+}
+```
+
+## Promotion rule
+
+A Metal phase may enter real generation only if CPU-only greedy output before
+and after the phase matches generated token IDs and decoded text. Until a full
+route candidate proves end-to-end autoregressive decode on Metal with fallback
+false, Metal receipts must set `full_metal_inference_claimed = false`.
+
+## Not-claims
+
+Metal visibility is not Metal execution. CPU fallback is not Metal execution.
+MPSGraph smoke is not native Metal proof. Metal subgraph parity is not full
+Metal inference. Phase-local timing is not a broad speedup claim unless a later
+spec explicitly allows and proves that claim.

--- a/docs/specs/BITNET-SPEC-APPLE-QUALITY-CORPUS.md
+++ b/docs/specs/BITNET-SPEC-APPLE-QUALITY-CORPUS.md
@@ -1,0 +1,62 @@
+# BITNET-SPEC-APPLE-QUALITY-CORPUS
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple M4 dense SLM appliance](BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md), [Apple M4 BitNet CPU/NEON](BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; corpus contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Unify Apple quality-corpus rules while keeping dense SLM and BitNet evidence
+separate. Corpus receipts report mechanical quality envelopes for exact model,
+tokenizer, prompt, backend, fallback, machine, and corpus identities; they do
+not make broad quality claims.
+
+## Dense SLM corpus
+
+Dense SLM evidence uses:
+
+- 500 deterministic cases where promoted;
+- mechanical scoring only;
+- task-family pass rates;
+- failure taxonomy;
+- matching-history refresh;
+- no broad quality claim.
+
+Dense Qwen evidence remains in the dense SLM proof family and cannot be reused
+as BitNet proof.
+
+## BitNet corpus
+
+BitNet evidence uses:
+
+- 100 to 250 to optional 500-case decision progression;
+- BitNet-specific tasks;
+- reference-vs-Rust deltas;
+- task-family taxonomy;
+- evidence separated from dense Qwen evidence.
+
+## Mechanical scoring modes
+
+Apple quality corpora may use these mechanical checks:
+
+- exact match;
+- normalized match;
+- numeric tolerance;
+- JSON/schema validation;
+- required keywords;
+- forbidden tokens;
+- closed-label classification;
+- stop/special-token checks;
+- timeout/error/fallback taxonomy.
+
+LLM judging is not required for these corpora. If future qualitative review is
+added, it must be labeled advisory and cannot replace the mechanical corpus
+contract.

--- a/docs/specs/BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md
+++ b/docs/specs/BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md
@@ -1,0 +1,50 @@
+# BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; run identity contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Make Apple Silicon comparisons reproducible by requiring every receipt family to
+record machine, software, model, tokenizer, prompt, backend, fallback, corpus,
+profile, seed, and timing identity.
+
+## Required fields
+
+Apple receipts must record:
+
+- `machine_id`;
+- SoC;
+- OS name/version;
+- git commit;
+- binary hash or build profile;
+- command class;
+- model ID and SHA;
+- tokenizer authority and SHA;
+- prompt template ID and hash;
+- requested backend;
+- selected backend;
+- runtime API;
+- fallback used;
+- corpus/profile/seed identity;
+- timing source.
+
+## Comparison rules
+
+A matching-history comparison is valid only when identities match for the
+fields relevant to the receipt family. If any identity changes, the result may
+be a new baseline, compatibility refresh, or diagnostic run, but it is not a
+same-identity trend point.
+
+Receipts must expose enough identity to distinguish M4 Mac Mini from MacBook,
+dense SLM from BitNet, CPU/NEON from Metal, Metal from MPSGraph, and fallback
+behavior from requested-backend execution.

--- a/docs/specs/BITNET-SPEC-APPLE-SERVICE-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-APPLE-SERVICE-SURFACE.md
@@ -1,0 +1,56 @@
+# BITNET-SPEC-APPLE-SERVICE-SURFACE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md), [Apple reproducible run identity](BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md)
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no service promotion; readiness contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define Mac ask/chat/serve readiness for exact Apple profiles without implying
+production hosting, broad Apple Silicon support, unsupported BitNet service
+status, or unproven acceleration.
+
+## Surfaces
+
+Apple service-surface work covers:
+
+- `bitnet mac doctor`;
+- `bitnet mac evidence`;
+- `bitnet mac ask`;
+- `bitnet mac chat`;
+- `bitnet mac serve`;
+- `bitnet mac receipts-check`;
+- `bitnet mac regression`;
+- `bitnet mac report-refresh`;
+- `bitnet mac benchmark`.
+
+## Serve readiness
+
+Serve readiness for an exact profile requires:
+
+- health endpoint;
+- ready endpoint;
+- streaming semantics;
+- timeout behavior;
+- cancellation behavior;
+- per-request receipt;
+- `fallback_used = false` for backend proof routes;
+- model/tokenizer/backend identity;
+- exact-profile scope.
+
+## Status rules
+
+- A surface may be enabled for dense SLM without being enabled for BitNet.
+- BitNet chat or serve cannot be claimed until the relevant campaign gate has
+  matching receipts.
+- Service readiness is exact-profile readiness, not broad production hosting.
+- Operator output must expose model, tokenizer, requested backend, selected
+  backend, runtime API, fallback, machine, and proof-family status.

--- a/docs/specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md
@@ -1,0 +1,72 @@
+# BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: [Apple Silicon implementation plan](../../plans/apple-silicon/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; route labels and receipt rules only
+Policy impact: no policy exception
+
+## Purpose
+
+Define Apple Silicon backend labels, proof-family IDs, and receipt fields so
+CPU/NEON, Metal, MPSGraph, Neural Engine, MacBook, dense SLM, and BitNet
+evidence cannot be conflated.
+
+## Route IDs
+
+| Proof family | Requested/selected backend label | Runtime API | Machine scope | Model family |
+| --- | --- | --- | --- | --- |
+| `apple_m4_cpu_neon_dense_slm` | `apple-m4-cpu-neon` | `cpu` | `apple-m4-mac-mini` | `dense_slm` |
+| `apple_m4_cpu_neon_bitnet` | `apple-m4-cpu-neon` | `cpu` | `apple-m4-mac-mini` | `bitnet` |
+| `apple_m4_metal_phase` | `apple-m4-metal` | `metal` | `apple-m4-mac-mini` | phase-specific |
+| `apple_m4_mpsgraph_reference` | `apple-m4-mpsgraph` | `mpsgraph` | `apple-m4-mac-mini` | reference/graph |
+| `apple_m4_neural_engine_research` | future explicit label | `neural_engine` only if receipt-proven | `apple-m4-mac-mini` | research |
+| `apple_macbook_cpu_neon_bitnet` | MacBook CPU/NEON route | `cpu` | `apple-silicon-macbook` | `bitnet` |
+| `apple_macbook_metal_phase` | MacBook Metal route | `metal` | `apple-silicon-macbook` | phase-specific |
+
+## Required receipt fields
+
+Apple route receipts must include enough information to reject aliasing and
+fallback confusion. Minimal fields are:
+
+```json
+{
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "machine_id": "apple-m4-mac-mini",
+  "fallback_used": false,
+  "model_family": "dense_slm|bitnet",
+  "proof_family": "apple_m4_cpu_neon_dense_slm",
+  "metal_proof": false,
+  "mpsgraph_proof": false,
+  "neural_engine_proof": false,
+  "broad_apple_silicon_claim": false
+}
+```
+
+## Hard rules
+
+- `apple-m4-metal` cannot alias to CPU/NEON, MPSGraph, or Neural Engine.
+- `apple-m4-mpsgraph` cannot count as native Metal proof.
+- `apple-m4-cpu-neon` cannot count as acceleration.
+- MacBook receipts must use a different `machine_id` and `proof_family` from M4
+  Mac Mini receipts.
+- `fallback_used = true` invalidates backend-specific proof for the requested
+  backend unless the proof is explicitly a fallback-behavior test.
+- A receipt with `runtime_api = "cpu"` cannot set `metal_proof = true`.
+- A receipt with `runtime_api = "mpsgraph"` cannot set `neural_engine_proof = true`
+  unless the resolved target is independently receipt-backed.
+- No single M4 Mac Mini receipt may set `broad_apple_silicon_claim = true`.
+
+## Failure behavior
+
+Unsupported or unavailable backends must fail with a clear selected-backend and
+fallback receipt. Silent fallback is not proof. Operator-facing output must make
+requested backend, selected backend, runtime API, and fallback status visible.

--- a/plans/apple-silicon/README.md
+++ b/plans/apple-silicon/README.md
@@ -1,0 +1,18 @@
+# Apple Silicon plans
+
+Status: active
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../../docs/proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon source-of-truth map](../../docs/apple-silicon/README.md)
+Linked ADRs: n/a
+Linked plan: [implementation-plan.md](implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion
+Policy impact: no policy exception
+
+This directory sequences Apple Silicon documentation and rail-setting work. It
+keeps source-of-truth cleanup separate from runtime/product changes so future M4
+Mac Mini, MacBook, dense SLM, BitNet CPU/NEON, and Metal phase work can proceed
+without proof-family conflation.

--- a/plans/apple-silicon/implementation-plan.md
+++ b/plans/apple-silicon/implementation-plan.md
@@ -1,0 +1,72 @@
+# Apple Silicon docs and rails implementation plan
+
+Status: active
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0005 Apple Silicon productization](../../docs/proposals/BITNET-PROP-0005-apple-silicon-productization.md)
+Linked specs: [Apple Silicon route contract](../../docs/specs/BITNET-SPEC-APPLE-SILICON-ROUTE-CONTRACT.md), [Apple M4 dense SLM appliance](../../docs/specs/BITNET-SPEC-APPLE-M4-DENSE-SLM-APPLIANCE.md), [Apple M4 BitNet CPU/NEON](../../docs/specs/BITNET-SPEC-APPLE-M4-BITNET-CPU-NEON.md), [Apple Metal phased acceleration](../../docs/specs/BITNET-SPEC-APPLE-METAL-PHASED-ACCELERATION.md), [Apple quality corpus](../../docs/specs/BITNET-SPEC-APPLE-QUALITY-CORPUS.md), [Apple benchmark envelope](../../docs/specs/BITNET-SPEC-APPLE-BENCHMARK-ENVELOPE.md), [Apple reproducible run identity](../../docs/specs/BITNET-SPEC-APPLE-REPRODUCIBLE-RUN-IDENTITY.md), [Apple MacBook auxiliary lane](../../docs/specs/BITNET-SPEC-APPLE-MACBOOK-AUXILIARY-LANE.md), [Apple service surface](../../docs/specs/BITNET-SPEC-APPLE-SERVICE-SURFACE.md)
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; docs/spec contracts only
+Policy impact: no policy exception
+
+## Scope
+
+Lay down Apple Silicon proposal/spec/plan rails that route every Apple proof
+family to the correct authority. This plan does not change runtime code,
+default models, backend selection, server behavior, kernels, or support tiers.
+
+## PR sequence
+
+1. **Source-of-truth map**: add `docs/apple-silicon/README.md`, this plan
+   directory, index links, and active-campaign references. Acceptance: proof
+   families and historical/current authorities are explicit.
+2. **Productization proposal**: add the Apple Silicon proposal. Acceptance:
+   dense SLM first, BitNet CPU/NEON second, Metal phase-scoped, MacBook
+   auxiliary, no Neural Engine or broad Apple Silicon promotion.
+3. **Route contract**: add route IDs, receipt fields, fallback semantics, and
+   proof-family separation.
+4. **Dense SLM appliance spec**: elevate the supported dense model matrix gates
+   into a contractual M4 appliance spec.
+5. **BitNet CPU/NEON spec**: define the accepted BitNet artifact proof ladder
+   and not-claims.
+6. **Metal phased acceleration spec**: define visibility, smoke, parity,
+   phase-contribution, real-generation-candidate, and full-route-candidate
+   boundaries.
+7. **Quality and benchmark specs**: define dense/BitNet corpus separation and
+   benchmark-envelope fields/profiles.
+8. **Identity and MacBook specs**: define reproducible run identity and the
+   MacBook auxiliary lane.
+9. **Service surface spec**: define Mac doctor/evidence/ask/chat/serve,
+   receipts-check, regression, report-refresh, and benchmark semantics.
+
+A single documentation PR may include multiple steps only when it remains a
+rails-only change and does not promote runtime claims.
+
+## Validation
+
+Run these proof commands for docs/rails changes:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-inference-excellence
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+If a command cannot run because of environment limitations, record the command,
+reason, substitute evidence, and whether it blocks merge.
+
+## Claim boundaries
+
+- Do not promote new runtime claims in docs/spec PRs.
+- Do not claim full `apple-m4-metal` inference.
+- Do not claim Neural Engine execution.
+- Do not claim MPSGraph as native Metal.
+- Do not claim dense SLM evidence proves BitNet.
+- Do not claim BitNet CPU/NEON evidence proves Metal.
+- Do not claim MacBook evidence proves M4 Mac Mini behavior.
+- Do not touch QK256, Metal kernels, server runtime, or model binaries unless a
+  later work item explicitly allows it.
+- Keep live hardware/model timing out of ordinary generic CI.


### PR DESCRIPTION
## Summary
- consolidates the useful Apple Silicon source-of-truth/proof-rail docs from the stale Codex batch onto current main
- adds route, dense SLM, BitNet CPU/NEON, Metal phase, quality, benchmark, reproducible identity, MacBook auxiliary, and service-surface specs
- adds an Apple Silicon implementation plan while preserving claim boundaries around M4, MacBook, Metal, MPSGraph, Neural Engine, dense SLM, and BitNet proof families

## Validation
- `npx --yes markdownlint-cli2 "docs/apple-silicon/README.md" "docs/proposals/BITNET-PROP-0005-apple-silicon-productization.md" "docs/specs/BITNET-SPEC-APPLE-*.md" "plans/apple-silicon/*.md"`
- `git diff --check`
- `git diff --cached --check`

## Notes
I intentionally did not carry over stale tracker edits from the original Apple Codex branches. I also avoided touching `docs/specs/INDEX.md` because markdownlint reports pre-existing failures in that file unrelated to this consolidation.