### PR TITLE
docs(bitnet-3b): add 3B TL candidate proposal, specs, campaign, and plan

### DIFF
--- a/ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
+++ b/ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
@@ -105,7 +105,7 @@ known_sha256 = "pending"
 known_size_bytes = 13297592664
 storage_estimate = "official_safetensors_shards_total_13297592664_bytes; current M3 Air preflight would leave about 4435547 KiB free after shards"
 format = "blocked_no_official_gguf"
-quantization = "tl1_or_tl2_only_until_compatibility_changes"
+quantization = "arm_tl1_candidate_only_until_compatibility_changes"
 tokenizer_authority = "official_tokenizer_files_present"
 pretokenizer_authority = "pending_runner_conversion_path"
 prompt_template = "blocked_until_gguf_or_converter_path"
@@ -117,7 +117,8 @@ notes = [
   "Compatibility ledger marks 3B I2_S unsupported upstream for ARM and x86.",
   "The official repository at revision af89e318d78a70802061246bf037199d2fb97020 contains safetensors shards and tokenizer/config files, but no .gguf artifact.",
   "Current M3 Air preflight records only 17427716 KiB available; downloading the official safetensors shards without cleanup or conversion approval would leave about 4435547 KiB, below the hard free-space floor.",
-  "Use only TL1/TL2 diagnostic routes if a verified runner path and coherent reference output exist.",
+  "Use only ARM TL1 diagnostic routes if a verified runner path and coherent reference output exist; ARM TL2 is unsupported by the compatibility ledger.",
+  "Treat 3B as a separate TL-model lane; do not inherit Microsoft 2B I2_S/QK256 proof or dense SLM proof.",
 ]
 
   [[candidate.route]]
@@ -135,8 +136,8 @@ notes = [
   [[candidate.route]]
   arch = "arm"
   kernel = "tl2"
-  status = "blocked_no_official_gguf_or_conversion_path"
-  proof_use = "diagnostic_route_until_runner_path_verified"
+  status = "unsupported_upstream"
+  proof_use = "diagnostic_rejection_only"
 
 [[candidate]]
 id = "falcon_e_1b_instruct_i2s_secondary"

--- a/docs/apple-silicon/bitnet-candidate-matrix.md
+++ b/docs/apple-silicon/bitnet-candidate-matrix.md
@@ -22,7 +22,7 @@ ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
 |---:|---|---|---|
 | 1 | `microsoft/bitnet-b1.58-2B-4T-gguf` `ggml-model-i2_s.gguf` | ARM `I2_S`, then `TL1` | Shared answer gate says the official I2_S artifact is answer-ready when paired with external Microsoft tokenizer authority and `tokenizer.ggml.pre=llama-bpe`; MacBook must rerun before Apple claims. |
 | 2 | `1bitLLM/bitnet_b1_58-large` | ARM `I2_S` or `TL1` | Smaller 0.7B control candidate; currently blocked on artifact/conversion authority because the recorded official repo revision exposes safetensors/tokenizer files but no official GGUF. Follow [BITNET-PROP-0009](../proposals/BITNET-PROP-0009-bitnet-b158-large-control-model.md), the [source map](../bitnet/bitnet-b158-large/README.md), and the B158-large specs before any answer/backend claim. |
-| 3 | `1bitLLM/bitnet_b1_58-3B` | ARM `TL1`/`TL2` diagnostic only | Blocked at revision `af89e318d78a70802061246bf037199d2fb97020`: the official repository has safetensors shards and tokenizer files but no GGUF, and the current M3 Air free-space state cannot safely absorb the shards without cleanup or an approved conversion plan. |
+| 3 | `1bitLLM/bitnet_b1_58-3B` | ARM `TL1` diagnostic candidate; ARM `TL2` unsupported | Separate TL-model lane. Blocked at revision `af89e318d78a70802061246bf037199d2fb97020`: the official repository has safetensors shards and tokenizer files but no GGUF, and the current M3 Air free-space state cannot safely absorb the shards without cleanup or an approved conversion plan. Use only TL1 diagnostic routes until a verified runner path and coherent reference output exist; do not inherit Microsoft 2B `I2_S`/QK256 proof. |
 | 4 | `tiiuae/Falcon-E-1B-Instruct-GGUF` | Verify `I2_S` runner path | Secondary BitNet-like family after Microsoft and 1bitLLM behavior is understood. |
 | 5 | `tiiuae/Falcon-E-3B-Instruct-GGUF` | Verify `I2_S` runner path | Larger secondary family; use only if storage and smaller-candidate results justify it. |
 
@@ -80,3 +80,14 @@ binaries stay local-only.
 ## Claim Boundary
 
 This matrix is planning evidence. It does not prove Rust Apple BitNet local answers, full Apple Metal inference, QK256 on Apple Silicon, Neural Engine execution, MPSGraph model inference, or broad Apple Silicon performance.
+
+### 3B TL candidate boundary
+
+`1bitLLM/bitnet_b1_58-3B` is governed by
+[`BITNET-PROP-0010`](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+and the 3B TL specs. For Apple, only ARM TL1 is a listed candidate route; ARM
+`I2_S` and ARM TL2 are unsupported unless the compatibility ledger changes. No
+Apple answer, benchmark, Metal, or server claim may be made until artifact
+inventory, TL1 conversion/runner authority, tokenizer/prompt authority,
+reference-good output, TL1 scalar/NEON fixtures, and strict Apple receipts pass
+with `fallback=false`.

--- a/docs/bitnet/bitnet-b158-3b/README.md
+++ b/docs/bitnet/bitnet-b158-3b/README.md
@@ -1,0 +1,57 @@
+# BitNet b1.58 3B TL candidate source map
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [artifact](../../specs/BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md), [conversion](../../specs/BITNET-SPEC-B158-3B-CONVERSION.md), [TL layout](../../specs/BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [tokenizer/prompt](../../specs/BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md), [quality](../../specs/BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md), [CPU](../../specs/BITNET-SPEC-B158-3B-CPU.md), [CUDA](../../specs/BITNET-SPEC-B158-3B-CUDA.md), [Apple](../../specs/BITNET-SPEC-B158-3B-APPLE.md), [performance](../../specs/BITNET-SPEC-B158-3B-PERFORMANCE.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: diagnostic candidate only
+Policy impact: no policy exception
+
+## Source map
+
+| Field | Value |
+| --- | --- |
+| Model id | `onebitllm_bitnet_b158_3b` |
+| Upstream repo | `1bitLLM/bitnet_b1_58-3B` |
+| Current pinned revision for initial inventory | `af89e318d78a70802061246bf037199d2fb97020` |
+| Source format | sharded safetensors plus tokenizer/config/Python model assets |
+| Official GGUF status | `blocked_no_official_gguf` until inventory proves otherwise |
+| x86 candidate route | TL2 listed upstream, runner/conversion unverified |
+| ARM candidate route | TL1 listed upstream, runner/conversion unverified |
+| Forbidden route | `I2_S`/QK256 except diagnostic rejection receipts |
+
+## Current claim boundary
+
+BitNet-rs may say only:
+
+```text
+1bitLLM/bitnet_b1_58-3B is a registered BitNet-rs TL candidate with guarded
+artifact inventory and runner/conversion verification work pending.
+```
+
+BitNet-rs must not say:
+
+- 3B `I2_S` is supported.
+- 3B inherits the official Microsoft 2B `I2_S`/QK256 proof.
+- 3B inherits dense Qwen or dense SLM proof.
+- x86 TL2, ARM TL1, CUDA TL2, OpenCL TL2, Apple TL1, server, or speedup is
+  answer-ready before route-specific receipts pass.
+
+## First proof question
+
+The first blocker is not a kernel optimization. The first blocker is:
+
+```text
+Do we have a verified TL1/TL2 artifact and reference runner that produces
+coherent deterministic output for the exact 3B artifact, tokenizer, and prompt
+policy?
+```
+
+Only after that question is answered may Rust structural loading, scalar TL
+oracles, CPU answer proof, accelerator proof, benchmark qualification, and
+product CLI/server promotion proceed.

--- a/docs/proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md
+++ b/docs/proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md
@@ -1,0 +1,103 @@
+# BITNET-PROP-0010: BitNet b1.58 3B TL model lane
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: [3B artifact contract](../specs/BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md), [3B conversion contract](../specs/BITNET-SPEC-B158-3B-CONVERSION.md), [3B TL1/TL2 layout](../specs/BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [3B tokenizer and prompt](../specs/BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md), [3B reference quality](../specs/BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md), [3B CPU](../specs/BITNET-SPEC-B158-3B-CPU.md), [3B CUDA](../specs/BITNET-SPEC-B158-3B-CUDA.md), [3B Apple](../specs/BITNET-SPEC-B158-3B-APPLE.md), [3B performance](../specs/BITNET-SPEC-B158-3B-PERFORMANCE.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registers a diagnostic TL-model lane only; no answer, backend, server, or speed promotion
+Policy impact: no policy exception
+
+## Thesis
+
+`1bitLLM/bitnet_b1_58-3B` is a larger supported BitNet b1.58 model that can
+validate BitNet-rs beyond the official Microsoft 2B `I2_S`/QK256 artifact.
+Because upstream support is listed as TL2 on x86 and TL1 on ARM, and because no
+official GGUF is present in the current Hugging Face file listing, this lane is
+an artifact, conversion, and runner-authority project before it is a CPU, CUDA,
+Apple, or performance project.
+
+## Why this model is valuable
+
+- It exercises a larger 3.3B BitNet b1.58 artifact instead of only the official
+  Microsoft 2B artifact.
+- It forces TL1/TL2 kernel and layout support to become first-class in
+  BitNet-rs rather than treating QK256 as the only BitNet path.
+- It is relevant to Apple demonstrations because upstream lists ARM TL1 support
+  and shows 3B-class Apple usage, but BitNet-rs must still prove the exact route
+  and artifact before making Apple claims.
+- It gives x86, CUDA, and A770 lanes a future TL2 target after CPU TL2 reference
+  proof exists.
+
+## Why this lane is risky
+
+- The current Hugging Face listing exposes sharded safetensors and tokenizer /
+  config files, not an official `.gguf` artifact.
+- Upstream lists x86 TL2 support for the model, but the shown setup helper only
+  exposes `--quant-type {i2_s,tl1}`; x86 TL2 therefore needs a reproducible
+  conversion and runner command before it can become proof authority.
+- Upstream marks `I2_S` unsupported for this model on both x86 and ARM.
+- TL1 and TL2 are route-specific proof families. TL1 proof does not prove TL2,
+  and TL2 proof does not prove TL1.
+
+## Non-inheritance rules
+
+This proposal explicitly rejects proof inheritance from other lanes:
+
+- Official Microsoft 2B `I2_S`/QK256 answer, CPU, CUDA, or Apple proof does not
+  prove this 3B model.
+- Dense Qwen or other dense SLM proof does not prove this 3B BitNet model.
+- `I2_S`/QK256 rejection or success for another artifact does not prove TL1 or
+  TL2 layout correctness for this artifact.
+- A third-party GGUF may be diagnostic only until an artifact-authority decision
+  approves its provenance, hashes, tokenizer policy, and route metadata.
+
+## Product ladder
+
+The only honest initial status is:
+
+```text
+registered / diagnostic candidate
+blocked_no_official_gguf
+TL1/TL2 runner path unverified
+no answer-ready claim
+no backend claim
+```
+
+Promotion must proceed through:
+
+```text
+artifact authority
+→ conversion / runner authority
+→ TL1/TL2 layout spec
+→ reference-good output
+→ Rust structural loader
+→ scalar TL oracle
+→ CPU answer proof
+→ AVX/CUDA/Apple backend proof
+→ benchmark qualification
+→ product status
+```
+
+## Non-goals
+
+- `I2_S` or QK256 enablement for the 3B artifact except unsupported-path or
+  diagnostic rejection receipts.
+- Dense SLM proof, dense regular-LLM CUDA proof, or dense prompt/template
+  inheritance.
+- Speedup, benchmark, server, or broad product-readiness claims.
+- Full GPU residency or accelerator execution before reference-good and CPU TL
+  answer proof exist.
+- Committing model binaries or generated GGUF files to the repository.
+
+## Acceptance
+
+This proposal is accepted when the linked plan and specs make the 3B lane a
+registered TL candidate with explicit artifact inventory, conversion, TL layout,
+tokenizer/prompt, reference-quality, CPU, CUDA, Apple, and performance claim
+boundaries, while keeping all answer, backend, server, and speed claims false
+until receipt-backed gates pass.

--- a/docs/specs/BITNET-SPEC-B158-3B-APPLE.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-APPLE.md
@@ -1,0 +1,59 @@
+# BITNET-SPEC-B158-3B-APPLE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B CPU](BITNET-SPEC-B158-3B-CPU.md), [3B TL layout](BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [3B performance](BITNET-SPEC-B158-3B-PERFORMANCE.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no Apple support promotion until receipts pass
+Policy impact: no policy exception
+
+## Purpose
+
+Define the Apple proof path for the 3B ARM TL1 lane. Apple is a natural first
+hardware candidate because upstream lists ARM TL1 for this model, but BitNet-rs
+must still prove artifact inventory, conversion/runner authority, tokenizer /
+prompt authority, reference-good output, and TL1 CPU/NEON receipts.
+
+## Required path
+
+```text
+MacBook artifact inventory
+→ storage/free-space receipt
+→ TL1 conversion or runner proof
+→ reference-good output
+→ M4 or MacBook CPU/NEON TL1 structural loader
+→ TL1 scalar/NEON fixtures
+→ strict Apple answer corpus
+→ warm-session
+→ benchmark
+```
+
+## Required Apple receipts
+
+Apple receipts must record:
+
+- machine identity and whether it is MacBook, M4 Mac Mini, or another exact
+  profile;
+- storage/free-space context for large safetensors or converted artifacts;
+- source revision, artifact hash, tokenizer hashes, and prompt policy;
+- route `tl1`;
+- selected backend, for example `apple-macbook-cpu-neon`;
+- selected kernel, for example `tl1-scalar-reference-gemv` or
+  `tl1-neon-reference-gemv`;
+- fallback status with `fallback_used = false` for strict proof;
+- generated token IDs and decoded text;
+- `speedup_claim = false` until benchmark review.
+
+## Hard rules
+
+- MacBook proof does not prove M4 Mac Mini.
+- M4 proof does not prove MacBook.
+- Apple CPU/NEON proof does not prove Metal.
+- Metal phase proof does not prove full Metal inference.
+- ARM TL2 is unsupported for this model unless the compatibility ledger changes
+  through a separate authority update.

--- a/docs/specs/BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md
@@ -1,0 +1,83 @@
+# BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; artifact inventory contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define the minimum artifact inventory required before BitNet-rs may make any
+artifact-known claim for `1bitLLM/bitnet_b1_58-3B`. The contract records source
+identity, exact files, exact hashes, tokenizer/config authority, storage
+context, cleanup status, and claim boundaries. It does not prove inference.
+
+## Required artifact receipt
+
+```json
+{
+  "artifact_kind": "bitnet_b158_3b_artifact_inventory",
+  "model_id": "onebitllm_bitnet_b158_3b",
+  "source_repo": "1bitLLM/bitnet_b1_58-3B",
+  "source_revision": "af89e318d78a70802061246bf037199d2fb97020",
+  "source_format": "safetensors_sharded",
+  "official_gguf_present": false,
+  "files": [
+    {
+      "name": "model-00001-of-00003.safetensors",
+      "size_bytes": 4990000000,
+      "sha256": "..."
+    }
+  ],
+  "tokenizer_files": {
+    "tokenizer_json_sha256": "...",
+    "tokenizer_model_sha256": "...",
+    "tokenizer_config_sha256": "...",
+    "special_tokens_map_sha256": "..."
+  },
+  "claim_boundary": {
+    "answer_ready": false,
+    "cpu_ready": false,
+    "cuda_ready": false,
+    "apple_ready": false,
+    "server_ready": false,
+    "speedup_claim": false
+  }
+}
+```
+
+## Required inventory fields
+
+The inventory receipt must record:
+
+- source repository and exact source revision;
+- all safetensors shard names, byte sizes, and SHA256 values;
+- `model.safetensors.index.json` SHA256;
+- `config.json` SHA256;
+- `tokenizer.json` SHA256;
+- `tokenizer.model` SHA256;
+- `added_tokens.json` SHA256 when present;
+- `special_tokens_map.json` SHA256;
+- `tokenizer_config.json` SHA256;
+- whether any official `.gguf` is present in the source listing;
+- storage context including local cache path class, available space before and
+  after probe, and cleanup status;
+- explicit booleans for answer, CPU, CUDA, Apple, server, and speed claims.
+
+## Hard rules
+
+- No exact hashes, no artifact claim.
+- No tokenizer authority, no answer claim.
+- No approved GGUF or conversion route, no Rust backend proof.
+- No model binaries, safetensors shards, GGUFs, tokenizer binaries from model
+  repositories, or generated model outputs may be committed.
+- Third-party GGUF substitution is diagnostic until an artifact-authority
+  decision approves provenance, hash identity, tokenizer policy, and route
+  metadata.

--- a/docs/specs/BITNET-SPEC-B158-3B-CONVERSION.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-CONVERSION.md
@@ -1,0 +1,68 @@
+# BITNET-SPEC-B158-3B-CONVERSION
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B artifact contract](BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md), [3B TL layout](BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; conversion/runner authority contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define allowed conversion and runner-authority lanes for the 3B artifact. A
+conversion receipt may prove a candidate artifact or an explicit blocker, but it
+cannot by itself prove answer readiness, backend readiness, or speed.
+
+## Allowed lanes
+
+| Lane | Meaning | Claim |
+| --- | --- | --- |
+| `hf_safetensors_inventory` | Hugging Face shard inspection only. | No inference. |
+| `transformers_reference` | Transformers, vLLM, or SGLang reference run on safetensors. | Reference only, not BitNet-rs. |
+| `bitnetcpp_tl1_conversion` | Upstream-compatible ARM TL1 conversion. | Candidate TL1 artifact. |
+| `bitnetcpp_tl2_conversion` | Upstream-compatible x86 TL2 conversion. | Candidate TL2 artifact. |
+| `st2gguf_f16_reference` | BitNet-rs F16 structural conversion. | Structural/reference only. |
+| `third_party_gguf` | External GGUF. | Diagnostic unless explicitly approved. |
+
+## Required conversion proof
+
+A conversion or blocked-conversion receipt must record:
+
+- tool name, repository, and commit;
+- exact command and host platform;
+- input artifact hashes;
+- output path class, output size, and output SHA256 when produced;
+- output GGUF metadata needed to identify model family and quantization route;
+- quantization route, either `tl1`, `tl2`, `f16_reference`, or
+  `diagnostic_unknown`;
+- whether tokenizer and pre-tokenizer authority are embedded or external;
+- reference runner command and whether the runner loads the output;
+- `claim_boundary = "diagnostic_only"` until reference quality passes.
+
+## Blocked conversion receipts
+
+A blocked route is useful evidence when it records the exact blocker:
+
+```json
+{
+  "status": "blocked",
+  "reason": "bitnet.cpp setup_env help exposes i2_s/tl1 only; TL2 path listed in support table but no reproducible command verified",
+  "claim_boundary": "diagnostic_only"
+}
+```
+
+## Hard rules
+
+- The existing `bitnet-st2gguf` F16 path cannot satisfy TL1/TL2 packed BitNet
+  proof.
+- A reference runner load does not prove Rust CPU, CUDA, Apple, server, or speed
+  readiness.
+- x86 TL2 and ARM TL1 remain `listed_supported_verify_runner` until conversion
+  and runner receipts identify reproducible commands.
+- `I2_S`/QK256 conversion for this model is unsupported except diagnostic
+  rejection receipts.

--- a/docs/specs/BITNET-SPEC-B158-3B-CPU.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-CPU.md
@@ -1,0 +1,64 @@
+# BITNET-SPEC-B158-3B-CPU
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B TL layout](BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [3B reference quality](BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no CPU support promotion until receipts pass
+Policy impact: no policy exception
+
+## Purpose
+
+Define CPU proof paths for the 3B TL lane. CPU proof is the first BitNet-rs
+answer-ready target after artifact, conversion, tokenizer, reference-quality,
+layout, loader, and scalar-oracle gates pass.
+
+## Valid CPU routes
+
+| Platform | Valid route |
+| --- | --- |
+| x86 | TL2 only |
+| ARM | TL1 only |
+| x86 `I2_S` | diagnostic rejection only |
+| ARM `I2_S` | diagnostic rejection only |
+
+## Required receipt shape
+
+```json
+{
+  "model_id": "onebitllm_bitnet_b158_3b",
+  "route": "tl2",
+  "selected_backend": "cpu-rust",
+  "selected_kernel": "tl2-scalar-reference-gemv",
+  "fallback_used": false,
+  "prompt_token_ids": [],
+  "generated_token_ids": [],
+  "quality_passed": true,
+  "speedup_claim": false
+}
+```
+
+## CPU acceptance
+
+A CPU answer-ready claim requires:
+
+- reference-good artifact exists for the same source revision and route family;
+- Rust loader recognizes the TL route and classifies tensor roles;
+- scalar TL oracle passes fixtures for the route family;
+- strict CPU answer corpus passes;
+- prompt and generated token IDs are recorded;
+- `fallback_used = false`;
+- `speedup_claim = false`.
+
+## Hard rules
+
+- No 3B CPU answer claim may use `I2_S`/QK256 kernels.
+- x86 TL2 CPU proof does not prove ARM TL1 CPU proof.
+- ARM TL1 CPU proof does not prove x86 TL2 CPU proof.
+- AVX2, AVX-512, NEON, CUDA, Apple, OpenCL, or server claims require separate
+  follow-on receipts.

--- a/docs/specs/BITNET-SPEC-B158-3B-CUDA.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-CUDA.md
@@ -1,0 +1,54 @@
+# BITNET-SPEC-B158-3B-CUDA
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B CPU](BITNET-SPEC-B158-3B-CPU.md), [3B TL layout](BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [3B performance](BITNET-SPEC-B158-3B-PERFORMANCE.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no CUDA support promotion until receipts pass
+Policy impact: no policy exception
+
+## Purpose
+
+Define the CUDA proof boundary for the 3B TL2 lane. CUDA is valid only after the
+same artifact and tokenizer/prompt profile pass x86 TL2 CPU proof.
+
+## Required path
+
+```text
+x86 TL2 reference-good
+→ Rust TL2 structural loader
+→ scalar TL2 oracle
+→ CPU answer-ready
+→ TL2 CUDA fixture
+→ one-token CUDA
+→ short-decode CUDA
+→ warm-session CUDA
+→ benchmark review
+```
+
+## Required CUDA receipts
+
+CUDA receipts must record:
+
+- model id, source revision, artifact hash, and tokenizer/prompt hashes;
+- route `tl2`;
+- selected backend, for example `nvidia-rtx-5070-ti-cuda`;
+- selected kernel, for example `tl2-cuda-reference-gemv`;
+- fallback status with `fallback_used = false` for strict proof;
+- prompt token IDs, generated token IDs, decoded text, and divergence taxonomy;
+- quality result;
+- `speedup_claim = false` unless exact-profile benchmark review accepts it.
+
+## Hard rules
+
+- No 3B CUDA proof before x86 TL2 CPU answer-ready.
+- No QK256 CUDA kernel reuse unless proving diagnostic rejection.
+- No dense regular-LLM CUDA proof inheritance.
+- No speedup claim before exact-profile review.
+- A one-token CUDA receipt does not prove short-decode, warm-session, server, or
+  benchmark readiness.

--- a/docs/specs/BITNET-SPEC-B158-3B-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-PERFORMANCE.md
@@ -1,0 +1,75 @@
+# BITNET-SPEC-B158-3B-PERFORMANCE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B CPU](BITNET-SPEC-B158-3B-CPU.md), [3B CUDA](BITNET-SPEC-B158-3B-CUDA.md), [3B Apple](BITNET-SPEC-B158-3B-APPLE.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no performance support promotion until exact-profile review
+Policy impact: no policy exception
+
+## Purpose
+
+Define performance profiles and promotion rules for the 3B TL lane. Performance
+receipts are invalid unless answer quality already passed for the same artifact,
+tokenizer, prompt profile, and route with fallback disabled.
+
+## Profiles
+
+- `cold_load`
+- `warm_load`
+- `one_token`
+- `first_token`
+- `prefill_128_decode_16`
+- `prefill_512_decode_32`
+- `decode_32`
+- `decode_128`
+- `warm_session_3_turns`
+- `warm_session_10_turns`
+- `server_nonstream_exact_profile`
+
+## Metrics
+
+Receipts should record:
+
+- `model_load_ms`;
+- `tokenizer_load_ms`;
+- conversion/load metadata;
+- `prompt_render_ms`;
+- `tokenize_ms`;
+- `prefill_ms`;
+- `first_token_ms`;
+- `decode_total_ms`;
+- `steady_tok_per_s`;
+- `kernel_time_ms`;
+- launch count;
+- memory high-water;
+- VRAM or RSS high-water;
+- thread count;
+- selected backend;
+- selected kernel;
+- fallback status.
+
+## Promotion rule
+
+No performance or speedup claim is valid without:
+
+- same artifact;
+- same tokenizer;
+- same prompt profile;
+- `fallback_used = false`;
+- answer quality passed;
+- CPU comparator for accelerator claims;
+- exact-profile benchmark review.
+
+## Hard rules
+
+- Benchmarks before reference-good and CPU answer-ready are diagnostic only.
+- TL1 benchmark results do not prove TL2 performance, and TL2 benchmark results
+  do not prove TL1 performance.
+- Server performance requires exact-profile server receipts and does not inherit
+  from CLI receipts.

--- a/docs/specs/BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md
@@ -1,0 +1,61 @@
+# BITNET-SPEC-B158-3B-REFERENCE-QUALITY
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B conversion](BITNET-SPEC-B158-3B-CONVERSION.md), [3B tokenizer/prompt](BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; reference-quality contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define the reference-good gate that must pass before Rust CPU or accelerator
+work can claim useful answers for the 3B lane. Reference quality is
+route-specific and artifact-specific.
+
+## Reference levels
+
+| Corpus | Purpose |
+| --- | --- |
+| `tiny_smoke` | Can the model answer at all? |
+| `answer_corpus_v1` | Bounded answer-ready gate. |
+| `behavior_suite_v1` | Prompt conditioning, stop behavior, non-repetition. |
+| `long_decode_v1` | Stability and warm-session behavior. |
+
+## Minimum reference cases
+
+- `math_2_plus_2`
+- `capital_france`
+- `copy_color_sequence`
+- `yes_no_clear_sky`
+- `short_continuation`
+- `prompt_conditioning_pair`
+- `stop_token_behavior`
+- `special_token_garbage_check`
+
+## Pass criteria
+
+A reference-quality receipt must show:
+
+- non-empty output;
+- printable UTF-8;
+- no raw special-token garbage;
+- no uncontrolled repetition;
+- constrained answers satisfy gates;
+- prompt-conditioned pair changes appropriately;
+- stop policy is respected;
+- deterministic decoding configuration is recorded.
+
+## Hard rules
+
+- Reference-good output requires an approved artifact or approved reference
+  route, tokenizer authority, prompt authority, and deterministic settings.
+- Transformers, vLLM, SGLang, or bitnet.cpp reference success does not prove
+  BitNet-rs Rust CPU support.
+- Reference-good for TL1 does not prove TL2. Reference-good for TL2 does not
+  prove TL1.

--- a/docs/specs/BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md
@@ -1,0 +1,69 @@
+# BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B conversion](BITNET-SPEC-B158-3B-CONVERSION.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; TL layout contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define what BitNet-rs must know before it can load, fixture, or execute TL1/TL2
+artifacts for the 3B lane. This spec is intentionally stricter than a support
+matrix row: kernels may not execute until the route layout is known and a scalar
+oracle exists.
+
+## Layout fields to specify before runtime proof
+
+A TL1 or TL2 artifact-authority decision must define:
+
+- TL1 tensor layout and tensor role mapping;
+- TL2 tensor layout and tensor role mapping;
+- bit packing order and values for ternary weights;
+- lookup-table semantics and table indexing;
+- weight scale and group scale semantics;
+- activation type expected by TL kernels;
+- embedding quantization policy;
+- row stride, block size, and alignment;
+- tail behavior for non-multiple rows and columns;
+- endianness;
+- GGUF metadata required to identify `tl1` or `tl2` routes;
+- explicit differences from `I2_S` and QK256.
+
+## Required kernel IDs
+
+The route registry and receipts must use stable kernel IDs:
+
+- `tl1-scalar-reference-gemv`
+- `tl1-neon-reference-gemv`
+- `tl2-scalar-reference-gemv`
+- `tl2-avx2-reference-gemv`
+- `tl2-avx512-reference-gemv`
+- `tl2-cuda-reference-gemv`
+
+Additional OpenCL, Metal, or platform-specific IDs may be added later only after
+scalar TL fixture coverage exists for the same route family.
+
+## Fixture requirements
+
+TL fixtures must include:
+
+- tiny synthetic TL1 and TL2 tensors independent of 3B model binaries;
+- row stride and tail cases;
+- lookup-table and scale cases;
+- known output vectors generated from the scalar definition;
+- negative fixtures that prove `I2_S`/QK256 code paths are not called.
+
+## Hard rules
+
+- TL1/TL2 are not QK256.
+- TL1/TL2 fixtures must not call `I2_S` scalar or CUDA QK256 kernels.
+- No TL accelerator work may start before a scalar TL oracle exists for that
+  route family.
+- TL1 proof does not prove TL2, and TL2 proof does not prove TL1.

--- a/docs/specs/BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md
+++ b/docs/specs/BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md
@@ -1,0 +1,57 @@
+# BITNET-SPEC-B158-3B-TOKENIZER-PROMPT
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [3B artifact contract](BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md), [3B reference quality](BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md)
+Linked ADRs: n/a
+Linked plan: [3B TL implementation plan](../../plans/bitnet-b158-3b/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion; tokenizer/prompt contract only
+Policy impact: no policy exception
+
+## Purpose
+
+Define tokenizer and prompt authority for deterministic 3B reference and Rust
+runs. The 3B lane must not inherit the official Microsoft 2B
+`bitnetcpp-answer` prompt template or tokenizer compatibility decision.
+
+## Required audit fields
+
+A tokenizer/prompt receipt must record:
+
+- `tokenizer.json` SHA256;
+- `tokenizer.model` SHA256;
+- `tokenizer_config.json` SHA256;
+- `added_tokens.json` SHA256 when present;
+- `special_tokens_map.json` SHA256;
+- BOS, EOS, PAD, and UNK token IDs;
+- chat template if present;
+- completion template when no chat template is used;
+- stop-token policy;
+- rendered prompt text;
+- prompt token IDs;
+- deterministic decoding settings;
+- reference runner command;
+- runner conversation mode, yes or no.
+
+## Prompt authority levels
+
+| Level | Meaning | Claim |
+| --- | --- | --- |
+| `files_hashed` | Tokenizer files exist and hashes are recorded. | Tokenizer inventory only. |
+| `template_identified` | Chat or completion template is selected and rendered. | Prompt candidate only. |
+| `runner_accepted` | Reference runner accepts tokenizer and prompt settings. | Reference-run candidate. |
+| `reference_good` | Reference corpus passes with the selected tokenizer/prompt. | Reference quality candidate. |
+| `rust_matched` | Rust tokenization and prompt IDs match bounded reference evidence. | Rust route candidate. |
+
+## Hard rules
+
+- Do not assume the official Microsoft 2B `bitnetcpp-answer` prompt template
+  applies to `1bitLLM/bitnet_b1_58-3B`.
+- No tokenizer hashes, no answer claim.
+- No prompt rendering and prompt token IDs, no deterministic answer receipt.
+- A different tokenizer revision invalidates previous prompt-token receipts
+  until rerun.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -93,6 +93,41 @@ Do not proceed from upstream support, HF safetensors presence, or F16 structural
 conversion to answer, backend, or speed claims. Claims require exact artifact,
 tokenizer, prompt, reference, backend, fallback, and benchmark receipts.
 
+## BitNet b1.58 3B TL Candidate
+
+Use these specs before implementing or claiming support for
+`1bitLLM/bitnet_b1_58-3B`:
+
+1. [3B Artifact Contract](BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md)
+   - Defines exact source revision, shard, tokenizer/config, hash, storage, and
+     claim-boundary requirements.
+2. [3B Conversion Contract](BITNET-SPEC-B158-3B-CONVERSION.md)
+   - Defines allowed safetensors, reference-runner, TL1/TL2 conversion, F16
+     structural, and third-party GGUF diagnostic lanes.
+3. [3B TL1/TL2 Layout](BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md)
+   - Defines the route-specific TL layout fields and scalar-oracle prerequisite
+     before accelerator work.
+4. [3B Tokenizer and Prompt](BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md)
+   - Defines tokenizer hashes, special token IDs, prompt rendering, token IDs,
+     stop policy, and reference runner mode.
+5. [3B Reference Quality](BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md)
+   - Defines tiny smoke, answer corpus, behavior, and long-decode reference
+     gates.
+6. [3B CPU](BITNET-SPEC-B158-3B-CPU.md)
+   - Defines x86 TL2 and ARM TL1 CPU proof paths and `I2_S` diagnostic
+     rejection boundaries.
+7. [3B CUDA](BITNET-SPEC-B158-3B-CUDA.md)
+   - Defines the CUDA TL2 path after x86 TL2 CPU answer proof.
+8. [3B Apple](BITNET-SPEC-B158-3B-APPLE.md)
+   - Defines the ARM TL1 Apple CPU/NEON path and MacBook/M4/Metal boundaries.
+9. [3B Performance](BITNET-SPEC-B158-3B-PERFORMANCE.md)
+   - Defines exact-profile benchmark metrics and promotion rules.
+
+Do not treat the 3B model as an `I2_S`/QK256 sibling of the official Microsoft
+2B artifact. x86 TL2 and ARM TL1 remain runner/conversion candidates until
+route-specific receipts prove them; all answer, backend, server, and speed
+claims remain false before the shared artifact gate and these specs pass.
+
 ## CPU AVX-512 Kernel Proof
 
 Use these specs before implementing or claiming AVX-512 CPU kernel support:

--- a/docs/tracking/campaigns/bitnet-b158-3b/CAMPAIGN.md
+++ b/docs/tracking/campaigns/bitnet-b158-3b/CAMPAIGN.md
@@ -1,0 +1,49 @@
+# BitNet b1.58 3B TL Candidate Campaign
+
+Campaign ID: `bitnet-b158-3b`
+
+Status: active
+
+## Objective
+
+Make `1bitLLM/bitnet_b1_58-3B` a first-class BitNet-rs TL-model candidate
+without treating it as an `I2_S`/QK256 extension of the official Microsoft 2B
+artifact.
+
+## Why This Exists
+
+Upstream bitnet.cpp lists the 3B model as a supported model with x86 TL2 and ARM
+TL1 routes while marking `I2_S` unsupported for both x86 and ARM. The current
+Hugging Face listing exposes safetensors shards and tokenizer/config assets, not
+an official GGUF. BitNet-rs therefore needs artifact authority, conversion /
+runner authority, TL1/TL2 layout contracts, tokenizer/prompt authority, and
+reference-good output before any Rust CPU, CUDA, Apple, server, or performance
+claim can be made.
+
+## Scope Boundary
+
+This campaign is a BitNet TL candidate lane. It does not promote model coverage,
+does not commit model binaries, does not enable runtime inference, and does not
+claim answer readiness. `I2_S`/QK256 use for this model is limited to diagnostic
+rejection receipts.
+
+## End State
+
+- The proposal, source map, plan, and specs define the support ladder from
+  `registered` through `server_exact_profile_ready`.
+- Artifact inventory and conversion/runner receipts can be added without
+  overclaiming.
+- TL1 and TL2 route families are independent; proof does not cross-inherit.
+- Backend and speed claims remain blocked until exact-profile receipts pass.
+
+## Work Items
+
+| Work item | Status | Notes |
+| --- | --- | --- |
+| B158-3B-001 | ready | Add docs rails and specs for guarded 3B TL candidate registration. |
+
+## Review Policy
+
+Docs/spec PRs must run the campaign check, campaign generated-status check, and
+`git diff --check`. Runtime, model-binary, model-coverage, artifact-receipt, and
+backend changes belong to later work items with narrower proof commands.

--- a/docs/tracking/campaigns/bitnet-b158-3b/active.toml
+++ b/docs/tracking/campaigns/bitnet-b158-3b/active.toml
@@ -1,0 +1,65 @@
+id = "bitnet-b158-3b"
+title = "BitNet b1.58 3B TL candidate"
+status = "active"
+
+objective = "Make 1bitLLM/bitnet_b1_58-3B a first-class BitNet-rs TL-model candidate with guarded artifact, conversion, runner, TL layout, tokenizer, quality, backend, and performance authority before any answer or speed claim."
+
+end_state = [
+  "The 3B model is registered as a diagnostic TL candidate with exact source-map and claim-boundary docs.",
+  "Artifact inventory, conversion, TL layout, tokenizer/prompt, reference-quality, CPU, CUDA, Apple, and performance specs define promotion gates.",
+  "I2_S/QK256, Microsoft 2B, and dense SLM proof inheritance are explicitly forbidden for the 3B lane.",
+]
+
+hard_constraints = [
+  "Do not commit model binaries.",
+  "Do not claim 3B I2_S or QK256 support except diagnostic rejection receipts.",
+  "Do not claim x86 TL2 or ARM TL1 answer readiness until runner/conversion and reference-quality evidence pass.",
+  "Do not claim CPU, CUDA, Apple, server, or speed readiness before route-specific receipts with fallback=false exist.",
+]
+
+[[work_item]]
+id = "B158-3B-001"
+status = "ready"
+branch = "codex/bitnet-b158-3b/docs-rails-and-specs"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = [
+  "Add the 3B TL model proposal, source map, campaign, and implementation plan.",
+  "Add artifact, conversion, TL layout, tokenizer/prompt, reference-quality, CPU, CUDA, Apple, and performance specs.",
+  "Update specs index and Apple candidate matrices without promoting model coverage or runtime claims.",
+  "Keep 3B I2_S/QK256 unsupported and TL1/TL2 verification pending.",
+]
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check bitnet-b158-3b",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md",
+  "docs/bitnet/bitnet-b158-3b/**",
+  "plans/bitnet-b158-3b/**",
+  "docs/tracking/campaigns/bitnet-b158-3b/**",
+  "docs/specs/BITNET-SPEC-B158-3B-*.md",
+  "docs/specs/INDEX.md",
+  "docs/apple-silicon/bitnet-candidate-matrix.md",
+  "ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+  "crates/**",
+  "ci/model-artifacts/model-coverage-matrix.toml",
+  "ci/model-artifacts/bitnet-b158-3b/**",
+]
+may_claim = [
+  "1bitLLM/bitnet_b1_58-3B is a registered diagnostic TL candidate with docs/spec promotion gates.",
+]
+must_not_claim = [
+  "3B I2_S/QK256 support is available.",
+  "x86 TL2 or ARM TL1 is answer-ready.",
+  "3B inherits official Microsoft 2B or dense SLM proof.",
+  "3B CPU, CUDA, Apple, server, or speedup support is proven.",
+]

--- a/docs/tracking/campaigns/bitnet-b158-3b/generated/status.md
+++ b/docs/tracking/campaigns/bitnet-b158-3b/generated/status.md
@@ -1,0 +1,19 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# BitNet b1.58 3B TL candidate Campaign Status
+
+- Campaign: `bitnet-b158-3b`
+- State: `active`
+- Objective: Make 1bitLLM/bitnet_b1_58-3B a first-class BitNet-rs TL-model candidate with guarded artifact, conversion, runner, TL layout, tokenizer, quality, backend, and performance authority before any answer or speed claim.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| B158-3B-001 | ready | TBD | `codex/bitnet-b158-3b/docs-rails-and-specs` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the 3B TL model proposal, source map, campaign, and implementation plan.; Add artifact, conversion, TL layout, tokenizer/prompt, reference-quality, CPU, CUDA, Apple, and performance specs.; Update specs index and Apple candidate matrices without promoting model coverage or runtime claims.; Keep 3B I2_S/QK256 unsupported and TL1/TL2 verification pending. |
+
+## Hard Constraints
+
+- Do not commit model binaries.
+- Do not claim 3B I2_S or QK256 support except diagnostic rejection receipts.
+- Do not claim x86 TL2 or ARM TL1 answer readiness until runner/conversion and reference-quality evidence pass.
+- Do not claim CPU, CUDA, Apple, server, or speed readiness before route-specific receipts with fallback=false exist.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,6 +28,7 @@
 | apple-m4-slm-model-breadth | M4-MODEL-008 | TBD | blocked | none | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | MB-AS-002 | TBD | blocked | MB-AS-004 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
+| bitnet-b158-3b | B158-3B-001 | TBD | ready | none | Do not commit model binaries. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-AVX512-000 | TBD | in_progress | CPU-SCALAR-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -28,6 +28,7 @@
 | apple-m4-slm-model-breadth | Apple M4 SLM model breadth | M4-MODEL-008 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | Apple M4 SLM performance | M4-SLM-PERF-007 | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | Apple Silicon MacBook cross-reference | MB-AS-002 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
+| bitnet-b158-3b | BitNet b1.58 3B TL candidate | B158-3B-001 | Do not commit model binaries. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-AVX512-000 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/plans/bitnet-b158-3b/README.md
+++ b/plans/bitnet-b158-3b/README.md
@@ -1,0 +1,20 @@
+# BitNet b1.58 3B TL candidate plan
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../../docs/proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [artifact](../../docs/specs/BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md), [conversion](../../docs/specs/BITNET-SPEC-B158-3B-CONVERSION.md), [TL layout](../../docs/specs/BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [tokenizer/prompt](../../docs/specs/BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md), [quality](../../docs/specs/BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md), [CPU](../../docs/specs/BITNET-SPEC-B158-3B-CPU.md), [CUDA](../../docs/specs/BITNET-SPEC-B158-3B-CUDA.md), [Apple](../../docs/specs/BITNET-SPEC-B158-3B-APPLE.md), [performance](../../docs/specs/BITNET-SPEC-B158-3B-PERFORMANCE.md)
+Linked ADRs: n/a
+Linked plan: [implementation-plan.md](implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no promotion; registers a guarded candidate lane
+Policy impact: no policy exception
+
+This directory sequences the `1bitLLM/bitnet_b1_58-3B` TL candidate lane. The
+lane is artifact-safe first, TL-correct second, answer-good third, and fast
+fourth.
+
+Start with [`implementation-plan.md`](implementation-plan.md) for PR order,
+proof commands, allowed paths, and claim boundaries.

--- a/plans/bitnet-b158-3b/implementation-plan.md
+++ b/plans/bitnet-b158-3b/implementation-plan.md
@@ -1,0 +1,82 @@
+# BitNet b1.58 3B TL candidate implementation plan
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0010](../../docs/proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md)
+Linked specs: [artifact](../../docs/specs/BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md), [conversion](../../docs/specs/BITNET-SPEC-B158-3B-CONVERSION.md), [TL layout](../../docs/specs/BITNET-SPEC-B158-3B-TL1-TL2-LAYOUT.md), [tokenizer/prompt](../../docs/specs/BITNET-SPEC-B158-3B-TOKENIZER-PROMPT.md), [quality](../../docs/specs/BITNET-SPEC-B158-3B-REFERENCE-QUALITY.md), [CPU](../../docs/specs/BITNET-SPEC-B158-3B-CPU.md), [CUDA](../../docs/specs/BITNET-SPEC-B158-3B-CUDA.md), [Apple](../../docs/specs/BITNET-SPEC-B158-3B-APPLE.md), [performance](../../docs/specs/BITNET-SPEC-B158-3B-PERFORMANCE.md)
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no support promotion until proof receipts pass
+Policy impact: no policy exception
+
+## Scope
+
+Make `1bitLLM/bitnet_b1_58-3B` a first-class BitNet-rs TL-model candidate
+without overclaiming. This plan does not enable runtime inference, commit model
+binaries, promote support tiers, or treat the model as an `I2_S`/QK256 sibling
+of the official Microsoft 2B artifact.
+
+## PR sequence
+
+1. **Docs and source-of-truth rails.** Add the proposal, source map, campaign,
+   plan, and candidate-matrix clarifications. Acceptance: docs only, no model
+   binaries, no runtime claims, 3B `I2_S` blocked explicitly, TL1/TL2
+   verification path explicit.
+2. **Artifact and conversion contracts.** Add the 3B artifact inventory and
+   conversion specs. Acceptance: exact source revision, file/hash requirements,
+   no official-GGUF assumption, blocked-conversion receipts allowed.
+3. **TL layout and tokenizer contracts.** Add TL1/TL2 layout and tokenizer /
+   prompt specs. Acceptance: TL1/TL2 are not QK256, tokenizer/prompt authority
+   is model-specific, no Microsoft 2B prompt inheritance.
+4. **Quality, backend, and performance contracts.** Add reference-quality, CPU,
+   CUDA, Apple, and performance specs. Acceptance: each backend has prerequisite
+   gates, fallback is explicit, speedup is false until exact-profile review.
+5. **Coverage candidate registration.** Add a guarded model coverage row with
+   `current_tier = "registered"` and forbidden answer/backend/speed claims.
+6. **Artifact inventory receipt.** Probe the Hugging Face repo in cache only,
+   record source revision, sizes, hashes, tokenizer/config hashes, storage
+   context, cleanup status, and no official GGUF if true.
+7. **Conversion and runner authority.** Verify or block upstream TL1/TL2
+   conversion and runner commands with tool commits, input hashes, output hashes
+   when produced, route metadata, and diagnostic-only claim boundaries.
+8. **Tokenizer and reference output.** Audit tokenizer/prompt authority and run
+   a deterministic reference corpus only after an approved reference route
+   exists.
+9. **TL fixtures, loader, and scalar oracle.** Add synthetic TL1/TL2 fixtures,
+   structural loader recognition, unsupported `I2_S` rejection receipts, and
+   scalar TL oracle tests before accelerator work.
+10. **CPU answer proof.** Prove x86 TL2 CPU or ARM TL1 CPU/NEON only after
+    reference-good and scalar TL oracle prerequisites pass.
+11. **Accelerator proof.** Add AVX, CUDA, Apple, or OpenCL proof only after the
+    exact CPU route is answer-ready for the same artifact and route family.
+12. **Benchmark and product promotion.** Promote CLI/server support only from
+    exact-profile receipts with fallback=false, quality passed, and speedup
+    claims separately reviewed.
+
+## Validation for docs/spec PRs
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check bitnet-b158-3b
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+If a command cannot run because of environment limits, record the unavailable
+command, why it could not run, substitute evidence, and whether that blocks
+merge.
+
+## Claim boundaries
+
+- Do not commit model binaries.
+- Do not claim 3B `I2_S` support.
+- Do not route 3B through QK256/`I2_S` except diagnostic rejection receipts.
+- Do not claim x86 TL2 until runner/conversion evidence is verified.
+- Do not claim ARM TL1 until runner/conversion evidence is verified.
+- Do not substitute third-party GGUFs without an artifact-authority decision.
+- Do not inherit official Microsoft 2B `I2_S` proof.
+- Do not inherit dense Qwen or dense SLM proof.
+- Do not claim CPU, CUDA, Apple, server, or speed readiness before the artifact
+  gate and route-specific receipts pass.


### PR DESCRIPTION
### Motivation

- Treat `1bitLLM/bitnet_b1_58-3B` as a separate TL-model lane (TL1/TL2) rather than an `I2_S`/QK256 extension of the official Microsoft 2B artifact. 
- Upstream listing and the Hugging Face repo show sharded `safetensors` and tokenizer/config assets but no official `.gguf`, so artifact, conversion, and runner authority must be proven before any answer/backend/speed claims. 
- Prevent proof inheritance from Microsoft 2B `I2_S`/QK256 and dense-SLM families and enforce strict claim boundaries for artifact, tokenizer, prompt, reference, CPU, and accelerator proofs. 
- Provide a phased PR-by-PR plan and campaign rails to move the lane from `registered` through artifact inventory, conversion, TL layout proof, reference-good, Rust loader, scalar oracles, CPU answer proof, and then accelerator/benchmark proof.

### Description

- Added a proposal and source map: `docs/proposals/BITNET-PROP-0010-bitnet-b158-3b-tl-model.md` and `docs/bitnet/bitnet-b158-3b/README.md`, describing the lane, non-inheritance rules, and the promotion ladder. 
- Added a plan and campaign rails: `plans/bitnet-b158-3b/implementation-plan.md` and `docs/tracking/campaigns/bitnet-b158-3b/{active.toml,CAMPAIGN.md,generated/status.md}` to sequence PR-sized work, allowed/forbidden paths, and acceptance checks. 
- Added a full 3B spec set under `docs/specs/`: `BITNET-SPEC-B158-3B-ARTIFACT-CONTRACT.md`, `-CONVERSION.md`, `-TL1-TL2-LAYOUT.md`, `-TOKENIZER-PROMPT.md`, `-REFERENCE-QUALITY.md`, `-CPU.md`, `-CUDA.md`, `-APPLE.md`, and `-PERFORMANCE.md`, and updated `docs/specs/INDEX.md` to reference them. 
- Updated Apple candidate matrices and compatibility entries to mark 3B as a guarded TL candidate (ARM TL1 diagnostic candidate, ARM TL2 unsupported, I2_S unsupported), and added explicit claim-boundary text to `docs/apple-silicon/bitnet-candidate-matrix.md` and `ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml`. 

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- campaign check bitnet-b158-3b`, which completed successfully and reported the campaign manifest OK. 
- Ran `cargo run --locked -p xtask --no-default-features -- campaign generate --check`, regenerated dashboards and verified generated files are current, and the check passed. 
- Ran `git diff --check` as part of validation and it reported no blocking issues. All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae9e7e5ac8333b639f9aac1608a3e)

### Rebase refresh on 2026-05-18

- Rebased onto current `main` after `#5730` landed.
- Resolved conflicts in `docs/apple-silicon/bitnet-candidate-matrix.md` and `docs/specs/INDEX.md` by preserving the B158-large control-model rails and adding the 3B TL candidate rails beside them.
- Ran markdownlint on the new 3B docs/spec/plan/campaign files: passed.
- Ran `git diff --check origin/main..HEAD` and `git diff --check`: passed.
- Attempted `cargo run --locked -p xtask --no-default-features -- campaign check bitnet-b158-3b`; local run timed out after 5 minutes without an emitted campaign error, and the spawned cargo processes were stopped. Hosted CI should be used for the refreshed campaign verdict.
