### PR TITLE
fix(receipts): simplify generated token check

### DIFF
--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -8215,7 +8215,10 @@ fn reject_openvino_gpu_opencl_claim(object: &Value, path: &str) -> Result<()> {
 }
 
 fn validate_lunar_lake_openvino_generated_token_marking(object: &Value, path: &str) -> Result<()> {
-    if !object.get("generated_token_ids").is_some_and(|value| value.as_array().is_some()) {
+    if object
+        .get("generated_token_ids")
+        .is_none_or(|value| value.as_array().is_none())
+    {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
- fixes the post-merge CI Clippy failure from #5623 by applying Clippy's nonminimal-bool simplification in bitnet-receipts-core
- preserves the same behavior: missing/non-array generated_token_ids still skips source marking validation

## Validation
- git diff --check
- attempted local cargo clippy/test for bitnet-receipts-core and the CI clippy shape, but Windows cargo invocations timed out before emitting diagnostics; hosted Linux CI is the merge gate

## Claim boundary
No receipt semantics, support tier, accelerator, quality, speed, residency, or server-readiness claim is promoted.