### PR TITLE
docs(rocm): add AMD ROCm source-of-truth map, specs, plan, and campaign

### DIFF
--- a/docs/hardware/HARDWARE_MATRIX.md
+++ b/docs/hardware/HARDWARE_MATRIX.md
@@ -13,7 +13,7 @@ receipt/artifact
 claim allowed
 ```
 
-Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, or OpenVINO NPU claims just because the hardware, vendor name, or accelerator class overlaps.
+Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, OpenVINO NPU, or AMD ROCm claims just because the hardware, vendor name, or accelerator class overlaps.
 
 ## Lane Matrix
 
@@ -34,6 +34,7 @@ Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, or O
 | M4 Mac mini CPU | `apple-m4-cpu-neon` | ARM64 CPU/NEON fallback and parity | AVX2/AVX-512 behavior |
 | RTX 5070 Ti | `nvidia-rtx-5070-ti-cuda` | Modern NVIDIA CUDA kernel/perf lane | Generic GPU or wgpu proof |
 | RTX 5070 Ti WGPU/Vulkan | `nvidia-rtx-5070-ti-wgpu` | Cross-platform GPU reference lane | CUDA kernel proof |
+| Selected AMD Radeon / Radeon PRO / Instinct | `amd-rocm` (registered only; selected backend must become concrete, for example `amd-radeon-rx-7900-xtx-rocm`) | AMD GPU HIP/ROCm lane scaffold for selected devices | Generic AMD GPU support, CUDA/OpenCL/WGPU/OpenVINO/CPU proof, source-text-as-compile proof, speed, full residency, or server readiness |
 
 ## Machine Summary
 
@@ -46,6 +47,7 @@ Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, or O
 | 258V | `intel-258v-cpu-avx2`, `intel-arc-140v-opencl`, `intel-npu-openvino` | `intel-arc-140v-openvino-gpu` | Lunar Lake tri-device box; BitNet CPU lead and same-machine CPU/NPU/Arc comparison plate |
 | M4 Mac mini | `apple-m4-metal` | `apple-m4-mpsgraph`, `apple-m4-cpu-neon` | Apple Silicon Metal lane |
 | RTX 5070 Ti | `nvidia-rtx-5070-ti-cuda` | `nvidia-rtx-5070-ti-wgpu` | Modern NVIDIA CUDA lane |
+| AMD ROCm candidate host | `amd-rocm` | selected concrete AMD ROCm route TBD | Registered scaffold only; first real product target depends on available supported AMD GPU and recorded GFX/HIP/ROCm identity |
 
 ## Required Identity Fields
 
@@ -140,6 +142,31 @@ For AMD desktop CPU:
 }
 ```
 
+For AMD ROCm:
+
+```json
+{
+  "requested_backend": "amd-rocm",
+  "selected_backend": "amd-radeon-rx-7900-xtx-rocm",
+  "runtime_api": "hip",
+  "runtime_stack": "rocm",
+  "rocm_version": "7.2.3",
+  "hip_version": "7.2.53211",
+  "gfx_target": "gfx1100",
+  "resolved_device": {
+    "name": "AMD Radeon RX 7900 XTX",
+    "arch": "RDNA3",
+    "pci_bus_id": "..."
+  },
+  "fallback_used": false
+}
+```
+
+The example above is a required receipt shape, not a current support claim.
+`amd-rocm` may be requested by users, but proof must resolve to a concrete
+selected backend and must preserve ROCm/HIP version, GFX target, device
+identity, proof stage, fallback state, and applicable not-claims.
+
 Never use these as proof labels:
 
 ```text
@@ -152,6 +179,11 @@ metal
 mpsgraph
 cuda
 wgpu
+amd
+gpu
+rocm
+hip
+radeon
 ```
 
 ## First PR Queue
@@ -167,6 +199,7 @@ wgpu
 | 258V platform | `LNL258V-001` | Tri-device platform profile only |
 | M4 Mac mini | `M4-001` | Apple Silicon docs and status only |
 | RTX 5070 Ti | `RTX5070TI-001` | NVIDIA CUDA docs and status only |
+| AMD ROCm | `ROCM-DOCS-000` | Docs and backend status only; no runtime, compile, execution, model, speed, residency, or server claim |
 
 Implementation sequence for any lane:
 

--- a/docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md
+++ b/docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md
@@ -1,0 +1,117 @@
+# BITNET-PROP-0008: AMD ROCm Productization
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: [ROCm route contract](../specs/BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm device identity](../specs/BITNET-SPEC-ROCM-DEVICE-IDENTITY.md), [ROCm kernel compile](../specs/BITNET-SPEC-ROCM-KERNEL-COMPILE.md), [ROCm BitNet QK256](../specs/BITNET-SPEC-ROCM-BITNET-QK256.md), [ROCm dense SLM](../specs/BITNET-SPEC-ROCM-DENSE-SLM.md), [ROCm quality](../specs/BITNET-SPEC-ROCM-QUALITY.md), [ROCm performance](../specs/BITNET-SPEC-ROCM-PERFORMANCE.md), [ROCm residency](../specs/BITNET-SPEC-ROCM-RESIDENCY.md), [ROCm status surface](../specs/BITNET-SPEC-ROCM-STATUS-SURFACE.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: proposes an AMD ROCm lane; does not promote runtime support
+Policy impact: live ROCm proof remains opt-in and outside ordinary PR CI
+
+## Thesis
+
+AMD ROCm support gives BitNet-rs a vendor-diverse native GPU path. The lane
+should start with strict HIP/ROCm selected-device proof, then BitNet QK256 and
+dense SLM route proof, then profile-specific performance and residency. It is
+not generic AMD GPU support and it does not inherit CUDA, OpenCL, WGPU, CPU,
+OpenVINO, or generic GPU proof.
+
+## Why ROCm Exists As A Lane
+
+BitNet-rs already has hardware-specific lanes for CPU, Intel OpenCL/OpenVINO,
+Apple Metal, and NVIDIA CUDA. AMD GPU users need the same level of proof: exact
+hardware identity, runtime identity, selected backend identity, fallback truth,
+quality gates, parity, profile timing, residency, and user-visible status.
+
+ROCm should therefore be a first-class lane for selected AMD Radeon, Radeon PRO,
+and Instinct devices. The first product target must be one exact route that is
+available to the project, such as `amd-radeon-rx-7900-xtx-rocm`,
+`amd-radeon-pro-w7900-rocm`, or `amd-instinct-mi300x-rocm`, not an "all AMD
+GPUs" promise.
+
+## Why HIP First
+
+HIP is the correct first runtime API because it is AMD's C++ runtime and kernel
+programming interface for GPU device management, streams, memory, module
+loading, runtime compilation, launch APIs, and CUDA-adjacent kernel structure.
+BitNet-rs already has HIP-looking embedded kernel sources, so the next proof
+step should be HIP compile and launch evidence rather than a parallel OpenCL,
+WGPU, OpenVINO, or CPU path.
+
+HIP does not make ROCm proof interchangeable with CUDA proof. A HIP kernel that
+compiles for `gfx1100` proves a different runtime, compiler, device ISA, and
+receipt family from a CUDA kernel on an RTX 5070 Ti.
+
+## Why Dense SLM And BitNet QK256 Are Separate
+
+BitNet QK256 proof requires official Microsoft I2_S/QK256 GGUF semantics,
+canonical packed layout, BitNet.cpp-aligned I2_S code mapping, I8_S activation
+quantization, scale and `act_sum` math, tail behavior, row stride behavior, and
+strict tokenizer/template authority.
+
+Dense SLM proof uses regular dense GGUF tensors and model-specific tokenizer,
+prompt, quality, and warm-session rules. A dense Qwen ROCm route can prove dense
+SLM ROCm for that artifact and profile, but it cannot prove packed BitNet
+I2_S/QK256. A BitNet QK256 receipt can prove the official BitNet route, but it
+cannot prove dense Qwen, Qwen3, SmolLM2, Llama, Gemma, or Phi routes.
+
+## Why Source Text Tests Are Insufficient
+
+Source-text tests can show that embedded `.hip` files contain expected symbols,
+`__global__` markers, HIP indexing, and structural safety checks. They do not
+prove that HIP headers are available, the source compiles under a specific HIP
+or ROCm version, the compiler targets a specific GFX architecture, a module can
+load, a kernel can launch, memory transfers work, or model inference uses the
+kernel.
+
+The ROCm ladder therefore separates source embedding, static syntax, hostless
+hipcc compile, target GFX compile, HIPRTC compile, tiny kernel launch, fixture
+kernel launch, and model route launch.
+
+## Exact Device, GFX Target, And Runtime Version
+
+ROCm support shifts across devices, operating systems, ROCm releases, and HIP
+API versions. Receipts must record ROCm version, HIP version, selected AMD GPU,
+architecture family, GFX target, PCI identity, VRAM, compute units, wavefront
+size, driver/kernel context, and official support status where available.
+
+A receipt must not say "ROCm available" if it only found `/opt/rocm`. A receipt
+must not say "selected AMD GPU" unless the runtime/device identity is resolved.
+A kernel compiled under one HIP/ROCm release does not prove another release.
+
+## Linux And Windows Evidence Are Separate
+
+Linux ROCm and Windows HIP SDK support have different installation, driver,
+device, and tooling boundaries. Linux proof should record distro, kernel,
+glibc, amdgpu driver, `rocminfo`, `rocm-smi`, `hipconfig`, `ROCM_PATH`,
+`HIP_PATH`, render/video device permissions, and topology. Windows HIP SDK proof
+should record Windows version, HIP SDK version, AMD driver version, HIP runtime
+availability, HIP SDK availability, GPU name, GFX target, and debugger
+availability when relevant.
+
+A Windows HIP SDK receipt does not prove Linux ROCm support, and a Linux ROCm
+receipt does not prove Windows HIP SDK support.
+
+## Exact-Profile Speed And Residency
+
+Speed and residency are profile-specific claims. BitNet-rs may record timings
+as benchmark candidates before it accepts a speedup. Promotion requires quality
+passed, fallback false, applicable profile timing, same-model CPU comparator,
+relevant same-model CUDA/A770 comparator where useful, repeated same-device
+history receipts, and review acceptance.
+
+Full ROCm residency is also separate from partial acceleration. QK256 linears
+on ROCm are not full decode residency. Dense linears on ROCm are not full model
+residency. Receipts must name per-phase residency before any full-residency
+claim is allowed.
+
+## Claim Boundary
+
+This proposal permits only a docs/status registration claim until later proof
+lands. It does not promote runtime detection, selected AMD GPU support, compile
+proof, execution proof, BitNet QK256 proof, dense SLM proof, answer quality,
+speedup, full residency, product CLI readiness, or server readiness.

--- a/docs/rocm/README.md
+++ b/docs/rocm/README.md
@@ -1,0 +1,119 @@
+# AMD ROCm Lane
+
+Status: registered
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](../specs/BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm device identity](../specs/BITNET-SPEC-ROCM-DEVICE-IDENTITY.md), [ROCm kernel compile](../specs/BITNET-SPEC-ROCM-KERNEL-COMPILE.md), [ROCm BitNet QK256](../specs/BITNET-SPEC-ROCM-BITNET-QK256.md), [ROCm dense SLM](../specs/BITNET-SPEC-ROCM-DENSE-SLM.md), [ROCm quality](../specs/BITNET-SPEC-ROCM-QUALITY.md), [ROCm performance](../specs/BITNET-SPEC-ROCM-PERFORMANCE.md), [ROCm residency](../specs/BITNET-SPEC-ROCM-RESIDENCY.md), [ROCm status surface](../specs/BITNET-SPEC-ROCM-STATUS-SURFACE.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registers AMD ROCm as a docs-only hardware lane at claim level 0
+Policy impact: no CI or runtime policy exception
+
+## Purpose
+
+This directory is the source-of-truth map for AMD ROCm productization. It
+registers AMD ROCm as BitNet-rs's selected-device AMD GPU lane without claiming
+that any AMD GPU, HIP compile, HIP runtime launch, BitNet QK256 model route,
+dense SLM route, performance profile, residency class, or server profile is
+ready.
+
+The lane starts from the existing `bitnet-rocm` crate and its source-text HIP
+kernel checks, then sequences proof toward a product route only after concrete
+HIP/ROCm runtime identity and selected AMD GPU identity are recorded.
+
+## First User-Facing End State
+
+The desired user path is intentionally receipt-backed:
+
+```bash
+bitnet rocm doctor --format json
+bitnet model status --device amd-rocm
+bitnet ask --device amd-rocm --model microsoft-bitnet-b1.58-2B-4T-i2s "..."
+bitnet chat --device amd-rocm --model qwen2.5-0.5b-instruct-q8_0
+bitnet bench --device amd-rocm --model <model-id> --profile warm_session
+bitnet receipts explain --latest
+```
+
+None of those commands are promoted by this registration document. They are the
+end state that later PRs must earn through the implementation plan.
+
+## Required Receipt Questions
+
+Every ROCm receipt must eventually answer:
+
+- Which AMD GPU?
+- Which ROCm and HIP runtime?
+- Which GFX target?
+- Which model family?
+- Which kernel or graph route?
+- Was fallback used?
+- Did answer quality pass?
+- Did CPU/ROCm parity pass?
+- Was speedup accepted for this exact profile?
+- Which not-claims still apply?
+
+## Candidate Selected Backends
+
+The first real product target must be one exact route, chosen from available
+hardware and AMD support status, for example:
+
+```text
+amd-radeon-rx-7900-xtx-rocm
+amd-radeon-rx-7900-xt-rocm
+amd-radeon-rx-7800-xt-rocm
+amd-radeon-pro-w7900-rocm
+amd-instinct-mi300x-rocm
+```
+
+`amd`, `gpu`, `rocm`, `hip`, and `radeon` are forbidden as standalone proof
+labels because they do not identify a selected backend.
+
+## Current Registered State
+
+| Area | Current status | Claim boundary |
+| --- | --- | --- |
+| ROCm source and detection scaffolding | exists in `bitnet-rocm` | source/detection only |
+| HIP kernel source text checks | exists | not compile proof |
+| Selected AMD GPU runtime proof | missing | no selected backend claim |
+| HIP compile smoke | missing | no compile claim |
+| HIP execution smoke | missing | no execution claim |
+| BitNet QK256 ROCm parity | missing | no BitNet route claim |
+| Dense SLM ROCm proof | missing | no dense route claim |
+| Answer-ready ROCm route | missing | no user-facing support claim |
+| Speed, residency, and server readiness | missing | no speed, full-residency, or server claim |
+
+## Permanent Not-Claims
+
+Early ROCm docs, receipts, and status surfaces must preserve these not-claims
+until exact-profile proof promotes a narrower claim:
+
+```text
+not_cuda
+not_opencl
+not_wgpu
+not_openvino_gpu
+not_cpu_acceleration
+not_full_rocm_residency
+not_generic_amd_gpu_support
+not_all_rocm_versions
+not_all_radeon_support
+not_bitnet_qk256_proof_from_dense_slm
+not_dense_slm_proof_from_bitnet
+not_speedup_without_profile_review
+not_server_ready_without_server_receipt
+```
+
+## External Authority Boundary
+
+AMD's current ROCm Linux documentation says the supported GPU table is the
+official support boundary and that unlisted GPUs are not officially supported.
+It also publishes LLVM targets such as `gfx1100`, `gfx1101`, `gfx1200`,
+`gfx1201`, and `gfx942` for selected Radeon, Radeon PRO, and Instinct devices.
+The ROCm status surface must record the exact ROCm/HIP version and support
+status seen at proof time instead of treating a visible HIP device as generic
+AMD GPU support.
+
+Linux ROCm proof and Windows HIP SDK proof are separate evidence families.

--- a/docs/specs/BITNET-SPEC-ROCM-BITNET-QK256.md
+++ b/docs/specs/BITNET-SPEC-ROCM-BITNET-QK256.md
@@ -1,0 +1,67 @@
+# BITNET-SPEC-ROCM-BITNET-QK256: ROCm BitNet QK256 Semantics
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm kernel compile](BITNET-SPEC-ROCM-KERNEL-COMPILE.md), [ROCm quality](BITNET-SPEC-ROCM-QUALITY.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines BitNet ROCm requirements; no model promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Define the ROCm BitNet route so packed I2_S/QK256 proof cannot be satisfied by
+dense ROCm kernels, diagnostic F32 kernels, source-text tests, or other backend
+proof.
+
+## Required Semantics
+
+The production BitNet ROCm path must match the existing CPU scalar oracle and
+CUDA/A770 semantics:
+
+```text
+official Microsoft I2_S/QK256 GGUF
+canonical QK256 packed layout
+BitNet.cpp-aligned I2_S code mapping
+activation quantization to I8_S
+act_scale
+act_sum
+integer dot
+(dot - act_sum) / act_scale * weight_scale
+tail-column behavior
+row-stride behavior
+strict tokenizer/template authority
+```
+
+## Kernel IDs
+
+```text
+qk256-rocm-i8s-scaled-gemv
+qk256-rocm-i8s-scaled-gemm
+qk256-rocm-f32-diagnostic-gemv
+```
+
+## Fixture Scope
+
+The scalar oracle fixture set must include rows `1`, `2`, `7`, and `32`; columns
+`1`, `2`, `127`, `128`, `129`, `255`, `256`, `257`, `512`, and `1024`; all-zero,
+all-one, all-two, all-three, cyclic, and pseudorandom packed patterns; zero,
+constant, signed-ramp, and pseudorandom activations; and weight scales `0.125`,
+`0.5`, and `1.0`.
+
+## Hard Rules
+
+```text
+No-scale F32 diagnostic GEMV cannot satisfy production BitNet QK256 proof.
+Dense SLM ROCm kernels cannot satisfy BitNet packed I2_S/QK256 proof.
+HIP source text proof cannot satisfy QK256 model proof.
+```
+
+Model-level BitNet ROCm promotion requires fallback false, selected AMD GPU,
+selected HIP/ROCm runtime, QK256 invocation counters, CPU/ROCm parity or first
+divergence classification, strict tokenizer/template authority, and answer
+quality evidence.

--- a/docs/specs/BITNET-SPEC-ROCM-DENSE-SLM.md
+++ b/docs/specs/BITNET-SPEC-ROCM-DENSE-SLM.md
@@ -1,0 +1,58 @@
+# BITNET-SPEC-ROCM-DENSE-SLM: ROCm Dense SLM Route
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm quality](BITNET-SPEC-ROCM-QUALITY.md), [ROCm performance](BITNET-SPEC-ROCM-PERFORMANCE.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines dense SLM ROCm requirements; no model promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Define dense model ROCm support separately from BitNet QK256. Dense SLM proof
+must identify the exact artifact, tensor route, tokenizer, prompt authority,
+answer quality, fallback state, performance profile, and residency scope for the
+selected AMD ROCm backend.
+
+## Initial Model Ladder
+
+```text
+Qwen2.5 0.5B Q8_0
+Qwen2.5 1.5B Q4_K_M
+Qwen3 0.6B Q8_0
+SmolLM2 360M / 1.7B if CPU reference passes
+Llama 3.2 1B / 3B candidate
+Gemma/Phi small candidates
+```
+
+## Proof Ladder
+
+```text
+artifact contract
+CPU answer sanity
+ROCm all-layer plan
+single-linear parity
+one-token proof
+short-decode proof
+warm-session proof
+benchmark review
+product CLI promotion
+server exact-profile review
+```
+
+## Not-Claims
+
+```text
+not_bitnet_qk256
+not_cuda
+not_full_residency
+not_speedup_without_review
+```
+
+A dense SLM ROCm receipt must not set BitNet QK256 proof fields true, and a
+BitNet QK256 receipt must not promote dense SLM model support.

--- a/docs/specs/BITNET-SPEC-ROCM-DEVICE-IDENTITY.md
+++ b/docs/specs/BITNET-SPEC-ROCM-DEVICE-IDENTITY.md
@@ -1,0 +1,89 @@
+# BITNET-SPEC-ROCM-DEVICE-IDENTITY: AMD ROCm Device Identity
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines identity fields; no runtime promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Make AMD GPU identity precise enough that ROCm receipts can distinguish an
+installed toolkit, a visible HIP runtime, an officially supported selected GPU,
+an unsupported but visible GPU, and a model route that actually executed.
+
+## Required Linux Fields
+
+Linux ROCm receipts must record:
+
+```text
+OS/distro/kernel/glibc
+ROCm version
+HIP version
+rocminfo available
+rocm-smi available
+hipconfig available
+ROCM_PATH / HIP_PATH
+GPU name
+GFX target
+architecture family
+PCI bus ID
+VRAM
+compute units
+wavefront size
+max workgroup size
+driver version
+amdgpu kernel driver
+render/video device permissions
+multi-GPU topology
+XGMI/PCIe link info where available
+```
+
+## Required Windows Fields
+
+Windows HIP SDK receipts must record:
+
+```text
+Windows version
+HIP SDK version
+AMD driver version
+GPU name
+GFX target
+HIP runtime availability
+HIP SDK availability
+debugger availability if relevant
+```
+
+## Official Support Status
+
+A receipt must distinguish these states:
+
+```text
+supported_official
+unsupported_official
+community_enabled
+unknown
+```
+
+Official support status is versioned evidence. It must be recorded with the
+ROCm or HIP SDK documentation/runtime version consulted at proof time and must
+not silently carry forward to later versions.
+
+## Acceptance Rules
+
+- Linux ROCm proof and Windows HIP SDK proof are separate.
+- A receipt must not say "ROCm available" if it only found `/opt/rocm` but no
+  GPU.
+- A receipt must not say "selected AMD GPU" unless runtime/device identity is
+  resolved.
+- A selected backend must be concrete, such as
+  `amd-radeon-rx-7900-xtx-rocm`, not `amd`, `gpu`, `rocm`, `hip`, or `radeon`.
+- Unsupported official status does not block diagnostic receipts, but it blocks
+  user-facing support promotion unless a policy exception explicitly allows the
+  exact scope.

--- a/docs/specs/BITNET-SPEC-ROCM-KERNEL-COMPILE.md
+++ b/docs/specs/BITNET-SPEC-ROCM-KERNEL-COMPILE.md
@@ -1,0 +1,65 @@
+# BITNET-SPEC-ROCM-KERNEL-COMPILE: HIP Kernel Compile Proof
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm device identity](BITNET-SPEC-ROCM-DEVICE-IDENTITY.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines compile ladder; no compile proof yet
+Policy impact: live compile remains opt-in unless feature-gated and available
+
+## Purpose
+
+Move ROCm proof beyond embedded source-text checks. Current tests can prove that
+HIP source text exists and contains expected markers; they do not prove that the
+source compiles, targets a specific GFX architecture, loads into a runtime
+module, launches, or participates in model inference.
+
+## Compile Levels
+
+```text
+source_embedded
+hip_syntax_static
+hipcc_compile_hostless
+hipcc_compile_for_gfx_target
+hiprtc_compile_runtime
+tiny_kernel_launch
+fixture_kernel_launch
+model_route_launch
+```
+
+## Required Receipt Fields
+
+```json
+{
+  "kernel_source_id": "qk256_i8s_scaled_gemv_hip",
+  "compile_mode": "hipcc|hiprtc",
+  "gfx_target": "gfx1100",
+  "compile_status": "passed",
+  "build_log": "",
+  "runtime_launch": false,
+  "fallback_used": false
+}
+```
+
+Receipts must also include the ROCm route contract identity fields when compile
+or launch proof is tied to a selected backend.
+
+## Hard Rules
+
+```text
+source text contains "__global__" is not compile proof.
+compile proof is not execution proof.
+execution smoke is not model inference proof.
+```
+
+## Ordinary CI Boundary
+
+Ordinary PRs may run source-text tests without ROCm hardware. HIP compile and
+runtime smoke must be feature-gated or explicit opt-in when the HIP SDK and
+selected AMD GPU are present. Missing ROCm prerequisites should produce blocked
+or unavailable receipts, not panics or false success.

--- a/docs/specs/BITNET-SPEC-ROCM-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-ROCM-PERFORMANCE.md
@@ -1,0 +1,79 @@
+# BITNET-SPEC-ROCM-PERFORMANCE: ROCm Profile-Specific Performance
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm quality](BITNET-SPEC-ROCM-QUALITY.md), [ROCm residency](BITNET-SPEC-ROCM-RESIDENCY.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines performance receipt rules; no speed promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Make ROCm speed claims exact-profile claims. Timings may be recorded before
+speed is accepted, but no receipt, status row, or CLI summary may imply global
+ROCm speedup.
+
+## Profiles
+
+```text
+kernel_micro_qk256_gemv
+kernel_micro_qk256_gemm
+single_layer_decode
+one_token
+ask_short
+ask_normal
+prefill_128_decode_16
+prefill_512_decode_32
+decode_32
+decode_128
+warm_session_3_turns
+warm_session_10_turns
+server_nonstream_exact_profile
+```
+
+## Required Timing Fields
+
+```text
+model_load_ms
+tokenizer_load_ms
+prompt_render_ms
+tokenize_ms
+rocm_context_init_ms
+hip_module_compile_ms
+kernel_compile_ms
+weight_upload_ms
+prefill_ms
+first_token_ms
+decode_total_ms
+steady_tok_per_s
+kernel_time_ms
+launch_count
+H2D_bytes
+H2D_ms
+D2H_bytes
+D2H_ms
+VRAM_high_water
+power_temperature_context
+fallback_used
+```
+
+## Promotion Requirements
+
+```text
+quality_passed=true
+fallback_used=false
+profile_timing_applicable=true
+same-model CPU comparator
+same-model CUDA/A770 comparator where useful
+two same-device history receipts
+speedup accepted by review
+```
+
+A rejected profile may remain valuable benchmark evidence, but it must keep
+`speedup_claim=false` and must not promote product support beyond the accepted
+quality/residency level.

--- a/docs/specs/BITNET-SPEC-ROCM-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-ROCM-QUALITY.md
@@ -1,0 +1,69 @@
+# BITNET-SPEC-ROCM-QUALITY: ROCm Answer Quality
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm BitNet QK256](BITNET-SPEC-ROCM-BITNET-QK256.md), [ROCm dense SLM](BITNET-SPEC-ROCM-DENSE-SLM.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines quality gates; no answer-ready promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Ensure "working on ROCm" means intelligible, bounded outputs with fallback
+false, route identity, tokenizer/template authority, and CPU/ROCm parity or
+classified divergence.
+
+## BitNet ROCm Quality Set
+
+```text
+tiny deterministic answer corpus
+expanded answer corpus
+prompt-conditioning pairs
+copy/repeat
+yes/no
+format following
+stop-token behavior
+long decode
+CPU/ROCm generated-token parity or first divergence classification
+```
+
+## Dense SLM ROCm Quality Set
+
+```text
+same dense SLM corpus used by CUDA/CPU lanes
+direct prompt IDs when available
+generated IDs
+decoded text
+failure taxonomy
+warm-session behavior
+```
+
+## Failure Taxonomy
+
+```text
+exact_answer_overgenerated
+exact_answer_instruction_not_followed
+missing_required_keyword
+forbidden_token_observed
+raw_special_token_seen
+empty_answer
+repetition
+stop_policy_failed
+context_sensitivity_failed
+structured_output_failed
+tokenizer_mismatch
+runtime_error
+timeout
+first_divergence_logits_topk
+```
+
+## Promotion Rule
+
+Answer-ready ROCm promotion requires all applicable quality cases to pass or an
+exact blocker to be recorded. Benchmark, speed, residency, and server readiness
+remain false unless their separate specs are satisfied.

--- a/docs/specs/BITNET-SPEC-ROCM-RESIDENCY.md
+++ b/docs/specs/BITNET-SPEC-ROCM-RESIDENCY.md
@@ -1,0 +1,65 @@
+# BITNET-SPEC-ROCM-RESIDENCY: ROCm Residency Claims
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm performance](BITNET-SPEC-ROCM-PERFORMANCE.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines residency classes; no residency promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Prevent partial ROCm acceleration from becoming a "full ROCm" claim. Residency
+must be per-phase evidence, not a synonym for one kernel or one tensor op.
+
+## Residency Classes
+
+```text
+none
+runtime_detected
+source_compiled
+kernel_smoke
+qk256_linears_only
+dense_linears_only
+decode_partial
+warm_session_partial
+full_decode_candidate
+full_device_resident
+```
+
+## Phase Table
+
+```json
+{
+  "residency": {
+    "weights": "rocm|cpu|mixed|unknown",
+    "qk256_linears": "rocm|cpu|mixed|unknown",
+    "dense_linears": "rocm|cpu|mixed|unknown",
+    "embedding": "rocm|cpu|mixed|unknown",
+    "kv_cache": "rocm|cpu|mixed|unknown",
+    "rmsnorm": "rocm|cpu|mixed|unknown",
+    "rope": "rocm|cpu|mixed|unknown",
+    "attention_scores": "rocm|cpu|mixed|unknown",
+    "softmax": "rocm|cpu|mixed|unknown",
+    "attention_value_mix": "rocm|cpu|mixed|unknown",
+    "mlp_activation": "rocm|cpu|mixed|unknown",
+    "lm_head": "rocm|cpu|mixed|unknown",
+    "sampling": "rocm|cpu|host_logits_only|unknown"
+  }
+}
+```
+
+## Hard Rule
+
+```text
+QK256 linears on ROCm are not full ROCm residency.
+Dense linear kernels on ROCm are not full model residency.
+```
+
+Full device residency requires phase evidence for every applicable phase and
+must remain independent from speedup and server-readiness claims.

--- a/docs/specs/BITNET-SPEC-ROCM-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-ROCM-ROUTE-CONTRACT.md
@@ -1,0 +1,133 @@
+# BITNET-SPEC-ROCM-ROUTE-CONTRACT: AMD ROCm Route Contract
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm device identity](BITNET-SPEC-ROCM-DEVICE-IDENTITY.md), [ROCm kernel compile](BITNET-SPEC-ROCM-KERNEL-COMPILE.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines labels; no runtime promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Define the ROCm backend labels, route IDs, proof families, and receipt identity
+fields that keep AMD ROCm proof separate from CUDA, OpenCL, WGPU, CPU,
+OpenVINO, and generic GPU support.
+
+## Required Route IDs
+
+```text
+amd_rocm_runtime_probe
+amd_rocm_hip_compile_smoke
+amd_rocm_tiny_kernel_smoke
+amd_rocm_bitnet_qk256_gemv
+amd_rocm_bitnet_qk256_gemm
+amd_rocm_dense_slm_gemv
+amd_rocm_dense_slm_warm_session
+amd_rocm_server_exact_profile
+```
+
+## Backend Labels
+
+Receipts must preserve the requested backend, concrete selected backend,
+runtime API, runtime stack, and target ISA:
+
+```text
+requested_backend = "amd-rocm"
+selected_backend = "amd-radeon-rx-7900-xtx-rocm"
+runtime_api = "hip"
+runtime_stack = "rocm"
+gfx_target = "gfx1100"
+```
+
+`selected_backend` must be a concrete route for the selected device. The values
+below are examples only and must not be claimed until the device is actually
+resolved and proven:
+
+```text
+amd-radeon-rx-7900-xtx-rocm
+amd-radeon-rx-7900-xt-rocm
+amd-radeon-rx-7800-xt-rocm
+amd-radeon-pro-w7900-rocm
+amd-instinct-mi300x-rocm
+```
+
+## Forbidden Standalone Proof Labels
+
+Do not use these labels by themselves as proof labels:
+
+```text
+amd
+gpu
+rocm
+hip
+radeon
+```
+
+They are too generic to identify a selected backend, route, runtime, device,
+model family, or proof stage.
+
+## Proof Families
+
+ROCm proof must use ROCm-specific families such as:
+
+```text
+rocm_bitnet_qk256_hip
+rocm_dense_slm_hip
+rocm_dense_llm_hip
+rocm_source_compile_smoke
+rocm_runtime_smoke
+rocm_external_reference
+```
+
+CUDA, A770 OpenCL, OpenVINO GPU, Apple Metal, CPU AVX2/AVX-512, NPU, and
+generic GPU proof families are not interchangeable with these families.
+
+## Required Receipt Fields
+
+```json
+{
+  "requested_backend": "amd-rocm",
+  "selected_backend": "amd-radeon-rx-7900-xtx-rocm",
+  "runtime_api": "hip",
+  "runtime_stack": "rocm",
+  "rocm_version": "7.2.3",
+  "hip_version": "7.2.53211",
+  "gfx_target": "gfx1100",
+  "device": {
+    "name": "AMD Radeon RX 7900 XTX",
+    "arch": "RDNA3",
+    "pci_bus_id": "...",
+    "vram_bytes": 0,
+    "compute_units": 0,
+    "wavefront_size": 64
+  },
+  "fallback_used": false,
+  "fallback_reason": null,
+  "proof_family": "rocm_bitnet_qk256_hip"
+}
+```
+
+If any field is not available, the receipt must say so explicitly and must not
+promote a selected-backend claim that depends on it.
+
+## Claim Levels
+
+| Level | Meaning | Public claim |
+| ---: | --- | --- |
+| 0 | `registered` | ROCm lane exists as docs/status only. |
+| 1 | `runtime_detected` | ROCm/HIP and selected AMD GPU visible. |
+| 2 | `source_compile_smoke` | HIP source compiles for target GFX. |
+| 3 | `runtime_smoke` | Tiny HIP kernel executes on selected GPU. |
+| 4 | `parity_tested` | CPU/ROCm fixture parity for selected op. |
+| 5 | `answer_candidate` | Model answers bounded prompts on ROCm. |
+| 6 | `answer_ready` | Corpus/profile quality passes. |
+| 7 | `benchmark_candidate` | Timings recorded, speed not accepted. |
+| 8 | `performance_proven` | Exact-profile speed/power accepted. |
+| 9 | `resident_proven` | Named phases resident on ROCm. |
+| 10 | `product_cli_ready` | ask/chat/status/receipts are user-ready. |
+| 11 | `server_exact_profile_ready` | Bounded server route proven. |

--- a/docs/specs/BITNET-SPEC-ROCM-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-ROCM-STATUS-SURFACE.md
@@ -1,0 +1,55 @@
+# BITNET-SPEC-ROCM-STATUS-SURFACE: ROCm Status And Doctor UX
+
+Status: proposed
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm device identity](BITNET-SPEC-ROCM-DEVICE-IDENTITY.md), [ROCm kernel compile](BITNET-SPEC-ROCM-KERNEL-COMPILE.md), [ROCm quality](BITNET-SPEC-ROCM-QUALITY.md), [ROCm performance](BITNET-SPEC-ROCM-PERFORMANCE.md), [ROCm residency](BITNET-SPEC-ROCM-RESIDENCY.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [AMD ROCm implementation plan](../../plans/rocm/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future status UX; no CLI promotion
+Policy impact: no CI policy exception
+
+## Purpose
+
+Make ROCm status visible without overclaiming. Status commands must summarize
+the next missing proof and preserve not-claims instead of turning a toolkit path
+or source-text test into product support.
+
+## Commands
+
+```bash
+bitnet rocm doctor --format json
+bitnet model status --device amd-rocm
+bitnet receipts explain <receipt>
+bitnet gpu doctor --vendor amd
+```
+
+## Status Output Fields
+
+```text
+ROCm installed
+HIP available
+selected AMD GPU
+GFX target
+supported/unsupported official status
+kernel source compile status
+tiny kernel smoke status
+BitNet QK256 status
+dense SLM status
+quality status
+performance status
+residency status
+server status
+not-claims
+next proof required
+```
+
+## Fail-Closed Behavior
+
+`--device amd-rocm --strict` must fail before generation or benchmarking when a
+required ROCm proof field is missing. Non-strict diagnostics may report missing
+prerequisites, but they must set fallback and support fields truthfully and must
+not promote an accelerator claim.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,6 +1,46 @@
 # Specs Index
 
 
+## AMD ROCm Productization
+
+Use these specs before implementing or claiming AMD ROCm support:
+
+1. [AMD ROCm Productization Proposal](../proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+   - Explains why ROCm exists as a selected-device AMD GPU lane and why HIP,
+     BitNet QK256, dense SLM, quality, speed, residency, and server proof stay
+     separate.
+2. [ROCm Route Contract](BITNET-SPEC-ROCM-ROUTE-CONTRACT.md)
+   - Defines concrete backend labels, route IDs, proof families, receipt fields,
+     and forbidden generic proof labels.
+3. [ROCm Device Identity](BITNET-SPEC-ROCM-DEVICE-IDENTITY.md)
+   - Defines Linux ROCm and Windows HIP SDK identity fields, official support
+     status, and selected-device acceptance rules.
+4. [ROCm Kernel Compile](BITNET-SPEC-ROCM-KERNEL-COMPILE.md)
+   - Separates source embedding, HIP compile, runtime launch, fixture launch,
+     and model route launch proof.
+5. [ROCm BitNet QK256](BITNET-SPEC-ROCM-BITNET-QK256.md)
+   - Defines packed I2_S/QK256 ROCm semantics, kernel IDs, fixtures, and hard
+     boundaries against dense SLM and diagnostic F32 proof.
+6. [ROCm Dense SLM](BITNET-SPEC-ROCM-DENSE-SLM.md)
+   - Defines dense ROCm model candidates and the proof ladder separate from
+     BitNet QK256.
+7. [ROCm Quality](BITNET-SPEC-ROCM-QUALITY.md)
+   - Defines answer-quality corpora, generated-token evidence, and failure
+     taxonomy for BitNet and dense SLM ROCm.
+8. [ROCm Performance](BITNET-SPEC-ROCM-PERFORMANCE.md)
+   - Defines exact profiles, timing fields, comparators, and speed promotion
+     gates.
+9. [ROCm Residency](BITNET-SPEC-ROCM-RESIDENCY.md)
+   - Defines residency classes and per-phase residency evidence.
+10. [ROCm Status Surface](BITNET-SPEC-ROCM-STATUS-SURFACE.md)
+    - Defines future `rocm doctor`, `model status`, `receipts explain`, and
+      AMD GPU doctor status fields.
+
+The ROCm lane is currently registered/scaffold only. Do not proceed from source
+text checks, ROCm installation paths, HIP visibility, or generic AMD GPU labels
+to compile, execution, model, quality, speed, residency, or server claims.
+
+
 ## CPU AVX-512 Kernel Proof
 
 Use these specs before implementing or claiming AVX-512 CPU kernel support:

--- a/docs/tracking/campaigns/amd-rocm/CAMPAIGN.md
+++ b/docs/tracking/campaigns/amd-rocm/CAMPAIGN.md
@@ -1,0 +1,59 @@
+# AMD ROCm Productization Campaign
+
+Campaign ID: `amd-rocm`
+
+Status: active
+
+## Objective
+
+Register and sequence AMD ROCm as BitNet-rs's selected-device HIP/ROCm lane for
+exact AMD Radeon, Radeon PRO, and Instinct routes without inheriting CUDA,
+OpenCL, WGPU, CPU, OpenVINO, BitNet QK256, dense SLM, speed, residency, or
+server proof.
+
+## End State
+
+- ROCm status surfaces answer which AMD GPU, ROCm/HIP runtime, GFX target,
+  model family, route, fallback state, quality result, parity result, speed
+  review, and not-claims apply.
+- Selected backend labels are concrete AMD ROCm device routes, never generic
+  `amd`, `gpu`, `rocm`, `hip`, or `radeon` labels.
+- HIP source embedding, HIP compile, HIP runtime smoke, BitNet QK256 parity,
+  dense SLM proof, answer quality, performance, residency, and server readiness
+  remain separate proof stages.
+
+## Hard Constraints
+
+- Do not claim generic AMD GPU support.
+- Do not claim ROCm from source text tests.
+- Do not claim HIP compile from source embedding.
+- Do not claim execution from compile smoke.
+- Do not claim BitNet QK256 from dense SLM ROCm proof.
+- Do not claim dense SLM from BitNet QK256 proof.
+- Do not claim speedup without exact-profile review.
+- Do not claim full residency without per-phase residency evidence.
+- Do not add live ROCm hardware execution to ordinary PR CI.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| ROCM-DOCS-000 | ready | Add source-of-truth map, proposal, specs, plan, campaign tracker, specs index, and hardware matrix row. |
+| ROCM-PROBE-001 | planned | Harden ROCm detection receipt and `bitnet rocm doctor --format json`. |
+| ROCM-PROBE-002 | planned | Add strict selected-device identity. |
+| ROCM-KERNEL-003 | planned | Add HIP compile-smoke harness. |
+| ROCM-KERNEL-004 | planned | Add tiny HIP runtime smoke. |
+| ROCM-RECEIPT-005 | planned | Validate ROCm receipt claim booleans. |
+| ROCM-QK256-006..009 | planned | Lock QK256 fixtures, add HIP GEMV, persist context, and route strict QK256 through ROCm. |
+| ROCM-QUALITY-010..012 | planned | Add BitNet one-token, corpus, long-decode, and warm-session proof. |
+| ROCM-DENSE-013..016 | planned | Add dense SLM artifact, single-linear, decode, and warm-session proof. |
+| ROCM-BENCH-017..018 | planned | Add profile timing receipts and exact-profile speed review. |
+| ROCM-CLAIMS-019 | planned | Promote product CLI route only after proof gates. |
+| ROCM-SERVER-020..021 | planned | Add exact-profile dense and BitNet server smoke. |
+
+## Review Policy
+
+ROCm PRs must keep device identity, runtime identity, route family, model
+family, fallback truth, quality, parity, speed, residency, and server claims
+separate. Documentation PRs may register the lane only; runtime PRs must link
+the specific spec and plan item they implement.

--- a/docs/tracking/campaigns/amd-rocm/active.toml
+++ b/docs/tracking/campaigns/amd-rocm/active.toml
@@ -1,0 +1,67 @@
+id = "amd-rocm"
+title = "AMD ROCm productization"
+status = "active"
+
+objective = "Register and sequence AMD ROCm as BitNet-rs's selected-device HIP/ROCm lane for exact AMD Radeon, Radeon PRO, and Instinct routes without inheriting CUDA, OpenCL, WGPU, CPU, OpenVINO, BitNet QK256, dense SLM, speed, residency, or server proof."
+
+end_state = [
+  "ROCm status surfaces answer which AMD GPU, ROCm/HIP runtime, GFX target, model family, route, fallback state, quality result, parity result, speed review, and not-claims apply.",
+  "Selected backend labels are concrete AMD ROCm device routes, never generic amd/gpu/rocm/hip/radeon labels.",
+  "HIP source embedding, HIP compile, HIP runtime smoke, BitNet QK256 parity, dense SLM proof, answer quality, performance, residency, and server readiness remain separate proof stages.",
+]
+
+hard_constraints = [
+  "Do not claim generic AMD GPU support.",
+  "Do not claim ROCm from source text tests.",
+  "Do not claim HIP compile from source embedding.",
+  "Do not claim execution from compile smoke.",
+  "Do not claim BitNet QK256 from dense SLM ROCm proof.",
+  "Do not claim dense SLM from BitNet QK256 proof.",
+  "Do not claim speedup without exact-profile review.",
+  "Do not claim full residency without per-phase residency evidence.",
+  "Do not add live ROCm hardware execution to ordinary PR CI.",
+]
+
+[[work_item]]
+id = "ROCM-DOCS-000"
+status = "ready"
+branch = "codex/amd-rocm/ROCM-DOCS-000-source-of-truth"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add AMD ROCm source-of-truth docs, proposal, specs, plan, campaign tracker, specs index entry, and hardware matrix row as docs-only registered/scaffold evidence with no runtime, model, speed, residency, or server promotion."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check amd-rocm",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/rocm/**",
+  "plans/rocm/**",
+  "docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md",
+  "docs/specs/BITNET-SPEC-ROCM-*.md",
+  "docs/specs/INDEX.md",
+  "docs/hardware/HARDWARE_MATRIX.md",
+  "docs/tracking/campaigns/amd-rocm/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "ci/model-artifacts/**",
+  "ci/hardware/**",
+  ".github/workflows/**",
+]
+may_claim = [
+  "AMD ROCm lane is registered as docs/status scaffold at claim level 0.",
+]
+must_not_claim = [
+  "ROCm/HIP runtime is detected.",
+  "A selected AMD GPU is proven.",
+  "HIP source compiles for a target GFX.",
+  "A HIP kernel executed.",
+  "BitNet QK256 works on ROCm.",
+  "Dense SLM works on ROCm.",
+  "ROCm answer quality passed.",
+  "ROCm speedup, full residency, product CLI readiness, or server readiness is proven.",
+]

--- a/docs/tracking/campaigns/amd-rocm/generated/status.md
+++ b/docs/tracking/campaigns/amd-rocm/generated/status.md
@@ -1,0 +1,24 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# AMD ROCm productization Campaign Status
+
+- Campaign: `amd-rocm`
+- State: `active`
+- Objective: Register and sequence AMD ROCm as BitNet-rs's selected-device HIP/ROCm lane for exact AMD Radeon, Radeon PRO, and Instinct routes without inheriting CUDA, OpenCL, WGPU, CPU, OpenVINO, BitNet QK256, dense SLM, speed, residency, or server proof.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| ROCM-DOCS-000 | ready | TBD | `codex/amd-rocm/ROCM-DOCS-000-source-of-truth` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add AMD ROCm source-of-truth docs, proposal, specs, plan, campaign tracker, specs index entry, and hardware matrix row as docs-only registered/scaffold evidence with no runtime, model, speed, residency, or server promotion. |
+
+## Hard Constraints
+
+- Do not claim generic AMD GPU support.
+- Do not claim ROCm from source text tests.
+- Do not claim HIP compile from source embedding.
+- Do not claim execution from compile smoke.
+- Do not claim BitNet QK256 from dense SLM ROCm proof.
+- Do not claim dense SLM from BitNet QK256 proof.
+- Do not claim speedup without exact-profile review.
+- Do not claim full residency without per-phase residency evidence.
+- Do not add live ROCm hardware execution to ordinary PR CI.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,6 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
+| amd-rocm | ROCM-DOCS-000 | TBD | ready | none | Do not claim generic AMD GPU support. |
 | apple-bitnet-artifact-sweep | ABAS-001 | TBD | proposed | ABAS-002 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m3-macbook-air | M3MBA-006 | TBD | blocked | M3MBA-007 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,6 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
+| amd-rocm | AMD ROCm productization | ROCM-DOCS-000 | Do not claim generic AMD GPU support. |
 | apple-bitnet-artifact-sweep | Apple BitNet artifact sweep | ABAS-001 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m3-macbook-air | Apple M3 MacBook Air | M3MBA-006 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | Apple M4 Mac mini validation | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |

--- a/plans/rocm/README.md
+++ b/plans/rocm/README.md
@@ -1,0 +1,21 @@
+# AMD ROCm Plans
+
+Status: active
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../../docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm specs](../../docs/specs/INDEX.md#amd-rocm-productization)
+Linked ADRs: [BITNET-ADR-0005](../../docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [implementation-plan.md](implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: planning only
+Policy impact: no CI policy exception
+
+This directory sequences AMD ROCm from a registered lane through selected-device
+HIP/ROCm proof, source compile, runtime smoke, BitNet QK256 parity, dense SLM
+proof, quality, performance, residency, status UX, and exact-profile server
+readiness.
+
+Start with `implementation-plan.md` and the campaign active goal at
+`docs/tracking/campaigns/amd-rocm/active.toml`.

--- a/plans/rocm/implementation-plan.md
+++ b/plans/rocm/implementation-plan.md
@@ -1,0 +1,122 @@
+# AMD ROCm Implementation Plan
+
+Status: active
+Owner: rocm/productization
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0008](../../docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md)
+Linked specs: [ROCm route contract](../../docs/specs/BITNET-SPEC-ROCM-ROUTE-CONTRACT.md), [ROCm device identity](../../docs/specs/BITNET-SPEC-ROCM-DEVICE-IDENTITY.md), [ROCm kernel compile](../../docs/specs/BITNET-SPEC-ROCM-KERNEL-COMPILE.md), [ROCm BitNet QK256](../../docs/specs/BITNET-SPEC-ROCM-BITNET-QK256.md), [ROCm dense SLM](../../docs/specs/BITNET-SPEC-ROCM-DENSE-SLM.md), [ROCm quality](../../docs/specs/BITNET-SPEC-ROCM-QUALITY.md), [ROCm performance](../../docs/specs/BITNET-SPEC-ROCM-PERFORMANCE.md), [ROCm residency](../../docs/specs/BITNET-SPEC-ROCM-RESIDENCY.md), [ROCm status surface](../../docs/specs/BITNET-SPEC-ROCM-STATUS-SURFACE.md)
+Linked ADRs: [BITNET-ADR-0005](../../docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registers and sequences AMD ROCm without runtime promotion
+Policy impact: ordinary PRs remain source-only; live ROCm proof is opt-in
+
+## Work Item: ROCM-DOCS-000
+
+Status: ready
+Campaign: `docs/tracking/campaigns/amd-rocm/active.toml`
+Blocked by: n/a
+Blocks: ROCM-PROBE-001 through ROCM-SERVER-025
+
+### Goal
+
+Add the AMD ROCm source-of-truth map, campaign tracker, proposal, specs, and
+claim rails so follow-on PRs can productize ROCm without conflating HIP/ROCm,
+CUDA, OpenCL, WGPU, CPU, OpenVINO, BitNet QK256, dense SLM, speed, residency,
+or server proof families.
+
+### Production Delta
+
+Docs and planning only. This item registers the lane at `registered` claim
+level 0 and does not change runtime code, kernels, model coverage, or CI live
+hardware execution.
+
+### Non-Goals
+
+- Do not claim generic AMD GPU support.
+- Do not claim ROCm from source text tests.
+- Do not claim HIP compile from source embedding.
+- Do not claim execution from compile smoke.
+- Do not claim BitNet QK256 from dense SLM ROCm proof.
+- Do not claim dense SLM from BitNet QK256 proof.
+- Do not claim speedup without exact-profile review.
+- Do not claim full residency without per-phase residency evidence.
+- Do not add live ROCm hardware execution to ordinary PR CI.
+- Do not touch CUDA, A770 OpenCL, Apple Metal, Intel NPU, or CPU kernels.
+
+### Acceptance
+
+- `docs/rocm/README.md` registers the ROCm lane and current claim boundary.
+- `plans/rocm/README.md` and this plan define the PR sequence and validation.
+- `docs/tracking/campaigns/amd-rocm/active.toml` and `CAMPAIGN.md` define the
+  ready documentation item and follow-on sequence.
+- `docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md` explains why the
+  lane exists.
+- ROCm route, device, compile, BitNet QK256, dense SLM, quality, performance,
+  residency, and status specs exist.
+- `docs/specs/INDEX.md` and `docs/hardware/HARDWARE_MATRIX.md` list ROCm as a
+  registered/scaffold lane without runtime, model, speed, residency, or server
+  promotion.
+
+### Proof Commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check amd-rocm
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+### Rollback
+
+Revert the ROCm docs, plan, proposal, specs, campaign tracker, specs index row,
+and hardware matrix row. No runtime migration is needed.
+
+## Follow-On PR Queue
+
+| Order | ID | Title | Scope | Acceptance summary |
+| --- | --- | --- | --- | --- |
+| 1 | ROCM-PROBE-001 | `probe(rocm): harden ROCm detection receipt` | CLI/receipt doctor surface | `bitnet rocm doctor --format json` works without ROCm, reports missing prerequisites, and claims no execution. |
+| 2 | ROCM-PROBE-002 | `probe(rocm): selected-device identity` | strict selected device probe | `--device 0 --strict` resolves selected backend only with GPU identity and fails closed otherwise. |
+| 3 | ROCM-KERNEL-003 | `rocm(kernel): add HIP compile-smoke harness` | hipcc/HIPRTC compile receipt | compile logs and GFX target recorded; no runtime launch or model claim. |
+| 4 | ROCM-KERNEL-004 | `rocm(kernel): add tiny HIP runtime smoke` | vector-add HIP launch | selected AMD GPU, HIP launch success, CPU parity, fallback false; no BitNet claim. |
+| 5 | ROCM-RECEIPT-005 | `rocm(receipts): validate ROCm receipt claim booleans` | receipt validation | rejects generic selected backend, strict fallback, ungated speed, ungated full residency, and proof-family leakage. |
+| 6 | ROCM-QK256-006 | `test(rocm): QK256 scaled I2S-I8S fixtures` | CPU scalar oracle fixtures | locks rows, columns, tails, patterns, activations, scales; no ROCm execution required. |
+| 7 | ROCM-QK256-007 | `feat(rocm): QK256 scaled I2S-I8S HIP GEMV` | HIP GEMV kernel | HIP launch, scalar parity, tails pass, fallback false; no model-level claim. |
+| 8 | ROCM-QK256-008 | `feat(rocm): persistent ROCm BitNet context` | context/streams/modules/workspaces | weights uploaded once, no per-token upload, workspace reused. |
+| 9 | ROCM-QK256-009 | `dispatch(rocm): route strict QK256 through ROCm` | strict dispatch wiring | strict `amd-rocm` fails closed when unavailable; QK256 ROCm invocations > 0; CPU fallback 0. |
+| 10 | ROCM-QUALITY-010 | `test(rocm): one-token BitNet proof` | official BitNet one-token | generated token or divergence classified; fallback false; speedup false. |
+| 11 | ROCM-QUALITY-011 | `test(rocm): deterministic BitNet answer corpus` | answer corpus | tiny corpus passes or exact blocker recorded; prompt/generated IDs and parity/divergence recorded. |
+| 12 | ROCM-QUALITY-012 | `test(rocm): long-decode and warm-session proof` | decode/warm session | upload once, context reused, quality passes, fallback false, speedup false. |
+| 13 | ROCM-DENSE-013 | `model(rocm): dense SLM artifact contract` | Qwen2.5 0.5B Q8_0 candidate | CPU sanity exists or is recorded; no BitNet QK256 claim. |
+| 14 | ROCM-DENSE-014 | `test(rocm): dense single-linear parity` | dense linear fixture | CPU/ROCm parity, shape/tensor role recorded, fallback false, no full model claim. |
+| 15 | ROCM-DENSE-015 | `test(rocm): dense one-token / short-decode` | dense decode proof | valid text, generated IDs where available, dense route, speed false, BitNet proof false. |
+| 16 | ROCM-DENSE-016 | `test(rocm): dense warm-session` | dense session proof | model loaded once, weights uploaded once, multi-turn quality gate. |
+| 17 | ROCM-BENCH-017 | `bench(rocm): ROCm phase timing profiles` | benchmark receipts | same-model CPU comparator and relevant CUDA/A770 comparator; speedup false. |
+| 18 | ROCM-BENCH-018 | `bench(rocm): exact-profile speed review` | profile review | accept/reject each profile; no global speedup, unsupported model, or full residency claim. |
+| 19 | ROCM-CLAIMS-019 | `claims(rocm): promote product CLI route` | model status/receipts UX | coverage/status/quickstart promotion only after quality, warm session, and benchmark review. |
+| 20 | ROCM-SERVER-020 | `server(rocm): dense SLM exact-profile server smoke` | non-streaming server | selected concrete AMD ROCm backend, fallback false, quality pass, exact-profile server scope. |
+| 21 | ROCM-SERVER-021 | `server(rocm): BitNet exact-profile server smoke` | BitNet server | official route, QK256 invocation count, fallback false, answer pass, exact-profile server scope. |
+
+## Default Validation
+
+Docs/spec PRs:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check amd-rocm
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+Source-only ROCm PRs:
+
+```bash
+cargo test --locked -p bitnet-rocm --no-default-features
+cargo check --locked -p bitnet-rocm --no-default-features
+git diff --check
+```
+
+Live ROCm proof is opt-in only under workflow dispatch, main, scheduled,
+release, explicit `rocm-ci`/`gpu-ci`/`model-validation` labels, or a hardware
+campaign receipt. Ordinary PRs must not require ROCm hardware, HIP compile,
+model downloads, or live device launches.


### PR DESCRIPTION
### Motivation

- Register AMD ROCm as a docs-only selected-device HIP/ROCm lane and establish clear claim boundaries so ROCm proof does not get conflated with CUDA, OpenCL, WGPU, CPU, OpenVINO, or generic GPU evidence.
- Provide the source-of-truth artifacts (proposal, route/device/compile/QK256/dense/quality/performance/residency/status specs, plan) needed for sequenced, receipt-backed ROCm productization.
- Ensure future runtime/compile/smoke/parity/benchmark work has a tracked campaign and explicit rules for receipts, not-claims, and promotion ladders before any user-facing ROCm claims are allowed.

### Description

- Add docs and scaffolding: `docs/rocm/README.md`, `docs/proposals/BITNET-PROP-0008-amd-rocm-productization.md`, `plans/rocm/README.md`, and `plans/rocm/implementation-plan.md` to register the lane and sequence follow-on work. 
- Add ROCm specs under `docs/specs/`: `BITNET-SPEC-ROCM-ROUTE-CONTRACT.md`, `BITNET-SPEC-ROCM-DEVICE-IDENTITY.md`, `BITNET-SPEC-ROCM-KERNEL-COMPILE.md`, `BITNET-SPEC-ROCM-BITNET-QK256.md`, `BITNET-SPEC-ROCM-DENSE-SLM.md`, `BITNET-SPEC-ROCM-QUALITY.md`, `BITNET-SPEC-ROCM-PERFORMANCE.md`, `BITNET-SPEC-ROCM-RESIDENCY.md`, and `BITNET-SPEC-ROCM-STATUS-SURFACE.md` to define labels, receipt shapes, claim ladders, and hard rules. 
- Add campaign tracker and generated status: `docs/tracking/campaigns/amd-rocm/active.toml`, `CAMPAIGN.md`, and regenerated dashboards, and update `docs/specs/INDEX.md` and `docs/hardware/HARDWARE_MATRIX.md` to include the registered `amd-rocm` scaffold row and required receipt shape. 

### Testing

- Ran campaign validation and generation: `cargo run --locked -p xtask --no-default-features -- campaign check amd-rocm` and `cargo run --locked -p xtask --no-default-features -- campaign generate --check`, both passed. 
- Ran package tests and checks for the ROCm crate: `cargo test --locked -p bitnet-rocm --no-default-features` and `cargo check --locked -p bitnet-rocm --no-default-features`, all tests passed. 
- Ran repo validation `git diff --check` and the xtask generation to refresh dashboards; generated dashboards are current and checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad359fb388333aa5a85fe4db41d8d)