### PR TITLE
docs(openvino): mark corpus v2 report merged in plan

### DIFF
--- a/plans/openvino-lunar-lake/implementation-plan.md
+++ b/plans/openvino-lunar-lake/implementation-plan.md
@@ -283,7 +283,8 @@ Acceptance additions:
 
 ### Work item: LNL258V-OPENVINO-QUAL-REPORT-001
 
-Status: in_progress
+Status: merged
+Linked PR: #5633
 Blocked by: `LNL258V-OPENVINO-UX-001`, `LNL258V-OV-QUAL-005`
 
 Add `docs/reports/OPENVINO_LUNAR_LAKE_CORPUS_V2_FAILURES.md` and classify


### PR DESCRIPTION
Summary:
- mark the OpenVINO Lunar Lake corpus-v2 failure report work item merged in the implementation plan
- link PR #5633 so the plan agrees with the campaign tracker closeout

Claim boundary:
Documentation consistency only. No runtime changes, inference, route promotion, speedup, power claim, accelerator claim, or BitNet QK256/I2_S behavior change.

Validation:
- npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc plans/openvino-lunar-lake/implementation-plan.md
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check