### PR TITLE
fix(transformer): remove workspace no-panic policy debt

### DIFF
--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -421,7 +421,7 @@ impl FeedForward {
         let output = self.forward(x, raw_tensors)?;
         workspace.record_feed_forward_output(&output);
         workspace.store_feed_forward_output(output);
-        Ok(workspace.take_feed_forward_output())
+        workspace.take_feed_forward_output()
     }
 
     fn apply_activation(&self, input: &Tensor) -> Result<Tensor> {
@@ -606,10 +606,13 @@ impl TransformerForwardWorkspace {
         self.feed_forward_output_slot = Some(tensor);
     }
 
-    fn take_feed_forward_output(&mut self) -> Tensor {
-        self.feed_forward_output_slot.take().expect(
-            "TransformerForwardWorkspace feed-forward output slot must be populated before take",
-        )
+    fn take_feed_forward_output(&mut self) -> Result<Tensor> {
+        self.feed_forward_output_slot.take().ok_or_else(|| {
+            BitNetError::Validation(
+                "TransformerForwardWorkspace feed-forward output slot must be populated before take"
+                    .to_string(),
+            )
+        })
     }
 }
 

--- a/crates/bitnet-transformer/tests/transformer_model_tests.rs
+++ b/crates/bitnet-transformer/tests/transformer_model_tests.rs
@@ -215,8 +215,9 @@ fn test_incremental_forward_workspace_matches_existing_path() -> anyhow::Result<
     assert_eq!(workspace.last_output_shape(), &[1, 1, hidden]);
     assert_eq!(workspace.reuse_status(), "feed_forward_output_workspace_owned_reuse_not_enabled");
     assert_eq!(workspace.workspace_owned_output_count(), model.config.model.num_layers);
-    let surface =
-        workspace.first_output_surface().expect("workspace should classify one output surface");
+    let Some(surface) = workspace.first_output_surface() else {
+        anyhow::bail!("workspace should classify one output surface");
+    };
     assert_eq!(surface.name, "feed_forward.output");
     assert_eq!(surface.storage_owner, "TransformerForwardWorkspace");
     assert_eq!(surface.status, "workspace_owns_returned_tensor_reuse_not_enabled");


### PR DESCRIPTION
## Summary
- Replace the SLM-CPU-039 workspace output-slot expect with a fallible validation error.
- Make the matching transformer test fail with nyhow::bail! instead of expect.
- Keeps this as policy hygiene only: no model, route, hardware, or readiness claim changes.

## Why
The Policy job blocking #5697 reports new no-panic-family debt from the already-merged SLM-CPU-039 workspace change:
- crates/bitnet-transformer/src/lib.rs feed-forward output slot expect
- crates/bitnet-transformer/tests/transformer_model_tests.rs output-surface expect

## Validation
- cargo fmt -p bitnet-transformer --check
- cargo test --locked -p bitnet-transformer --no-default-features --features cpu
- git diff --check

## Local validation gap
- cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports --fail-on-error timed out locally while building xtask/native dependencies under Cargo contention, including an isolated-target retry. The PR Policy workflow should provide the canonical no-panic-family proof.