### PR TITLE
test(cli): pin last-token hidden extraction

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -11497,6 +11497,33 @@ fn extract_last_token_hidden(
     }
 }
 
+#[cfg(test)]
+mod extract_last_token_hidden_tests {
+    use super::{extract_last_token_hidden, tensor_to_vec};
+    use bitnet_common::Tensor as _;
+
+    #[test]
+    fn extract_last_token_hidden_uses_final_sequence_position() -> anyhow::Result<()> {
+        let device = candle_core::Device::Cpu;
+        let hidden = candle_core::Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, 4.0, // position 0
+                10.0, 20.0, 30.0, 40.0, // position 1
+                100.0, 200.0, 300.0, 400.0, // position 2
+            ],
+            (1usize, 3usize, 4usize),
+            &device,
+        )?;
+        let tensor =
+            bitnet_common::ConcreteTensor::BitNet(bitnet_common::BitNetTensor::new(hidden));
+
+        let last = extract_last_token_hidden(&tensor)?;
+        assert_eq!(last.shape(), vec![1, 4]);
+        assert_eq!(tensor_to_vec(&last)?, vec![100.0f32, 200.0, 300.0, 400.0]);
+        Ok(())
+    }
+}
+
 #[cfg(any(test, feature = "full-cli"))]
 fn can_use_direct_greedy_logits(
     temperature: f32,


### PR DESCRIPTION
## Summary

- port the durable #4761 test onto current main
- verify extract_last_token_hidden selects the final sequence position from a [B, T, H] tensor
- keep this as test-only diagnostic hardening with no runtime behavior change

## Scope

- crates/bitnet-cli/src/main.rs test module only

## Claim boundary

No A770/OpenCL/CUDA/AVX/server/speed/residency/reference-parity/model-readiness claim is promoted. This is a regression test for existing CLI hidden-state extraction behavior only.

## Validation

- PASS: rtk rustfmt --edition 2024 --check --config skip_children=true crates\\bitnet-cli\\src\\main.rs
- PASS: rtk git diff --check
- PASS: isolated CARGO_TARGET_DIR=target/codex-port-4761 rtk cargo test --locked -p bitnet-cli extract_last_token_hidden_uses_final_sequence_position --no-default-features --features cpu,opencl -- --nocapture
- GAP: first shared-target cargo test attempt with --exact timed out / filtered the test; isolated non-exact rerun executed 1 test and passed

## Generated files

None.

## Follow-up / supersedes

Ports durable test content from closed diagnostic PR #4761. The old branch-chain PR remains closed as port-durable-content.
