### PR TITLE
docs(a770): map diagnostic branch lineage

### DIFF
--- a/docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
+++ b/docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
@@ -1,0 +1,145 @@
+# A770 Diagnostic Lineage Map
+
+Status: active disposition map
+Owner: Codex
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs:
+
+- `docs/specs/intel-arc-a770-gpu-roadmap.md`
+- `docs/specs/a770-bitnet-claim-boundary.md`
+
+Linked ADRs:
+
+- `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+
+Linked plan:
+
+- `plans/a770-bitnet-claim-boundary-implementation.md`
+
+Linked issues: n/a
+Linked PRs: #4744 through #5711 A770 diagnostic branch chain
+Support-tier impact: no promotion
+Policy impact: none
+
+## Scope
+
+This report maps the open A770 diagnostic PR chain into mainline disposition
+buckets. It is a queue-recovery aid, not proof that any branch-chain PR is
+mergeable into `main`.
+
+The committed A770 source of truth remains diagnostic. This report does not add
+kernels, model support, runtime behavior, benchmark claims, receipt promotion,
+or A770 support claims.
+
+## Current Queue Snapshot
+
+Snapshot command:
+
+```powershell
+rtk gh pr list --state open --limit 220 --json number,title,headRefName,baseRefName,isDraft,mergeable,mergeStateStatus,updatedAt
+```
+
+Observed snapshot on 2026-05-18:
+
+| Scope | Count |
+| --- | ---: |
+| Open scoped PRs with `a770/*`, `codex/*`, or `claude/*` heads | 154 |
+| Open `a770/*` PRs | 153 |
+| Open `codex/*` PRs | 0 |
+| Open `claude/*` PRs | 1 |
+| Draft PRs in that scope | 1 |
+| PRs in that scope based directly on `main` | 1 |
+
+The direct `main` PR is the draft AVX2 performance PR #5092. The A770 PRs are
+stacked on other `a770/*` branches and should not be merged linearly.
+
+## Disposition Rule
+
+Do not merge current A770 diagnostic probes directly into `main`.
+
+Use them as source material for replacement PRs only when the replacement:
+
+- is based on current `main`;
+- has one semantic purpose;
+- keeps A770 support at `diagnostic` unless claim-grade receipts exist;
+- removes transcript-only or temp-target artifacts;
+- includes focused tests or documented no-reuse/no-promotion proof;
+- preserves the not-claims in the A770 claim-boundary spec.
+
+## Extraction Buckets
+
+| Bucket | Representative PRs | Durable value | Disposition |
+| --- | --- | --- | --- |
+| Backend identity and claim guards | #4744, #4745, #4750 | Backend/fallback/status vocabulary and non-claiming route identity. | Rebuild as A770-003/A770-004 replacement PRs only. Do not inherit old generated/dependency edits. |
+| Loader, tokenizer, and model invariants | #4751-#4756, #4801, #4841, #4847, #4887, #4959, #4961, #4966 | Candidate strict GGUF, tied-logit, embedding-row, tokenizer, and model-contract fixes. | Compare against current `main`; port only confirmed invariants with direct tests. |
+| QK256/OpenCL mechanics | #4763, #4764, #4767, #4770, #4774, #4776, #4850, #4853, #4855, #4856 | QK256 layout, activation quantization, and OpenCL dispatch evidence. | Hold until A770-005/A770-006 smoke/parity path exists. No support or performance claim. |
+| Reference setup and compare tools | #4782, #4788, #4793, #4796, #4799, #4819, #4821, #4823, #4825, #4827, #4830, #4831, #4833, #4862-#4908, #4910-#4949 | Reference setup, prompt identity, hidden/logit/layer trace planning, run, and compare tooling. | Collapse into one or two durable `xtask` trace/compare PRs with stable command names and tests. |
+| Attention score, softmax, and value-mix hypotheses | #4990-#5064, #5098-#5131, #5711 | Diagnostic localization of score input, value cache, probability, value mix, history, and selected query boundary rows. | Archive lineage first. Port no runtime math fix until contradictory hypotheses are reconciled against current `main`. |
+| Transient probe rows | Most one-off `diag-*history*`, `diag-*boundary*`, and selected-row probes in #4976-#5131 and #5711 | Local investigation evidence. | Close as superseded after the durable trace tools and lineage summary preserve the useful conclusion. |
+| Draft AVX2 perf branch | #5092 | Possible QK256 AVX2 optimization. | Leave draft until parity proof, repeatable benchmark context, CPU flags, samples, and claim boundary are current. |
+
+## Immediate Queue Decisions
+
+### #5711
+
+`diag(bitnet): bind selected query boundary rows` is diagnostic-only and stacked
+on `a770/diag-rust-score-input-operand-drift`, not `main`.
+
+The PR body reports:
+
+- `query_boundary_present = false`;
+- `boundary_rows_present = false`;
+- `claim_allowed = false`.
+
+Disposition: do not merge as-is. If the selected-query boundary handling remains
+useful, port it into the durable reference trace/compare replacement PR after
+the branch-chain lineage is flattened.
+
+### #5092
+
+`perf(qk256-avx2): VPERMPS LUT decode + shared byte loads` remains draft.
+
+Disposition: do not merge from this lane until repeatable benchmark receipts,
+CPU/flags/sample context, and parity tests support the stated performance
+claim.
+
+## Replacement PR Order
+
+1. `docs(a770): archive diagnostic lineage and current blockers`
+   - Preserve the branch-chain decision map and close/supersession criteria.
+   - No runtime, route, or support-tier change.
+2. `identity(a770): preserve requested and selected backend identity`
+   - Implement the A770-003 identity slice from current `main`.
+   - No kernels or A770 execution claim.
+3. `diag(bitnet): add durable reference trace and compare tools`
+   - Collapse the reusable plan/run/compare pieces from the trace branches.
+   - Keep command outputs diagnostic and fallback/claim fields explicit.
+4. `fix(bitnet): preserve confirmed GGUF/tokenizer/logit invariants`
+   - Port only small confirmed loader/tokenizer/model fixes with direct tests.
+   - No A770 quality, reference-parity, residency, or performance claim.
+
+After each replacement lands, close the corresponding transient branch-chain PRs
+with a link to the replacement and this map.
+
+## Claim Boundary
+
+This report may claim only:
+
+```text
+The open A770 diagnostic queue has been mapped into replacement and closure
+buckets, and none of the current diagnostic probes is a direct merge candidate.
+```
+
+It must not claim:
+
+```text
+A770 OpenCL BitNet execution works.
+A770 semantic quality is proven.
+A770 performance is proven.
+Selected attention is proven.
+Resident KV, attention scores, softmax, or value mix are resident.
+Full support-op or full device residency is proven.
+Reference parity is complete.
+BitNet inference completion is achieved.
+```

--- a/docs/tracking/codex-web-pr-ledger.md
+++ b/docs/tracking/codex-web-pr-ledger.md
@@ -33,6 +33,10 @@ Snapshot source:
   refresh showed 166 open scoped PRs: 4 `codex/*`, 160 `a770/*`, 1 `cuda-*`,
   and 1 `claude/*`. Current non-A770 queue head: #5569, #5568, #5549, #5547,
   and #5541.
+- Queue refresh: after #5697, #5709, and #5710 merged, a follow-up
+  `gh pr list` refresh showed 154 open scoped PRs: 153 `a770/*`, 0
+  `codex/*`, and 1 `claude/*`. The only direct `main` PR in that scope is
+  draft perf PR #5092; the A770 queue remains a stacked diagnostic chain.
 
 ## Initial Queue Summary
 
@@ -88,6 +92,10 @@ Snapshot source:
 | 2026-05-18 | #5461 | Merged by concurrent queue activity after local review | Local review confirmed the API gateway facade preserved exports; package fmt, check, API-gateway tests, clippy, and GitHub merge state were inspected. A follow-up format issue from current `main` was split to #5571. |
 | 2026-05-18 | #5567 | Closed as superseded | The intended no-panic-family cleanup was already present on `origin/main`; closing avoided a redundant/conflicting cleanup PR. |
 | 2026-05-18 | #5571 | Merged by concurrent queue activity | One-file BDD grid rustfmt repair for the format gate. Local package fmt/check and GitHub merge state were inspected. |
+| 2026-05-18 | #5697 | Merged by concurrent queue activity after local review | The CLI proof summary now exposes `backend_fallback_used` and `backend_fallback_reason`; local package fmt/checks passed before merge, and GitHub Policy/PR Gate were green at merge. |
+| 2026-05-18 | #5706 | Closed as duplicate | The same no-panic-family transformer cleanup landed in #5697, so the standalone repair branch was no longer needed. |
+| 2026-05-18 | #5709 | Merged | Tracker-only M4-ROBUSTNESS-001 closeout after #5699. Campaign tracker, PR Gate, CI core, docs, and link checks were green. |
+| 2026-05-18 | #5710 | Merged | Tracker-only SLM-CPU-040 setup after SLM-CPU-039. Campaign tracker, generated dashboards, PR Gate, CI core, docs, and link checks were green. |
 
 ## New Open Cluster After Refresh
 
@@ -104,3 +112,11 @@ Snapshot source:
 | #5549 | Apple M4 prompt generation identity receipts | Conflicting receipt/schema/docs/generated update. | Do not merge as-is; refresh or salvage only after resolving conflicts and rerunning campaign generators. |
 | #5547 | AVX2 hot-path docs/plan | Conflicting member of the AVX2 duplicate planning cluster. | Compare against #5541 and related #5540-#5547 attempts; keep one canonical plan if still useful. |
 | #5541 | AVX2 QK256 hot-path counters and receipt fields | Mergeable code/test change, but Policy failed and the PR body lacks final test completion evidence. | Triage Policy and rerun exact QK256 proof before considering as the canonical implementation. |
+
+## Latest Queue Head
+
+| PR or cluster | Lane | Current signal | Disposition rule |
+|---:|---|---|---|
+| #5711 | A770 selected-query boundary diagnostic | Stacked on `a770/diag-rust-score-input-operand-drift`, not `main`; body reports `claim_allowed = false` and missing boundary rows. | Do not merge as-is. Salvage only through a durable trace/compare replacement PR after lineage flattening. |
+| #4744-#5131 plus #5711 | A770 diagnostic branch chain | 153 open `a770/*` PRs remain, mostly one-PR-per-probe branch-chain diagnostics. | Use `docs/reports/2026-05-18-a770-diagnostic-lineage-map.md`; no probe-by-probe merges. |
+| #5092 | Draft AVX2 QK256 perf | Only direct `main` PR in the scoped queue; still draft with a speedup claim. | Leave draft until parity proof, repeatable benchmark context, CPU flags, samples, and claim boundary are current. |


### PR DESCRIPTION
Summary: adds a docs-only A770 diagnostic lineage map, updates the Codex web PR ledger with the latest queue refresh/dispositions, and marks #5711 plus the remaining A770 probes as replacement-only rather than direct merge candidates. Claim boundary: no runtime code, generated tracker state, A770 execution, quality, performance, selected-attention, residency, reference-parity, or support-tier promotion. Validation: git diff --check; npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc docs/reports/2026-05-18-a770-diagnostic-lineage-map.md docs/tracking/codex-web-pr-ledger.md; linked source-of-truth paths checked with Test-Path; current scoped queue counts refreshed with gh pr list.