### PR TITLE
ci: remove dead PR plan changed count

### DIFF
--- a/xtask/src/ci/plan.rs
+++ b/xtask/src/ci/plan.rs
@@ -97,8 +97,6 @@ pub struct Plan {
     pub estimated_lem: u64,
     #[serde(skip_serializing)]
     pub band: String,
-    #[serde(skip_serializing)]
-    pub changed_count: usize,
     /// Soft-budget guard verdict (PR 18). One of "ok", "warn",
     /// "strong-warn", "ack-suggested", "block".
     #[serde(skip_serializing)]
@@ -657,7 +655,6 @@ pub fn build_plan(changed: &[String], labels: &[String]) -> Plan {
         lanes,
         estimated_lem: total,
         band: band_for(total).to_string(),
-        changed_count: changed.len(),
         guard,
         override_labels_present,
     }


### PR DESCRIPTION
## Summary
- remove the unused skipped-serialization changed_count field from xtask ci plan
- unblock campaign doctor / tracker fast-path compilation under -D warnings
- keep the active SLM tracker closeout PR tracker-scoped instead of mixing CI repair into it

## Claim boundary
CI planner compile cleanup only. No runtime, model, receipt, tracker, generated dashboard, backend, hardware, or readiness claim behavior changes.

## Validation
- PASS: rtk git diff --check origin/main...HEAD
- PASS: rtk rg -n changed_count xtask/src/ci/plan.rs returned no matches
- GAP: local rtk cargo check --locked -p xtask --no-default-features timed out after 10 minutes during a cold compile in target/codex-ci-plan-check; remote CI should provide the cargo proof

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated internal build system data structures to refine tracking and categorization metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/5740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->