### PR TITLE
docs(falcon3): register Falcon3 family lane

### DIFF
--- a/ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
+++ b/ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
@@ -217,6 +217,153 @@ notes = [
   proof_use = "registered_candidate_only_until_artifact_tokenizer_reference_and_i2s_layout_receipts_pass"
 
 [[candidate]]
+id = "falcon3_1b_instruct_158_i2s_gguf_family_candidate"
+priority = 7
+model_family = "falcon3_158bit"
+role = "multi_size_bitnet_family_first_direct_gguf"
+source_repo = "tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF"
+source_url = "https://huggingface.co/tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF"
+file = "ggml-model-i2_s.gguf"
+known_sha256 = "pending"
+known_size_bytes = 0
+storage_estimate = "1b_class; exact bytes pending Falcon3 artifact probe"
+format = "gguf"
+quantization = "i2_s"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+pretokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_template = "pending_falcon3_chat_template_audit"
+reference_runner = "microsoft_bitnet_cpp_or_upstream_falcon3_runner_pending"
+reference_status = "registered_family_candidate_only"
+cleanup_required = true
+next_item = "falcon3-family F3-001"
+notes = [
+  "First Falcon3 direct I2_S target because it exposes ggml-model-i2_s.gguf and is small enough for quick artifact/tokenizer/reference proof.",
+  "Does not inherit Microsoft BitNet 2B, Falcon-E, Llama3-8B-1.58, dense Falcon3, or dense SLM proof.",
+  "Does not prove Falcon3 7B, 3B, 10B, TL1/TL2, Apple answer readiness, Metal, speedup, or server readiness.",
+]
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "i2_s"
+  status = "listed_supported_verify_runner"
+  proof_use = "candidate_only_until_artifact_tokenizer_reference_i2s_layout_and_cpu_neon_receipts_exist"
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "tl1"
+  status = "listed_supported_verify_runner"
+  proof_use = "unpromoted_until_conversion_or_runner_authority_and_TL_scalar_oracle"
+
+[[candidate]]
+id = "falcon3_7b_instruct_158_i2s_gguf_family_candidate"
+priority = 8
+model_family = "falcon3_158bit"
+role = "multi_size_bitnet_family_second_direct_gguf"
+source_repo = "tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF"
+source_url = "https://huggingface.co/tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF"
+file = "ggml-model-i2_s.gguf"
+known_sha256 = "pending"
+known_size_bytes = 0
+storage_estimate = "7b_class; exact bytes pending Falcon3 artifact probe"
+format = "gguf"
+quantization = "i2_s"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+pretokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_template = "pending_falcon3_chat_template_audit"
+reference_runner = "microsoft_bitnet_cpp_or_upstream_falcon3_runner_pending"
+reference_status = "registered_family_candidate_only"
+cleanup_required = true
+next_item = "falcon3-family F3-001"
+notes = [
+  "Second Falcon3 direct I2_S target because it exposes ggml-model-i2_s.gguf and is large enough to pressure Apple CPU/NEON memory and timing after 1B proof.",
+  "Needs independent artifact, tokenizer, reference, layout, CPU/NEON, and cleanup receipts.",
+]
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "i2_s"
+  status = "listed_supported_verify_runner"
+  proof_use = "candidate_only_until_independent_7b_receipts_exist"
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "tl1"
+  status = "listed_supported_verify_runner"
+  proof_use = "unpromoted_until_conversion_or_runner_authority_and_TL_scalar_oracle"
+
+[[candidate]]
+id = "falcon3_3b_instruct_158_conversion_family_candidate"
+priority = 9
+model_family = "falcon3_158bit"
+role = "multi_size_bitnet_family_conversion_candidate"
+source_repo = "tiiuae/Falcon3-3B-Instruct-1.58bit"
+source_url = "https://huggingface.co/tiiuae/Falcon3-3B-Instruct-1.58bit"
+file = "pending_conversion_output"
+known_sha256 = "pending"
+known_size_bytes = 0
+storage_estimate = "3b_safetensors_or_converted_output; exact bytes pending conversion authority"
+format = "safetensors_conversion_required"
+quantization = "conversion_required_i2_s"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+pretokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_template = "pending_falcon3_chat_template_audit"
+reference_runner = "upstream_setup_env_conversion_or_approved_runner_pending"
+reference_status = "conversion_runner_authority_required"
+cleanup_required = true
+next_item = "falcon3-family F3-014"
+notes = [
+  "Safetensors/Transformers route; do not treat as Apple answer candidate until conversion/runner authority and reference-good receipts exist.",
+]
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "i2_s"
+  status = "listed_supported_verify_runner"
+  proof_use = "diagnostic_until_conversion_output_artifact_is_authorized"
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "tl1"
+  status = "listed_supported_verify_runner"
+  proof_use = "unpromoted_until_TL_layout_and_scalar_oracle"
+
+[[candidate]]
+id = "falcon3_10b_instruct_158_conversion_family_candidate"
+priority = 10
+model_family = "falcon3_158bit"
+role = "multi_size_bitnet_family_conversion_candidate_after_1b_7b"
+source_repo = "tiiuae/Falcon3-10B-Instruct-1.58bit"
+source_url = "https://huggingface.co/tiiuae/Falcon3-10B-Instruct-1.58bit"
+file = "pending_conversion_output"
+known_sha256 = "pending"
+known_size_bytes = 0
+storage_estimate = "10b_safetensors_or_converted_output; exact bytes pending conversion authority"
+format = "safetensors_conversion_required"
+quantization = "conversion_required_i2_s"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+pretokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_template = "pending_falcon3_chat_template_audit"
+reference_runner = "upstream_setup_env_conversion_or_approved_runner_pending"
+reference_status = "conversion_runner_authority_required_after_direct_gguf_path"
+cleanup_required = true
+next_item = "falcon3-family F3-014"
+notes = [
+  "Use after 1B/7B direct-GGUF proof is boring and storage/conversion authority is approved.",
+]
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "i2_s"
+  status = "listed_supported_verify_runner"
+  proof_use = "diagnostic_until_conversion_output_artifact_is_authorized"
+
+  [[candidate.route]]
+  arch = "arm"
+  kernel = "tl1"
+  status = "listed_supported_verify_runner"
+  proof_use = "unpromoted_until_TL_layout_and_scalar_oracle"
+
+[[candidate]]
 id = "falcon_e_3b_instruct_i2s_secondary"
 priority = 6
 model_family = "falcon_e_1_58bit"

--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -98,6 +98,199 @@ claim_boundary = "Official Microsoft 2B I2_S is the current BitNet QK256 x86/CUD
   dense_regular_llm_cuda_proof = false
 
 [[entry]]
+id = "falcon3_1b_instruct_158_i2s_gguf_candidate"
+model_class = "bitnet"
+family = "falcon3_158bit"
+artifact_kind = "gguf_i2_s_candidate"
+contract_id = "tiiuae_falcon3_1b_instruct_158_i2s_gguf"
+status = "registered_direct_gguf_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model contracts tiiuae_falcon3_1b_instruct_158_i2s_gguf"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_authority = "pending_falcon3_prompt_audit"
+cpu_reference = "pending_reference_good"
+accelerator_routes = []
+required_receipts = [
+  "artifact_inventory",
+  "tokenizer_prompt_authority",
+  "reference_runner_quality",
+  "i2s_layout_proof",
+  "cpu_answer_corpus",
+]
+forbidden_claims = [
+  "microsoft_2b_proof_inheritance",
+  "falcon_e_proof_inheritance",
+  "llama3_8b_158_proof_inheritance",
+  "dense_falcon3_proof_inheritance",
+  "dense_slm_proof_inheritance",
+  "cuda_answer_ready",
+  "apple_answer_ready",
+  "a770_answer_ready",
+  "speedup",
+  "server_ready",
+]
+next_proof = "Probe the official 1B direct I2_S GGUF artifact, record exact revision/file/size/SHA/tokenizer metadata, audit tokenizer/prompt authority, run reference quality, then prove I2_S layout and CPU answer corpus."
+claim_boundary = "Falcon3 1B is a registered direct-GGUF candidate only. It does not inherit Microsoft BitNet 2B, Falcon-E, Llama3-8B-1.58, dense Falcon3, or dense SLM proof and does not prove any other Falcon3 size, TL route, backend, speed, or server claim."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+[[entry]]
+id = "falcon3_7b_instruct_158_i2s_gguf_candidate"
+model_class = "bitnet"
+family = "falcon3_158bit"
+artifact_kind = "gguf_i2_s_candidate"
+contract_id = "tiiuae_falcon3_7b_instruct_158_i2s_gguf"
+status = "registered_direct_gguf_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model contracts tiiuae_falcon3_7b_instruct_158_i2s_gguf"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_authority = "pending_falcon3_prompt_audit"
+cpu_reference = "pending_reference_good"
+accelerator_routes = []
+required_receipts = [
+  "artifact_inventory",
+  "tokenizer_prompt_authority",
+  "reference_runner_quality",
+  "i2s_layout_proof",
+  "cpu_answer_corpus",
+]
+forbidden_claims = [
+  "microsoft_2b_proof_inheritance",
+  "falcon_e_proof_inheritance",
+  "falcon3_1b_proof_inheritance",
+  "dense_falcon3_proof_inheritance",
+  "cuda_answer_ready",
+  "apple_answer_ready",
+  "a770_answer_ready",
+  "speedup",
+  "server_ready",
+]
+next_proof = "Probe the official 7B direct I2_S GGUF artifact after/alongside 1B, then record tokenizer/prompt authority, reference quality, I2_S layout proof, CPU corpus, memory envelope, and load timing."
+claim_boundary = "Falcon3 7B is a registered direct-GGUF candidate only. It needs independent proof and does not inherit Falcon3 1B, Microsoft BitNet 2B, Falcon-E, Llama3-8B-1.58, dense Falcon3, or dense SLM evidence."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+[[entry]]
+id = "falcon3_3b_instruct_158_conversion_candidate"
+model_class = "bitnet"
+family = "falcon3_158bit"
+artifact_kind = "safetensors_conversion_i2_s_candidate"
+contract_id = "tiiuae_falcon3_3b_instruct_158_safetensors"
+status = "registered_conversion_candidate"
+current_tier = "registered"
+verifier_surface = "model coverage matrix only"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_authority = "pending_falcon3_prompt_audit"
+cpu_reference = "pending_conversion_and_reference_good"
+accelerator_routes = []
+required_receipts = [
+  "conversion_runner_authority",
+  "artifact_inventory",
+  "tokenizer_prompt_authority",
+  "reference_runner_quality",
+  "i2s_layout_proof",
+  "cpu_answer_corpus",
+]
+forbidden_claims = [
+  "direct_gguf_authority_without_conversion_receipt",
+  "microsoft_2b_proof_inheritance",
+  "falcon_e_proof_inheritance",
+  "falcon3_1b_or_7b_proof_inheritance",
+  "cuda_answer_ready",
+  "apple_answer_ready",
+  "speedup",
+  "server_ready",
+]
+next_proof = "Record exact safetensors input hashes, conversion/setup_env command, tool commit, output artifact hash if produced, runner command, tokenizer/prompt authority, and reference quality before any backend proof."
+claim_boundary = "Falcon3 3B is a registered conversion candidate only. No direct-GGUF, answer, CPU, accelerator, speed, or server claim is allowed until conversion/runner authority and independent quality receipts exist."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+[[entry]]
+id = "falcon3_10b_instruct_158_conversion_candidate"
+model_class = "bitnet"
+family = "falcon3_158bit"
+artifact_kind = "safetensors_conversion_i2_s_candidate"
+contract_id = "tiiuae_falcon3_10b_instruct_158_safetensors"
+status = "registered_conversion_candidate"
+current_tier = "registered"
+verifier_surface = "model coverage matrix only"
+tokenizer_authority = "pending_falcon3_tokenizer_prompt_audit"
+prompt_authority = "pending_falcon3_prompt_audit"
+cpu_reference = "pending_conversion_and_reference_good"
+accelerator_routes = []
+required_receipts = [
+  "conversion_runner_authority",
+  "artifact_inventory",
+  "tokenizer_prompt_authority",
+  "reference_runner_quality",
+  "i2s_layout_proof",
+  "cpu_answer_corpus",
+]
+forbidden_claims = [
+  "direct_gguf_authority_without_conversion_receipt",
+  "microsoft_2b_proof_inheritance",
+  "falcon_e_proof_inheritance",
+  "falcon3_1b_or_7b_proof_inheritance",
+  "cuda_answer_ready",
+  "apple_answer_ready",
+  "speedup",
+  "server_ready",
+]
+next_proof = "After 1B/7B direct-GGUF proof is boring, record exact 10B safetensors input hashes, conversion/setup_env command, tool commit, output artifact hash if produced, runner command, tokenizer/prompt authority, and reference quality."
+claim_boundary = "Falcon3 10B is a registered conversion candidate only. It needs independent conversion, artifact, tokenizer, reference, layout, CPU, and backend receipts before any claim beyond planning."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+[[entry]]
 id = "bitnet_official_2b_tl1_arm_candidate"
 source_map = "docs/bitnet/official-2b/README.md"
 model_class = "bitnet"

--- a/ci/model-artifacts/model-kernel-compatibility.toml
+++ b/ci/model-artifacts/model-kernel-compatibility.toml
@@ -67,6 +67,53 @@ notes = [
   status = "unsupported_upstream"
 
 [[model_kernel_support]]
+model = "Falcon3 Family"
+model_aliases = [
+  "tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF",
+  "tiiuae/Falcon3-3B-Instruct-1.58bit",
+  "tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF",
+  "tiiuae/Falcon3-10B-Instruct-1.58bit",
+]
+family = "falcon3_158bit"
+role = "multi_size_bitnet_family_candidate"
+answer_authority = false
+notes = [
+  "Falcon3 Family is registered as a candidate multi-size BitNet-family lane only; listed upstream support does not prove BitNet-rs runner, tokenizer, layout, answer, backend, speed, or server readiness.",
+  "Direct I2_S GGUF artifact inventory starts with 1B and 7B; 3B and 10B remain conversion/runner-authority candidates.",
+  "Falcon3 proof must not inherit Microsoft BitNet 2B, Falcon-E, Llama3-8B-1.58, dense Falcon3, or dense SLM proof.",
+]
+
+  [[model_kernel_support.route]]
+  arch = "x86"
+  kernel = "i2_s"
+  status = "listed_supported_verify_runner"
+
+  [[model_kernel_support.route]]
+  arch = "x86"
+  kernel = "tl1"
+  status = "unsupported_upstream"
+
+  [[model_kernel_support.route]]
+  arch = "x86"
+  kernel = "tl2"
+  status = "listed_supported_verify_runner"
+
+  [[model_kernel_support.route]]
+  arch = "arm"
+  kernel = "i2_s"
+  status = "listed_supported_verify_runner"
+
+  [[model_kernel_support.route]]
+  arch = "arm"
+  kernel = "tl1"
+  status = "listed_supported_verify_runner"
+
+  [[model_kernel_support.route]]
+  arch = "arm"
+  kernel = "tl2"
+  status = "unsupported_upstream"
+
+[[model_kernel_support]]
 model = "1bitLLM/bitnet_b1_58-3B"
 model_aliases = [
   "bitnet_b1_58-3B",

--- a/docs/apple-silicon/bitnet-candidate-matrix.md
+++ b/docs/apple-silicon/bitnet-candidate-matrix.md
@@ -26,6 +26,10 @@ ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
 | 4 | `1bitLLM/bitnet_b1_58-3B` | ARM `TL1` diagnostic candidate; ARM `TL2` unsupported | Separate TL-model lane. Blocked at revision `af89e318d78a70802061246bf037199d2fb97020`: the official repository has safetensors shards and tokenizer files but no GGUF, and the current M3 Air free-space state cannot safely absorb the shards without cleanup or an approved conversion plan. Use only TL1 diagnostic routes until a verified runner path and coherent reference output exist; do not inherit Microsoft 2B `I2_S`/QK256 proof. |
 | 5 | `tiiuae/Falcon-E-1B-Instruct-GGUF` | ARM `I2_S` artifact inventory, tokenizer/prompt audit, reference-good, then CPU/NEON | Compact secondary BitNet-like family; registered only until exact source/file/SHA/size/tokenizer/reference output and cleanup status are recorded. |
 | 6 | `tiiuae/Falcon-E-3B-Instruct-GGUF` | ARM `I2_S` after 1B source-map and storage checks | Larger secondary family; must not inherit 1B proof and remains registered only until its own receipts pass. |
+| 7 | `tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF` `ggml-model-i2_s.gguf` | ARM `I2_S`, TL1 listed but unpromoted | First Falcon3 direct I2_S family target; candidate only until artifact, tokenizer/prompt, reference, I2_S layout, and CPU/NEON receipts exist. |
+| 8 | `tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF` `ggml-model-i2_s.gguf` | ARM `I2_S`, TL1 listed but unpromoted | Second Falcon3 direct I2_S target and larger Apple pressure candidate; needs independent 7B receipts. |
+| 9 | `tiiuae/Falcon3-3B-Instruct-1.58bit` | Conversion-required `I2_S`; TL1 listed but unpromoted | Safetensors/conversion candidate only until exact conversion/runner authority exists. |
+| 10 | `tiiuae/Falcon3-10B-Instruct-1.58bit` | Conversion-required `I2_S`; TL1 listed but unpromoted | Later safetensors/conversion candidate after the direct-GGUF path is boring. |
 
 ## bitnet_b1_58-large control-model lane
 
@@ -86,6 +90,10 @@ passes the shared answer gate or records the exact failing prompt IDs
 
 Rejected runs should keep enough output in the report for review, but model
 binaries stay local-only.
+
+## Falcon3 Family Boundary
+
+Falcon3 is tracked separately from Falcon-E, Microsoft BitNet 2B, 1bitLLM, Llama3-8B-1.58, and dense SLM evidence. A Falcon3 candidate must record its own exact source revision, file, SHA256, size, tokenizer authority, prompt template, reference-runner command, coherent prompt-suite output, I2_S/TL layout proof where applicable, backend/fallback receipt, and cleanup status before any answer/backend claim. Falcon3 1B proof does not prove Falcon3 7B, 3B, or 10B. Falcon3 I2_S proof does not prove TL1/TL2.
 
 ## Claim Boundary
 

--- a/docs/bitnet/falcon3-family/README.md
+++ b/docs/bitnet/falcon3-family/README.md
@@ -1,0 +1,67 @@
+# Falcon3 Family Source Map
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: [Falcon3 specs](../../specs/INDEX.md#falcon3-family-onboarding)
+Linked ADRs: [BITNET-ADR-0005](../../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: planning/registered only
+Policy impact: no policy exception
+
+## Current Honest Status
+
+```text
+registered candidate family
+not answer-ready
+not CPU answer-ready
+not CUDA answer-ready
+not Apple answer-ready
+not A770/OpenCL answer-ready
+not benchmark-qualified
+not server-ready
+```
+
+Falcon3 is being registered as a multi-size BitNet-family onboarding lane. Registration records that candidate repositories exist and that direct I2_S GGUFs are the first intended proof path for 1B and 7B. It does not prove loader compatibility, prompt correctness, answer quality, backend execution, speed, or server readiness.
+
+## Artifact Source Map
+
+| Priority | Artifact ID | Source repo | Source format | File / route | Initial posture |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | `falcon3_1b_instruct_158_i2s_gguf` | `tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF` | GGUF | `ggml-model-i2_s.gguf` / `i2_s` | first direct I2_S target |
+| 2 | `falcon3_7b_instruct_158_i2s_gguf` | `tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF` | GGUF | `ggml-model-i2_s.gguf` / `i2_s` | second direct I2_S target |
+| 3 | `falcon3_3b_instruct_158_safetensors` | `tiiuae/Falcon3-3B-Instruct-1.58bit` | safetensors / Transformers | conversion-required `i2_s` | conversion/runner target |
+| 4 | `falcon3_10b_instruct_158_safetensors` | `tiiuae/Falcon3-10B-Instruct-1.58bit` | safetensors / Transformers | conversion-required `i2_s` | conversion/runner target after 1B/7B |
+
+Artifact inventory receipts must record both nominal model size and Hugging Face displayed model-size metadata when a probe observes a discrepancy.
+
+## Support Ladder
+
+| Level | State | Meaning | Allowed claim |
+| ---: | --- | --- | --- |
+| 0 | `registered` | Falcon3 family and candidate repos are known. | Planning only. |
+| 1 | `artifact_inventory` | Exact repo, revision, files, sizes, hashes captured. | Artifact known. |
+| 2 | `artifact_authorized` | Official/approved GGUF or conversion route exists. | Candidate only. |
+| 3 | `structurally_valid` | Rust loader parses artifact and classifies tensor roles. | Structural proof. |
+| 4 | `runner_verified` | Reference runner loads the artifact. | Runner path proof. |
+| 5 | `reference_good` | Deterministic reference corpus passes. | Reference quality candidate. |
+| 6 | `cpu_answer_ready` | Rust CPU path passes strict corpus with fallback false. | CPU answer support. |
+| 7 | `accelerator_answer_ready` | CUDA/AVX/Apple/A770 route passes strict receipts. | Exact backend support. |
+| 8 | `benchmark_qualified` | Exact-profile benchmark accepted/rejected. | Profile-specific performance. |
+| 9 | `product_cli_ready` | `verify`, `status`, `ask`, `chat`, `bench`, `receipts explain` work. | User-facing support. |
+| 10 | `server_exact_profile_ready` | Bounded server profile passes. | Exact server profile only. |
+
+## Claim Boundary
+
+- Falcon3 proof is not Falcon-E proof.
+- Falcon3 proof is not Microsoft BitNet 2B proof.
+- Falcon3 proof is not Llama3-8B-1.58 proof.
+- Falcon3 proof is not dense Falcon3 / dense SLM proof.
+- Falcon3 1B proof is not 7B, 3B, or 10B proof.
+- I2_S proof is not TL1/TL2 proof.
+- TL1/TL2 proof is not I2_S/QK256 proof.
+- x86 TL2 and ARM TL1 remain listed-supported-but-unpromoted until runner/conversion receipts exist.
+- No model binaries may be committed.

--- a/docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md
+++ b/docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md
@@ -1,0 +1,76 @@
+# BITNET-PROP-0012: Falcon3 Family Supported Models
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: n/a
+Linked specs: [Falcon3 artifact contract](../specs/BITNET-SPEC-FALCON3-FAMILY-ARTIFACT-CONTRACT.md), [Falcon3 route compatibility](../specs/BITNET-SPEC-FALCON3-FAMILY-ROUTE-COMPATIBILITY.md), [Falcon3 tokenizer/prompt](../specs/BITNET-SPEC-FALCON3-FAMILY-TOKENIZER-PROMPT.md), [Falcon3 reference quality](../specs/BITNET-SPEC-FALCON3-FAMILY-REFERENCE-QUALITY.md), [Falcon3 I2_S](../specs/BITNET-SPEC-FALCON3-FAMILY-I2S.md), [Falcon3 TL1/TL2](../specs/BITNET-SPEC-FALCON3-FAMILY-TL1-TL2.md), [Falcon3 CPU](../specs/BITNET-SPEC-FALCON3-FAMILY-CPU.md), [Falcon3 CUDA](../specs/BITNET-SPEC-FALCON3-FAMILY-CUDA.md), [Falcon3 Apple](../specs/BITNET-SPEC-FALCON3-FAMILY-APPLE.md), [Falcon3 A770/OpenCL](../specs/BITNET-SPEC-FALCON3-FAMILY-A770-OPENCL.md), [Falcon3 performance](../specs/BITNET-SPEC-FALCON3-FAMILY-PERFORMANCE.md)
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registers a candidate family only; no answer/backend/speed promotion
+Policy impact: no policy exception
+
+## Thesis
+
+Falcon3 Family should be BitNet-rs's first multi-size supported BitNet-family onboarding lane. It spans 1B through 10B, has upstream bitnet.cpp route support for `I2_S` on x86 and ARM, and can pressure-test artifact authority, tokenizer/prompt authority, QK256/I2_S compatibility, TL route handling, CPU, AVX, CUDA, Apple CPU/NEON, A770/OpenCL, and exact-profile performance across realistic model sizes.
+
+The lane is a family-aware proof stack, not a single-model experiment. BitNet-rs must make claims per artifact, per route, per backend, and per profile.
+
+## Why Falcon3 Starts With 1B
+
+`tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF` is the first target because it exposes the direct `ggml-model-i2_s.gguf` route and is small enough for fast artifact inventory, tokenizer/prompt audit, reference-runner checks, structural Rust load, and CPU answer proof.
+
+The 1B target is allowed to prove only its own exact artifact/profile. It does not prove Falcon3 7B, 3B, 10B, TL routes, CUDA, Apple, A770, speedup, server readiness, or any non-Falcon3 family.
+
+## Why 7B Is Second
+
+`tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF` is the second target because it also exposes `ggml-model-i2_s.gguf` and is large enough to pressure memory, load time, CUDA, AVX, Apple CPU/NEON, and A770/OpenCL route planning after the 1B direct-GGUF path is boring.
+
+The 7B target still needs independent artifact inventory, tokenizer/prompt authority, reference-good output, structural load, I2_S layout proof, and CPU answer receipts.
+
+## Why 3B and 10B Come Later
+
+`tiiuae/Falcon3-3B-Instruct-1.58bit` and `tiiuae/Falcon3-10B-Instruct-1.58bit` are conversion/runner-authority candidates first. They must not enter backend proof until BitNet-rs records exact input revisions, conversion command, tool commit, output artifact hash if produced, reference runner command, tokenizer/prompt authority, and reference-good behavior.
+
+Direct-GGUF 1B/7B routes may start sooner. Safetensors-only or non-GGUF routes must go through conversion/runner authority first.
+
+## Falcon3 Is Not Falcon-E
+
+The existing Apple candidate matrix mentions Falcon-E as a secondary BitNet-like family. Falcon3 is a different onboarding lane with its own family identity, artifact contracts, prompt authority, route support matrix, and support ladder. Falcon-E receipts cannot promote Falcon3 rows, and Falcon3 receipts cannot promote Falcon-E rows.
+
+## Falcon3 Does Not Inherit Microsoft 2B Proof
+
+Microsoft BitNet 2B I2_S/QK256 evidence is useful as a pattern, not as Falcon3 proof. Falcon3 artifacts need their own GGUF metadata audit, tensor-role classification, tokenizer/chat-template decision, I2_S/QK256 compatibility proof, reference-quality receipts, and strict CPU/backend receipts.
+
+This proposal follows the proof-family separation recorded in BITNET-ADR-0005.
+
+## Non-Goals
+
+- Broad Falcon support.
+- Dense Falcon3 or dense SLM support.
+- Falcon-E promotion.
+- Microsoft BitNet 2B promotion.
+- Llama3-8B-1.58 promotion.
+- Speedup claims.
+- Server readiness claims.
+- Full device residency claims.
+- Runtime, kernel, loader, or tokenizer implementation changes in the documentation/spec PRs.
+- Committing model binaries.
+
+## Claim Boundary
+
+```text
+Falcon3 Family proof is not Microsoft BitNet 2B proof.
+Falcon3 Family proof is not Falcon-E proof.
+Falcon3 Family proof is not Llama3-8B-1.58 proof.
+Falcon3 Family proof is not dense Falcon3 / dense SLM proof.
+Falcon3 1B proof is not Falcon3 7B/10B proof.
+Falcon3 I2_S proof is not TL1/TL2 proof.
+Falcon3 TL1/TL2 proof is not I2_S/QK256 proof.
+No third-party artifact substitution without artifact-authority decision.
+No speedup claim before exact-profile benchmark review.
+No server readiness before exact-profile server receipts.
+No model binaries committed.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-A770-OPENCL.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-A770-OPENCL.md
@@ -1,0 +1,41 @@
+# BITNET-SPEC-FALCON3-FAMILY-A770-OPENCL: Falcon3 A770/OpenCL Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define the optional later A770/OpenCL path for Falcon3 without implying CUDA, Microsoft 2B, or full-residency proof.
+
+## A770 Route
+
+```text
+Falcon3 1B I2_S CPU answer-ready
+→ I2_S layout compatible with QK256 OpenCL
+→ A770 fixture parity
+→ one-token proof
+→ behavior suite
+→ exact-profile benchmark
+```
+
+## Receipt Requirements
+
+A770 receipts must include hardware identity, driver/runtime identity, requested backend, selected backend, selected kernel, exact artifact hash, tokenizer/prompt receipt, route ID, fallback=false, fixture/corpus ID, generated IDs, decoded text, H2D/D2H transfer metadata when applicable, and explicit not-claims for CUDA, Apple, speedup, server readiness, and full residency.
+
+## Hard Rules
+
+```text
+A770 Falcon3 proof is not CUDA proof.
+A770 Falcon3 proof is not Microsoft 2B proof.
+A770 QK256 proof does not imply full device residency.
+A770 proof does not prove all Falcon3 sizes or TL routes.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-APPLE.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-APPLE.md
@@ -1,0 +1,41 @@
+# BITNET-SPEC-FALCON3-FAMILY-APPLE: Falcon3 Apple Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define Apple CPU/NEON and later Metal boundaries for Falcon3 without conflating MacBook, M4 Mac mini, CPU/NEON, and Metal evidence.
+
+## Apple Route
+
+```text
+MacBook artifact inventory
+M4 / MacBook reference runner
+ARM I2_S CPU/NEON strict answer proof
+ARM TL1 candidate after layout proof
+Metal phase candidates only after CPU/NEON proof
+```
+
+## Required Apple Receipt Fields
+
+Apple receipts must record machine identity, chip, memory, macOS, storage context, backend label, requested route, selected route, selected kernel, fallback=false, tokenizer/prompt authority, prompt IDs, generated IDs, decoded text, thermal/mobile context when available, and cleanup status.
+
+## Hard Rules
+
+```text
+MacBook proof does not prove M4 Mac Mini.
+M4 proof does not prove MacBook.
+Apple CPU/NEON proof does not prove Metal.
+Metal phase proof does not prove full Metal inference.
+Falcon3 Apple proof is not Falcon-E or Microsoft 2B Apple proof.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-ARTIFACT-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-ARTIFACT-CONTRACT.md
@@ -1,0 +1,96 @@
+# BITNET-SPEC-FALCON3-FAMILY-ARTIFACT-CONTRACT: Falcon3 Artifact Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define exact artifact identity and receipt requirements for Falcon3 Family onboarding. This spec registers candidate artifacts only; it does not authorize answer, backend, speed, or server claims.
+
+## Required Artifact Table
+
+```toml
+[[falcon3_artifact]]
+id = "falcon3_1b_instruct_158_i2s_gguf"
+source_repo = "tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF"
+source_format = "gguf"
+file = "ggml-model-i2_s.gguf"
+nominal_size = "1B"
+hf_display_size = "recorded_from_probe"
+route = "i2_s"
+priority = 1
+
+[[falcon3_artifact]]
+id = "falcon3_7b_instruct_158_i2s_gguf"
+source_repo = "tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF"
+source_format = "gguf"
+file = "ggml-model-i2_s.gguf"
+nominal_size = "7B"
+hf_display_size = "recorded_from_probe"
+route = "i2_s"
+priority = 2
+
+[[falcon3_artifact]]
+id = "falcon3_3b_instruct_158_safetensors"
+source_repo = "tiiuae/Falcon3-3B-Instruct-1.58bit"
+source_format = "safetensors"
+route = "conversion_required_i2_s"
+priority = 3
+
+[[falcon3_artifact]]
+id = "falcon3_10b_instruct_158_safetensors"
+source_repo = "tiiuae/Falcon3-10B-Instruct-1.58bit"
+source_format = "safetensors"
+route = "conversion_required_i2_s"
+priority = 4
+```
+
+## Required Inventory Receipt Fields
+
+```json
+{
+  "artifact_kind": "falcon3_artifact_inventory",
+  "model_family": "falcon3_158bit",
+  "source_repo": "tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF",
+  "source_revision": "...",
+  "file": "ggml-model-i2_s.gguf",
+  "size_bytes": 0,
+  "sha256": "...",
+  "nominal_model_size": "1B",
+  "hf_display_model_size": "...",
+  "format": "gguf",
+  "quantization_route": "i2_s",
+  "tokenizer_files": {},
+  "license": "Falcon License",
+  "claim_boundary": {
+    "answer_ready": false,
+    "cpu_ready": false,
+    "cuda_ready": false,
+    "apple_ready": false,
+    "a770_ready": false,
+    "speedup_claim": false,
+    "server_ready": false
+  }
+}
+```
+
+Receipts must also record file list, cleanup status, local storage context, GGUF metadata when applicable, tokenizer metadata if embedded, and whether any HF displayed model-size metadata differs from the nominal size.
+
+## Hard Rules
+
+```text
+No exact file hash, no artifact claim.
+No tokenizer/prompt authority, no answer claim.
+No GGUF/conversion authority, no backend proof.
+No model binaries committed.
+No third-party artifact substitution without artifact-authority decision.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-CPU.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-CPU.md
@@ -1,0 +1,47 @@
+# BITNET-SPEC-FALCON3-FAMILY-CPU: Falcon3 CPU Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define CPU proof requirements for Falcon3 exact artifacts and routes.
+
+## CPU Paths
+
+```text
+x86 I2_S scalar
+x86 I2_S AVX2
+x86 I2_S AVX512
+x86 TL2 scalar/AVX candidate
+ARM I2_S scalar/NEON
+ARM TL1 scalar/NEON candidate
+```
+
+## CPU Acceptance
+
+```text
+artifact inventory exists
+reference-good receipt exists
+Rust loader recognizes Falcon3 route
+I2_S/TL scalar oracle passes fixtures
+strict CPU answer corpus passes
+fallback=false
+prompt IDs recorded
+generated IDs recorded
+decoded text recorded
+speedup=false
+```
+
+## Receipt Requirements
+
+CPU receipts must include requested backend, selected backend, selected kernel, exact artifact ID/hash, tokenizer/prompt receipt, route ID, fixture or corpus ID, deterministic generation settings, prompt IDs, generated IDs, decoded text, fallback flag, and explicit not-claims for CUDA, Apple, A770, TL when not selected, speedup, product CLI readiness, and server readiness.

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-CUDA.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-CUDA.md
@@ -1,0 +1,52 @@
+# BITNET-SPEC-FALCON3-FAMILY-CUDA: Falcon3 CUDA Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define the gated CUDA path for Falcon3. CUDA proof starts only after CPU answer-ready proof for the exact Falcon3 artifact/route.
+
+## First CUDA Ladder
+
+```text
+Falcon3 1B I2_S CPU answer-ready
+→ Falcon3 I2_S CUDA fixture parity
+→ one-token CUDA
+→ short-decode CUDA
+→ warm-session CUDA
+→ exact-profile benchmark review
+```
+
+## Required CUDA Fields
+
+```text
+all-layer execution plan
+Falcon3 tensor role classification
+QK256/I2_S invocation count
+unsupported op count
+CPU fallback count = 0
+weights uploaded once
+per-token weight upload = false
+CPU/CUDA answer parity or first divergence classification
+speedup=false until review
+```
+
+## Hard Rules
+
+```text
+No CUDA proof before CPU answer-ready.
+No TL CUDA before TL scalar oracle.
+No dense Falcon3 CUDA inheritance.
+No Microsoft 2B CUDA inheritance.
+No speedup claim before exact-profile benchmark review.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-I2S.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-I2S.md
@@ -1,0 +1,53 @@
+# BITNET-SPEC-FALCON3-FAMILY-I2S: Falcon3 I2_S Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define the highest-priority Falcon3 kernel/layout proof path. Direct Falcon3 1B and 7B GGUF candidates expose `ggml-model-i2_s.gguf`, but Falcon3 I2_S must be proven layout-compatible before using existing QK256 kernels as aliases.
+
+## Required Layout Topics
+
+```text
+Falcon3 GGUF metadata required for I2_S
+QK256 / grouped block layout verification
+weight scale semantics
+activation quantization to I8_S
+act_scale
+act_sum
+integer dot correction
+tail-column behavior
+row stride behavior
+embedding policy
+LM head / tied-head policy
+compatibility with existing qk256-scalar-i8s-scaled-gemv
+```
+
+## Candidate Kernel IDs
+
+```text
+falcon3-i2s-scalar-reference-gemv
+falcon3-i2s-avx2-gemv
+falcon3-i2s-avx512-gemv
+falcon3-i2s-cuda-gemv
+falcon3-i2s-apple-neon-gemv
+falcon3-i2s-opencl-gemv
+```
+
+These IDs may alias existing QK256 kernels only after compatibility proof records exact metadata, block layout, scale semantics, tail behavior, row stride, and fixture parity.
+
+## Hard Rule
+
+```text
+Existing Microsoft 2B QK256 kernel proof does not automatically prove Falcon3 I2_S layout compatibility.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-PERFORMANCE.md
@@ -1,0 +1,65 @@
+# BITNET-SPEC-FALCON3-FAMILY-PERFORMANCE: Falcon3 Performance Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define exact-profile performance gates for Falcon3. Performance is not claimable from detection, successful loading, answer quality, or generic backend execution.
+
+## Profiles
+
+```text
+cold_load
+warm_load
+artifact_probe
+one_token
+first_token
+prefill_128_decode_16
+prefill_512_decode_32
+decode_32
+decode_128
+warm_session_3_turns
+warm_session_10_turns
+server_nonstream_exact_profile
+```
+
+## Required Metrics
+
+```text
+model_load_ms
+tokenizer_load_ms
+prompt_render_ms
+tokenize_ms
+prefill_ms
+first_token_ms
+decode_total_ms
+steady_tok_per_s
+kernel_time_ms
+launch_count
+memory high-water
+VRAM high-water
+H2D/D2H bytes and timing
+thread count
+selected backend
+selected kernel
+fallback_used
+```
+
+## Promotion Rule
+
+```text
+No performance claim without same artifact, same tokenizer, same prompt profile,
+fallback=false, answer quality passed, CPU comparator, and exact-profile review.
+```
+
+Speedup, full residency, product CLI readiness, and server readiness are separate claims. Server profiles require exact endpoint/profile receipts after product CLI readiness.

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-REFERENCE-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-REFERENCE-QUALITY.md
@@ -1,0 +1,56 @@
+# BITNET-SPEC-FALCON3-FAMILY-REFERENCE-QUALITY: Falcon3 Reference Quality Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define reference-runner quality gates before any Rust CPU or accelerator claim. Reference-good is a prerequisite, not a product claim.
+
+## Corpus Levels
+
+| Corpus | Purpose |
+| --- | --- |
+| `tiny_smoke` | Can the artifact answer at all? |
+| `answer_corpus_v1` | Bounded answer-ready gate. |
+| `behavior_suite_v1` | Prompt conditioning, stop behavior, non-repetition. |
+| `long_decode_v1` | Warm-session and stability. |
+
+## Minimum Cases
+
+```text
+math_2_plus_2
+capital_france
+copy_color_sequence
+yes_no_clear_sky
+short_continuation
+prompt_conditioning_pair
+chat_template_sanity
+stop_token_behavior
+special_token_garbage_check
+```
+
+## Pass Criteria
+
+```text
+non-empty output
+printable UTF-8
+no raw special-token garbage
+no uncontrolled repetition
+constrained answers satisfy gates
+prompt-conditioned pairs differ appropriately
+stop policy respected
+```
+
+## Receipt Fields
+
+Reference-quality receipts must record artifact ID, source revision, artifact hash, tokenizer/prompt authority receipt, reference-runner command, deterministic generation settings, prompt IDs, generated IDs when available, decoded text, case-level pass/fail, and claim boundary with CPU/backend/speed/server readiness false.

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-ROUTE-COMPATIBILITY.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-ROUTE-COMPATIBILITY.md
@@ -1,0 +1,49 @@
+# BITNET-SPEC-FALCON3-FAMILY-ROUTE-COMPATIBILITY: Falcon3 Route Compatibility
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Mirror upstream route support as candidate information while preventing BitNet-rs from treating listed upstream support as proof authority.
+
+## Initial Route Table
+
+| Route | Status |
+| --- | --- |
+| x86 `I2_S` | `listed_supported_verify_runner` |
+| x86 `TL1` | `unsupported_upstream` |
+| x86 `TL2` | `listed_supported_verify_runner` |
+| ARM `I2_S` | `listed_supported_verify_runner` |
+| ARM `TL1` | `listed_supported_verify_runner` |
+| ARM `TL2` | `unsupported_upstream` |
+
+`listed_supported_verify_runner` means BitNet-rs may plan artifact, conversion, reference-runner, layout, and backend work. It is not answer readiness and not backend readiness.
+
+## Promotion Requirements
+
+- Artifact inventory receipt for the exact model size and route.
+- Tokenizer/prompt authority receipt.
+- Reference-runner receipt that loads the exact artifact or converted output.
+- Layout proof for the exact route.
+- CPU scalar oracle before accelerator proof.
+- Backend receipt with requested backend, selected backend, selected route, selected kernel, fallback=false, generated IDs, decoded text, and claim boundary.
+
+## Hard Rules
+
+```text
+I2_S routes can use QK256 kernels only after layout proof.
+TL1/TL2 routes require separate layout specs and scalar oracles.
+Unsupported upstream routes may produce diagnostic rejection receipts only.
+x86 TL2 remains unpromoted until runner/conversion proof exists.
+ARM TL1 remains unpromoted until runner/conversion proof exists.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-TL1-TL2.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-TL1-TL2.md
@@ -1,0 +1,52 @@
+# BITNET-SPEC-FALCON3-FAMILY-TL1-TL2: Falcon3 TL1/TL2 Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Prepare listed Falcon3 TL routes without blocking the direct I2_S path. TL1/TL2 are separate proof families and are not QK256.
+
+## Required Layout Topics
+
+```text
+TL1 tensor layout
+TL2 tensor layout
+lookup-table semantics
+bit packing
+group/block size
+scale semantics
+activation type
+row stride
+tail behavior
+GGUF metadata
+difference from I2_S/QK256
+```
+
+## Required Proof Order
+
+1. Route/conversion authority.
+2. Synthetic TL1/TL2 fixture corpus.
+3. Scalar TL oracle.
+4. Reference-runner proof for an exact artifact or converted output.
+5. CPU route proof.
+6. Accelerator proof only after scalar oracle and CPU proof.
+
+## Hard Rules
+
+```text
+TL1/TL2 are not QK256.
+No TL accelerator work before scalar TL oracle exists.
+No x86 TL2 claim from x86 I2_S proof.
+No ARM TL1 claim from ARM I2_S proof.
+No TL proof from Microsoft 2B I2_S proof.
+```

--- a/docs/specs/BITNET-SPEC-FALCON3-FAMILY-TOKENIZER-PROMPT.md
+++ b/docs/specs/BITNET-SPEC-FALCON3-FAMILY-TOKENIZER-PROMPT.md
@@ -1,0 +1,56 @@
+# BITNET-SPEC-FALCON3-FAMILY-TOKENIZER-PROMPT: Falcon3 Tokenizer and Prompt Contract
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: n/a
+Linked ADRs: [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: defines future gates only; no promotion
+Policy impact: no policy exception
+
+## Purpose
+
+Define the tokenizer, chat-template, prompt rendering, and stop-policy audit required before Falcon3 answer claims. Falcon3 must not copy Microsoft BitNet 2B or Falcon-E prompt authority without evidence.
+
+## Required Audit Fields
+
+```text
+tokenizer.json hash
+tokenizer.model hash if present
+tokenizer_config.json hash
+special_tokens_map hash
+BOS/EOS/PAD/UNK IDs
+chat template text
+completion template fallback
+stop-token policy
+prompt rendering
+prompt token IDs
+reference-runner command
+conversation mode / -cnv policy
+```
+
+## Prompt Receipt Requirements
+
+Each tokenizer/prompt authority receipt must bind:
+
+- source repository and revision;
+- tokenizer file names, byte sizes, and SHA256 hashes;
+- exact chat template text or explicit absence;
+- rendered prompts for every corpus item;
+- prompt token IDs for every corpus item;
+- stop-token IDs and decoded stop strings;
+- reference runner and command line;
+- deterministic generation settings used for prompt verification.
+
+## Hard Rules
+
+```text
+Do not assume Microsoft BitNet 2B prompt authority applies to Falcon3.
+Do not assume Falcon-E prompt authority applies to Falcon3.
+No tokenizer/prompt authority, no answer claim.
+A changed tokenizer file, chat template, stop policy, or conversation mode resets answer-proof eligibility.
+```

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -43,6 +43,34 @@ Falcon-E size to answer, backend, speed, server, or full-residency claims. Claim
 require exact artifact, tokenizer/prompt, layout, quality, and backend receipts
 for the specific model size and route.
 
+## Falcon3 Family Onboarding
+
+Use these artifacts before implementing or claiming Falcon3 Family support:
+
+1. [Falcon3 Family Proposal](../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+   - Explains why Falcon3 is the first multi-size BitNet-family onboarding lane and why 1B/7B direct GGUFs precede 3B/10B conversion routes.
+2. [Falcon3 Artifact Contract](BITNET-SPEC-FALCON3-FAMILY-ARTIFACT-CONTRACT.md)
+   - Defines exact artifact IDs, required inventory receipts, nominal/HF-displayed size recording, and no-binary rules.
+3. [Falcon3 Route Compatibility](BITNET-SPEC-FALCON3-FAMILY-ROUTE-COMPATIBILITY.md)
+   - Mirrors listed upstream I2_S/TL route support as unpromoted runner-verification candidates.
+4. [Falcon3 Tokenizer and Prompt Contract](BITNET-SPEC-FALCON3-FAMILY-TOKENIZER-PROMPT.md)
+   - Requires tokenizer hashes, chat-template authority, prompt token IDs, stop policy, and reference-runner command before answer claims.
+5. [Falcon3 Reference Quality Contract](BITNET-SPEC-FALCON3-FAMILY-REFERENCE-QUALITY.md)
+   - Defines tiny smoke, answer corpus, behavior, and long-decode gates.
+6. [Falcon3 I2_S Contract](BITNET-SPEC-FALCON3-FAMILY-I2S.md)
+   - Defines I2_S/QK256 layout verification before kernel aliasing.
+7. [Falcon3 TL1/TL2 Contract](BITNET-SPEC-FALCON3-FAMILY-TL1-TL2.md)
+   - Keeps TL routes separate from I2_S/QK256 and requires scalar TL oracles.
+8. [Falcon3 CPU Contract](BITNET-SPEC-FALCON3-FAMILY-CPU.md), [CUDA Contract](BITNET-SPEC-FALCON3-FAMILY-CUDA.md), [Apple Contract](BITNET-SPEC-FALCON3-FAMILY-APPLE.md), [A770/OpenCL Contract](BITNET-SPEC-FALCON3-FAMILY-A770-OPENCL.md), and [Performance Contract](BITNET-SPEC-FALCON3-FAMILY-PERFORMANCE.md)
+   - Define exact backend and benchmark gates after artifact, tokenizer/prompt, reference-good, and layout proof.
+9. [Falcon3 Family Plan](../../plans/falcon3-family/implementation-plan.md)
+   - Defines the PR order from registered candidates through artifact inventory, CPU proof, accelerated backends, benchmarks, product CLI, and server exact-profile work.
+
+Do not proceed from Falcon3 registration, upstream listed support, Falcon-E
+evidence, Microsoft BitNet 2B evidence, Llama3-8B-1.58 evidence, dense Falcon3
+evidence, or dense SLM evidence to Falcon3 answer/backend/speed/server claims.
+Claims are exact artifact, route, backend, and profile scoped.
+
 ## NPU productization
 
 Use these artifacts before implementing or claiming NPU product support:

--- a/docs/tracking/campaigns/falcon3-family/CAMPAIGN.md
+++ b/docs/tracking/campaigns/falcon3-family/CAMPAIGN.md
@@ -1,0 +1,30 @@
+# Falcon3 Family Campaign
+
+Status: active
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../../../proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: [Falcon3 specs](../../../specs/INDEX.md#falcon3-family-onboarding)
+Linked ADRs: [BITNET-ADR-0005](../../../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [Falcon3 family implementation plan](../../../../plans/falcon3-family/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: candidate registration only until receipts promote exact rows
+Policy impact: no policy exception
+
+## Scope
+
+This campaign registers Falcon3 as BitNet-rs's first multi-size BitNet-family onboarding lane. It starts with documentation, artifact authority, tokenizer/prompt authority, route compatibility, and reference-quality contracts. Runtime, backend, performance, and server claims require later receipts.
+
+## Current Item
+
+`F3-000` adds source-of-truth docs, spec contracts, and candidate-only matrix rows. It must not add model binaries, runtime changes, answer-readiness claims, backend-readiness claims, speedup claims, or server-readiness claims.
+
+## Proof Commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check falcon3-family
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```

--- a/docs/tracking/campaigns/falcon3-family/active.toml
+++ b/docs/tracking/campaigns/falcon3-family/active.toml
@@ -1,0 +1,68 @@
+id = "falcon3-family"
+title = "Falcon3 multi-size BitNet-family onboarding"
+status = "active"
+
+objective = "Register Falcon3 Family as a first-class multi-size BitNet-family onboarding lane while keeping artifact, tokenizer/prompt, route, backend, performance, and server claims exact and unpromoted until receipts exist."
+
+end_state = [
+  "Falcon3 1B and 7B direct I2_S GGUF candidates have exact artifact inventory, tokenizer/prompt authority, reference-good output, structural Rust load, I2_S layout proof, and strict CPU answer receipts before any backend promotion.",
+  "Falcon3 3B and 10B remain conversion/runner-authority candidates until exact conversion receipts exist.",
+  "Falcon3 TL1/TL2 routes remain separate from I2_S/QK256 and require scalar oracles before backend proof.",
+  "Falcon3 claims remain per artifact, route, backend, and profile.",
+]
+
+hard_constraints = [
+  "Do not commit model binaries.",
+  "Do not claim all Falcon3 works from one model size.",
+  "Do not claim Falcon3 proof inherits Microsoft 2B, Falcon-E, Llama3-8B-1.58, or dense SLM proof.",
+  "Do not claim I2_S/QK256 compatibility before layout proof.",
+  "Do not route TL1/TL2 through QK256/I2_S kernels.",
+  "Do not claim CPU/CUDA/Apple/A770 answer readiness before artifact, tokenizer/prompt, reference-good, and exact backend receipts pass.",
+  "Do not claim speedup before exact-profile benchmark review.",
+]
+
+[[work_item]]
+id = "F3-000"
+status = "ready"
+branch = "codex/falcon3-family/F3-000-source-map-specs"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add Falcon3 family proposal, source map, implementation plan, active campaign tracker, spec contracts, and registered-only model/hardware matrix rows without runtime changes, model binaries, answer readiness, backend readiness, speedup, server readiness, or proof inheritance claims."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check falcon3-family",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "cargo run --locked -p xtask --no-default-features -- check-model-coverage",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md",
+  "docs/bitnet/falcon3-family/**",
+  "plans/falcon3-family/**",
+  "docs/tracking/campaigns/falcon3-family/**",
+  "docs/tracking/generated/**",
+  "docs/specs/BITNET-SPEC-FALCON3-FAMILY-*.md",
+  "docs/specs/INDEX.md",
+  "ci/model-artifacts/model-kernel-compatibility.toml",
+  "ci/model-artifacts/model-coverage-matrix.toml",
+  "docs/apple-silicon/bitnet-candidate-matrix.md",
+  "ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml",
+]
+forbidden_paths = [
+  "models/**",
+  "crates/**",
+]
+may_claim = [
+  "Falcon3 Family is registered as a candidate multi-size BitNet-family onboarding lane.",
+  "Falcon3 1B and 7B direct I2_S GGUF routes are prioritized for future artifact inventory and proof.",
+  "Falcon3 3B and 10B are conversion/runner-authority candidates.",
+]
+must_not_claim = [
+  "Falcon3 answers correctly in BitNet-rs.",
+  "Falcon3 CPU, CUDA, Apple, A770, TL1, or TL2 execution is proven.",
+  "Falcon3 inherits Microsoft BitNet 2B, Falcon-E, Llama3-8B-1.58, dense Falcon3, or dense SLM proof.",
+  "Falcon3 I2_S is QK256-compatible before layout proof.",
+  "Falcon3 speedup, full residency, product CLI readiness, or server readiness is proven.",
+]

--- a/docs/tracking/campaigns/falcon3-family/generated/status.md
+++ b/docs/tracking/campaigns/falcon3-family/generated/status.md
@@ -1,0 +1,22 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Falcon3 multi-size BitNet-family onboarding Campaign Status
+
+- Campaign: `falcon3-family`
+- State: `active`
+- Objective: Register Falcon3 Family as a first-class multi-size BitNet-family onboarding lane while keeping artifact, tokenizer/prompt, route, backend, performance, and server claims exact and unpromoted until receipts exist.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| F3-000 | ready | TBD | `codex/falcon3-family/F3-000-source-map-specs` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add Falcon3 family proposal, source map, implementation plan, active campaign tracker, spec contracts, and registered-only model/hardware matrix rows without runtime changes, model binaries, answer readiness, backend readiness, speedup, server readiness, or proof inheritance claims. |
+
+## Hard Constraints
+
+- Do not commit model binaries.
+- Do not claim all Falcon3 works from one model size.
+- Do not claim Falcon3 proof inherits Microsoft 2B, Falcon-E, Llama3-8B-1.58, or dense SLM proof.
+- Do not claim I2_S/QK256 compatibility before layout proof.
+- Do not route TL1/TL2 through QK256/I2_S kernels.
+- Do not claim CPU/CUDA/Apple/A770 answer readiness before artifact, tokenizer/prompt, reference-good, and exact backend receipts pass.
+- Do not claim speedup before exact-profile benchmark review.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -34,6 +34,7 @@
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | falcon-e-family | FE-000 | TBD | ready | FE-001 | Do not commit model binaries. |
+| falcon3-family | F3-000 | TBD | ready | none | Do not commit model binaries. |
 | intel-258v-platform | LNL258V-OP-006 | #5749 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | proposed | A770-004 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-012 | #5634 | merged | none | Device-node detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -34,6 +34,7 @@
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | falcon-e-family | Falcon-E Family compact 1.58-bit lane | FE-000 | Do not commit model binaries. |
+| falcon3-family | Falcon3 multi-size BitNet-family onboarding | F3-000 | Do not commit model binaries. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-OP-006 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-012 | Device-node detection is not inference. |

--- a/plans/falcon3-family/README.md
+++ b/plans/falcon3-family/README.md
@@ -1,0 +1,15 @@
+# Falcon3 Family Plan Index
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../../docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: [Falcon3 specs](../../docs/specs/INDEX.md#falcon3-family-onboarding)
+Linked ADRs: [BITNET-ADR-0005](../../docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: [implementation-plan.md](implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered/candidate only
+Policy impact: no policy exception
+
+Use [implementation-plan.md](implementation-plan.md) for the PR sequence and proof commands. The first executable item registers Falcon3 as a candidate family, adds source maps/spec contracts, and updates model/hardware matrices without runtime or backend claims.

--- a/plans/falcon3-family/implementation-plan.md
+++ b/plans/falcon3-family/implementation-plan.md
@@ -1,0 +1,123 @@
+# Falcon3 Family Implementation Plan
+
+Status: draft
+Owner: model-artifacts
+Created: 2026-05-18
+Linked proposal: [BITNET-PROP-0012](../../docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md)
+Linked specs: [Falcon3 specs](../../docs/specs/INDEX.md#falcon3-family-onboarding)
+Linked ADRs: [BITNET-ADR-0005](../../docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: sequences registered/candidate proof only until receipts promote exact rows
+Policy impact: no policy exception
+
+## Goal
+
+Make Falcon3 Family a first-class multi-size BitNet-family onboarding lane without overclaiming. The lane starts with artifact authority, tokenizer/prompt authority, I2_S layout proof, and reference-good output for 1B/7B direct GGUFs; backend acceleration and performance come later.
+
+## Hard Rails
+
+```text
+Do not commit model binaries.
+Do not claim all Falcon3 works from one model size.
+Do not claim Falcon3 1B proof proves Falcon3 7B/10B.
+Do not claim Falcon3 proof inherits Microsoft 2B, Falcon-E, Llama3, or dense SLM proof.
+Do not claim I2_S/QK256 compatibility before layout proof.
+Do not route TL1/TL2 through QK256/I2_S kernels.
+Do not claim CUDA/Apple/A770/CPU answer readiness before the artifact gate and reference-good gate pass.
+Do not claim speedup before exact-profile benchmark review.
+Keep all receipts fallback-explicit and claim-boundary-explicit.
+Keep docs/spec PRs free of runtime/kernel changes.
+```
+
+## PR Sequence
+
+### F3-000 — Source-of-truth proposal, source map, specs, and registered rows
+
+Add the Falcon3 proposal, source map, implementation plan, campaign tracker, all Falcon3 family specs, and candidate-only matrix rows. Update Apple candidate matrices to mention Falcon3 separately from Falcon-E.
+
+Acceptance:
+
+- Docs/specs only; no runtime/kernel changes.
+- No model binaries.
+- No answer/backend/speed/server claims.
+- Falcon3 vs Falcon-E boundary explicit.
+- 1B/7B direct GGUF priority explicit.
+- 3B/10B conversion-route status explicit.
+- Model coverage rows are registered-only with all answer/backend/speed booleans false.
+
+Proof commands:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check falcon3-family
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+Rollback: revert the Falcon3 docs/spec/matrix/campaign files and regenerated campaign dashboards.
+
+### F3-001 — Artifact inventory for direct GGUFs
+
+Probe `tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF` and `tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF` for exact revision, file list, `ggml-model-i2_s.gguf` size, SHA256, GGUF metadata, license, tokenizer metadata if embedded, HF displayed model size, nominal model size, storage context, and cleanup status.
+
+### F3-002 — Tokenizer and prompt authority audit
+
+Record tokenizer files, hashes, BOS/EOS/PAD/UNK IDs, chat template text, completion fallback, stop policy, rendered prompts, prompt token IDs, reference runner command, and conversation mode policy.
+
+### F3-003 — Reference-good corpus for 1B
+
+Run the deterministic reference prompt suite for Falcon3 1B I2_S and record pass/fail output without claiming Rust CPU readiness.
+
+### F3-004 — Reference-good corpus for 7B
+
+Run the deterministic reference prompt suite for Falcon3 7B I2_S and record pass/fail output without claiming Rust CPU readiness.
+
+### F3-005 — Structural loader recognition
+
+Teach or verify Rust structural loading for Falcon3 1B/7B I2_S GGUFs, tensor-role classification, family tagging, and rejection of unapproved TL routes. This is the first runtime/loader PR and is not part of documentation-only registration.
+
+### F3-006 — I2_S scalar fixture parity
+
+Prove Falcon3 I2_S layout compatibility before aliasing QK256 kernels.
+
+### F3-007 — Strict CPU answer proof for 1B
+
+Promote only the exact Falcon3 1B CPU path after artifact, tokenizer/prompt, reference-good, layout, and CPU corpus receipts pass with fallback=false.
+
+### F3-008 — Strict CPU answer proof for 7B
+
+Promote only the exact Falcon3 7B CPU path after independent receipts pass, adding memory envelope and load timing.
+
+### F3-009 — AVX2/AVX512 parity
+
+Compare scalar versus AVX generated-token parity and record first divergence, selected kernels, and fallback=false without speed claims.
+
+### F3-010 — CUDA all-layer route plan
+
+Classify Falcon3 BitLinear layers, QK256/I2_S invocation count, unsupported ops, and route requirements without execution claims.
+
+### F3-011 — Falcon3 1B CUDA one-token proof
+
+After CPU answer-ready, prove one-token CUDA for the exact 1B artifact/profile with fallback=false and speedup=false.
+
+### F3-012 — CUDA short-decode and warm-session proof
+
+Extend exact 1B CUDA proof to short decode and warm sessions.
+
+### F3-013 — Apple CPU/NEON proof
+
+Run strict Apple CPU/NEON proof on MacBook or M4 with fallback=false and no Metal claim.
+
+### F3-014 — 3B/10B conversion authority
+
+Verify exact conversion paths, tool commits, input/output hashes, and runner commands before any reference-good or backend claim.
+
+### F3-015 — TL fixture corpus and scalar oracle
+
+Define TL1/TL2 fixtures and scalar oracles before any TL accelerator work.
+
+### F3-016 — Exact-profile benchmarks and product promotion
+
+Benchmark only exact artifacts/profiles with fallback=false, accepted answer quality, CPU comparators, and explicit review. Product CLI and server promotion require later exact receipts.


### PR DESCRIPTION
### Motivation

- Register Falcon3 as BitNet-rs's first multi-size BitNet-family onboarding lane (1B-10B) and establish a guarded onboarding path that does not inherit proof from Microsoft BitNet 2B, Falcon-E, Llama3, dense SLM, or other families.
- Prioritize the direct I2_S GGUF routes for `tiiuae/Falcon3-1B-Instruct-1.58bit-GGUF` and `tiiuae/Falcon3-7B-Instruct-1.58bit-GGUF` while deferring safetensors/conversion candidates (3B/10B) until conversion/runner authority is recorded.
- Encode hard rails so claims remain per artifact/route/backend/profile and prevent accidental promotion of runtime/kernel/proof claims from documentation changes.

### Description

- Add a new proposal and source map: `docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md` and `docs/bitnet/falcon3-family/README.md` to describe goals, priorities, and claim boundaries.
- Add a Falcon3 implementation plan and campaign tracker: `plans/falcon3-family/implementation-plan.md` and `docs/tracking/campaigns/falcon3-family/active.toml` with work item `F3-000`.
- Add Falcon3 spec contracts under `docs/specs/` (`BITNET-SPEC-FALCON3-FAMILY-*.md`) covering artifact contract, route compatibility, tokenizer/prompt, reference quality, I2_S, TL1/TL2, CPU/CUDA/Apple/A770, and performance.
- Register candidate rows and updates to tracker/config ledgers: append Falcon3 entries to `ci/model-artifacts/model-coverage-matrix.toml`, `ci/model-artifacts/model-kernel-compatibility.toml`, and `ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml`, update `docs/apple-silicon/bitnet-candidate-matrix.md`, `docs/specs/INDEX.md`, and the generated campaign dashboards.

### Claim boundary

- Docs/spec/campaign only.
- No model binaries.
- No runtime code, tokenizer implementation, model loading proof, answer proof, backend proof, speed claim, A770 claim, Apple claim, CUDA claim, server claim, or full-residency claim.
- Falcon3 evidence must remain exact artifact/route/backend/profile scoped and must not inherit Microsoft BitNet 2B, Falcon-E, Llama3-8B-1.58, dense Falcon3, or dense SLM proof.

### Validation

- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc docs/bitnet/falcon3-family/README.md docs/proposals/BITNET-PROP-0012-falcon3-family-supported-models.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-A770-OPENCL.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-APPLE.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-ARTIFACT-CONTRACT.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-CPU.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-CUDA.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-I2S.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-PERFORMANCE.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-REFERENCE-QUALITY.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-ROUTE-COMPATIBILITY.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-TL1-TL2.md docs/specs/BITNET-SPEC-FALCON3-FAMILY-TOKENIZER-PROMPT.md docs/tracking/campaigns/falcon3-family/CAMPAIGN.md docs/tracking/campaigns/falcon3-family/generated/status.md plans/falcon3-family/README.md plans/falcon3-family/implementation-plan.md docs/apple-silicon/bitnet-candidate-matrix.md`
- Python `tomllib` parse for `ci/model-artifacts/model-coverage-matrix.toml`, `ci/model-artifacts/model-kernel-compatibility.toml`, `ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml`, and `docs/tracking/campaigns/falcon3-family/active.toml`
- `git diff --check`
- Conflict-marker scan across the Falcon3 docs/campaign/plan files and touched matrix/dashboard files

### Local validation limits

- `cargo run --locked -p xtask --no-default-features -- campaign generate --check` exceeded the 184s local timeout before completion.
- `cargo run --locked -p xtask --no-default-features -- campaign check falcon3-family` exceeded the 184s local timeout before completion.
- I stopped the timed-out local cargo child processes. Hosted CI should be treated as authority for the full xtask campaign validation on this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4dc1569c8333aeab85f055b60691)
