### PR TITLE
ci(apple): preserve in-flight tier0 runs

### DIFF
--- a/.github/workflows/apple-m4-inference-ops-tier0.yml
+++ b/.github/workflows/apple-m4-inference-ops-tier0.yml
@@ -25,7 +25,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # The tier-0 lane is bounded by timeout-minutes. Let started report-refresh
+  # runs finish so PR Gate receives a real result instead of paying most of the
+  # CI cost and replacing it with a cancellation.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/apple-m4-slm-eval-tier0.yml
+++ b/.github/workflows/apple-m4-slm-eval-tier0.yml
@@ -33,7 +33,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # The tier-0 lane is bounded by timeout-minutes. Let started parser/schema
+  # runs finish so PR Gate receives a real result instead of paying most of the
+  # CI cost and replacing it with a cancellation.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/apple-silicon.yml
+++ b/.github/workflows/apple-silicon.yml
@@ -11,7 +11,10 @@ on:
 
 concurrency:
   group: apple-silicon-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Apple Silicon jobs are capped by timeout-minutes below. Do not cancel an
+  # in-flight run on a new push: once macOS/arm64 work has started, discarding
+  # the result wastes scarce platform minutes and can hide useful failure data.
+  cancel-in-progress: false
 
 env:
   BITNET_SKIP_SLOW_TESTS: "1"

--- a/plans/native-rust-inference/ci-economics.md
+++ b/plans/native-rust-inference/ci-economics.md
@@ -81,6 +81,47 @@ cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
 
 Restore default PR performance trigger.
 
+## Work item: CI-3
+
+Status: ready
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md`
+Linked ADRs:
+Campaign:
+Blocks: CI-5
+Blocked by: CI-1
+
+### Goal
+
+Preserve in-flight CI evidence for bounded Apple and hardware-adjacent lanes.
+
+### Production delta
+
+Selected Apple Silicon, Apple M4 SLM eval, and Apple M4 inference-ops tier-0
+jobs use timeout caps as the budget control and no longer cancel started runs
+on a newer push to the same PR/ref.
+
+### Non-goals
+
+No expansion of default PR coverage, no live model downloads, and no removal of
+job-level `timeout-minutes` caps.
+
+### Acceptance
+
+Selected bounded Apple lanes set `cancel-in-progress: false` and document why
+timeouts, not cancellation, are the cap for long-running evidence jobs.
+
+### Proof commands
+
+```bash
+git diff --check
+rg -n "cancel-in-progress: true" .github/workflows/apple-silicon.yml .github/workflows/apple-m4-slm-eval-tier0.yml .github/workflows/apple-m4-inference-ops-tier0.yml
+```
+
+### Rollback
+
+Restore `cancel-in-progress: true` for the affected workflows.
+
 ## Work item: CI-5
 
 Status: blocked


### PR DESCRIPTION
## Summary

- keep selected Apple Silicon and Apple M4 tier-0 CI runs from being cancelled on newer pushes
- document timeout caps as the budget control for these bounded evidence lanes
- add CI-3 to the CI economics plan for preserving in-flight evidence

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/apple-silicon.yml .github/workflows/apple-m4-slm-eval-tier0.yml .github/workflows/apple-m4-inference-ops-tier0.yml`
- `rg -n "cancel-in-progress: true" .github/workflows/apple-silicon.yml .github/workflows/apple-m4-slm-eval-tier0.yml .github/workflows/apple-m4-inference-ops-tier0.yml` (no matches)
- `cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check` (passes; existing duplicate_of warnings remain)
