### PR TITLE
ci: move test telemetry off default PRs

### DIFF
--- a/.github/workflows/test-telemetry.yml
+++ b/.github/workflows/test-telemetry.yml
@@ -6,16 +6,7 @@ name: Test Telemetry
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'crates/**'
-      - 'tests/**'
-      - 'tools/bitnet-task/**'
-      - 'xtask/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - '.config/nextest.toml'
-      - '.github/workflows/test-telemetry.yml'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches: [ main ]
     paths:
@@ -44,8 +35,53 @@ env:
   BITNET_SKIP_SLOW_TESTS: "1"
 
 jobs:
+  route-test-telemetry:
+    name: Route Test Telemetry
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      selected: ${{ steps.route.outputs.selected }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Decide whether test telemetry is selected
+        id: route
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          selected=false
+          reason="ordinary PR without test-telemetry/slow-tests/full-ci label"
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            selected=true
+            reason="$EVENT_NAME"
+          elif python - "$LABELS_JSON" <<'PY'
+          import json
+          import sys
+
+          labels = set(json.loads(sys.argv[1] or "[]"))
+          selected = bool(labels & {"test-telemetry", "slow-tests", "full-ci"})
+          sys.exit(0 if selected else 1)
+          PY
+          then
+            selected=true
+            reason="explicit test-telemetry/slow-tests/full-ci label"
+          fi
+
+          echo "selected=$selected" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Test telemetry route"
+            echo "- selected: $selected"
+            echo "- reason: $reason"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   nextest-junit:
     name: Test Telemetry (JUnit + slow tests)
+    needs: route-test-telemetry
+    if: needs.route-test-telemetry.outputs.selected == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     continue-on-error: true

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -215,6 +215,10 @@ The former default PR `cargo check --workspace --features cpu` smoke now runs
 only when performance tracking is selected, while the comprehensive benchmark
 matrix remains on schedule and manual dispatch.
 
+Test Telemetry is advisory observability, not a merge gate. Ordinary PRs run
+only its cheap route job; nextest/JUnit and slow-test summaries run on `main`,
+manual dispatch, or labels `test-telemetry`, `slow-tests`, and `full-ci`.
+
 The goal is not to spend less by testing less. **The goal is to spend less on
 unrelated work so we can afford more verification where the change actually
 creates risk.**

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -272,6 +272,10 @@ selects the historical workspace smoke; the full benchmark matrix remains
 scheduled/manual evidence unless a later rollout explicitly promotes PR
 benchmark selection.
 
+Test Telemetry also stays selected-only. Ordinary PRs only run its route job;
+`test-telemetry`, `slow-tests`, or `full-ci` runs the nextest/JUnit lane for
+PR observability, while `main` and manual dispatch keep the same summaries.
+
 ## Label Matrix
 
 | Label | Workflow | Duration | Blocking on `main` | Blocking on PRs |

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -130,12 +130,33 @@ review_after = "2026-06-07"
 expires = "2026-11-07"
 
 [[lane]]
+id = "test-telemetry-route"
+workflow = ".github/workflows/test-telemetry.yml"
+job = "Route Test Telemetry"
+kind = "control"
+tier = "frontdoor"
+default_pr = true
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 1
+owner = "testing/telemetry"
+intent = "Select test telemetry only for non-PR events or explicit telemetry labels."
+failure_mode = "Ordinary PRs spend advisory nextest/JUnit minutes even when no telemetry signal was requested."
+proof_obligation = "Evaluate event and labels and emit selected=true/false with a route reason."
+evidence = ["GitHub step summary", "job logs"]
+allowed_triggers = ["pull_request", "push", "workflow_dispatch"]
+labels = ["test-telemetry", "slow-tests", "full-ci"]
+duplicate_of = []
+review_after = "2026-06-18"
+expires = "2026-11-18"
+
+[[lane]]
 id = "test-telemetry"
 workflow = ".github/workflows/test-telemetry.yml"
 job = "Test Telemetry (JUnit + slow tests)"
 kind = "observability"
 tier = "frontdoor-advisory"
-default_pr = true
+default_pr = false
 blocking = false
 runner = "ubuntu_22_04"
 base_lem = 18
@@ -144,10 +165,11 @@ intent = "Emit nextest JUnit and slow-test summaries for PR test-observability w
 failure_mode = "Per-test timing, slow-test, and future flake/actuals signals remain invisible."
 proof_obligation = "Run cargo-nextest on the CI Core Rust test surface and upload target/nextest/ci/junit.xml."
 evidence = ["target/nextest/ci/junit.xml", "GitHub step summary"]
-allowed_triggers = ["pull_request:path-gated", "push", "workflow_dispatch"]
+allowed_triggers = ["push", "workflow_dispatch", "pull_request:labeled"]
+labels = ["test-telemetry", "slow-tests", "full-ci"]
 duplicate_of = ["ci-core-build-test for pass/fail semantics"]
-review_after = "2026-06-07"
-expires = "2026-11-07"
+review_after = "2026-06-18"
+expires = "2026-11-18"
 
 [[lane]]
 id = "ci-actuals"

--- a/policy/ci-lanes.toml
+++ b/policy/ci-lanes.toml
@@ -45,10 +45,16 @@ runner = "ubuntu_22_04"
 default_pr = true
 blocking = true
 
+[lane.test-telemetry-route]
+base_lem = 1
+runner = "ubuntu_22_04"
+default_pr = true
+blocking = false
+
 [lane.test-telemetry]
 base_lem = 18
 runner = "ubuntu_22_04"
-default_pr = true
+default_pr = false
 blocking = false
 
 [lane.ci-actuals]


### PR DESCRIPTION
## Summary

- Add a cheap `Route Test Telemetry` job to `.github/workflows/test-telemetry.yml`.
- Skip the advisory nextest/JUnit lane on ordinary PRs unless `test-telemetry`, `slow-tests`, or `full-ci` is present.
- Update CI lane policy and docs so Test Telemetry is selected observability instead of default PR proof.

## CI economics
- Default PR LEM before: ~18 LEM from advisory nextest/JUnit telemetry.
- Default PR LEM after: ~1 LEM for the Linux route job; no default nextest/JUnit telemetry.
- Lanes removed from default: Test Telemetry (JUnit + slow tests).
- Lanes still available by label/main/manual: `test-telemetry`, `slow-tests`, `full-ci`, push to `main`, and `workflow_dispatch`.
- Branch protection impact: none intended; this lane remains advisory.

## Verification preserved
- What failure mode this still catches: selected telemetry runs still produce nextest JUnit and slow-test summaries.
- What moved to main/label/nightly: advisory telemetry moves to main/manual/explicit telemetry labels.
- Why that is acceptable: CI Core remains the merge proof; telemetry is observability, not a blocking correctness gate.

## Boundaries
- No macOS default PR runner.
- No Windows default PR runner.
- No Docker/model/download default PR work.
- No branch-protection change.
- No unrelated Rust/runtime changes.

## Validation
- [x] `rtk git diff --check`
- [x] `rtk python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/test-telemetry.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe ci-lane-whitelist check`
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe check-file-policy --report-dir target\bitnet\reports --fail-on-error`

Note: local source-built `cargo run -p xtask` remains impractical in this Windows checkout because xtask dependency compilation does not complete within the local timeout. The checked xtask binary validates the policy files locally; hosted CI covers workflow/source-build behavior.