### PR TITLE
docs(a770): reconcile committed OpenCL proof state

### DIFF
--- a/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
+++ b/docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
@@ -35,14 +35,13 @@ cpu:
 a770:
   support: diagnostic
   target_support: trusted_partial
-  claim_status: diagnostic_pending_claim_grade_receipts
+  claim_status: diagnostic
+  promotion_blocker: clean claim-grade A770 OpenCL receipts are not committed for the required operations
   selected_backend: intel-arc-a770-opencl
-  receipt_requirement: "Commit strict selected-device OpenCL receipts before promoting qk256_linears, embedding, or lm_head_tied_logits."
   required_claimed_ops:
     - qk256_linears
     - embedding
     - lm_head_tied_logits
-  claim_ready_required_ops: []
   not_claims:
     - selected_attention_residency
     - resident_kv_decode

--- a/docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md
+++ b/docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md
@@ -1,0 +1,82 @@
+# OPENCL_A770_000 Truth Reconciliation
+
+Status: complete
+Owner: Codex
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs:
+
+- docs/specs/intel-arc-a770-gpu-roadmap.md
+- docs/specs/a770-bitnet-claim-boundary.md
+
+Linked ADRs: n/a
+Linked plan: plans/a770-bitnet-claim-boundary-implementation.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: keeps A770 OpenCL at diagnostic claim level until committed receipts prove promotion
+Policy impact: n/a
+
+## Scope
+
+This report reconciles the committed repository state for the Intel Arc A770
+OpenCL BitNet lane. It does not add kernels, dispatch behavior, benchmark
+claims, or inference claims.
+
+## Inspection Summary
+
+The committed repository does not contain claim-grade A770 receipts matching the
+later transcript state described outside the repository. In particular, the
+committed A770 hardware directory contains only the capability matrix and no
+per-run receipt bundle under a dated A770 run directory. The committed campaign
+event directory contains only its placeholder. No local branch whose name
+matches `a770` or `A770` exists in this checkout.
+
+The committed source of truth is therefore the conservative state:
+
+- `ci/hardware/device-kernel-routing.toml` keeps A770 BitNet QK256, embedding,
+  and LM-head routes at `claim_level = "diagnostic"` with empty proof receipts.
+- `ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json` keeps
+  QK256, embedding, and LM-head kernels diagnostic or missing with empty proof
+  receipts.
+- `ci/claims/claim-ledger.json` keeps the trusted-partial A770 experience claim
+  at `status = "diagnostic"`.
+- The A770 model contract now records the current support state as diagnostic
+  while preserving `target_support: trusted_partial` for the intended promotion.
+- The campaign tracker now makes this reconciliation the next ready work item,
+  ahead of backend-identity, probe, smoke, parity, and receipt work.
+
+## Decision
+
+Because no committed claim-grade A770 proof receipts were found, this PR does
+not promote any A770 OpenCL route. The repo remains diagnostic for A770 BitNet
+OpenCL until later PRs land selected-device smoke, compile/execution proof,
+strict QK256 routing, quality gates, phase timing, and same-device history.
+
+## Claim Boundary
+
+This reconciliation may claim only:
+
+```text
+The committed A770 OpenCL source-of-truth files agree that trusted partial
+BitNet A770 acceleration is not yet claim-grade.
+```
+
+It must not claim:
+
+```text
+A770 OpenCL execution works.
+A770 QK256/embedding/LM-head operations ran with fallback_used=false.
+Full BitNet inference works on A770.
+Full support-op residency or full device residency is proven.
+Dense SLM, Gemma, or small LLM OpenCL support exists.
+OpenVINO GPU proof is native OpenCL proof.
+Generic OpenCL or Arc 140V proof is A770 proof.
+```
+
+## Rollback Plan
+
+Revert this documentation/tracker reconciliation if a branch with claim-grade
+A770 receipts is intentionally merged first. Any such replacement must commit
+receipts under the A770 hardware/report/tracking paths and update the route
+matrix, kernel capability matrix, claim ledger, model contract, active goal,
+and campaign tracker in one coherent promotion PR.

--- a/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
@@ -6,11 +6,12 @@ Status: active
 
 ## Objective
 
-Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. OpenVINO GPU is a reference lane and must not be used as native OpenCL proof.
+Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. OpenVINO GPU is a reference lane and must not be used as native OpenCL proof. Uncommitted transcript evidence cannot promote committed A770 claims.
 
 ## End State
 
 - A770 backend identity is distinct from generic OpenCL, Intel NPU, Arc 140V, CUDA, and CPU fallback.
+- Tracker, route matrix, kernel matrix, model contract, and claim ledger agree on the committed proof level.
 - Runtime probe records OpenCL, Level Zero, OpenVINO GPU, PCI, VRAM, ReBAR, and render-node facts.
 - Tiny OpenCL smoke executes with fallback=false.
 - CPU/OpenCL parity exists for one kernel or subgraph.
@@ -19,30 +20,26 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 ## Hard Constraints
 
 - OpenCL-first for native A770 proof.
+- Uncommitted transcript evidence cannot promote A770 claims.
 - OpenVINO GPU is reference only.
+- Generic OpenCL and Arc 140V proof cannot count as A770 proof.
 - CPU fallback cannot count as A770 execution.
 - Performance claims require driver, PCIe, ReBAR, VRAM, power, and thermal context.
-
-## Current Reconciliation
-
-The current repository has no committed claim-grade A770 OpenCL BitNet inference
-receipt. The route matrix, kernel capability matrix, claim ledger, and model
-contract therefore remain at `diagnostic` for A770 BitNet until a later PR lands
-strict selected-device OpenCL execution receipts. Local or uploaded transcript
-claims are not product claims unless their receipt artifacts are committed under
-`ci/hardware/amd-5700x-intel-a770/<date>/`, summarized in `docs/reports/`, and
-linked from the matrices.
 
 ## Work Items
 
 | Work item | Status | Notes |
-|---|---|---|
-| A770-OPENCL-TRUTH-000 | ready | Reconcile tracker, route, capability, claim, and contract state before runtime work. |
-| A770-003 | proposed | Preserve selected-device identity after reconciliation lands. |
+| --- | --- | --- |
+| A770-000 | ready | Reconcile committed tracker, matrices, claim ledger, and model contract before runtime work. |
+| A770-003 | proposed | Preserve selected-device identity after reconciliation. |
 | A770-004 | proposed | Add runtime probe. |
 | A770-005 | proposed | Run OpenCL smoke. |
 | A770-006 | proposed | Add CPU/OpenCL parity. |
 | A770-007 | proposed | Record receipt identity. |
+
+## Current Claim Boundary
+
+Committed A770 OpenCL proof remains diagnostic. The campaign does not currently claim full BitNet inference, trusted partial acceleration, performance speedup, support-op residency, full device residency, dense SLM support, Gemma support, or native OpenCL proof from OpenVINO GPU.
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -2,10 +2,11 @@ id = "intel-a770"
 title = "Intel Arc A770 validation"
 status = "active"
 
-objective = "Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, or OpenVINO GPU conflation."
+objective = "Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, OpenVINO GPU, or uncommitted proof conflation."
 
 end_state = [
-  "A770 backend identity is distinct from generic OpenCL and Intel NPU.",
+  "A770 backend identity is distinct from generic OpenCL, Intel NPU, Arc 140V, CUDA, and CPU fallback.",
+  "Tracker, route matrix, kernel matrix, model contract, and claim ledger agree on the committed proof level.",
   "Runtime probe records OpenCL, Level Zero, OpenVINO GPU, PCI, VRAM, ReBAR, and render-node facts.",
   "Tiny OpenCL smoke executes with fallback_used=false.",
   "CPU/OpenCL parity exists for one kernel or subgraph.",
@@ -14,25 +15,22 @@ end_state = [
 
 hard_constraints = [
   "OpenCL-first for native A770 proof.",
+  "Uncommitted transcript evidence cannot promote A770 claims.",
   "OpenVINO GPU is reference only.",
+  "Generic OpenCL and Arc 140V proof cannot count as A770 proof.",
   "CPU fallback cannot count as A770 execution.",
 ]
 
 [[work_item]]
-id = "A770-OPENCL-TRUTH-000"
+id = "A770-000"
 status = "ready"
-branch = "codex/intel-a770/opencl-truth-reconciliation"
+branch = "codex/intel-a770/A770-000-truth-reconciliation"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
 blocked_by = []
-acceptance = [
-  "Inspect committed A770 proof artifacts and record whether claim-grade OpenCL inference receipts exist.",
-  "Keep A770 BitNet routes diagnostic unless committed receipts prove strict selected-device OpenCL execution.",
-  "Make active.toml, CAMPAIGN.md, route matrix, kernel matrix, model contract, and reconciliation report agree on the same claim level.",
-  "Do not change OpenCL kernels or QK256 dispatch in this reconciliation PR.",
-]
+acceptance = "Reconcile active.toml, CAMPAIGN.md, route matrix, kernel matrix, claim ledger, and model contract so no full inference or trusted-partial A770 claim is present without committed claim-grade receipts."
 commands = [
   "cargo run --locked -p xtask --no-default-features -- campaign check intel-a770",
   "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
@@ -42,23 +40,26 @@ allowed_paths = [
   "ci/claims/claim-ledger.json",
   "ci/hardware/device-kernel-routing.toml",
   "ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json",
-  "docs/hardware/HARDWARE_MATRIX.md",
   "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
-  "docs/reports/**",
+  "docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md",
   "docs/tracking/campaigns/intel-a770/**",
 ]
 forbidden_paths = [
-  "crates/**",
-  "ci/hardware/amd-5700x-intel-a770/*/*.json",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/**",
 ]
 may_claim = [
-  "A770 OpenCL BitNet route state is reconciled as diagnostic pending committed claim-grade receipts.",
+  "Committed A770 OpenCL proof remains diagnostic until claim-grade receipts land.",
 ]
 must_not_claim = [
   "A770 OpenCL execution works.",
   "OpenVINO GPU proves native OpenCL kernels.",
+  "Generic OpenCL or Arc 140V proof proves A770.",
   "BitNet inference works on A770.",
-  "Full A770 inference or full device residency is proven.",
+  "A770 trusted partial acceleration is claim-grade.",
+  "Full A770 residency is proven.",
 ]
 
 [[work_item]]
@@ -69,7 +70,7 @@ stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
-blocked_by = ["A770-OPENCL-TRUTH-000"]
+blocked_by = ["A770-000"]
 acceptance = "Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims."
 commands = [
   "cargo fmt --all -- --check",
@@ -88,5 +89,139 @@ forbidden_paths = [
   "crates/bitnet-qk256-dispatch/**",
   "crates/bitnet-server/**",
 ]
-may_claim = []
-must_not_claim = []
+may_claim = [
+  "A770 backend identity is preserved through config and logging surfaces.",
+]
+must_not_claim = [
+  "A770 OpenCL execution works.",
+  "OpenVINO GPU proves native OpenCL kernels.",
+  "BitNet inference works on A770.",
+]
+
+[[work_item]]
+id = "A770-004"
+status = "proposed"
+branch = "codex/intel-a770/A770-004-runtime-probe"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["A770-003"]
+acceptance = "Add A770 runtime probe evidence without promoting OpenCL execution or BitNet inference claims."
+commands = [
+  "cargo test --locked -p bitnet-device-probe --no-default-features --features opencl",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/**",
+  "docs/tracking/campaigns/intel-a770/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "A770 runtime probe records selected-device facts.",
+]
+must_not_claim = [
+  "A770 OpenCL kernels execute.",
+  "BitNet inference works on A770.",
+]
+
+[[work_item]]
+id = "A770-005"
+status = "proposed"
+branch = "codex/intel-a770/A770-005-opencl-smoke"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["A770-004"]
+acceptance = "Run a tiny selected-device OpenCL smoke with fallback_used=false and CPU parity, without BitNet inference claims."
+commands = [
+  "BITNET_RUN_A770_OPENCL_SMOKE=1 cargo test --locked -p bitnet-device-probe --no-default-features --features opencl a770",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/**",
+  "ci/hardware/amd-5700x-intel-a770/**",
+  "docs/tracking/campaigns/intel-a770/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Tiny selected-device A770 OpenCL smoke executes with fallback_used=false when the opt-in hardware test is run.",
+]
+must_not_claim = [
+  "BitNet QK256 runs on A770.",
+  "BitNet inference works on A770.",
+  "A770 trusted partial acceleration is claim-grade.",
+]
+
+[[work_item]]
+id = "A770-006"
+status = "proposed"
+branch = "codex/intel-a770/A770-006-opencl-parity"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["A770-005"]
+acceptance = "Add CPU/OpenCL parity for a minimal kernel or subgraph without promoting official BitNet QK256 inference."
+commands = [
+  "cargo test --locked -p bitnet-kernels --no-default-features --features opencl",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/**",
+  "ci/hardware/amd-5700x-intel-a770/**",
+  "docs/tracking/campaigns/intel-a770/**",
+]
+forbidden_paths = [
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "A minimal OpenCL kernel or subgraph has CPU parity on the selected A770 route.",
+]
+must_not_claim = [
+  "Official BitNet QK256 production semantics are proven.",
+  "BitNet inference works on A770.",
+  "Full A770 residency is proven.",
+]
+
+[[work_item]]
+id = "A770-007"
+status = "proposed"
+branch = "codex/intel-a770/A770-007-receipt-identity"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["A770-006"]
+acceptance = "Record selected-device receipt identity for the validated smoke/parity path before any performance or trusted-partial claim."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check intel-a770",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/amd-5700x-intel-a770/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/intel-a770/**",
+]
+forbidden_paths = [
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Selected-device receipt identity exists for the validated A770 smoke/parity path.",
+]
+must_not_claim = [
+  "A770 trusted partial acceleration is claim-grade.",
+  "Full A770 residency is proven.",
+  "Performance speedup is proven.",
+]

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-18T093300Z-A770-000-in-progress.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-18T093300Z-A770-000-in-progress.toml
@@ -1,0 +1,14 @@
+schema_version = "1.0"
+campaign = "intel-a770"
+timestamp = "2026-05-18T09:33:00Z"
+event = "in_progress"
+item = "A770-000"
+branch = "codex/a770-truth-reconciliation-consolidated"
+actor = "codex"
+summary = "Started the consolidated A770 committed-truth reconciliation slice."
+
+notes = [
+  "This slice reconciles committed tracker, campaign, report, and model-contract state to diagnostic until claim-grade A770 OpenCL receipts land.",
+  "Uncommitted transcript evidence, generic OpenCL proof, Arc 140V proof, and OpenVINO GPU proof do not promote A770 native OpenCL claims.",
+  "No OpenCL kernels, QK256 dispatch, server code, or runtime acceleration claims are changed.",
+]

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -3,17 +3,23 @@
 
 - Campaign: `intel-a770`
 - State: `active`
-- Objective: Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, or OpenVINO GPU conflation.
+- Objective: Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, OpenVINO GPU, or uncommitted proof conflation.
 
 ## Work Items
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| A770-OPENCL-TRUTH-000 | ready | TBD | `codex/intel-a770/opencl-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Inspect committed A770 proof artifacts and record whether claim-grade OpenCL inference receipts exist.; Keep A770 BitNet routes diagnostic unless committed receipts prove strict selected-device OpenCL execution.; Make active.toml, CAMPAIGN.md, route matrix, kernel matrix, model contract, and reconciliation report agree on the same claim level.; Do not change OpenCL kernels or QK256 dispatch in this reconciliation PR. |
+| A770-000 | ready | TBD | `codex/intel-a770/A770-000-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Reconcile active.toml, CAMPAIGN.md, route matrix, kernel matrix, claim ledger, and model contract so no full inference or trusted-partial A770 claim is present without committed claim-grade receipts. |
 | A770-003 | proposed | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-004 | proposed | TBD | `codex/intel-a770/A770-004-runtime-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add A770 runtime probe evidence without promoting OpenCL execution or BitNet inference claims. |
+| A770-005 | proposed | TBD | `codex/intel-a770/A770-005-opencl-smoke` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run a tiny selected-device OpenCL smoke with fallback_used=false and CPU parity, without BitNet inference claims. |
+| A770-006 | proposed | TBD | `codex/intel-a770/A770-006-opencl-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add CPU/OpenCL parity for a minimal kernel or subgraph without promoting official BitNet QK256 inference. |
+| A770-007 | proposed | TBD | `codex/intel-a770/A770-007-receipt-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record selected-device receipt identity for the validated smoke/parity path before any performance or trusted-partial claim. |
 
 ## Hard Constraints
 
 - OpenCL-first for native A770 proof.
+- Uncommitted transcript evidence cannot promote A770 claims.
 - OpenVINO GPU is reference only.
+- Generic OpenCL and Arc 140V proof cannot count as A770 proof.
 - CPU fallback cannot count as A770 execution.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -346,7 +346,11 @@
 | intel-258v-platform | LNL258V-OPENVINO-DOCS-006 | LNL258V-OPENVINO-DOCS-005 | merged |
 | intel-258v-platform | LNL258V-OPENVINO-VALIDATE-001 | LNL258V-OPENVINO-DOCS-006 | merged |
 | intel-258v-platform | LNL258V-OPENVINO-STATUS-001 | LNL258V-OPENVINO-VALIDATE-001 | merged |
-| intel-a770 | A770-003 | A770-OPENCL-TRUTH-000 | proposed |
+| intel-a770 | A770-003 | A770-000 | proposed |
+| intel-a770 | A770-004 | A770-003 | proposed |
+| intel-a770 | A770-005 | A770-004 | proposed |
+| intel-a770 | A770-006 | A770-005 | proposed |
+| intel-a770 | A770-007 | A770-006 | proposed |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-OPENVINO-STATUS-001 | #5620 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-OPENCL-TRUTH-000 | TBD | ready | A770-003 | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-000 | TBD | ready | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -32,7 +32,7 @@
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-OPENVINO-STATUS-001 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-OPENCL-TRUTH-000 | OpenCL-first for native A770 proof. |
+| intel-a770 | Intel Arc A770 validation | A770-000 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- consolidates the useful A770 truth-reconciliation work from the stale Codex duplicate PRs onto current main
- keeps A770 OpenCL at diagnostic claim level until committed claim-grade receipts exist
- aligns the model contract, campaign docs, active tracker, and generated dashboards around that conservative state

## Validation
- `cargo run -p xtask --no-default-features -- campaign generate --check`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `npx --yes markdownlint-cli2 "docs/reports/OPENCL_A770_000_TRUTH_RECONCILIATION.md" "docs/tracking/campaigns/intel-a770/CAMPAIGN.md"`
- `git diff --check`
- `git diff --cached --check`

## Claim boundary
No OpenCL kernels, QK256 dispatch, server code, runtime acceleration, full inference, trusted partial acceleration, performance, OpenVINO GPU, Arc 140V, or generic OpenCL promotion is claimed here.