### PR TITLE
SLM-CPU-039: remove workspace panic paths

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -420,8 +420,7 @@ impl FeedForward {
         workspace.record_feed_forward_input(x);
         let output = self.forward(x, raw_tensors)?;
         workspace.record_feed_forward_output(&output);
-        workspace.store_feed_forward_output(output);
-        Ok(workspace.take_feed_forward_output())
+        workspace.store_feed_forward_output(output)
     }
 
     fn apply_activation(&self, input: &Tensor) -> Result<Tensor> {
@@ -591,7 +590,7 @@ impl TransformerForwardWorkspace {
         self.last_output_shape = tensor.dims().to_vec();
     }
 
-    fn store_feed_forward_output(&mut self, tensor: Tensor) {
+    fn store_feed_forward_output(&mut self, tensor: Tensor) -> Result<Tensor> {
         let last_shape = tensor.dims().to_vec();
         self.last_output_shape = last_shape.clone();
         self.feed_forward_output_surface = Some(TransformerWorkspaceOutputSurface {
@@ -604,12 +603,13 @@ impl TransformerForwardWorkspace {
         });
         self.workspace_owned_output_count += 1;
         self.feed_forward_output_slot = Some(tensor);
-    }
-
-    fn take_feed_forward_output(&mut self) -> Tensor {
-        self.feed_forward_output_slot.take().expect(
-            "TransformerForwardWorkspace feed-forward output slot must be populated before take",
-        )
+        if let Some(output) = self.feed_forward_output_slot.take() {
+            Ok(output)
+        } else {
+            Err(BitNetError::Validation(
+                "TransformerForwardWorkspace feed-forward output slot was empty".to_string(),
+            ))
+        }
     }
 }
 

--- a/crates/bitnet-transformer/tests/transformer_model_tests.rs
+++ b/crates/bitnet-transformer/tests/transformer_model_tests.rs
@@ -215,8 +215,9 @@ fn test_incremental_forward_workspace_matches_existing_path() -> anyhow::Result<
     assert_eq!(workspace.last_output_shape(), &[1, 1, hidden]);
     assert_eq!(workspace.reuse_status(), "feed_forward_output_workspace_owned_reuse_not_enabled");
     assert_eq!(workspace.workspace_owned_output_count(), model.config.model.num_layers);
-    let surface =
-        workspace.first_output_surface().expect("workspace should classify one output surface");
+    let Some(surface) = workspace.first_output_surface() else {
+        anyhow::bail!("workspace should classify one output surface");
+    };
     assert_eq!(surface.name, "feed_forward.output");
     assert_eq!(surface.storage_owner, "TransformerForwardWorkspace");
     assert_eq!(surface.status, "workspace_owns_returned_tensor_reuse_not_enabled");


### PR DESCRIPTION
## Summary
- replace the SLM-CPU-039 workspace output `expect` with a `BitNetError::Validation` path
- replace the workspace surface test `expect` with an `anyhow::bail!` branch

## Why
#5693 merged before the no-panic policy follow-up landed. This PR removes the two no-new-panic findings from `main` without changing the SLM-CPU-039 claim boundary.

## Validation
- `cargo test --locked -p bitnet-transformer --no-default-features --features cpu test_incremental_forward_workspace_matches_existing_path`
- `cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports`
- `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --all-targets -- -D warnings`
- `git diff --check`