### PR TITLE
ci(coverage): run in rust-ci job container

### DIFF
--- a/.github/images/rust-ci/Dockerfile
+++ b/.github/images/rust-ci/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     cmake \
     g++ \
+    git \
     jq \
     libssl-dev \
     make \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,9 +28,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  RUST_CI_IMAGE: ghcr.io/effortlessmetrics/bitnet-rs-ci:rust-1.95
-
 jobs:
   coverage:
     name: Code Coverage
@@ -39,6 +36,11 @@ jobs:
     permissions:
       contents: read
       packages: read
+    container:
+      image: ghcr.io/effortlessmetrics/bitnet-rs-ci:rust-1.95
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     # PRs: only run when explicitly labeled "coverage" or "full-ci"
     if: >-
@@ -50,73 +52,28 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /usr/local/share/boost /usr/share/swift /usr/share/miniconda \
-            /usr/local/.ghcup /opt/hostedtoolcache /usr/local/share/chromium \
-            /usr/local/share/powershell /usr/share/az_* /opt/microsoft
-          sudo docker image prune --all --force
-          df -h /
-
-      - name: Log in to GHCR
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull rust-ci image
-        run: docker pull "${{ env.RUST_CI_IMAGE }}"
-
       - name: Disk usage before coverage
         run: df -h /
 
-      - name: Generate coverage in rust-ci image
+      - name: Generate coverage
         env:
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: "0"
           CARGO_PROFILE_TEST_DEBUG: "0"
         run: |
           set -euo pipefail
-          docker run --rm \
-            -v "$PWD:/workspace" \
-            -w /workspace \
-            -e RUST_BACKTRACE \
-            -e CARGO_INCREMENTAL \
-            -e CARGO_PROFILE_TEST_DEBUG \
-            "${{ env.RUST_CI_IMAGE }}" \
-            bash -c '
-              set -euo pipefail
-              export PATH="/usr/local/cargo/bin:${PATH}"
-              cargo llvm-cov clean --workspace
-              cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
-                --ignore-run-fail
-              cargo llvm-cov report --json --output-path coverage.json
-              cargo llvm-cov report --lcov --output-path lcov.info
-              cargo llvm-cov report --text | tee coverage.txt
-            '
-
-      - name: Restore coverage receipt ownership
-        if: always()
-        run: |
-          sudo mkdir -p target/bitnet/reports
-          sudo chown -R "$USER:$USER" target/bitnet
-          for file in coverage.json coverage.txt lcov.info; do
-            if [ -e "$file" ]; then
-              sudo chown "$USER:$USER" "$file"
-            fi
-          done
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
+            --ignore-run-fail
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
 
       - name: Disk usage after coverage
         if: always()
         run: |
           df -h /
           du -sh target/ || true
-
-      - name: Install jq
-        if: github.event_name == 'push'
-        run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Enforce threshold on main (70%)
         if: github.event_name == 'push'

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -30,9 +30,11 @@ Coverage runs are gated by branch, label, or manual dispatch:
 - Timeout: 60 minutes
 - Threshold: 70% line coverage on pushes to `main`
 
-The workflow lives in `.github/workflows/coverage.yml`. It runs
-`cargo llvm-cov nextest` inside the pinned Rust CI image and emits JSON, LCOV,
-and text reports.
+The workflow lives in `.github/workflows/coverage.yml`. It runs as a job
+container using the pinned Rust CI image, then runs `cargo llvm-cov nextest`
+and emits JSON, LCOV, and text reports. The hosted runner is not cleaned before
+coverage starts; the image keeps the large Rust coverage toolchain out of the
+runner payload instead.
 
 ## Artifacts
 
@@ -41,6 +43,7 @@ The `coverage-report` artifact is uploaded on every run and contains:
 - `coverage.json`
 - `coverage.txt`
 - `lcov.info`
+- `target/bitnet/reports/coverage-receipt.json`
 
 Artifacts are retained for 7 days.
 

--- a/docs/tracking/campaigns/ci-coverage/CAMPAIGN.md
+++ b/docs/tracking/campaigns/ci-coverage/CAMPAIGN.md
@@ -24,7 +24,8 @@ Make coverage upload and reporting reliable without turning forked PRs or missin
 
 | Work item | Status | Notes |
 |---|---|---|
-| CI-COVERAGE-001 | pr_open | Canonical Codecov upload guard is open in #3620. |
+| CI-COVERAGE-001 | merged | Canonical Codecov upload guard merged in #3620. |
+| CI-COVERAGE-002 | pr_open | Move coverage onto the rust-ci job container and remove hosted-runner disk cleanup. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/ci-coverage/active.toml
+++ b/docs/tracking/campaigns/ci-coverage/active.toml
@@ -46,3 +46,37 @@ must_not_claim = [
   "Coverage thresholds are complete.",
   "Runtime behavior changed.",
 ]
+
+[[work_item]]
+id = "CI-COVERAGE-002"
+status = "pr_open"
+branch = "codex/coverage-container-cleanup-3394"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Run coverage as a rust-ci job container and remove hosted-runner disk cleanup and nested Docker execution from the coverage workflow."
+commands = [
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".github/images/rust-ci/**",
+  ".github/workflows/coverage.yml",
+  "docs/ci/coverage.md",
+  "docs/tracking/campaigns/ci-coverage/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "Coverage no longer relies on hosted-runner disk cleanup before collection.",
+  "Coverage runs inside the pinned rust-ci job container.",
+]
+must_not_claim = [
+  "Coverage thresholds are complete.",
+  "Runtime behavior changed.",
+  "Coverage proves test quality or model correctness.",
+]

--- a/docs/tracking/campaigns/ci-coverage/events/2026-05-18T181809Z-CI-COVERAGE-002-pr-open.toml
+++ b/docs/tracking/campaigns/ci-coverage/events/2026-05-18T181809Z-CI-COVERAGE-002-pr-open.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-18T18:18:09Z"
+campaign = "ci-coverage"
+item = "CI-COVERAGE-002"
+event = "pr_open"
+branch = "codex/coverage-container-cleanup-3394"
+actor = "codex"
+
+notes = [
+  "Issue #3394 requested moving coverage to a slim Rust container image and removing the hosted-runner disk cleanup workaround.",
+  "The rust-ci image and image publishing workflow already exist; this item converts coverage to a first-class job container and documents the boundary.",
+]

--- a/docs/tracking/campaigns/ci-coverage/generated/status.md
+++ b/docs/tracking/campaigns/ci-coverage/generated/status.md
@@ -10,6 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | CI-COVERAGE-001 | merged | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
+| CI-COVERAGE-002 | pr_open |  | `codex/coverage-container-cleanup-3394` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run coverage as a rust-ci job container and remove hosted-runner disk cleanup and nested Docker execution from the coverage workflow. |
 
 ## Hard Constraints
 


### PR DESCRIPTION
## Summary
- convert the coverage workflow from nested Docker execution to a first-class rust-ci job container
- remove the hosted-runner disk cleanup, GHCR login/pull, nested docker run, and per-run jq install steps
- add git to the rust-ci image for checkout compatibility and record CI-COVERAGE-002 in the coverage tracker

Closes #3394

## Validation
- git diff --check
- cargo fmt --all -- --check
- ruby YAML parse for coverage.yml and rust-ci-image.yml

## Notes
- cargo run -p xtask --no-default-features -- campaign generate was attempted, but the local rustc child wedged at 0% CPU; generated status was updated consistently from active.toml.
- docker and actionlint are not installed on this M3 MacBook, so image build and full Actions validation are left to CI.