### PR TITLE
test(lunar-lake): avoid panic in source receipt test

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -13476,7 +13476,7 @@ mod tests {
 
     #[cfg(feature = "full-cli")]
     #[test]
-    fn lunar_lake_operator_ask_receipt_accepts_openvino_source_shape() {
+    fn lunar_lake_operator_ask_receipt_accepts_openvino_source_shape() -> anyhow::Result<()> {
         let route = commands::lunar_lake::OperatorRoute {
             route_id: "dense_slm_openvino_gpu_candidate".to_string(),
             workload: "ask".to_string(),
@@ -13549,7 +13549,7 @@ mod tests {
             },
             "timing": {"generation_wall_ms": 301.0}
         });
-        validate_lunar_lake_ask_source_receipt(&source, &route).expect("openvino source receipt");
+        validate_lunar_lake_ask_source_receipt(&source, &route)?;
         let answer = lunar_lake_source_answer_text(&source);
         let normalized = lunar_lake_source_normalized_answer(&source, &answer);
         let gate = evaluate_lunar_lake_answer_gate(&normalized, Some("4"));
@@ -13588,6 +13588,7 @@ mod tests {
         assert_eq!(receipt["prompt"]["token_ids"], serde_json::json!([1, 2, 3]));
         assert_eq!(receipt["tokens"]["generated_count"], 9);
         assert_eq!(receipt["answer"]["normalized_text"], "2 + 2 equals 4.");
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -1938,7 +1938,9 @@ mod tests {
 
         super::normalize_embed_and_lm_head(&mut tensor_map, &config, &device)?;
 
-        let normalized = tensor_map.get("token_embd.weight").expect("normalized embedding");
+        let normalized = tensor_map.get("token_embd.weight").ok_or_else(|| {
+            bitnet_common::BitNetError::Validation("missing normalized embedding".to_string())
+        })?;
         assert_eq!(normalized.shape().dims(), &[3, 4]);
         assert_eq!(
             normalized.to_vec2::<f32>()?,


### PR DESCRIPTION
## Summary
- replace the Lunar Lake OpenVINO source-receipt test expect() with Result/? propagation
- replace the GGUF embedding normalization test expect() with Result/? propagation
- keep test behavior unchanged while satisfying the no-panic-family policy gate

## Validation
- PASS: rtk git diff --check origin/main...HEAD
- PASS: rtk cargo fmt -p bitnet-cli -p bitnet-models -- --check
- PASS: rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli lunar_lake_operator_ask_receipt_accepts_openvino_source_shape
- PASS: rtk cargo test --locked -p bitnet-models --no-default-features normalize_embed_preserves_ggml_hidden_vocab_token_rows -- --nocapture
- GAP: rtk cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports timed out locally on Windows after 15 minutes with no failure output; remote Policy is authoritative for the no-panic proof.

## Claim boundary
No runtime, route, readiness, OpenVINO, performance, fallback, hardware, tokenizer, or model math claim changes. This is test policy debt cleanup only.