### PR TITLE
ci: move performance tracking off default PRs

### DIFF
--- a/.github/workflows/performance-tracking.yml
+++ b/.github/workflows/performance-tracking.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths-ignore:
-      - 'docs/tracking/**'
-      - '.codex/campaigns/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   schedule:
     # Run performance tracking daily at 4 AM UTC
     - cron: '0 4 * * *'
@@ -38,9 +36,54 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  # Lightweight smoke test — runs on every push and PR so the workflow never has 0 jobs.
+  route-performance:
+    name: Route Performance Tracking
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      selected: ${{ steps.route.outputs.selected }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Decide whether performance tracking is selected
+        id: route
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          selected=false
+          reason="ordinary PR without performance/perf/full-ci label"
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            selected=true
+            reason="$EVENT_NAME"
+          elif python - "$LABELS_JSON" <<'PY'
+          import json
+          import sys
+
+          labels = set(json.loads(sys.argv[1] or "[]"))
+          selected = bool(labels & {"performance", "perf", "full-ci"})
+          sys.exit(0 if selected else 1)
+          PY
+          then
+            selected=true
+            reason="explicit performance/perf/full-ci label"
+          fi
+
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Performance route"
+            echo "- selected: $selected"
+            echo "- reason: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Lightweight smoke test selected for main, schedules, manual dispatch, or explicit labels.
   cargo-tests:
     name: Cargo Tests (smoke)
+    needs: route-performance
+    if: needs.route-performance.outputs.selected == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
@@ -71,6 +114,7 @@ jobs:
 
   performance-benchmark:
     name: Performance Benchmark (${{ matrix.platform }})
+    needs: route-performance
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -92,7 +136,7 @@ jobs:
             target: aarch64-apple-darwin
 
     # Only run on schedule or manual dispatch
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: needs.route-performance.outputs.selected == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
 
     steps:
     - name: Checkout repository

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -209,6 +209,12 @@ the fuzz workflow itself. Docs / tracking-only PRs use the docs and campaign
 tracker lanes instead of spending CI minutes compiling fuzz targets that
 cannot be affected by the diff.
 
+Performance Baseline Tracking follows the same rule. Pull requests run only a
+cheap Linux route job unless `performance`, `perf`, or `full-ci` is present.
+The former default PR `cargo check --workspace --features cpu` smoke now runs
+only when performance tracking is selected, while the comprehensive benchmark
+matrix remains on schedule and manual dispatch.
+
 The goal is not to spend less by testing less. **The goal is to spend less on
 unrelated work so we can afford more verification where the change actually
 creates risk.**

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -266,6 +266,12 @@ Those control jobs do not start `macos-14`. Applying `macos`,
 `apple-silicon`, `metal`, or `full-ci` selects the expensive Apple jobs; main,
 manual, merge-queue, and Mac/Metal-path changes still preserve Apple proof.
 
+Performance Baseline Tracking uses the same selected-lane shape. Ordinary PRs
+only run its cheap route job. Applying `performance`, `perf`, or `full-ci`
+selects the historical workspace smoke; the full benchmark matrix remains
+scheduled/manual evidence unless a later rollout explicitly promotes PR
+benchmark selection.
+
 ## Label Matrix
 
 | Label | Workflow | Duration | Blocking on `main` | Blocking on PRs |

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -350,6 +350,88 @@ review_after = "2026-06-18"
 expires = "2026-11-18"
 
 [[lane]]
+id = "performance-tracking-route"
+workflow = ".github/workflows/performance-tracking.yml"
+job = "Route Performance Tracking"
+kind = "control"
+tier = "frontdoor"
+default_pr = true
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 1
+owner = "release/ci"
+intent = "Select performance tracking only for non-PR events or explicit performance labels."
+failure_mode = "Ordinary PRs spend duplicated workspace-check minutes in Performance Baseline Tracking."
+proof_obligation = "Evaluate event and labels and emit selected=true/false with a route reason."
+evidence = ["GitHub step summary", "job logs"]
+allowed_triggers = ["pull_request", "push", "schedule", "workflow_dispatch"]
+labels = ["performance", "perf", "full-ci"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "performance-tracking-smoke"
+workflow = ".github/workflows/performance-tracking.yml"
+job = "Cargo Tests (smoke)"
+kind = "performance"
+tier = "selected-support"
+default_pr = false
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 20
+owner = "performance"
+intent = "Run the historical workspace performance-smoke check only when performance tracking is selected."
+failure_mode = "Selected performance tracking loses the quick workspace compile smoke."
+proof_obligation = "Run cargo check --locked --workspace --no-default-features --features cpu."
+evidence = ["job logs"]
+allowed_triggers = ["push", "schedule", "workflow_dispatch", "pull_request:labeled"]
+labels = ["performance", "perf", "full-ci"]
+duplicate_of = ["ci-core-build-test", "feature-matrix-pr"]
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "performance-tracking-benchmark"
+workflow = ".github/workflows/performance-tracking.yml"
+job = "Performance Benchmark (${{ matrix.platform }})"
+kind = "performance"
+tier = "deep"
+default_pr = false
+blocking = false
+runner = "macos_latest"
+base_lem = 1320
+owner = "performance"
+intent = "Run the full scheduled/manual performance benchmark matrix outside ordinary PR defaults."
+failure_mode = "Release and scheduled performance regressions are not tracked across the benchmark matrix."
+proof_obligation = "Build optimized CPU artifacts, generate fixtures, run benchmark scripts, detect regressions, and upload benchmark artifacts."
+evidence = ["benchmark-results-* artifacts", "job logs", "GitHub step summary"]
+allowed_triggers = ["schedule", "workflow_dispatch"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
+id = "performance-tracking-summary"
+workflow = ".github/workflows/performance-tracking.yml"
+job = "Performance Summary"
+kind = "performance"
+tier = "deep-summary"
+default_pr = false
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 15
+owner = "performance"
+intent = "Aggregate scheduled/manual performance benchmark artifacts into a durable summary."
+failure_mode = "Benchmark artifacts exist without a cross-platform summary or scheduled tracking issue."
+proof_obligation = "Download benchmark artifacts, generate performance-summary.md, optionally create the scheduled tracking issue, and upload the summary artifact."
+evidence = ["performance-summary artifact", "job logs"]
+allowed_triggers = ["schedule", "workflow_dispatch"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
 id = "feature-matrix-full"
 workflow = ".github/workflows/feature-matrix.yml"
 job = "Feature Matrix Full"

--- a/policy/ci-lanes.toml
+++ b/policy/ci-lanes.toml
@@ -111,6 +111,30 @@ runner = "ubuntu_22_04"
 default_pr = true
 blocking = false
 
+[lane.performance-tracking-route]
+base_lem = 1
+runner = "ubuntu_22_04"
+default_pr = true
+blocking = false
+
+[lane.performance-tracking-smoke]
+base_lem = 20
+runner = "ubuntu_22_04"
+default_pr = false
+blocking = false
+
+[lane.performance-tracking-benchmark]
+base_lem = 1320
+runner = "macos_latest"
+default_pr = false
+blocking = false
+
+[lane.performance-tracking-summary]
+base_lem = 15
+runner = "ubuntu_22_04"
+default_pr = false
+blocking = false
+
 [lane.gpu-native]
 base_lem = 18
 runner = "ubuntu_22_04"


### PR DESCRIPTION
## Summary

- Add a cheap `Route Performance Tracking` job to `.github/workflows/performance-tracking.yml`.
- Skip the historical `Cargo Tests (smoke)` workspace check on ordinary PRs unless `performance`, `perf`, or `full-ci` is present.
- Register Performance Baseline Tracking lanes in the CI lane policy and document the selected-lane behavior.

## CI economics
- Default PR LEM before: ~20 LEM from the duplicated workspace `cargo check --workspace --features cpu` smoke.
- Default PR LEM after: ~1 LEM for the Linux route job; no default performance smoke.
- Lanes removed from default: Performance Baseline Tracking cargo smoke.
- Lanes still available by label/main/manual: `performance`, `perf`, `full-ci`, push to `main`, schedule, and `workflow_dispatch`.
- Branch protection impact: none intended; this workflow is not made required.

## Verification preserved
- What failure mode this still catches: selected performance-tracking runs still execute the historical workspace smoke.
- What moved to main/label/nightly: the duplicated default PR workspace check moves to main/schedule/manual/explicit performance labels.
- Why that is acceptable: CI Core and Feature Matrix already cover ordinary PR compile proof; performance tracking is selected evidence, not default PR proof.

## Boundaries
- No macOS default PR runner.
- No Windows default PR runner.
- No Docker/model/download default PR work.
- No branch-protection change.
- No unrelated Rust/runtime changes.

## Validation
- [x] `rtk git diff --check`
- [x] `rtk python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/performance-tracking.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe ci-lane-whitelist check`
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe check-file-policy --report-dir target\bitnet\reports --fail-on-error`

Note: local source-built `cargo run -p xtask` is still impractical in this Windows checkout because xtask dependency compilation does not complete within the local timeout. The checked xtask binary validates the policy files locally; hosted CI covers workflow/source-build behavior.