### PR TITLE
docs(queue): refresh merged guardrail dispositions

### DIFF
--- a/docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
+++ b/docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
@@ -69,9 +69,11 @@ distance.
 
 Post-cleanup note on 2026-05-18: `#5724` landed the canonical tracker/CI-plan
 fix, `#5740` was closed as its duplicate, `#5731` was closed as a duplicate of
-`#5730`, and `#5730` then merged after rebase/review. After that merge, the
-remaining direct-to-main Codex docs/source-map PRs were `#5732`, `#5733`,
-`#5741`, `#5746`, `#5747`, and `#5748`.
+`#5730`, and `#5730` then merged after rebase/review. `#5733` also merged as a
+3B TL candidate docs lane. After the queue guardrail merge in `#5741`, the
+Llama3-8B-1.58 candidate docs lane in `#5732` merged after rebase/review. The
+remaining direct-to-main Codex docs/source-map PRs are `#5746`, `#5747`, and
+`#5748`, plus the temporary follow-up refresh `#5751`.
 
 ## Disposition Rule
 
@@ -124,6 +126,8 @@ Read-only audit on 2026-05-18 found:
 | #4774-#5131 | No exact-superseded group was proven. Many PRs preserve unique layer scope, trace infrastructure, report shape, or diagnostic evidence. | Keep open while replacement PRs are built; do not close by range. |
 | #4751-#4770, #4801, #4837, #4845, #4850, #4853, #4855, #4883, #4885, #4892, #4959, #4961, #5010, #5012, #5020 | Runtime, loader, tokenizer, QK256, embedding, attention, CLI, and proof candidates may still contain useful invariants. | Audit against current `main`; port smallest confirmed fixes with direct tests. |
 | #5730, #5731 | Exact duplicate docs/specs pair by stable patch-id. | #5731 was closed after naming #5730 as the survivor; #5730 merged after rebase/review. |
+| #5733 | Unique BitNet 3B TL candidate docs/specs/campaign lane. | Merged after rebase/review; do not treat its merge as runtime/model proof. |
+| #5732 | Unique Llama3-8B-1.58 candidate docs/specs/campaign lane. | Merged after rebase/review; do not treat its merge as runtime/model proof. |
 | #5746, #5747, #5748 | New direct-to-main model-family docs/source-map lanes opened after #5730 merged. | Treat as docs/spec source-of-truth waves; compare overlap before merging independently. |
 
 No diagnostic PR should be closed as "historical evidence" unless this map or a

--- a/docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
+++ b/docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
@@ -69,8 +69,9 @@ distance.
 
 Post-cleanup note on 2026-05-18: `#5724` landed the canonical tracker/CI-plan
 fix, `#5740` was closed as its duplicate, `#5731` was closed as a duplicate of
-`#5730`, and the remaining scoped Codex PRs were `#5730`, `#5732`, `#5733`, and
-`#5741`.
+`#5730`, and `#5730` then merged after rebase/review. After that merge, the
+remaining direct-to-main Codex docs/source-map PRs were `#5732`, `#5733`,
+`#5741`, `#5746`, `#5747`, and `#5748`.
 
 ## Disposition Rule
 
@@ -122,7 +123,8 @@ Read-only audit on 2026-05-18 found:
 | --- | --- | --- |
 | #4774-#5131 | No exact-superseded group was proven. Many PRs preserve unique layer scope, trace infrastructure, report shape, or diagnostic evidence. | Keep open while replacement PRs are built; do not close by range. |
 | #4751-#4770, #4801, #4837, #4845, #4850, #4853, #4855, #4883, #4885, #4892, #4959, #4961, #5010, #5012, #5020 | Runtime, loader, tokenizer, QK256, embedding, attention, CLI, and proof candidates may still contain useful invariants. | Audit against current `main`; port smallest confirmed fixes with direct tests. |
-| #5730, #5731 | Exact duplicate docs/specs pair by stable patch-id. | #5731 was closed after naming #5730 as the survivor. Keep #5730 for a real rebase/content review. |
+| #5730, #5731 | Exact duplicate docs/specs pair by stable patch-id. | #5731 was closed after naming #5730 as the survivor; #5730 merged after rebase/review. |
+| #5746, #5747, #5748 | New direct-to-main model-family docs/source-map lanes opened after #5730 merged. | Treat as docs/spec source-of-truth waves; compare overlap before merging independently. |
 
 No diagnostic PR should be closed as "historical evidence" unless this map or a
 successor ledger names the exact report, test, or behavior that preserves its

--- a/docs/tracking/codex-web-pr-ledger.md
+++ b/docs/tracking/codex-web-pr-ledger.md
@@ -74,9 +74,10 @@ Snapshot source:
   SLM-CPU-040/041 tracker sync and `xtask/src/ci/plan.rs` dead
   `changed_count` fix; #5740 was closed as superseded by #5724; #5731 was
   closed as a duplicate of #5730; #5730 then merged after rebase/review.
-- Live follow-up refresh on 2026-05-18 after #5730 merged showed 157 open PRs:
-  150 A770 branch-chain PRs, 6 direct `codex/*` PRs to `main`, and 1 draft
-  `claude/*` perf PR.
+- Live follow-up refresh on 2026-05-18 after #5730, #5732, #5733, and #5741
+  merged leaves three direct `codex/*` model-doc/source-map PRs to `main`
+  (`#5746`, `#5747`, `#5748`) plus draft perf PR `#5092`. The temporary
+  queue-refresh PR `#5751` exists only to update this ledger state.
 
 ## Post-Reopen Content Audit Addendum
 
@@ -87,8 +88,8 @@ queue pass.
 | PRs | Content audit result | Required action |
 |---|---|---|
 | #5730, #5731 | Exact duplicate BitNet-large docs/specs/plans by stable patch-id `d3a8898c691015cdf8fcc5f7468d9beb0bd792c1`. | #5731 was closed with #5730 named as the survivor; #5730 merged after rebase/review. |
-| #5732 | Unique Llama3-8B-1.58 candidate docs/specs/campaign lane. GitHub reports conflicts. | Rebase or port conflicts; do not close for non-mergeability. |
-| #5733 | Unique BitNet 3B TL candidate docs/specs/campaign lane. GitHub reports conflicts. | Rebase or port conflicts; do not close for non-mergeability. |
+| #5732 | Unique Llama3-8B-1.58 candidate docs/specs/campaign lane. | Merged after rebase/review; this is docs/source-map state only, not runtime/model proof. |
+| #5733 | Unique BitNet 3B TL candidate docs/specs/campaign lane. | Merged after rebase/review; this is docs/source-map state only, not runtime/model proof. |
 | #5746, #5747, #5748 | New direct-to-main model-family docs/source-map lanes opened after the #5730 merge. | Classify as docs/spec source-of-truth waves; compare overlap before merging independently. |
 | #5724, #5740 | Both touched `xtask/src/ci/plan.rs` dead `changed_count` cleanup; #5724 also carried SLM tracker updates. | #5724 merged after green CI and #5740 was closed as superseded. |
 | #5092 | Draft AVX2 QK256 performance branch with a speedup claim. | Keep draft/proof-gated until parity, benchmark context, CPU flags, samples, and receipts are current. |

--- a/docs/tracking/codex-web-pr-ledger.md
+++ b/docs/tracking/codex-web-pr-ledger.md
@@ -73,7 +73,10 @@ Snapshot source:
 - Follow-up cleanup on 2026-05-18: #5724 landed as the canonical
   SLM-CPU-040/041 tracker sync and `xtask/src/ci/plan.rs` dead
   `changed_count` fix; #5740 was closed as superseded by #5724; #5731 was
-  closed as a duplicate of #5730.
+  closed as a duplicate of #5730; #5730 then merged after rebase/review.
+- Live follow-up refresh on 2026-05-18 after #5730 merged showed 157 open PRs:
+  150 A770 branch-chain PRs, 6 direct `codex/*` PRs to `main`, and 1 draft
+  `claude/*` perf PR.
 
 ## Post-Reopen Content Audit Addendum
 
@@ -83,9 +86,10 @@ queue pass.
 
 | PRs | Content audit result | Required action |
 |---|---|---|
-| #5730, #5731 | Exact duplicate BitNet-large docs/specs/plans by stable patch-id `d3a8898c691015cdf8fcc5f7468d9beb0bd792c1`. | #5731 was closed with #5730 named as the survivor. Rebase/review #5730 before merge. |
+| #5730, #5731 | Exact duplicate BitNet-large docs/specs/plans by stable patch-id `d3a8898c691015cdf8fcc5f7468d9beb0bd792c1`. | #5731 was closed with #5730 named as the survivor; #5730 merged after rebase/review. |
 | #5732 | Unique Llama3-8B-1.58 candidate docs/specs/campaign lane. GitHub reports conflicts. | Rebase or port conflicts; do not close for non-mergeability. |
 | #5733 | Unique BitNet 3B TL candidate docs/specs/campaign lane. GitHub reports conflicts. | Rebase or port conflicts; do not close for non-mergeability. |
+| #5746, #5747, #5748 | New direct-to-main model-family docs/source-map lanes opened after the #5730 merge. | Classify as docs/spec source-of-truth waves; compare overlap before merging independently. |
 | #5724, #5740 | Both touched `xtask/src/ci/plan.rs` dead `changed_count` cleanup; #5724 also carried SLM tracker updates. | #5724 merged after green CI and #5740 was closed as superseded. |
 | #5092 | Draft AVX2 QK256 performance branch with a speedup claim. | Keep draft/proof-gated until parity, benchmark context, CPU flags, samples, and receipts are current. |
 | #4774-#5131 | Reopened A770 diagnostic chain contains content-bearing trace, score, probability, value-mix, cache, layer, and reference tooling evidence. | Keep open by default. Port or merge useful reports; close only after exact successor, duplicate, or historical-only evidence is recorded. |


### PR DESCRIPTION
## Decision record
PR: follow-up to #5741
Lane: docs/spec source-of-truth + queue guardrails
Decision: replace stale merged/open text with current disposition record
Reason: #5730, #5732, #5733, and #5741 have now merged; the ledger must not continue to describe #5732/#5733/#5741 as open work.
Proof checked: markdownlint and git diff --check.
Generated files: none.
Claim boundary: docs/queue coordination only; no runtime/model/hardware/readiness claim promotion.
Successor PR: none.
Human-needed: no.

## Summary
- record that #5730 merged after #5731 was closed as duplicate
- record that #5732 and #5733 merged as docs/source-map state only, not runtime/model proof
- refresh the direct-main model-doc/source-map PR composition after #5732/#5733/#5741 merged
- classify #5746-#5748 as docs/spec source-of-truth waves that need overlap comparison before independent merge

## Claim boundary
Docs/queue coordination only. No PR is closed, labeled, merged, retargeted, or promoted by this change. No A770 execution, semantic quality, residency, performance, reference parity, selected attention, resident KV, full residency, or completion claim is made.

## Validation
- PASS: npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc docs/tracking/codex-web-pr-ledger.md docs/reports/2026-05-18-a770-diagnostic-lineage-map.md
- PASS: git diff --check