### PR TITLE
test(cuda): lock status receipt JSON contracts

### DIFF
--- a/crates/bitnet-cli/src/commands/receipts.rs
+++ b/crates/bitnet-cli/src/commands/receipts.rs
@@ -1733,12 +1733,58 @@ fn sum_kernel_f64(receipt: &Value, field: &str) -> Option<f64> {
 mod tests {
     use super::*;
     use clap::Parser;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     #[derive(Parser, Debug)]
     struct TestReceiptsCli {
         #[command(subcommand)]
         action: ReceiptsAction,
+    }
+
+    struct ExpectedReceiptJson<'a> {
+        model_coverage_row: &'a str,
+        current_tier: &'a str,
+        selected_backend: &'a str,
+        selected_route: Option<&'a str>,
+        fallback_used: bool,
+        product_cli_ready: bool,
+        server_ready: bool,
+        server_ready_scope: Option<&'a str>,
+        speedup_claim: bool,
+        full_residency_claim: bool,
+        bitnet_packed_i2s_qk256_proof: bool,
+        dense_regular_llm_cuda_proof: bool,
+    }
+
+    fn assert_receipt_json_contract(
+        receipt: &Value,
+        expected: ExpectedReceiptJson<'_>,
+    ) -> Result<()> {
+        let explanation = explain_receipt(Path::new("receipt.json"), receipt);
+        let value = serde_json::to_value(&explanation)?;
+
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["model_coverage_row"], expected.model_coverage_row);
+        assert_eq!(value["current_tier"], expected.current_tier);
+        assert_eq!(value["selected_backend"], expected.selected_backend);
+        if let Some(route) = expected.selected_route {
+            assert_eq!(value["selected_route"], route);
+        } else {
+            assert!(value["selected_route"].is_null());
+        }
+        assert_eq!(value["fallback_used"], expected.fallback_used);
+        assert_eq!(value["product_cli_ready"], expected.product_cli_ready);
+        assert_eq!(value["server_ready"], expected.server_ready);
+        if let Some(scope) = expected.server_ready_scope {
+            assert_eq!(value["server_ready_scope"], scope);
+        } else {
+            assert!(value["server_ready_scope"].is_null());
+        }
+        assert_eq!(value["speedup_claim"], expected.speedup_claim);
+        assert_eq!(value["full_residency_claim"], expected.full_residency_claim);
+        assert_eq!(value["bitnet_packed_i2s_qk256_proof"], expected.bitnet_packed_i2s_qk256_proof);
+        assert_eq!(value["dense_regular_llm_cuda_proof"], expected.dense_regular_llm_cuda_proof);
+        Ok(())
     }
 
     #[test]
@@ -1750,6 +1796,162 @@ mod tests {
         assert!(latest);
         assert!(!json);
         assert_eq!(format, Some(ReceiptExplainFormat::Json));
+    }
+
+    #[test]
+    fn receipts_explain_json_contract_locks_cuda_model_rows() -> Result<()> {
+        assert_receipt_json_contract(
+            &json!({
+                "artifact_kind": "bitnet_cuda_answer",
+                "model": {
+                    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+                    "file": "ggml-model-i2_s.gguf"
+                },
+                "backend": {
+                    "selected_backend": "nvidia-rtx-5070-ti-cuda",
+                    "runtime_api": "cuda",
+                    "fallback_used": false
+                },
+                "execution_plan": {
+                    "selected_route": "bitnet_qk256_cuda",
+                    "model_family": "bitnet_b1_58",
+                    "speedup_claim": false
+                },
+                "claim_boundary": {
+                    "bitnet_packed_i2s_qk256_proof": true,
+                    "dense_gguf_inference_claimed": false
+                }
+            }),
+            ExpectedReceiptJson {
+                model_coverage_row: "bitnet_official_2b_i2s_qk256",
+                current_tier: "product_cli_ready",
+                selected_backend: "nvidia-rtx-5070-ti-cuda",
+                selected_route: Some("bitnet_qk256_cuda"),
+                fallback_used: false,
+                product_cli_ready: true,
+                server_ready: false,
+                server_ready_scope: None,
+                speedup_claim: false,
+                full_residency_claim: false,
+                bitnet_packed_i2s_qk256_proof: true,
+                dense_regular_llm_cuda_proof: false,
+            },
+        )?;
+
+        assert_receipt_json_contract(
+            &json!({
+                "artifact_kind": "dense_gguf_qwen_warm_session_strict_cuda_proof",
+                "model": {
+                    "id": "qwen2.5-0.5b-instruct-q8_0"
+                },
+                "execution_plan": {
+                    "selected_route": "dense_regular_llm_cuda",
+                    "model_family": "qwen",
+                    "selected_backend": "nvidia-rtx-5070-ti-cuda",
+                    "fallback_used": false,
+                    "speedup_claim": false
+                },
+                "claim_boundary": {
+                    "bitnet_packed_i2s_qk256_proof": false,
+                    "dense_regular_llm_cuda_claimed": true,
+                    "server_ready_claimed": false,
+                    "speedup_claim": false
+                }
+            }),
+            ExpectedReceiptJson {
+                model_coverage_row: "dense_qwen25_05b_q8_cuda",
+                current_tier: "product_cli_ready",
+                selected_backend: "nvidia-rtx-5070-ti-cuda",
+                selected_route: Some("dense_regular_llm_cuda"),
+                fallback_used: false,
+                product_cli_ready: true,
+                server_ready: true,
+                server_ready_scope: Some("exact_profile"),
+                speedup_claim: false,
+                full_residency_claim: false,
+                bitnet_packed_i2s_qk256_proof: false,
+                dense_regular_llm_cuda_proof: true,
+            },
+        )?;
+
+        assert_receipt_json_contract(
+            &json!({
+                "artifact_kind": "dense_gguf_qwen_ask_strict_cuda_proof",
+                "model": {
+                    "id": "qwen3-0.6b-instruct-q8_0",
+                    "file": "Qwen3-0.6B-Q8_0.gguf",
+                    "architecture": "qwen3"
+                },
+                "execution_plan": {
+                    "selected_route": "dense_regular_llm_cuda",
+                    "model_family": "qwen",
+                    "selected_backend": "nvidia-rtx-5070-ti-cuda",
+                    "fallback_used": false,
+                    "speedup_claim": false
+                },
+                "claim_boundary": {
+                    "bitnet_packed_i2s_qk256_proof": false,
+                    "dense_regular_llm_cuda_claimed": true,
+                    "server_ready_claimed": false,
+                    "speedup_claim": false,
+                    "full_cuda_residency_claimed": false
+                }
+            }),
+            ExpectedReceiptJson {
+                model_coverage_row: "dense_qwen3_06b_q8_candidate",
+                current_tier: "product_cli_ready",
+                selected_backend: "nvidia-rtx-5070-ti-cuda",
+                selected_route: Some("dense_regular_llm_cuda"),
+                fallback_used: false,
+                product_cli_ready: true,
+                server_ready: false,
+                server_ready_scope: None,
+                speedup_claim: false,
+                full_residency_claim: false,
+                bitnet_packed_i2s_qk256_proof: false,
+                dense_regular_llm_cuda_proof: true,
+            },
+        )?;
+
+        assert_receipt_json_contract(
+            &json!({
+                "artifact_kind": "smollm2_same_prompt_comparator_blocker",
+                "model_coverage_row": "dense_smollm2_360m_candidate",
+                "model": {
+                    "id": "smollm2-360m-instruct",
+                    "architecture": "smollm2"
+                },
+                "selected_backend": "nvidia-rtx-5070-ti-cuda",
+                "fallback_used": false,
+                "quality_gate": {
+                    "passed": false,
+                    "blocker": "same-prompt comparator required"
+                },
+                "claim_boundary": {
+                    "bitnet_packed_i2s_qk256_proof": false,
+                    "dense_regular_llm_cuda_claimed": false,
+                    "server_ready_claimed": false,
+                    "speedup_claim": false,
+                    "full_cuda_residency_claimed": false
+                }
+            }),
+            ExpectedReceiptJson {
+                model_coverage_row: "dense_smollm2_360m_candidate",
+                current_tier: "structurally_valid",
+                selected_backend: "nvidia-rtx-5070-ti-cuda",
+                selected_route: None,
+                fallback_used: false,
+                product_cli_ready: false,
+                server_ready: false,
+                server_ready_scope: None,
+                speedup_claim: false,
+                full_residency_claim: false,
+                bitnet_packed_i2s_qk256_proof: false,
+                dense_regular_llm_cuda_proof: false,
+            },
+        )?;
+
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -3036,6 +3036,16 @@ mod tests {
             .with_context(|| format!("missing model status row {id}"))
     }
 
+    fn model_status_json_row_for<'a>(
+        value: &'a serde_json::Value,
+        id: &str,
+    ) -> &'a serde_json::Value {
+        value["models"]
+            .as_array()
+            .and_then(|models| models.iter().find(|model| model["id"] == id))
+            .unwrap_or_else(|| panic!("missing model status JSON row {id}"))
+    }
+
     #[test]
     fn supported_manifest_contains_m4_runtime_artifact() {
         let model = supported_model("qwen2.5-0.5b-instruct-q8_0").unwrap();
@@ -3720,84 +3730,87 @@ mod tests {
 
         assert_eq!(value["schema_version"], 1);
         assert_eq!(value["device"], "nvidia-rtx-5070-ti-cuda");
-        assert!(value["models"].as_array().is_some_and(|models| {
-            models.iter().any(|model| {
-                model["id"] == "dense_qwen25_05b_q8_cuda"
-                    && model["model_coverage_row"] == "dense_qwen25_05b_q8_cuda"
-                    && model["current_tier"] == "product_cli_ready"
-                    && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
-                    && model["selected_route"] == "dense_regular_llm_cuda"
-                    && model["fallback_used"] == false
-                    && model["product_cli_ready"] == true
-                    && model["route"] == "dense_regular_llm_cuda"
-                    && model["speedup_claim"] == false
-                    && model["server_ready"] == true
-                    && model["server_ready_scope"] == "exact_profile"
-                    && model["server_scope"] == "exact_profile"
-                    && model["full_residency_claim"] == false
-                    && model["server_endpoint"] == "/v1/chat/completions"
-                    && model["server_streaming"] == false
-                    && model["server_smoke"] == true
-                    && model["server_reason"].is_null()
-                    && model["bitnet_packed_i2s_qk256_proof"] == false
-                    && model["dense_regular_llm_cuda_proof"] == true
-            })
-        }));
-        assert!(value["models"].as_array().is_some_and(|models| {
-            models.iter().any(|model| {
-                model["id"] == "dense_qwen3_06b_q8_candidate"
-                    && model["model_coverage_row"] == "dense_qwen3_06b_q8_candidate"
-                    && model["category"] == "supported"
-                    && model["current_tier"] == "product_cli_ready"
-                    && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
-                    && model["selected_route"] == "dense_regular_llm_cuda"
-                    && model["fallback_used"] == false
-                    && model["tier"] == "product_cli_ready"
-                    && model["product_cli_ready"] == true
-                    && model["route"] == "dense_regular_llm_cuda"
-                    && model["accelerator_answer_ready"] == true
-                    && model["speedup_claim"] == false
-                    && model["server_ready"] == false
-                    && model["server_ready_scope"].is_null()
-                    && model["full_residency_claim"] == false
-                    && model["server_smoke"] == false
-                    && model["bitnet_packed_i2s_qk256_proof"] == false
-                    && model["dense_regular_llm_cuda_proof"] == true
-            })
-        }));
-        assert!(value["models"].as_array().is_some_and(|models| {
-            models.iter().any(|model| {
-                model["id"] == "bitnet_official_2b_i2s_qk256"
-                    && model["selected_route"] == "bitnet_qk256_cuda"
-                    && model["product_cli_ready"] == true
-                    && model["server_ready"] == false
-                    && model["server_ready_scope"].is_null()
-                    && model["server_scope"].is_null()
-                    && model["full_residency_claim"] == false
-                    && model["server_endpoint"] == "/v1/chat/completions"
-                    && model["server_streaming"] == false
-                    && model["server_smoke"] == true
-                    && model["server_reason"] == "broad production readiness not qualified"
-            })
-        }));
-        assert!(value["models"].as_array().is_some_and(|models| {
-            models.iter().any(|model| {
-                model["id"] == "dense_smollm2_360m_candidate"
-                    && model["model_coverage_row"] == "dense_smollm2_360m_candidate"
-                    && model["category"] == "candidate"
-                    && model["current_tier"] == "structurally_valid"
-                    && model["selected_backend"] == "nvidia-rtx-5070-ti-cuda"
-                    && model["selected_route"].is_null()
-                    && model["fallback_used"].is_null()
-                    && model["product_cli_ready"] == false
-                    && model["speedup_claim"] == false
-                    && model["server_ready"] == false
-                    && model["server_ready_scope"].is_null()
-                    && model["full_residency_claim"] == false
-                    && model["bitnet_packed_i2s_qk256_proof"] == false
-                    && model["dense_regular_llm_cuda_proof"] == false
-            })
-        }));
+
+        let bitnet = model_status_json_row_for(&value, "bitnet_official_2b_i2s_qk256");
+        assert_eq!(bitnet["model_coverage_row"], "bitnet_official_2b_i2s_qk256");
+        assert_eq!(bitnet["current_tier"], "product_cli_ready");
+        assert_eq!(bitnet["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(bitnet["selected_route"], "bitnet_qk256_cuda");
+        assert_eq!(bitnet["fallback_used"], false);
+        assert_eq!(bitnet["product_cli_ready"], true);
+        assert_eq!(bitnet["route"], "bitnet_qk256_cuda");
+        assert_eq!(bitnet["speedup_claim"], false);
+        assert_eq!(bitnet["server_ready"], false);
+        assert!(bitnet["server_ready_scope"].is_null());
+        assert!(bitnet["server_scope"].is_null());
+        assert_eq!(bitnet["full_residency_claim"], false);
+        assert_eq!(bitnet["server_endpoint"], "/v1/chat/completions");
+        assert_eq!(bitnet["server_streaming"], false);
+        assert_eq!(bitnet["server_smoke"], true);
+        assert_eq!(bitnet["server_reason"], "broad production readiness not qualified");
+        assert_eq!(bitnet["bitnet_packed_i2s_qk256_proof"], true);
+        assert_eq!(bitnet["dense_regular_llm_cuda_proof"], false);
+
+        let qwen25 = model_status_json_row_for(&value, "dense_qwen25_05b_q8_cuda");
+        assert_eq!(qwen25["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
+        assert_eq!(qwen25["current_tier"], "product_cli_ready");
+        assert_eq!(qwen25["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(qwen25["selected_route"], "dense_regular_llm_cuda");
+        assert_eq!(qwen25["fallback_used"], false);
+        assert_eq!(qwen25["product_cli_ready"], true);
+        assert_eq!(qwen25["route"], "dense_regular_llm_cuda");
+        assert_eq!(qwen25["speedup_claim"], false);
+        assert_eq!(qwen25["server_ready"], true);
+        assert_eq!(qwen25["server_ready_scope"], "exact_profile");
+        assert_eq!(qwen25["server_scope"], "exact_profile");
+        assert_eq!(qwen25["full_residency_claim"], false);
+        assert_eq!(qwen25["server_endpoint"], "/v1/chat/completions");
+        assert_eq!(qwen25["server_streaming"], false);
+        assert_eq!(qwen25["server_smoke"], true);
+        assert!(qwen25["server_reason"].is_null());
+        assert_eq!(qwen25["bitnet_packed_i2s_qk256_proof"], false);
+        assert_eq!(qwen25["dense_regular_llm_cuda_proof"], true);
+
+        let qwen3 = model_status_json_row_for(&value, "dense_qwen3_06b_q8_candidate");
+        assert_eq!(qwen3["model_coverage_row"], "dense_qwen3_06b_q8_candidate");
+        assert_eq!(qwen3["category"], "supported");
+        assert_eq!(qwen3["current_tier"], "product_cli_ready");
+        assert_eq!(qwen3["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(qwen3["selected_route"], "dense_regular_llm_cuda");
+        assert_eq!(qwen3["fallback_used"], false);
+        assert_eq!(qwen3["tier"], "product_cli_ready");
+        assert_eq!(qwen3["product_cli_ready"], true);
+        assert_eq!(qwen3["route"], "dense_regular_llm_cuda");
+        assert_eq!(qwen3["accelerator_answer_ready"], true);
+        assert_eq!(qwen3["speedup_claim"], false);
+        assert_eq!(qwen3["server_ready"], false);
+        assert!(qwen3["server_ready_scope"].is_null());
+        assert_eq!(qwen3["full_residency_claim"], false);
+        assert_eq!(qwen3["server_smoke"], false);
+        assert_eq!(qwen3["bitnet_packed_i2s_qk256_proof"], false);
+        assert_eq!(qwen3["dense_regular_llm_cuda_proof"], true);
+
+        let smollm2 = model_status_json_row_for(&value, "dense_smollm2_360m_candidate");
+        assert_eq!(smollm2["model_coverage_row"], "dense_smollm2_360m_candidate");
+        assert_eq!(smollm2["category"], "candidate");
+        assert_eq!(smollm2["current_tier"], "structurally_valid");
+        assert_eq!(smollm2["selected_backend"], "nvidia-rtx-5070-ti-cuda");
+        assert!(smollm2["selected_route"].is_null());
+        assert!(smollm2["fallback_used"].is_null());
+        assert_eq!(smollm2["product_cli_ready"], false);
+        assert_eq!(smollm2["cpu_answer_ready"], false);
+        assert_eq!(smollm2["accelerator_answer_ready"], false);
+        assert_eq!(smollm2["speedup_claim"], false);
+        assert_eq!(smollm2["server_ready"], false);
+        assert!(smollm2["server_ready_scope"].is_null());
+        assert_eq!(smollm2["full_residency_claim"], false);
+        assert_eq!(smollm2["bitnet_packed_i2s_qk256_proof"], false);
+        assert_eq!(smollm2["dense_regular_llm_cuda_proof"], false);
+        assert!(
+            smollm2["next_proof"]
+                .as_str()
+                .is_some_and(|next| { next.contains("same-prompt SmolLM2") })
+        );
         Ok(())
     }
 

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -3039,11 +3039,11 @@ mod tests {
     fn model_status_json_row_for<'a>(
         value: &'a serde_json::Value,
         id: &str,
-    ) -> &'a serde_json::Value {
+    ) -> Result<&'a serde_json::Value> {
         value["models"]
             .as_array()
             .and_then(|models| models.iter().find(|model| model["id"] == id))
-            .unwrap_or_else(|| panic!("missing model status JSON row {id}"))
+            .with_context(|| format!("missing model status JSON row {id}"))
     }
 
     #[test]
@@ -3731,7 +3731,7 @@ mod tests {
         assert_eq!(value["schema_version"], 1);
         assert_eq!(value["device"], "nvidia-rtx-5070-ti-cuda");
 
-        let bitnet = model_status_json_row_for(&value, "bitnet_official_2b_i2s_qk256");
+        let bitnet = model_status_json_row_for(&value, "bitnet_official_2b_i2s_qk256")?;
         assert_eq!(bitnet["model_coverage_row"], "bitnet_official_2b_i2s_qk256");
         assert_eq!(bitnet["current_tier"], "product_cli_ready");
         assert_eq!(bitnet["selected_backend"], "nvidia-rtx-5070-ti-cuda");
@@ -3751,7 +3751,7 @@ mod tests {
         assert_eq!(bitnet["bitnet_packed_i2s_qk256_proof"], true);
         assert_eq!(bitnet["dense_regular_llm_cuda_proof"], false);
 
-        let qwen25 = model_status_json_row_for(&value, "dense_qwen25_05b_q8_cuda");
+        let qwen25 = model_status_json_row_for(&value, "dense_qwen25_05b_q8_cuda")?;
         assert_eq!(qwen25["model_coverage_row"], "dense_qwen25_05b_q8_cuda");
         assert_eq!(qwen25["current_tier"], "product_cli_ready");
         assert_eq!(qwen25["selected_backend"], "nvidia-rtx-5070-ti-cuda");
@@ -3771,7 +3771,7 @@ mod tests {
         assert_eq!(qwen25["bitnet_packed_i2s_qk256_proof"], false);
         assert_eq!(qwen25["dense_regular_llm_cuda_proof"], true);
 
-        let qwen3 = model_status_json_row_for(&value, "dense_qwen3_06b_q8_candidate");
+        let qwen3 = model_status_json_row_for(&value, "dense_qwen3_06b_q8_candidate")?;
         assert_eq!(qwen3["model_coverage_row"], "dense_qwen3_06b_q8_candidate");
         assert_eq!(qwen3["category"], "supported");
         assert_eq!(qwen3["current_tier"], "product_cli_ready");
@@ -3790,7 +3790,7 @@ mod tests {
         assert_eq!(qwen3["bitnet_packed_i2s_qk256_proof"], false);
         assert_eq!(qwen3["dense_regular_llm_cuda_proof"], true);
 
-        let smollm2 = model_status_json_row_for(&value, "dense_smollm2_360m_candidate");
+        let smollm2 = model_status_json_row_for(&value, "dense_smollm2_360m_candidate")?;
         assert_eq!(smollm2["model_coverage_row"], "dense_smollm2_360m_candidate");
         assert_eq!(smollm2["category"], "candidate");
         assert_eq!(smollm2["current_tier"], "structurally_valid");


### PR DESCRIPTION
## Summary
- clean-port #5755's CUDA model-status JSON contract assertions onto current main
- add receipts-explain flat JSON contract coverage for official BitNet, Qwen2.5, Qwen3, and SmolLM2 rows
- preserve claim boundaries: no speedup, broad server, full residency, dense/BitNet proof inheritance, or hardware-route promotion beyond the model coverage rows
- avoid the stale #5755 branch's obsolete main.rs policy-fix carryover, which was already handled by #5772

## Validation
- PASS: rtk git diff --check origin/main...HEAD
- PASS: rtk cargo fmt -p bitnet-cli -- --check
- PASS: rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
- PASS: rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
- GAP: local check-no-panic-family has timed out repeatedly on Windows in this workspace; remote Policy is authoritative for the no-panic proof.

## Supersedes
- Replaces #5755 with the same durable receipt/status contract value on a clean current-main branch.