### PR TITLE
docs(intel-gpu): consolidate proof rails

### DIFF
--- a/docs/intel-gpu/README.md
+++ b/docs/intel-gpu/README.md
@@ -1,0 +1,79 @@
+# Intel GPU source-of-truth map
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Documentation only; no route promotion.
+Policy impact: Preserves existing proof-family and no-fallback boundaries.
+
+## Purpose
+
+Intel GPU support is a vendor-specific accelerator family, not a generic
+"GPU works" bucket. This map exists so users, maintainers, and agents can tell
+which Intel GPU lane is being discussed before any receipt, route matrix, status
+page, or benchmark claim is interpreted.
+
+This file does not promote a runtime route. It records the source-of-truth map
+that future receipts and status surfaces must follow.
+
+## Lanes
+
+| Lane | Hardware | Runtime | First serious target | Claim family |
+| --- | --- | --- | --- | --- |
+| A770 native GPU | Arc A770 16GB discrete GPU | OpenCL first; Level Zero candidate later | BitNet I2_S/QK256 trusted partial acceleration | `intel-arc-a770-opencl` |
+| Lunar Lake integrated GPU | Arc 140V / Core Ultra 7 258V | OpenVINO GPU and native OpenCL | Dense Qwen SLM candidate routing first; BitNet-adjacent parity later | `openvino-gpu` / `arc140v-opencl` |
+
+## Route-family map
+
+| Route family | Meaning | Current posture |
+| --- | --- | --- |
+| A770 native OpenCL | Discrete Arc A770 selected-device BitNet path. | OpenCL-first path for native BitNet QK256 proof; no generic Intel GPU claim. |
+| A770 OpenVINO GPU | A770 through OpenVINO GPU runtime or graph APIs. | Reference runtime path only; not native OpenCL proof. |
+| Arc 140V native OpenCL | Lunar Lake integrated GPU selected-device OpenCL lane. | Smoke/parity lane; not A770 proof and not BitNet QK256 support until fixtures and answer proof exist. |
+| Arc 140V OpenVINO GPU | Lunar Lake OpenVINO GPU `GPU.X` dense SLM route. | Dense SLM candidate route; promotion remains exact-profile and quality-gated. |
+| Intel NPU | OpenVINO NPU / Intel AI Boost lane. | Separate from every GPU lane. |
+| CPU | Reference and comparator plate. | CPU proof cannot count as Intel GPU execution. |
+
+## Non-interchangeable proof families
+
+These boundaries must appear in specs, receipts, model coverage, status pages,
+route matrices, and `receipts explain` output:
+
+```text
+A770 OpenCL proof is not Arc 140V proof.
+Arc 140V OpenCL proof is not A770 proof.
+OpenVINO GPU proof is not native OpenCL proof.
+OpenVINO GPU proof is not NPU proof.
+Intel GPU proof is not CUDA proof.
+Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+BitNet QK256 proof is not dense SLM proof.
+CPU fallback cannot count as Intel GPU execution.
+Generic OpenCL is not selected Intel GPU proof.
+Generic GPU is not selected Intel GPU proof.
+```
+
+## Current truth anchors
+
+- `docs/specs/intel-arc-a770-gpu-roadmap.md` defines A770 as the discrete
+  OpenCL-first Intel GPU lane and keeps OpenVINO GPU reference evidence
+  separate.
+- `docs/specs/a770-bitnet-claim-boundary.md` defines the first A770 product
+  claim as trusted partial BitNet I2_S acceleration, not full residency.
+- `ci/hardware/device-kernel-routing.toml` remains the route-matrix truth for
+  committed device/kernel proof; diagnostic rows must not be promoted without
+  claim-grade receipts.
+- `docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md` keeps Core Ultra 7
+  258V CPU, Arc 140V GPU, and NPU proof labels separate.
+
+## Documentation-only boundary
+
+This source map adds no kernels, receipts, route promotions, model coverage
+claims, speed claims, or residency claims. Future implementation PRs must still
+produce selected-device receipts with `fallback_used=false` before claiming an
+Intel GPU route.

--- a/docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md
+++ b/docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md
@@ -1,0 +1,85 @@
+# BITNET-PROP-0006: Intel GPU productization
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines rationale only; no support claim promotion.
+Policy impact: No exception.
+
+## Thesis
+
+Intel GPU support gives BitNet-rs a vendor-diverse accelerator path: native
+OpenCL/Level-Zero-style kernels for packed BitNet on A770 and graph/runtime
+acceleration for dense SLMs on Lunar Lake Arc 140V through OpenVINO GPU. The
+value is not generic GPU detection; it is selected-device, selected-model,
+receipt-backed local inference.
+
+## Product lanes
+
+| Lane | Product purpose | First serious target |
+| --- | --- | --- |
+| A770 native OpenCL | Discrete Intel GPU path for packed BitNet kernels. | BitNet I2_S/QK256 trusted partial acceleration. |
+| Arc 140V OpenVINO GPU | Integrated Lunar Lake GPU graph/runtime path. | Dense Qwen SLM candidate routing and exact-profile promotion. |
+| Arc 140V native OpenCL | Integrated native-kernel smoke/parity path. | BitNet-adjacent parity evidence after A770 path is grounded. |
+| A770 OpenVINO GPU | Reference runtime comparison path. | Runtime/device comparison only unless separately specified. |
+
+OpenVINO GPU is a runtime/graph lane, not native OpenCL proof. Dense SLM proof
+and BitNet proof are separate. Performance is profile-specific. Full residency
+is named-phase only until every required phase is proven.
+
+## User value
+
+Users should eventually be able to ask for an Intel GPU route and receive an
+answer plus a receipt that explains:
+
+- exact selected backend and runtime API;
+- exact device identity;
+- model family and proof family;
+- whether fallback was used;
+- quality result and failure taxonomy when relevant;
+- timing profile and comparator boundary;
+- transfer and residency status;
+- not-claims and next proof needed.
+
+## Non-interchangeable proof families
+
+Intel GPU productization must preserve these boundaries:
+
+```text
+A770 OpenCL proof is not Arc 140V proof.
+Arc 140V OpenCL proof is not A770 proof.
+OpenVINO GPU proof is not native OpenCL proof.
+OpenVINO GPU proof is not NPU proof.
+Intel GPU proof is not CUDA proof.
+Dense SLM OpenVINO proof is not BitNet QK256/I2_S proof.
+BitNet QK256 proof is not dense SLM proof.
+CPU fallback cannot count as Intel GPU execution.
+Generic OpenCL is not selected Intel GPU proof.
+Generic GPU is not selected Intel GPU proof.
+```
+
+## Product posture
+
+A usable Intel GPU product is not a one-off fast run. It is a route-specific,
+quality-gated, receipt-backed claim where maintainers can explain exactly what
+ran and what did not run. A770 should mature toward named BitNet partial
+acceleration. Arc 140V should mature first through dense OpenVINO GPU exact
+profiles and separately through native OpenCL smoke/parity evidence.
+
+## Non-goals
+
+This proposal does not:
+
+- promote any current route;
+- claim generic Intel GPU support;
+- claim speedup;
+- claim full device residency;
+- claim OpenVINO GPU as native OpenCL;
+- transfer A770 proof to Arc 140V, or Arc 140V proof to A770;
+- transfer dense SLM proof to BitNet QK256, or BitNet proof to dense SLMs.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md
@@ -1,0 +1,66 @@
+# BITNET-SPEC-INTEL-GPU-BITNET-QK256
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines native BitNet route requirements; no promotion.
+Policy impact: No exception.
+
+## Purpose
+
+Define the native Intel GPU BitNet route for official I2_S/QK256 artifacts. The
+first product lane is A770 OpenCL trusted partial acceleration for named
+operations; Arc 140V native OpenCL remains a candidate until separately proven.
+
+## Required kernels and operations
+
+```text
+qk256_i2s_gemv_opencl
+embedding_lookup_opencl
+lm_head_tied_logits_opencl
+eventual qk256_i2s_prefill_gemm_opencl
+```
+
+A route may claim only the named operations it proves. QK256 linears alone are
+trusted partial acceleration, not full model residency.
+
+## Production semantics
+
+Production BitNet QK256 proof must match:
+
+```text
+official Microsoft I2_S/QK256 GGUF
+canonical packed layout
+BitNet.cpp-aligned activation quantization
+I2_S × I8_S scaled math
+weight scale
+activation scale/sum correction
+tail-column behavior
+row stride behavior
+strict tokenizer/template authority
+```
+
+## Hard rule
+
+A diagnostic four-values-per-byte toy I2_S kernel cannot satisfy official
+QK256 proof. Toy kernels may remain smoke/parity evidence only when receipts and
+status surfaces say they are not official BitNet QK256 execution.
+
+## Required receipt evidence
+
+A claim-grade native BitNet OpenCL receipt must include:
+
+- selected backend and runtime API;
+- official model contract and artifact hashes;
+- tokenizer and prompt-template authority;
+- QK256 kernel invocation counts greater than zero for claimed operations;
+- CPU fallback count zero;
+- `fallback_used=false`;
+- quality gate result or explicit unpromoted status;
+- not-claims for dense SLM, generic Intel GPU, full residency, and speedup.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md
@@ -1,0 +1,67 @@
+# BITNET-SPEC-INTEL-GPU-DENSE-SLM
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines dense SLM OpenVINO GPU requirements; no promotion.
+Policy impact: No exception.
+
+## Initial target
+
+The initial dense SLM Intel GPU target is:
+
+```text
+Qwen2.5 0.5B Instruct OpenVINO INT4 symmetric export on Lunar Lake Arc 140V GPU.0
+```
+
+This is dense SLM OpenVINO GPU proof. It is not BitNet QK256 proof, native
+OpenCL proof, NPU proof, CUDA proof, or A770 proof.
+
+## Proof ladder
+
+Dense SLM OpenVINO GPU routes graduate through:
+
+```text
+export manifest
+runtime/device identity
+OpenVINO GPU bounded smoke
+operator ask
+corpus v2
+phase timing
+profile comparison
+promotion review
+model status
+server exact-profile optional
+```
+
+## Promotion rule
+
+OpenVINO GPU can be promoted only per profile after:
+
+- `fallback_used=false`;
+- quality passes for that profile;
+- profile timing is applicable;
+- benchmark-qualified advantage exists, or a reviewed UX/power advantage is
+  accepted for that exact profile;
+- telemetry context is present or explicitly unavailable;
+- generated-token limitation is recorded.
+
+## Known blocker classes to formalize
+
+Candidate route reviews must classify and preserve blockers such as:
+
+- corpus quality failures;
+- missing direct generated-token IDs;
+- missing prompt-token timing applicability;
+- incomplete phase splits;
+- missing profile regression bundle;
+- missing benchmark-qualified speed or power advantage.
+
+A bounded OpenVINO GPU answer receipt can be useful evidence while the route
+remains unpromoted.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md
@@ -1,0 +1,54 @@
+# BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines identity fields; no promotion.
+Policy impact: No exception.
+
+## Purpose
+
+Normalize identity evidence across A770, Arc 140V, OpenCL, Level Zero,
+OpenVINO GPU, and system telemetry so proof receipts cannot inherit claims from
+another Intel device or runtime.
+
+## Required identity fields
+
+Every Intel GPU proof receipt must record, or explicitly mark unavailable:
+
+- OS and kernel/build;
+- native, WSL, container, or virtualized context;
+- GPU name;
+- GPU family;
+- PCI ID;
+- driver version;
+- OpenCL platform and device index;
+- Level Zero adapter identity;
+- OpenVINO available devices;
+- OpenVINO `GPU.X` full device name;
+- VRAM or shared memory;
+- ReBAR for A770;
+- PCIe link width and generation for A770;
+- Linux render-node and permission context;
+- power, thermal, and utilization tool availability.
+
+## Device-specific expectations
+
+| Device family | Required selected identity |
+| --- | --- |
+| A770 | Full Arc A770 device name, PCI ID `0x56A0` when exposed, discrete VRAM, OpenCL platform/device, and PCIe/ReBAR facts where available. |
+| Arc 140V | Full Arc 140V or Core Ultra 7 258V integrated GPU identity, PCI ID `0x64A0` when exposed, shared-memory context, and OpenVINO `GPU.X` mapping when OpenVINO is used. |
+| OpenVINO GPU | `GPU.X` selector, OpenVINO runtime or GenAI API version, available-device list, and resolved full device name. |
+| Level Zero | Adapter name, driver/runtime identity, and explicit candidate status unless promoted by a later spec. |
+
+## Unknown fields
+
+Unknown telemetry is acceptable only when the receipt records the attempted
+source and reason it is unavailable. Missing telemetry cannot silently become a
+performance, power, residency, or selected-device claim.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md
@@ -1,0 +1,73 @@
+# BITNET-SPEC-INTEL-GPU-PERFORMANCE
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines benchmark qualification; no speed claim.
+Policy impact: No exception.
+
+## Profiles
+
+Intel GPU performance evidence is profile-specific:
+
+```text
+cold_load
+warm_load
+one_token
+ask_short
+ask_normal
+prefill_128_decode_16
+prefill_512_decode_32
+decode_32
+decode_128
+warm_session_3_turns
+warm_session_10_turns
+resident_10x_ask_short
+server_nonstream_exact_profile
+```
+
+## Required timing fields
+
+Receipts used for performance claims must record, or explicitly mark
+not-applicable:
+
+```text
+model_load_ms
+tokenizer_load_ms
+prompt_render_ms
+tokenize_ms
+runtime_context_init_ms
+kernel_or_graph_compile_ms
+weight_upload_ms
+prefill_ms
+first_token_ms
+decode_total_ms
+steady_tok_per_s
+kernel_or_graph_time_ms
+launch_count
+H2D/D2H bytes and timing
+VRAM/shared-memory high-water
+power/thermal context
+```
+
+## Promotion requirements
+
+A performance claim requires:
+
+```text
+quality_passed=true
+fallback_used=false
+profile_timing_applicable=true
+same-model same-profile comparator
+two same-device history receipts for performance claim
+claim reviewed and accepted
+```
+
+A single fast run is a benchmark candidate only. It cannot become a public
+speedup claim without the full gate above.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md
@@ -1,0 +1,73 @@
+# BITNET-SPEC-INTEL-GPU-QUALITY
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines quality gates; no promotion.
+Policy impact: No exception.
+
+## Purpose
+
+Intel GPU "up and running" means the route produces intelligible, useful,
+route-scoped answers. Kernel execution, graph execution, or fast timing alone
+is not answer readiness.
+
+## BitNet A770/OpenCL gates
+
+BitNet native OpenCL answer proof requires:
+
+```text
+official answer corpus
+prompt conditioning
+paired context changes answer
+copy/repeat
+yes/no
+format following
+stop-token behavior
+long decode
+CPU/A770 generated-token parity or first divergence classification
+```
+
+## Dense SLM OpenVINO GPU gates
+
+Dense SLM OpenVINO GPU proof requires:
+
+```text
+lunar-lake answer corpus v2
+profile summaries
+category summaries
+failure taxonomy
+generation-budget sensitivity
+stop/EOS diagnosis
+retokenized-vs-direct-token-ID boundary
+```
+
+## Failure taxonomy
+
+Failures must use one or more of:
+
+```text
+exact_answer_instruction_not_followed
+exact_answer_overgenerated
+missing_required_keyword
+forbidden_token_observed
+raw_special_token_seen
+empty_answer
+repetition
+stop_policy_failed
+context_sensitivity_failed
+structured_output_failed
+timeout
+runtime_error
+```
+
+## Promotion rule
+
+A route with unclassified quality failures cannot be promoted to
+`answer_ready`, `behavior_proven`, `performance_proven`, or `complete`.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md
@@ -1,0 +1,64 @@
+# BITNET-SPEC-INTEL-GPU-RESIDENCY
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines residency classes; no residency promotion.
+Policy impact: No exception.
+
+## Purpose
+
+Partial acceleration must not become "full GPU" by implication. Residency is a
+named-phase claim and must be reported phase by phase.
+
+## Residency classes
+
+```text
+none
+kernel_smoke
+qk256_linears_only
+bitnet_trusted_partial
+dense_graph_runtime
+support_ops_partial
+decode_full
+full_device_resident
+```
+
+## Phase table
+
+Receipts that discuss residency must include this shape or an equivalent
+versioned table:
+
+```json
+{
+  "residency": {
+    "weights": "gpu|cpu|mixed|unknown",
+    "qk256_linears": "gpu|cpu|mixed|unknown",
+    "dense_linears": "gpu|cpu|mixed|unknown",
+    "embedding": "gpu|cpu|mixed|unknown",
+    "lm_head": "gpu|cpu|mixed|unknown",
+    "kv_cache": "gpu|cpu|mixed|unknown",
+    "rmsnorm": "gpu|cpu|mixed|unknown",
+    "rope": "gpu|cpu|mixed|unknown",
+    "attention_scores": "gpu|cpu|mixed|unknown",
+    "softmax": "gpu|cpu|mixed|unknown",
+    "attention_value_mix": "gpu|cpu|mixed|unknown",
+    "sampling": "gpu|cpu|host_logits_only|unknown"
+  }
+}
+```
+
+## Hard rules
+
+- QK256 linears on A770 are trusted partial acceleration, not full residency.
+- OpenVINO GPU LLMPipeline output is dense graph/runtime proof, not native
+  OpenCL residency.
+- `resident_proven` proves only the named phase or operation.
+- `complete` requires every required operation, residency phase, and server gate
+  for the selected route.

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md
@@ -1,0 +1,87 @@
+# BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines labels; no promotion.
+Policy impact: No exception.
+
+## Route identities
+
+Valid Intel GPU route IDs are concrete and model/runtime scoped:
+
+```text
+intel_arc_a770_opencl_bitnet_qk256
+intel_arc_a770_opencl_embedding
+intel_arc_a770_opencl_lm_head
+intel_arc_a770_openvino_gpu_reference
+intel_arc_140v_opencl_smoke
+intel_arc_140v_opencl_bitnet_candidate
+intel_arc_140v_openvino_gpu_dense_slm
+intel_gpu_level_zero_candidate
+```
+
+## Backend labels
+
+- `selected_backend` must be concrete. Values such as `gpu`, `opencl`, or
+  `intel-gpu` are convenience selectors only and cannot appear as selected
+  proof backends.
+- Native A770 OpenCL proof uses `selected_backend=intel-arc-a770-opencl` and
+  `runtime_api=opencl`.
+- Native Arc 140V OpenCL proof uses `selected_backend=intel-arc-140v-opencl` and
+  `runtime_api=opencl`.
+- OpenVINO GPU proof uses `selected_backend=openvino-gpu` and
+  `runtime_api=openvino_genai` or `runtime_api=openvino_runtime`.
+- Level Zero evidence remains candidate evidence until a route-specific spec and
+  proof receipts promote it.
+
+## Claim rules
+
+- `fallback_used=false` is required for any Intel GPU route claim.
+- `fallback_reason` must be `null` when `fallback_used=false`.
+- OpenVINO GPU receipts must record `GPU.X` and full device name.
+- OpenCL receipts must record platform index, device index, and full device
+  name.
+- A770 receipts must record PCI ID `0x56A0` when available.
+- Arc 140V receipts must record PCI ID `0x64A0` when available.
+- CPU fallback, generic GPU selection, or generic OpenCL selection cannot
+  satisfy selected Intel GPU proof.
+
+## Claim levels
+
+| Level | Meaning | Public claim |
+| --- | --- | --- |
+| `unsupported` | no valid route or proof | none |
+| `runtime_detected` | device visible | detection only |
+| `compile_smoke` | kernel/graph compiles | compile only |
+| `kernel_smoke` | tiny kernel/graph executes | smoke only |
+| `parity_tested` | CPU/GPU fixture parity | fixture parity |
+| `answer_ready` | strict answer corpus or bounded useful answers | answer route |
+| `behavior_proven` | prompt conditioning, stop/repetition, long decode | behavior route |
+| `benchmark_candidate` | timing fields recorded | diagnostic perf |
+| `performance_proven` | quality-gated profile beats baseline with history | exact-profile perf |
+| `resident_proven` | named op resident | named residency only |
+| `complete` | all required ops/residency/server gates pass | full route |
+
+`performance_proven`, `resident_proven`, and `complete` must never be collapsed.
+
+## Minimum route receipt shape
+
+```json
+{
+  "requested_backend": "intel-arc-a770 | intel-arc-140v | openvino-gpu",
+  "selected_backend": "intel-arc-a770-opencl | intel-arc-140v-opencl | openvino-gpu",
+  "runtime_api": "opencl | openvino_genai | openvino_runtime | level_zero",
+  "runtime_device": "GPU.0 | GPU.1 | OpenCL platform/device index",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "model_family": "bitnet | dense_slm | small_llm",
+  "proof_family": "bitnet_qk256_opencl | dense_slm_openvino_gpu | arc140v_opencl_smoke"
+}
+```

--- a/docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md
@@ -1,0 +1,68 @@
+# BITNET-SPEC-INTEL-GPU-STATUS-SURFACE
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Defines future UX; no route promotion.
+Policy impact: No exception.
+
+## Purpose
+
+Intel GPU status surfaces must make proof-family truth visible to users and
+agents without requiring them to inspect raw receipts.
+
+## Future commands
+
+Status surfaces should eventually include:
+
+```bash
+bitnet model status --device intel-arc-a770-opencl
+bitnet model status --device intel-arc-140v-openvino-gpu
+bitnet receipts explain <receipt>
+bitnet lunar-lake routes --format json
+bitnet gpu doctor --vendor intel
+```
+
+## Required output fields
+
+Human and JSON output should include:
+
+```text
+route id
+proof family
+claim level
+selected backend
+runtime API
+quality status
+performance status
+residency status
+server status
+not-claims
+next required proof
+```
+
+## Required explanations
+
+`receipts explain` and status pages must distinguish at least:
+
+- A770 native OpenCL BitNet proof;
+- A770 OpenVINO GPU reference proof;
+- Arc 140V OpenVINO GPU dense SLM proof;
+- Arc 140V native OpenCL smoke/parity proof;
+- Intel NPU proof;
+- CPU reference proof;
+- CUDA proof;
+- unsupported, candidate, exact-profile, and full-route states.
+
+## Not-claims
+
+Every Intel GPU status surface must say when a route is not generic Intel GPU
+support, not native OpenCL proof, not OpenVINO GPU proof, not NPU proof, not
+BitNet QK256 proof, not dense SLM proof, not a speedup claim, or not full
+residency.

--- a/plans/intel-gpu/README.md
+++ b/plans/intel-gpu/README.md
@@ -1,0 +1,20 @@
+# Intel GPU productization plans
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: `plans/intel-gpu/implementation-plan.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Documentation only; no support-tier promotion.
+Policy impact: Keeps A770, Arc 140V, OpenVINO GPU, NPU, CPU, and CUDA proof families separate.
+
+This directory sequences Intel GPU productization work. It spans the A770
+native OpenCL BitNet lane and the Lunar Lake Arc 140V OpenVINO/native OpenCL
+lanes while preserving strict proof-family boundaries.
+
+Start with `implementation-plan.md` for PR order, proof commands, non-goals,
+and rollback guidance.

--- a/plans/intel-gpu/implementation-plan.md
+++ b/plans/intel-gpu/implementation-plan.md
@@ -1,0 +1,120 @@
+# Intel GPU implementation plan
+
+Status: proposed
+Owner: intel-gpu/product
+Created: 2026-05-18
+Linked proposal: `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+Linked specs: `docs/specs/BITNET-SPEC-INTEL-GPU-ROUTE-CONTRACT.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DEVICE-IDENTITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-BITNET-QK256.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-DENSE-SLM.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-QUALITY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-PERFORMANCE.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-RESIDENCY.md`, `docs/specs/BITNET-SPEC-INTEL-GPU-STATUS-SURFACE.md`
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: Documentation only until a later runtime PR provides receipts.
+Policy impact: Adds no exceptions.
+
+## Goal
+
+Productize Intel GPU as a receipt-backed family of exact routes without
+conflating A770 native OpenCL, Arc 140V native OpenCL, OpenVINO GPU, Intel NPU,
+CPU, CUDA, BitNet QK256, and dense SLM proof.
+
+## Phase 0: source-of-truth alignment
+
+### INTELGPU-DOCS-000: source map and contracts
+
+Add:
+
+- `docs/intel-gpu/README.md`
+- `plans/intel-gpu/README.md`
+- `plans/intel-gpu/implementation-plan.md`
+- `docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md`
+- Intel GPU route, identity, BitNet QK256, dense SLM, quality, performance,
+  residency, and status-surface specs.
+
+Update:
+
+- `docs/specs/INDEX.md`
+- `docs/tracking/campaigns/intel-a770/active.toml`
+- `docs/tracking/campaigns/intel-258v-platform/active.toml`
+- generated campaign dashboards if required by `xtask`.
+
+Acceptance:
+
+- Documentation only.
+- No route promotion.
+- No receipt changes.
+- No QK256/OpenCL kernel or model coverage changes.
+- Campaign checks and `git diff --check` pass.
+
+Proof commands:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check intel-a770
+cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+Rollback:
+
+Revert the Intel GPU docs, specs, plan files, index update, campaign active
+manifest additions, and any generated dashboard changes from this plan item.
+
+## Phase 1: specs
+
+1. `docs(proposal): add Intel GPU productization proposal`
+2. `docs(spec): add Intel GPU route contract`
+3. `docs(spec): add Intel GPU device identity contract`
+4. `docs(spec): add Intel GPU BitNet QK256 contract`
+5. `docs(spec): add Intel GPU dense SLM contract`
+6. `docs(spec): add Intel GPU quality/performance/residency contracts`
+7. `docs(spec): add Intel GPU status surface contract`
+
+These PRs must not promote runtime claims. They define the proof rules that
+later runtime and receipt PRs must satisfy.
+
+## Phase 2: A770 route truth and proof ledger
+
+- Reconcile committed A770 proof receipts with `ci/hardware/device-kernel-routing.toml`.
+- Keep diagnostic rows diagnostic unless claim-grade receipts are committed.
+- Add validators that prevent promoted A770 rows without receipt paths,
+  `fallback_used=false`, selected backend `intel-arc-a770-opencl`, and explicit
+  not-claims.
+
+## Phase 3: A770 native OpenCL productization
+
+- Refresh selected-device OpenCL/Level Zero identity.
+- Lock QK256 scaled I2S-I8S scalar oracle and OpenCL parity fixtures.
+- Record claim-grade QK256 OpenCL receipts.
+- Add deterministic BitNet answer behavior gates.
+- Add quality-gated profile timings.
+- Promote only named trusted partial acceleration after all gates pass.
+
+## Phase 4: Lunar Lake Arc 140V OpenVINO GPU route
+
+- Classify OpenVINO GPU corpus-v2 failures.
+- Fix profile-specific timing applicability gaps.
+- Promote only exact OpenVINO GPU dense SLM profiles where quality,
+  fallback-free execution, comparator advantage, and telemetry rules pass.
+
+## Phase 5: Arc 140V native OpenCL BitNet-adjacent lane
+
+- Refresh selected-device native OpenCL parity.
+- Add BitNet QK256 candidate fixtures without claiming full BitNet support.
+- Decide whether Arc 140V native OpenCL should pursue BitNet QK256 before A770.
+
+## Phase 6: shared Intel GPU UX
+
+- Teach `receipts explain` to state proof families and not-claims.
+- Add an Intel GPU capability matrix.
+- Add `bitnet gpu doctor --vendor intel --format json` for route readiness and
+  driver/runtime identity.
+
+## Non-goals for docs/spec PRs
+
+- Do not add or modify QK256 kernels.
+- Do not add or modify OpenCL kernels.
+- Do not promote route-matrix rows.
+- Do not change model coverage.
+- Do not claim generic Intel GPU support.
+- Do not claim speedup, full residency, or cross-family proof inheritance.


### PR DESCRIPTION
## Summary
- consolidates the useful Intel GPU source-of-truth/proof-rail docs from the stale Codex batch onto current main
- adds route, device identity, residency, status, dense SLM, BitNet QK256, quality, and performance specs
- adds an Intel GPU implementation plan while keeping A770, Lunar Lake integrated GPU, OpenVINO/NPU, CPU fallback, and BitNet QK256 claim boundaries separate

## Validation
- `npx --yes markdownlint-cli2 "docs/intel-gpu/README.md" "docs/proposals/BITNET-PROP-0006-intel-gpu-productization.md" "docs/specs/BITNET-SPEC-INTEL-GPU-*.md" "plans/intel-gpu/*.md"`
- `git diff --check`
- `git diff --cached --check`

## Notes
I intentionally did not carry over stale tracker edits from the original Intel GPU Codex branches. This PR is docs/proof-rail consolidation only; no runtime code or accelerator claim changes.