### PR TITLE
fix(bitnet): preserve GGML embedding token row layout

### DIFF
--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -1562,16 +1562,19 @@ fn normalize_embed_and_lm_head(
                 tensor_map.insert("token_embd.weight".to_string(), embed);
             }
             [h, v] if *h == hidden_size && *v == vocab_size => {
-                // Transposed [hidden, vocab] -> transpose to [vocab, hidden]
+                // GGML stores ne[0] as the fastest-moving dimension. For
+                // embeddings shaped [hidden, vocab], each token row is already
+                // contiguous in file order; only the Candle shape needs to
+                // become [vocab, hidden].
                 tracing::info!(
-                    "Transposing embed_tokens from [hidden={}, vocab={}] to [vocab={}, hidden={}]",
+                    "Reshaping embed_tokens from GGML [hidden={}, vocab={}] to [vocab={}, hidden={}] without transposing token rows",
                     h,
                     v,
                     vocab_size,
                     hidden_size
                 );
-                let embed_t = embed.t()?.contiguous()?;
-                tensor_map.insert("token_embd.weight".to_string(), embed_t);
+                let embed_reshaped = embed.reshape(&[vocab_size, hidden_size])?;
+                tensor_map.insert("token_embd.weight".to_string(), embed_reshaped);
             }
             _ => {
                 tracing::warn!(
@@ -1912,7 +1915,41 @@ mod tests {
     use super::{GGUFLoaderConfig, load_gguf_full};
     use bitnet_common::Device;
     use serial_test::serial;
+    use std::collections::HashMap;
     use tempfile::TempDir;
+
+    #[test]
+    fn normalize_embed_preserves_ggml_hidden_vocab_token_rows() -> super::Result<()> {
+        let device = super::CDevice::Cpu;
+        let mut config = bitnet_common::BitNetConfig::default();
+        config.model.vocab_size = 3;
+        config.model.hidden_size = 4;
+
+        let embed = super::CandleTensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, 4.0, // token 0
+                10.0, 20.0, 30.0, 40.0, // token 1
+                100.0, 200.0, 300.0, 400.0, // token 2
+            ],
+            (4usize, 3usize),
+            &device,
+        )?;
+        let mut tensor_map = HashMap::from([("model.embed_tokens.weight".to_string(), embed)]);
+
+        super::normalize_embed_and_lm_head(&mut tensor_map, &config, &device)?;
+
+        let normalized = tensor_map.get("token_embd.weight").expect("normalized embedding");
+        assert_eq!(normalized.shape().dims(), &[3, 4]);
+        assert_eq!(
+            normalized.to_vec2::<f32>()?,
+            vec![
+                vec![1.0, 2.0, 3.0, 4.0],
+                vec![10.0, 20.0, 30.0, 40.0],
+                vec![100.0, 200.0, 300.0, 400.0],
+            ]
+        );
+        Ok(())
+    }
 
     #[test]
     #[serial]


### PR DESCRIPTION
## Summary

- Preserve GGML `[hidden, vocab]` embedding token-row order in `crates/bitnet-models/src/gguf_simple.rs`.
- Replace the old `.t()?.contiguous()` reinterpretation with a shape-only `reshape(&[vocab_size, hidden_size])` for embedding tensors whose GGML file order already stores token rows contiguously.
- Add a focused regression test proving `normalize_embed_and_lm_head` keeps token rows intact for a `[hidden, vocab]` fixture.

## Scope

- Runtime fix is limited to the simple GGUF embedding normalization path.
- No `loader.rs` changes; that path uses separate embedding row handling.
- No A770/OpenCL/CUDA/AVX/server/speed/residency/reference-parity/model-readiness claim is promoted.

## Origin

Ports durable content from the A770 diagnostic chain:

- #4959 `fix(bitnet): preserve GGML embedding token rows` identified the full-loader row-order issue.
- #4961 `fix(bitnet): align simple GGUF embedding rows` identified the simple-loader side of the same contract.

## Validation

- PASS: `cargo test --locked -p bitnet-models --no-default-features --features cpu normalize_embed_preserves_ggml_hidden_vocab_token_rows -- --nocapture`
- PASS: `cargo check --locked --no-default-features --features cpu -p bitnet-models`
- PASS: `rustfmt --edition 2024 --check crates\bitnet-models\src\gguf_simple.rs`
- PASS: `git diff --check`

## Generated files

None.
