### PR TITLE
fix(transformer): remove feed-forward workspace panics

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -421,7 +421,7 @@ impl FeedForward {
         let output = self.forward(x, raw_tensors)?;
         workspace.record_feed_forward_output(&output);
         workspace.store_feed_forward_output(output);
-        Ok(workspace.take_feed_forward_output())
+        workspace.take_feed_forward_output()
     }
 
     fn apply_activation(&self, input: &Tensor) -> Result<Tensor> {
@@ -606,10 +606,13 @@ impl TransformerForwardWorkspace {
         self.feed_forward_output_slot = Some(tensor);
     }
 
-    fn take_feed_forward_output(&mut self) -> Tensor {
-        self.feed_forward_output_slot.take().expect(
-            "TransformerForwardWorkspace feed-forward output slot must be populated before take",
-        )
+    fn take_feed_forward_output(&mut self) -> Result<Tensor> {
+        self.feed_forward_output_slot.take().ok_or_else(|| {
+            BitNetError::Validation(
+                "TransformerForwardWorkspace feed-forward output slot must be populated before take"
+                    .to_string(),
+            )
+        })
     }
 }
 

--- a/crates/bitnet-transformer/tests/transformer_model_tests.rs
+++ b/crates/bitnet-transformer/tests/transformer_model_tests.rs
@@ -215,8 +215,9 @@ fn test_incremental_forward_workspace_matches_existing_path() -> anyhow::Result<
     assert_eq!(workspace.last_output_shape(), &[1, 1, hidden]);
     assert_eq!(workspace.reuse_status(), "feed_forward_output_workspace_owned_reuse_not_enabled");
     assert_eq!(workspace.workspace_owned_output_count(), model.config.model.num_layers);
-    let surface =
-        workspace.first_output_surface().expect("workspace should classify one output surface");
+    let Some(surface) = workspace.first_output_surface() else {
+        anyhow::bail!("workspace should classify one output surface");
+    };
     assert_eq!(surface.name, "feed_forward.output");
     assert_eq!(surface.storage_owner, "TransformerForwardWorkspace");
     assert_eq!(surface.status, "workspace_owns_returned_tensor_reuse_not_enabled");


### PR DESCRIPTION
## Summary

- Replace the feed-forward workspace `expect` with a typed `BitNetError::Validation` path.
- Replace the test `expect` with an `anyhow::bail!` assertion path.
- Keep behavior unchanged for the valid workspace path while satisfying no-new-panic policy.

## Validation
- [x] `rtk C:\bntarget\bn-cuda-server-006-vs2019\debug\xtask.exe check-no-panic-family --report-dir target\bitnet\reports`
- [x] `rtk git diff --check`
- [x] `rtk cargo fmt -p bitnet-transformer -- --check`
- [ ] `rtk cargo test --locked -p bitnet-transformer --no-default-features --features cpu workspace` hit a 10-minute local Windows timeout before producing a result.

This unblocks the Policy failure currently visible on #5695 without mixing no-panic cleanup into the CI routing PR.