### PR TITLE
fix(server): preserve M3 Air backend labels

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -1539,6 +1539,8 @@ fn preserves_configured_backend_label(configured_device: &DeviceConfig) -> bool 
             | DeviceConfig::AppleM4Metal
             | DeviceConfig::AppleM4MpsGraph
             | DeviceConfig::AppleM4CpuNeon
+            | DeviceConfig::AppleM3AirMetal
+            | DeviceConfig::AppleM3AirMpsGraph
             | DeviceConfig::AppleM3AirCpuNeon
     )
 }
@@ -2598,6 +2600,58 @@ mod tests {
         assert!(!receipt.server_ready_claimed);
         assert!(!receipt.dense_regular_llm_cuda_inference_claimed);
         assert!(!receipt.bitnet_packed_i2s_qk256_proof);
+    }
+
+    #[test]
+    fn server_shared_engine_receipt_preserves_m3_air_backend_labels() {
+        let request = ChatCompletionRequest {
+            model: "qwen2.5-0.5b-instruct-q8_0".to_string(),
+            messages: vec![ChatCompletionMessage {
+                role: "user".to_string(),
+                content: "What is working capital?".to_string(),
+            }],
+            max_tokens: Some(16),
+            temperature: Some(0.0),
+            top_p: Some(1.0),
+            stream: Some(false),
+        };
+        let usage =
+            ChatCompletionUsage { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 };
+        let metadata = ModelMetadata {
+            model_id: "model-1".to_string(),
+            model_path: "models/qwen2.5-0.5b-q8_0.gguf".to_string(),
+            model_sha256: None,
+            device: "Cpu".to_string(),
+            quantization_type: "Q8_0".to_string(),
+            loaded_at: SystemTime::UNIX_EPOCH,
+            size_mb: 512,
+            parameters: 500_000_000,
+            context_length: 32_768,
+            inference_count: 0,
+            avg_tokens_per_second: 0.0,
+        };
+
+        for (configured_device, expected_label) in [
+            (DeviceConfig::AppleM3AirMetal, "apple-m3-air-metal"),
+            (DeviceConfig::AppleM3AirMpsGraph, "apple-m3-air-mpsgraph"),
+            (DeviceConfig::AppleM3AirCpuNeon, "apple-m3-air-cpu-neon"),
+        ] {
+            let receipt = build_server_shared_engine_receipt(
+                "request-1",
+                &request,
+                &metadata,
+                &configured_device,
+                "chatml",
+                &usage,
+                "Working capital is current assets minus current liabilities.",
+                25,
+                None,
+            );
+
+            assert_eq!(receipt.selected_backend, expected_label);
+            assert_eq!(receipt.requested_backend, expected_label);
+            assert_eq!(receipt.runtime_api, "Cpu");
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

M3 Air Metal and MPSGraph device configs are distinct backend identities, but server receipt labeling only preserved the M3 CPU/NEON identity. That made M3 Air Metal/MPSGraph requests collapse back to the active model device label in server receipts.

### Description

- Preserve `AppleM3AirMetal` and `AppleM3AirMpsGraph` in strict configured backend labels.
- Add a server receipt regression test covering all three M3 Air backend labels.

### Testing

- `cargo fmt --check --all`
- `git diff --check`
- `cargo test --locked -p bitnet-server --no-default-features --lib server_shared_engine_receipt_preserves_m3_air_backend_labels -- --nocapture`

Note: local full `check-no-panic-family` was stopped after it spent hours walking the workspace; current `main` already removed the Mac unwrap that triggered #5474 policy, and this PR does not touch that file.