### PR TITLE
docs(bitnet-official): add Official Microsoft BitNet 2B source map, plan, and campaign

### DIFF
--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -2,6 +2,7 @@ schema = 1
 artifact_kind = "model_coverage_matrix"
 updated = "2026-05-15"
 work_item = "MODEL-COVERAGE-005"
+source_map = "docs/bitnet/official-2b/README.md"
 claim_boundary = "Model coverage is a claim-control surface. Registered or structurally valid models cannot imply CPU answer-readiness, CUDA execution, speedup, server readiness, BitNet packed QK256 proof, or dense regular-LLM proof unless the corresponding receipts are listed and the claim booleans are explicitly true."
 
 [[tier]]
@@ -48,6 +49,7 @@ meaning = "Normal user CLI paths exist for verified ask/chat/bench receipt surfa
 
 [[entry]]
 id = "bitnet_official_2b_i2s_qk256"
+source_map = "docs/bitnet/official-2b/README.md"
 model_class = "bitnet"
 family = "bitnet_b1_58"
 artifact_kind = "gguf_i2_s"
@@ -97,6 +99,7 @@ claim_boundary = "Official Microsoft 2B I2_S is the current BitNet QK256 x86/CUD
 
 [[entry]]
 id = "bitnet_official_2b_tl1_arm_candidate"
+source_map = "docs/bitnet/official-2b/README.md"
 model_class = "bitnet"
 family = "bitnet_b1_58"
 artifact_kind = "gguf_tl1"
@@ -138,6 +141,7 @@ claim_boundary = "Official or derived TL1 BitNet rows are ARM-oriented candidate
 
 [[entry]]
 id = "bitnet_official_2b_tl2_x86_candidate"
+source_map = "docs/bitnet/official-2b/README.md"
 model_class = "bitnet"
 family = "bitnet_b1_58"
 artifact_kind = "gguf_tl2"
@@ -180,6 +184,7 @@ claim_boundary = "Official or derived TL2 BitNet rows are separate x86 LUT candi
 
 [[entry]]
 id = "bitnet_official_2b_bf16_gpu_int2_candidate"
+source_map = "docs/bitnet/official-2b/README.md"
 model_class = "bitnet"
 family = "bitnet_b1_58"
 artifact_kind = "bf16_master_to_gpu_packed_int2_w2a8"

--- a/ci/model-artifacts/model-kernel-compatibility.toml
+++ b/ci/model-artifacts/model-kernel-compatibility.toml
@@ -4,6 +4,7 @@ updated = "2026-05-08"
 work_item = "BITNET-COMPAT-001"
 source = "microsoft/BitNet README supported model table"
 source_url = "https://github.com/microsoft/BitNet/blob/main/README.md"
+source_map = "docs/bitnet/official-2b/README.md"
 claim_boundary = "Upstream model/kernel support is a precondition for answer_ready, reference_authority, backend_parity, and speedup claims. Unsupported combinations may only be used for diagnostic runs, artifact inspection, or unsupported-path receipts."
 
 proof_claims_rejected_when_unsupported = [

--- a/docs/bitnet/official-2b/README.md
+++ b/docs/bitnet/official-2b/README.md
@@ -1,0 +1,125 @@
+# Official BitNet 2B Source Map
+
+## Purpose
+
+`microsoft/BitNet-b1.58-2B-4T` is the official BitNet-rs reference model
+family. This source map records the current source-of-truth stack for making
+that model boringly correct, route-explicit, fallback-safe, benchmarkable, and
+impossible to overclaim.
+
+This is a governance source map only. It does not add model binaries, runtime
+code, new receipts, or claim promotion.
+
+## Current Answer Authority
+
+The current answer-authority artifact is the official Microsoft I2_S GGUF route
+recorded as:
+
+```text
+coverage_row = bitnet_official_2b_i2s_qk256
+model_family = bitnet_b1_58
+artifact_kind = gguf_i2_s
+route_family = gguf_i2_s_qk256
+tokenizer_authority = external_llama_bpe
+prompt_authority = bitnetcpp-answer
+current_tier = product_cli_ready
+```
+
+That row is the shared answer-ready plate for CPU and CUDA I2_S/QK256 work only
+when the exact official artifact, external Microsoft tokenizer authority,
+`llama-bpe` pre-tokenizer compatibility decision, and BitNet.cpp answer prompt
+authority are preserved.
+
+## Current Claim Boundary
+
+The official I2_S/QK256 row may remain `product_cli_ready` for bounded CPU/CUDA
+CLI use because the coverage matrix records:
+
+- `reference_good=true`
+- `cpu_answer_ready=true`
+- `accelerator_answer_ready=true`
+- `bitnet_packed_i2s_qk256_proof=true`
+
+The same row must continue to reject broader claims until route-specific proof
+exists:
+
+- `benchmark_qualified=false`
+- `server_ready=false`
+- `speedup_claim=false`
+- `full_residency_claim=false`
+- dense regular-LLM CUDA proof does not satisfy BitNet packed proof
+- exact-profile server smoke does not imply broad production server readiness
+
+## Route Split
+
+The official model family is not one vague `BitNet works` claim. Each route has
+its own row, specs, receipts, and promotion gate.
+
+| Route | Coverage row | Current posture | Claim boundary |
+|---|---|---|---|
+| I2_S/QK256 GGUF | `bitnet_official_2b_i2s_qk256` | Product CLI-ready for bounded CPU/CUDA answer lanes | Does not prove speedup, full residency, broad server readiness, Apple, A770, TL1, TL2, or BF16/GPU-int2. |
+| TL1 ARM | `bitnet_official_2b_tl1_arm_candidate` | Registered candidate | Needs TL1 layout, scalar oracle, and ARM/NEON or Apple proof; cannot inherit I2_S proof. |
+| TL2 x86 | `bitnet_official_2b_tl2_x86_candidate` | Registered candidate | Needs TL2 layout, scalar oracle, runner verification, and x86 proof; cannot inherit I2_S proof. |
+| BF16 to GPU int2/W2A8 | `bitnet_official_2b_bf16_gpu_int2_candidate` | Registered candidate | Needs BF16 artifact contract, packer parity, and GPU int2 runtime proof; cannot inherit GGUF I2_S proof. |
+| Dense fallback | none | Diagnostic only | Cannot promote BitNet answer, packed-kernel, speed, residency, or server claims. |
+
+## Product End State
+
+The official model is fully governed when normal user-facing commands can verify
+and explain all of these fields for every claimed route:
+
+```text
+exact official artifact
+exact tokenizer and pre-tokenizer authority
+exact prompt template and stop policy
+explicit route family: I2_S/QK256, TL1, TL2, or BF16/GPU-int2
+requested and selected backend
+selected kernel and invocation counters
+fallback_used=false where strict
+answer quality result
+profile-scoped speed decision
+per-phase residency class
+server readiness scope or explicit false
+forbidden claims and next proof required
+```
+
+Representative user surfaces are:
+
+```bash
+bitnet model verify microsoft-bitnet-b1.58-2B-4T-i2s
+bitnet model status --model microsoft-bitnet-b1.58-2B-4T-i2s
+bitnet ask --model microsoft-bitnet-b1.58-2B-4T-i2s --device cpu
+bitnet ask --model microsoft-bitnet-b1.58-2B-4T-i2s --device cuda
+bitnet chat --model microsoft-bitnet-b1.58-2B-4T-i2s --device cuda
+bitnet bench --model microsoft-bitnet-b1.58-2B-4T-i2s --device cuda
+bitnet receipts explain --latest
+```
+
+## Source-of-Truth Stack
+
+| Layer | Artifact |
+|---|---|
+| Proposal | `docs/proposals/BITNET-PROP-0014-official-bitnet-2b-productization.md` (planned) |
+| Artifact contract specs | `docs/specs/BITNET-SPEC-OFFICIAL-2B-ARTIFACT-CONTRACT.md` and `docs/specs/BITNET-SPEC-OFFICIAL-2B-TOKENIZER-PROMPT.md` (planned) |
+| Route specs | `docs/specs/BITNET-SPEC-OFFICIAL-2B-I2S-QK256.md` and `docs/specs/BITNET-SPEC-OFFICIAL-2B-TL1-TL2.md` (planned) |
+| Backend specs | CPU, CUDA, Apple, and A770/OpenCL official 2B specs (planned) |
+| Quality/perf/product specs | Quality, performance, residency, server, and status-surface specs (planned) |
+| Plan | `plans/official-bitnet-2b/implementation-plan.md` |
+| Active campaign | `docs/tracking/campaigns/official-bitnet-2b/active.toml` |
+| Current claim ledgers | `ci/model-artifacts/model-coverage-matrix.toml` and `ci/model-artifacts/model-kernel-compatibility.toml` |
+| Answer-artifact gate | `docs/model-artifacts/ANSWER_ARTIFACT_GATE.md` |
+| CPU path constraints | `docs/bitnet/BITNET_CPU_PATH_PLAN.md` |
+| CUDA proof lane | `docs/tracking/campaigns/nvidia-5070ti/active.toml` and `plans/cuda-5070ti-productization/bitnet-official-i2s.md` |
+
+## Non-goals
+
+This source map does not:
+
+- add or commit model binaries;
+- change loader, tokenizer, kernel, server, or CLI runtime behavior;
+- promote TL1, TL2, BF16/GPU-int2, Apple, A770, speed, full-residency, or broad
+  server readiness claims;
+- allow no-scale F32 diagnostic QK256 to count as production I2_S proof;
+- allow dense regular-LLM CUDA proof to satisfy BitNet packed I2_S/QK256 proof;
+- allow CUDA receipts to satisfy CPU, Apple, A770, TL1, TL2, or BF16/GPU-int2
+  proof.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,5 +1,26 @@
 # Specs Index
 
+## Official Microsoft BitNet 2B Productization
+
+Use these artifacts before implementing or claiming support for
+`microsoft/BitNet-b1.58-2B-4T`:
+
+1. [Official BitNet 2B Source Map](../bitnet/official-2b/README.md)
+   - Records the official model family, current I2_S/QK256 answer authority,
+     route split, claim boundaries, and source-of-truth stack.
+2. [Official BitNet 2B Implementation Plan](../../plans/official-bitnet-2b/implementation-plan.md)
+   - Sequences source-map, proposal, specs, CPU/CUDA excellence, Apple/A770,
+     TL1/TL2, BF16/GPU-int2, and product-polish work.
+3. [Official BitNet 2B Campaign](../tracking/campaigns/official-bitnet-2b/CAMPAIGN.md)
+   - Summarizes the active campaign boundaries and route-specific proof model.
+
+The current I2_S/QK256 row may remain bounded product-CLI-ready exactly as
+recorded in `ci/model-artifacts/model-coverage-matrix.toml`. Do not promote
+speedup, full residency, broad server readiness, TL1, TL2, BF16/GPU-int2,
+Apple, or A770 claims without route-specific specs and receipts. Dense SLM
+proof and diagnostic no-scale F32 QK256 proof do not satisfy production
+BitNet packed I2_S/QK256 proof.
+
 ## NPU productization
 
 Use these artifacts before implementing or claiming NPU product support:

--- a/docs/status/BITNET_CAPABILITY_MATRIX.md
+++ b/docs/status/BITNET_CAPABILITY_MATRIX.md
@@ -1,0 +1,34 @@
+# BitNet Capability Matrix
+
+## Official Microsoft BitNet 2B
+
+This status page summarizes the official `microsoft/BitNet-b1.58-2B-4T` model
+family without widening any support claim. The machine-readable authority
+remains `ci/model-artifacts/model-coverage-matrix.toml`; this page is the
+human-facing map for the official 2B rows.
+
+| Route | Coverage row | Current tier | Answer status | Speed | Residency | Server |
+|---|---|---|---|---|---|---|
+| I2_S/QK256 GGUF | `bitnet_official_2b_i2s_qk256` | `product_cli_ready` | CPU and accelerator answer-ready for the bounded official I2_S/QK256 lane | `speedup_claim=false` | `full_residency_claim=false` | Broad `server_ready=false`; exact-profile receipts do not imply broad production readiness |
+| TL1 ARM | `bitnet_official_2b_tl1_arm_candidate` | `registered` | Candidate only | false | false | false |
+| TL2 x86 | `bitnet_official_2b_tl2_x86_candidate` | `registered` | Candidate only | false | false | false |
+| BF16 master to GPU int2/W2A8 | `bitnet_official_2b_bf16_gpu_int2_candidate` | `registered` | Candidate only | false | false | false |
+
+## Required Not-Claims
+
+- TL1, TL2, and BF16/GPU-int2 do not inherit I2_S/QK256 answer or backend proof.
+- CUDA proof does not satisfy Apple, A770/OpenCL, CPU, TL1, TL2, or
+  BF16/GPU-int2 proof.
+- Dense regular-LLM CUDA proof does not satisfy BitNet packed-kernel proof.
+- No-scale F32 diagnostic QK256 does not satisfy production I2_S proof.
+- Upload-once weights and QK256 linears do not prove full device residency.
+- Exact-profile server smoke does not prove broad production server readiness.
+
+## Next Proof Families
+
+1. Artifact, tokenizer, and prompt contracts for the official 2B family.
+2. I2_S/QK256 and TL1/TL2 route contracts.
+3. CPU, CUDA, Apple, and A770/OpenCL backend contracts.
+4. Quality, performance, residency, server, and status-surface contracts.
+5. Route-specific receipts before any promotion beyond the current I2_S/QK256
+   bounded product CLI state.

--- a/docs/tracking/campaigns/official-bitnet-2b/CAMPAIGN.md
+++ b/docs/tracking/campaigns/official-bitnet-2b/CAMPAIGN.md
@@ -1,0 +1,42 @@
+# Official Microsoft BitNet 2B Productization Campaign
+
+## Objective
+
+Make `microsoft/BitNet-b1.58-2B-4T` the fully governed official BitNet-rs
+reference model family. The current I2_S/QK256 GGUF route remains the bounded
+answer-ready and product-CLI-ready CPU/CUDA lane. Every other route or product
+claim must be proven independently.
+
+## Current State
+
+- `bitnet_official_2b_i2s_qk256` is the current official I2_S/QK256 coverage
+  row and remains `product_cli_ready`.
+- That row records `reference_good`, `cpu_answer_ready`,
+  `accelerator_answer_ready`, and `bitnet_packed_i2s_qk256_proof`.
+- That row still keeps `benchmark_qualified`, `server_ready`,
+  `speedup_claim`, and `full_residency_claim` false.
+- TL1 ARM, TL2 x86, and BF16/GPU-int2 remain registered candidates with separate
+  proof requirements.
+
+## Claim Boundaries
+
+This campaign is route-specific:
+
+- I2_S/QK256 proof is not TL1 proof.
+- I2_S/QK256 proof is not TL2 proof.
+- I2_S/QK256 proof is not BF16/GPU-int2 proof.
+- CUDA proof is not CPU, Apple, A770, TL1, TL2, or BF16/GPU-int2 proof.
+- Dense regular-LLM CUDA proof is not BitNet packed-kernel proof.
+- Exact-profile server smoke is not broad production server readiness.
+- Upload-once QK256 weights are not full device residency.
+
+## Active Work
+
+The active machine-readable work queue is:
+
+- `docs/tracking/campaigns/official-bitnet-2b/active.toml`
+
+The source map and plan are:
+
+- `docs/bitnet/official-2b/README.md`
+- `plans/official-bitnet-2b/implementation-plan.md`

--- a/docs/tracking/campaigns/official-bitnet-2b/active.toml
+++ b/docs/tracking/campaigns/official-bitnet-2b/active.toml
@@ -1,0 +1,120 @@
+id = "official-bitnet-2b"
+title = "Official Microsoft BitNet 2B productization"
+status = "active"
+
+objective = "Govern microsoft/BitNet-b1.58-2B-4T as the official BitNet-rs reference model family while keeping I2_S/QK256, TL1, TL2, BF16/GPU-int2, CPU, CUDA, Apple, A770, speed, residency, and server claims route-specific and fallback-explicit."
+
+end_state = [
+  "The official I2_S/QK256 GGUF route remains bounded product-CLI-ready for CPU/CUDA answer lanes.",
+  "TL1, TL2, and BF16/GPU-int2 routes have separate specs, rows, receipts, and promotion gates.",
+  "Users can verify, run, benchmark, and explain the official model with exact artifact, tokenizer, prompt, route, backend, fallback, quality, speed, residency, and server-scope evidence.",
+  "Unsupported routes fail closed in strict mode and diagnostic routes cannot promote answer or speed claims.",
+]
+
+hard_constraints = [
+  "Do not commit model binaries.",
+  "Do not weaken the I2_S/QK256 product_cli_ready row.",
+  "Do not promote speedup without exact-profile benchmark review.",
+  "Do not promote full residency without per-phase residency proof.",
+  "Do not promote broad server readiness from exact-profile smoke.",
+  "Do not let TL1/TL2 inherit I2_S/QK256 proof.",
+  "Do not let dense SLM proof satisfy BitNet packed proof.",
+  "Do not let CUDA proof satisfy Apple, A770, CPU, TL1, TL2, or BF16/GPU-int2 proof.",
+  "Do not claim no-scale F32 diagnostic QK256 as production I2_S.",
+  "Keep receipts fallback-explicit and selected-route-explicit.",
+]
+
+[[work_item]]
+id = "OFFICIAL-2B-000"
+status = "ready"
+branch = "codex/official-bitnet-2b/OFFICIAL-2B-000-source-map"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add the official 2B source map, implementation plan, campaign manifest, campaign overview, specs index entry, and BitNet capability status page without model binaries, runtime changes, or claim promotion."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check official-bitnet-2b",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/bitnet/official-2b/**",
+  "plans/official-bitnet-2b/**",
+  "docs/tracking/campaigns/official-bitnet-2b/**",
+  "docs/tracking/campaigns/generated/**",
+  "docs/specs/INDEX.md",
+  "docs/status/BITNET_CAPABILITY_MATRIX.md",
+  "ci/model-artifacts/model-coverage-matrix.toml",
+  "ci/model-artifacts/model-kernel-compatibility.toml",
+]
+forbidden_paths = [
+  "models/**",
+  "crates/**",
+  "ci/hardware/**",
+  "ci/quality/**",
+]
+may_claim = [
+  "The official 2B source map and campaign exist.",
+  "The current I2_S/QK256 route remains bounded product-CLI-ready as already recorded in the model coverage matrix.",
+  "TL1, TL2, and BF16/GPU-int2 are separate registered candidates that cannot inherit I2_S/QK256 proof.",
+]
+must_not_claim = [
+  "Any new runtime behavior exists.",
+  "Any new model artifact was added.",
+  "Speedup is benchmark-qualified.",
+  "Full residency is proven.",
+  "Broad server readiness is proven.",
+  "TL1, TL2, BF16/GPU-int2, Apple, or A770 routes are answer-ready.",
+]
+
+[[work_item]]
+id = "OFFICIAL-2B-001"
+status = "blocked"
+branch = "codex/official-bitnet-2b/OFFICIAL-2B-001-proposal"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["OFFICIAL-2B-000"]
+acceptance = "Add BITNET-PROP-0014 explaining why the official Microsoft 2B model is the anchor and why speed, full residency, broad server readiness, TL1, TL2, and BF16/GPU-int2 remain separate proof families."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check official-bitnet-2b",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/proposals/BITNET-PROP-0014-official-bitnet-2b-productization.md",
+  "docs/tracking/campaigns/official-bitnet-2b/**",
+  "docs/tracking/campaigns/generated/**",
+]
+forbidden_paths = ["models/**", "crates/**", "ci/hardware/**"]
+may_claim = ["The official 2B productization proposal exists after merge."]
+must_not_claim = ["Any runtime behavior or support claim changed."]
+
+[[work_item]]
+id = "OFFICIAL-2B-002"
+status = "blocked"
+branch = "codex/official-bitnet-2b/OFFICIAL-2B-002-artifact-tokenizer-specs"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["OFFICIAL-2B-001"]
+acceptance = "Add official 2B artifact and tokenizer/prompt contracts with exact-artifact, tokenizer, pre-tokenizer, prompt, stop-policy, and route claim boundaries."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check official-bitnet-2b",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/specs/BITNET-SPEC-OFFICIAL-2B-ARTIFACT-CONTRACT.md",
+  "docs/specs/BITNET-SPEC-OFFICIAL-2B-TOKENIZER-PROMPT.md",
+  "docs/specs/INDEX.md",
+  "docs/tracking/campaigns/official-bitnet-2b/**",
+  "docs/tracking/campaigns/generated/**",
+]
+forbidden_paths = ["models/**", "crates/**", "ci/hardware/**"]
+may_claim = ["Official 2B artifact and tokenizer/prompt contracts exist after merge."]
+must_not_claim = ["Any new route, speed, residency, or server claim is promoted."]

--- a/docs/tracking/campaigns/official-bitnet-2b/generated/status.md
+++ b/docs/tracking/campaigns/official-bitnet-2b/generated/status.md
@@ -1,0 +1,27 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Official Microsoft BitNet 2B productization Campaign Status
+
+- Campaign: `official-bitnet-2b`
+- State: `active`
+- Objective: Govern microsoft/BitNet-b1.58-2B-4T as the official BitNet-rs reference model family while keeping I2_S/QK256, TL1, TL2, BF16/GPU-int2, CPU, CUDA, Apple, A770, speed, residency, and server claims route-specific and fallback-explicit.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| OFFICIAL-2B-000 | ready | TBD | `codex/official-bitnet-2b/OFFICIAL-2B-000-source-map` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the official 2B source map, implementation plan, campaign manifest, campaign overview, specs index entry, and BitNet capability status page without model binaries, runtime changes, or claim promotion. |
+| OFFICIAL-2B-001 | blocked | TBD | `codex/official-bitnet-2b/OFFICIAL-2B-001-proposal` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add BITNET-PROP-0014 explaining why the official Microsoft 2B model is the anchor and why speed, full residency, broad server readiness, TL1, TL2, and BF16/GPU-int2 remain separate proof families. |
+| OFFICIAL-2B-002 | blocked | TBD | `codex/official-bitnet-2b/OFFICIAL-2B-002-artifact-tokenizer-specs` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add official 2B artifact and tokenizer/prompt contracts with exact-artifact, tokenizer, pre-tokenizer, prompt, stop-policy, and route claim boundaries. |
+
+## Hard Constraints
+
+- Do not commit model binaries.
+- Do not weaken the I2_S/QK256 product_cli_ready row.
+- Do not promote speedup without exact-profile benchmark review.
+- Do not promote full residency without per-phase residency proof.
+- Do not promote broad server readiness from exact-profile smoke.
+- Do not let TL1/TL2 inherit I2_S/QK256 proof.
+- Do not let dense SLM proof satisfy BitNet packed proof.
+- Do not let CUDA proof satisfy Apple, A770, CPU, TL1, TL2, or BF16/GPU-int2 proof.
+- Do not claim no-scale F32 diagnostic QK256 as production I2_S.
+- Keep receipts fallback-explicit and selected-route-explicit.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -517,6 +517,8 @@
 | nvidia-5070ti | CUDA-DENSE-020 | CUDA-DENSE-019 | merged |
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
+| official-bitnet-2b | OFFICIAL-2B-001 | OFFICIAL-2B-000 | blocked |
+| official-bitnet-2b | OFFICIAL-2B-002 | OFFICIAL-2B-001 | blocked |
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
 | server-real-inference | SERVER-003 | SERVER-002 | merged |
 | server-real-inference | SERVER-004 | SERVER-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -39,6 +39,7 @@
 | llama3-8b-158 | LLAMA3-158-000 | TBD | ready | LLAMA3-158-001 | Do not commit model binaries. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
+| official-bitnet-2b | OFFICIAL-2B-000 | TBD | ready | OFFICIAL-2B-001 | Do not commit model binaries. |
 | server-real-inference | SERVER-005 | #4490 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-041 | TBD | ready | SLM-CPU-027 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -39,6 +39,7 @@
 | llama3-8b-158 | Llama3 8B 1.58 supported-model candidate | LLAMA3-158-000 | Do not commit model binaries. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |
+| official-bitnet-2b | Official Microsoft BitNet 2B productization | OFFICIAL-2B-000 | Do not commit model binaries. |
 | server-real-inference | Server real inference | SERVER-005 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-041 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/plans/official-bitnet-2b/README.md
+++ b/plans/official-bitnet-2b/README.md
@@ -1,0 +1,22 @@
+# Official BitNet 2B Productization Plan
+
+This plan governs `microsoft/BitNet-b1.58-2B-4T` as the official BitNet-rs
+reference model family.
+
+The current I2_S/QK256 GGUF route is already the bounded answer-ready and
+product-CLI-ready route for CPU/CUDA surfaces. This plan keeps that route intact
+while adding the governance and later proof steps needed for CPU excellence,
+CUDA speed/residency review, Apple/ARM promotion, A770/OpenCL promotion, TL1/TL2
+expansion, BF16-to-GPU-int2 research, and user-visible status/receipt polish.
+
+Read the implementation sequence in:
+
+- `plans/official-bitnet-2b/implementation-plan.md`
+
+Primary source map:
+
+- `docs/bitnet/official-2b/README.md`
+
+Active campaign manifest:
+
+- `docs/tracking/campaigns/official-bitnet-2b/active.toml`

--- a/plans/official-bitnet-2b/implementation-plan.md
+++ b/plans/official-bitnet-2b/implementation-plan.md
@@ -1,0 +1,96 @@
+# Official BitNet 2B Implementation Plan
+
+## Objective
+
+Make `microsoft/BitNet-b1.58-2B-4T` the fully governed official BitNet-rs
+reference model family without widening current claims. The existing
+I2_S/QK256 GGUF lane remains the product-CLI-ready CPU/CUDA answer lane; TL1,
+TL2, BF16/GPU-int2, Apple, A770/OpenCL, speedup, full residency, and broad
+server readiness remain route-specific future proof families.
+
+## Hard Constraints
+
+- Do not commit model binaries.
+- Do not weaken or demote the current I2_S/QK256 `product_cli_ready` row.
+- Do not promote speedup without same-artifact, same-tokenizer, same-prompt,
+  same-route, fallback-free exact-profile benchmark review.
+- Do not promote full residency without per-phase residency proof.
+- Do not promote broad server readiness from exact-profile smoke.
+- Do not let TL1/TL2 inherit I2_S/QK256 proof.
+- Do not let dense SLM proof satisfy BitNet packed proof.
+- Do not let CUDA proof satisfy Apple, A770, CPU, TL1, TL2, or BF16/GPU-int2
+  proof.
+- Do not claim no-scale F32 diagnostic QK256 as production I2_S.
+- Keep receipts fallback-explicit and selected-route-explicit.
+
+## Phase 0: Source-of-Truth Docs
+
+### OFFICIAL-2B-000: Add official 2B source map
+
+Status: ready
+
+Goal: add the official 2B source map, campaign manifest, and source-of-truth
+plan without runtime changes or claim promotion.
+
+Files:
+
+- `docs/bitnet/official-2b/README.md`
+- `plans/official-bitnet-2b/README.md`
+- `plans/official-bitnet-2b/implementation-plan.md`
+- `docs/tracking/campaigns/official-bitnet-2b/active.toml`
+- `docs/tracking/campaigns/official-bitnet-2b/CAMPAIGN.md`
+- `docs/specs/INDEX.md`
+- `docs/status/BITNET_CAPABILITY_MATRIX.md`
+- generated campaign dashboards, if required by `xtask campaign generate`
+
+Acceptance:
+
+- docs only;
+- no model binaries;
+- no runtime changes;
+- no claim promotion;
+- current I2_S/QK256 state summarized;
+- TL1/TL2/BF16 candidate boundaries explicit;
+- validation passes or unavailable proof is documented.
+
+Proof commands:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check official-bitnet-2b
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+Rollback: revert the source-map docs and generated campaign dashboard changes.
+
+## Phase 1: Proposal and Specs
+
+Future PRs add the proposal and behavior contracts as separate work items:
+
+1. `docs/proposals/BITNET-PROP-0014-official-bitnet-2b-productization.md`
+2. `docs/specs/BITNET-SPEC-OFFICIAL-2B-ARTIFACT-CONTRACT.md`
+3. `docs/specs/BITNET-SPEC-OFFICIAL-2B-TOKENIZER-PROMPT.md`
+4. `docs/specs/BITNET-SPEC-OFFICIAL-2B-I2S-QK256.md`
+5. `docs/specs/BITNET-SPEC-OFFICIAL-2B-TL1-TL2.md`
+6. `docs/specs/BITNET-SPEC-OFFICIAL-2B-CPU.md`
+7. `docs/specs/BITNET-SPEC-OFFICIAL-2B-CUDA.md`
+8. `docs/specs/BITNET-SPEC-OFFICIAL-2B-APPLE.md`
+9. `docs/specs/BITNET-SPEC-OFFICIAL-2B-A770-OPENCL.md`
+10. `docs/specs/BITNET-SPEC-OFFICIAL-2B-QUALITY.md`
+11. `docs/specs/BITNET-SPEC-OFFICIAL-2B-PERFORMANCE.md`
+12. `docs/specs/BITNET-SPEC-OFFICIAL-2B-RESIDENCY.md`
+13. `docs/specs/BITNET-SPEC-OFFICIAL-2B-SERVER.md`
+14. `docs/specs/BITNET-SPEC-OFFICIAL-2B-STATUS-SURFACE.md`
+
+## Later Runtime Phases
+
+Later phases remain blocked on their specs and route-specific proof:
+
+- CPU counter audit, scaled AVX2/AVX512 proof, and hot-path cleanup.
+- CUDA repeated benchmark, exact-profile speed review, transfer/residency
+  closure, and bounded server exact-profile readiness.
+- Apple/ARM I2_S and TL1 proof.
+- Intel Arc A770 OpenCL I2_S/QK256 proof.
+- x86 TL2 layout/scalar/answer proof.
+- BF16 master to GPU int2/W2A8 contract and packer parity.
+- CLI status and receipt explanation polish.


### PR DESCRIPTION
## Decision record
PR: #5746
Lane: Official Microsoft BitNet 2B docs/source-map governance
Decision: rebase onto current main and keep as docs/source-map only
Reason: anchor the official 2B source-of-truth before reviewing Falcon/Falcon3 model-family docs PRs.
Generated files: campaign status/dashboard rows already included by the PR.
Claim boundary: no runtime code, model binary, receipt, A770, speed, residency, server, TL1/TL2, or BF16/GPU-int2 promotion.
Human-needed: no, unless hosted CI finds a generated-campaign drift.

## Summary
- add `docs/bitnet/official-2b/README.md` as the official 2B source map
- add `plans/official-bitnet-2b/*` productization plan docs
- add `docs/tracking/campaigns/official-bitnet-2b/*` campaign docs/status
- add human-facing `docs/status/BITNET_CAPABILITY_MATRIX.md`
- link the source map from model-artifact ledgers and `docs/specs/INDEX.md`

## Claim boundary
Docs/source-map governance only. This PR does not change loader, tokenizer, kernel, server, CLI runtime behavior, receipts, or claim booleans. It preserves the existing bounded I2_S/QK256 row and keeps speedup, full residency, broad server readiness, Apple, A770/OpenCL, TL1, TL2, and BF16/GPU-int2 as separately gated work.

## Validation
- PASS: npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc docs/bitnet/official-2b/README.md docs/status/BITNET_CAPABILITY_MATRIX.md docs/tracking/campaigns/official-bitnet-2b/CAMPAIGN.md docs/tracking/campaigns/official-bitnet-2b/generated/status.md plans/official-bitnet-2b/README.md plans/official-bitnet-2b/implementation-plan.md
- PASS: git diff --check
- NOTE: full markdownlint including docs/specs/INDEX.md still hits pre-existing legacy errors below this PR's added section; the added diff hunk is clean.
- NOTE: cargo run --locked -p xtask --no-default-features -- campaign check official-bitnet-2b timed out locally after 5 minutes with no emitted campaign error; rely on hosted CI for the refreshed campaign verdict.