### PR TITLE
ci: remove macOS from ordinary PRs

### DIFF
--- a/.github/workflows/macos-arm64.yml
+++ b/.github/workflows/macos-arm64.yml
@@ -7,14 +7,7 @@ name: "macOS (Apple Silicon)"
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'crates/**'
-      - 'crossval/**'
-      - 'tests/**'
-      - 'xtask/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - '.github/workflows/macos-arm64.yml'
+    types: [ opened, synchronize, reopened, ready_for_review, labeled, unlabeled ]
   push:
     branches: [ main ]
     paths:
@@ -45,9 +38,67 @@ env:
   BITNET_SKIP_SLOW_TESTS: "1"
 
 jobs:
+  route-macos:
+    name: "Route macOS PR lane"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      selected: ${{ steps.route.outputs.selected }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether macOS is selected
+        id: route
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref || github.ref_name }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          selected=false
+          reason="ordinary PR without macOS label or Mac/Metal paths"
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            selected=true
+            reason="$EVENT_NAME"
+          elif python - "$LABELS_JSON" <<'PY'
+          import json
+          import sys
+
+          labels = set(json.loads(sys.argv[1] or "[]"))
+          selected = bool(labels & {"macos", "apple-silicon", "metal", "full-ci"})
+          sys.exit(0 if selected else 1)
+          PY
+          then
+            selected=true
+            reason="explicit macOS/Apple/Metal/full-ci label"
+          else
+            git fetch --no-tags --depth=1 origin "$BASE_REF"
+            changed="$(git diff --name-only "origin/$BASE_REF"...HEAD)"
+            if printf '%s\n' "$changed" | grep -E '^(\.github/workflows/macos-arm64\.yml|crates/bitnet-metal/|crates/bitnet-kernels/src/metal/|crates/bitnet-kernels/src/metal_compute\.rs|crates/bitnet-kernels/tests/metal|crates/bitnet-device-probe/src/apple_metal\.rs|crates/bitnet-gpu-hal/src/metal_backend\.rs|crates/bitnet-common/tests/metal_memory_patterns\.rs)' >/dev/null; then
+              selected=true
+              reason="Mac/Metal-specific paths changed"
+            fi
+          fi
+
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          {
+            echo "### macOS route"
+            echo "- selected: $selected"
+            echo "- reason: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Job 1: Build and test CPU inference on Apple Silicon
   build-cpu:
     name: "macOS: Build & Test (CPU)"
+    needs: route-macos
+    if: needs.route-macos.outputs.selected == 'true'
     runs-on: macos-14  # Apple Silicon M1
     timeout-minutes: 25
     env:
@@ -100,6 +151,8 @@ jobs:
   # Job 2: Metal feature compilation check
   build-metal:
     name: "macOS: Build (Metal)"
+    needs: route-macos
+    if: needs.route-macos.outputs.selected == 'true'
     runs-on: macos-14  # Apple Silicon M1
     timeout-minutes: 25
     env:
@@ -134,6 +187,8 @@ jobs:
   # Job 3: Clippy linting on macOS/arm64
   clippy:
     name: "macOS: Clippy"
+    needs: route-macos
+    if: needs.route-macos.outputs.selected == 'true'
     runs-on: macos-14  # Apple Silicon M1
     timeout-minutes: 15
     env:
@@ -171,6 +226,8 @@ jobs:
   # Job 4: Formatting check
   fmt:
     name: "macOS: Format"
+    needs: route-macos
+    if: needs.route-macos.outputs.selected == 'true'
     # rustfmt is platform-independent and does not need scarce Apple Silicon
     # capacity. Keeping the check name stable preserves branch protection while
     # preventing the final macOS gate from failing on an unstarted format job.
@@ -199,12 +256,15 @@ jobs:
     # an Apple Silicon runner after the platform-specific jobs have completed.
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build-cpu, build-metal, clippy, fmt]
+    needs: [route-macos, build-cpu, build-metal, clippy, fmt]
     if: always()
     steps:
       - name: Summarize results
         if: always()
         run: |
+          echo "macOS route:"
+          echo "  Selected:    ${{ needs.route-macos.outputs.selected }}"
+          echo "  Reason:      ${{ needs.route-macos.outputs.reason }}"
           echo "macOS arm64 results:"
           echo "  Build CPU:   ${{ needs.build-cpu.result }}"
           echo "  Build Metal: ${{ needs.build-metal.result }}"
@@ -214,6 +274,13 @@ jobs:
       - name: Check all jobs succeeded
         if: always()
         run: |
+          if [ "${{ needs.route-macos.result }}" != "success" ]; then
+            echo "macOS route job failed"; exit 1
+          fi
+          if [ "${{ needs.route-macos.outputs.selected }}" != "true" ]; then
+            echo "macOS arm64 CI skipped by policy"; exit 0
+          fi
+
           bad=0
           for r in "${{ needs.build-cpu.result }}" \
                    "${{ needs.build-metal.result }}" \

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -151,11 +151,14 @@ uploads the receipt directory with `if: always()`. Future M3 Air model, artifact
 or timing lanes should either reuse that pattern or explain why the selected
 lane can safely discard partial work.
 
-The shared macOS Apple Silicon PR workflow follows the same cancellation rule
-for started jobs. It is still bounded by per-job `timeout-minutes` and path
-filters, but it uses `cancel-in-progress: false` so platform-specific compile
-and test evidence is not thrown away by a later push after runner time has
-already been spent.
+The shared macOS Apple Silicon workflow follows the same cancellation rule only
+after Apple proof is selected. On pull requests, a cheap Linux routing job runs
+first; the `macos-14` jobs start only for labels `macos`, `apple-silicon`,
+`metal`, or `full-ci`, or for Mac/Metal-specific paths. Ordinary Rust PRs keep
+the branch-protection-compatible summary check, but they do not launch Apple
+Silicon runners. Once a selected macOS job starts, `cancel-in-progress: false`
+keeps platform-specific compile and test evidence from being thrown away by a
+later push after runner time has already been spent.
 
 ## Why the budget target is aggressive
 

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -260,6 +260,12 @@ and mirrored in `policy/ci-routed-rollout.toml`.
 | `gpu-ci` | GPU native compile proof. | Runs GPU compile lanes for GPU risk only. |
 | `coverage` | Codecov/coverage evidence with `rust-cpu` flag. | Runs coverage outside ordinary PR defaults. |
 
+The shared Apple Silicon workflow still emits a cheap Linux route/summary check
+on pull requests so existing branch protection does not see a missing check.
+Those control jobs do not start `macos-14`. Applying `macos`,
+`apple-silicon`, `metal`, or `full-ci` selects the expensive Apple jobs; main,
+manual, merge-queue, and Mac/Metal-path changes still preserve Apple proof.
+
 ## Label Matrix
 
 | Label | Workflow | Duration | Blocking on `main` | Blocking on PRs |

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -2,7 +2,7 @@ schema_version = "1.0"
 policy = "ci-lane-whitelist"
 owner = "release/ci"
 status = "advisory"
-updated = "2026-05-07"
+updated = "2026-05-18"
 
 # Linear LEM (Linux-Equivalent Minutes) budget bands for ordinary PRs.
 # These are the planning targets, not enforcement. Enforcement is
@@ -216,6 +216,138 @@ expensive_reason = "macOS is treated as 10x Linux in LEM planning."
 duplicate_of = ["ci-core-clippy"]
 review_after = "2026-06-07"
 expires = "2026-11-07"
+
+[[lane]]
+id = "macos-arm64-route"
+workflow = ".github/workflows/macos-arm64.yml"
+job = "Route macOS PR lane"
+kind = "control"
+tier = "frontdoor"
+default_pr = true
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 1
+owner = "release/ci"
+intent = "Select macOS proof only for labels, main/manual/merge-group, or Mac/Metal-specific paths."
+failure_mode = "Ordinary PRs silently launch expensive Apple Silicon runners or selected Apple proof is invisible."
+proof_obligation = "Evaluate event, labels, and Mac/Metal paths and emit selected=true/false with a route reason."
+evidence = ["GitHub step summary", "job logs"]
+allowed_triggers = ["pull_request", "push", "workflow_dispatch", "merge_group"]
+labels = ["macos", "apple-silicon", "metal", "full-ci"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "macos-arm64-build-test"
+workflow = ".github/workflows/macos-arm64.yml"
+job = "macOS: Build & Test (CPU)"
+kind = "platform"
+tier = "expensive"
+default_pr = false
+blocking = false
+runner = "macos_14"
+base_minutes = 25
+owner = "platform/apple"
+intent = "Validate CPU build, unit tests, and CPU golden path on Apple Silicon when Apple proof is selected."
+failure_mode = "Apple Silicon CPU build or runtime failures are missed for selected Mac proof."
+proof_obligation = "Run selected core CPU build, unit tests, and bitnet-inference CPU golden path on macOS arm64."
+evidence = ["job logs"]
+allowed_triggers = ["push", "workflow_dispatch", "merge_group", "pull_request:labeled", "pull_request:path-gated"]
+labels = ["macos", "apple-silicon", "full-ci"]
+expensive = true
+expensive_reason = "macOS is treated as 10x Linux in LEM planning."
+duplicate_of = ["ci-core-build-test"]
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "macos-arm64-metal-build"
+workflow = ".github/workflows/macos-arm64.yml"
+job = "macOS: Build (Metal)"
+kind = "platform"
+tier = "expensive"
+default_pr = false
+blocking = false
+runner = "macos_14"
+base_minutes = 25
+owner = "platform/apple"
+intent = "Compile Metal feature surfaces on Apple Silicon when Metal or Apple proof is selected."
+failure_mode = "Metal feature compilation breaks outside Linux-only ordinary PR proof."
+proof_obligation = "Run cargo check for the selected CPU and Metal package set on macOS arm64."
+evidence = ["job logs"]
+allowed_triggers = ["push", "workflow_dispatch", "merge_group", "pull_request:labeled", "pull_request:path-gated"]
+labels = ["macos", "apple-silicon", "metal", "full-ci"]
+expensive = true
+expensive_reason = "macOS is treated as 10x Linux in LEM planning."
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "macos-arm64-workflow-clippy"
+workflow = ".github/workflows/macos-arm64.yml"
+job = "macOS: Clippy"
+kind = "platform"
+tier = "expensive"
+default_pr = false
+blocking = false
+runner = "macos_14"
+base_minutes = 15
+owner = "platform/apple"
+intent = "Run core Clippy on Apple Silicon when Apple proof is selected."
+failure_mode = "Apple Silicon-specific lint or compile-shape failures are missed for selected Mac proof."
+proof_obligation = "Run Clippy for selected core crates on macOS arm64 with CPU features."
+evidence = ["job logs"]
+allowed_triggers = ["push", "workflow_dispatch", "merge_group", "pull_request:labeled", "pull_request:path-gated"]
+labels = ["macos", "apple-silicon", "full-ci"]
+expensive = true
+expensive_reason = "macOS is treated as 10x Linux in LEM planning."
+duplicate_of = ["ci-core-clippy", "macos-arm64-clippy"]
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "macos-arm64-format"
+workflow = ".github/workflows/macos-arm64.yml"
+job = "macOS: Format"
+kind = "lint"
+tier = "selected-support"
+default_pr = false
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 5
+owner = "core/rust"
+intent = "Preserve the selected macOS workflow format check without consuming Apple Silicon capacity."
+failure_mode = "The selected macOS workflow can pass platform jobs while formatting is unchecked in that workflow."
+proof_obligation = "Run cargo fmt --all -- --check when the macOS workflow is selected."
+evidence = ["job logs"]
+allowed_triggers = ["push", "workflow_dispatch", "merge_group", "pull_request:labeled", "pull_request:path-gated"]
+labels = ["macos", "apple-silicon", "metal", "full-ci"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "macos-arm64-success"
+workflow = ".github/workflows/macos-arm64.yml"
+job = "macOS arm64 Success"
+kind = "control"
+tier = "frontdoor"
+default_pr = true
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 1
+owner = "release/ci"
+intent = "Keep the branch-protection-compatible macOS summary check green when macOS is unselected."
+failure_mode = "Unselected macOS lanes leave a missing or failed branch-protection summary check."
+proof_obligation = "Pass on unselected PRs; on selected runs, fail unless all selected macOS workflow jobs succeed."
+evidence = ["GitHub step summary", "job logs"]
+allowed_triggers = ["pull_request", "push", "workflow_dispatch", "merge_group"]
+labels = ["macos", "apple-silicon", "metal", "full-ci"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
 
 [[lane]]
 id = "feature-matrix-full"

--- a/policy/ci-lanes.toml
+++ b/policy/ci-lanes.toml
@@ -2,7 +2,7 @@ schema_version = "1.0"
 policy = "ci-lanes"
 owner = "release/ci"
 status = "active"
-updated = "2026-05-07"
+updated = "2026-05-18"
 
 # policy/ci-lanes.toml is the planner's compact view of lane costs
 # and posture. The authoritative inventory is
@@ -73,6 +73,42 @@ blocking = true
 base_lem = 150
 runner = "macos_14"
 default_pr = false
+blocking = false
+
+[lane.macos-arm64-route]
+base_lem = 1
+runner = "ubuntu_22_04"
+default_pr = true
+blocking = false
+
+[lane.macos-arm64-build-test]
+base_lem = 250
+runner = "macos_14"
+default_pr = false
+blocking = false
+
+[lane.macos-arm64-metal-build]
+base_lem = 250
+runner = "macos_14"
+default_pr = false
+blocking = false
+
+[lane.macos-arm64-workflow-clippy]
+base_lem = 150
+runner = "macos_14"
+default_pr = false
+blocking = false
+
+[lane.macos-arm64-format]
+base_lem = 5
+runner = "ubuntu_22_04"
+default_pr = false
+blocking = false
+
+[lane.macos-arm64-success]
+base_lem = 1
+runner = "ubuntu_22_04"
+default_pr = true
 blocking = false
 
 [lane.gpu-native]


### PR DESCRIPTION
## Summary

- Route `.github/workflows/macos-arm64.yml` through a cheap Linux selector on PRs.
- Start `macos-14` jobs only for `macos`, `apple-silicon`, `metal`, or `full-ci` labels, main/manual/merge-queue events, or Mac/Metal-specific path changes.
- Register the selected Apple jobs as non-default lanes and document the route/summary compatibility behavior.

## CI economics
- Default PR LEM before: ~655+ LEM when broad macOS path filters matched (`build-cpu`, `build-metal`, `clippy`, and format/summary).
- Default PR LEM after: ~2 LEM for Linux route/summary controls; 0 default `macos-14` LEM.
- Lanes removed from default: macOS Apple Silicon CPU build/test, Metal build, macOS Clippy, selected format support.
- Lanes still available by label/main/manual: `macos`, `apple-silicon`, `metal`, `full-ci`, push to `main`, `workflow_dispatch`, `merge_group`, and Mac/Metal-specific path routing.
- Branch protection impact: none intended; `macOS arm64 Success` remains and passes when macOS is unselected.

## Verification preserved
- What failure mode this still catches: selected Apple Silicon CPU, Metal, and Clippy failures still fail the selected workflow.
- What moved to main/label/nightly: ordinary Rust PR Apple Silicon runner proof moves to label/main/manual/path-risk routing.
- Why that is acceptable: normal Linux PR proof remains the default; Apple Silicon evidence is preserved where it is relevant or explicitly requested.

## Boundaries
- No macOS default PR runner.
- No Windows default PR runner.
- No Docker/model/download default PR work.
- No branch-protection change.
- No unrelated Rust/runtime changes.

## Validation
- [x] `rtk git diff --check`
- [x] `rtk python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/macos-arm64.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe ci-lane-whitelist check`
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe check-file-policy --report-dir target\bitnet\reports --fail-on-error`

Note: I also attempted the exact source-built `cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check` path locally, but this Windows checkout spent the timeout compiling xtask dependencies before the command ran. The checked xtask binary path above validates the same policy files locally; hosted CI should cover source build behavior.