### PR TITLE
test(policy): avoid no-panic debt in metadata tests

### DIFF
--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -2342,11 +2342,11 @@ mod tests {
     }
 
     #[test]
-    fn strict_tensor_authority_allows_tied_lm_head_from_embeddings() {
+    fn strict_tensor_authority_allows_tied_lm_head_from_embeddings() -> Result<()> {
         let names = one_layer_names_with_embedding();
 
-        GgufLoader::validate_strict_tensor_authority_names(&names, &one_layer_config())
-            .expect("tied lm_head should be valid when token embeddings are present");
+        GgufLoader::validate_strict_tensor_authority_names(&names, &one_layer_config())?;
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -1927,7 +1927,7 @@ mod tests {
     use std::collections::HashMap;
     use tempfile::TempDir;
 
-    fn build_metadata_only_gguf(metadata: Vec<(&str, GgufValue)>) -> Vec<u8> {
+    fn build_metadata_only_gguf(metadata: Vec<(&str, GgufValue)>) -> super::Result<Vec<u8>> {
         const GGUF_VERSION: u32 = 2;
         const ALIGN: usize = 32;
 
@@ -1941,15 +1941,15 @@ mod tests {
             let key_bytes = key.as_bytes();
             data.extend_from_slice(&(key_bytes.len() as u64).to_le_bytes());
             data.extend_from_slice(key_bytes);
-            write_gguf_value(&mut data, value);
+            write_gguf_value(&mut data, value)?;
         }
 
         let pad = (ALIGN - (data.len() % ALIGN)) % ALIGN;
         data.resize(data.len() + pad, 0);
-        data
+        Ok(data)
     }
 
-    fn write_gguf_value(data: &mut Vec<u8>, value: GgufValue) {
+    fn write_gguf_value(data: &mut Vec<u8>, value: GgufValue) -> super::Result<()> {
         match value {
             GgufValue::U32(value) => {
                 data.extend_from_slice(&4u32.to_le_bytes());
@@ -1970,14 +1970,21 @@ mod tests {
                 data.extend_from_slice(&(values.len() as u64).to_le_bytes());
                 for value in values {
                     let GgufValue::String(value) = value else {
-                        panic!("test helper only writes string arrays");
+                        return Err(bitnet_common::BitNetError::Validation(
+                            "test helper only writes string arrays".to_string(),
+                        ));
                     };
                     data.extend_from_slice(&(value.len() as u64).to_le_bytes());
                     data.extend_from_slice(value.as_bytes());
                 }
             }
-            other => panic!("test helper does not write {other:?}"),
+            other => {
+                return Err(bitnet_common::BitNetError::Validation(format!(
+                    "test helper does not write {other:?}"
+                )));
+            }
         }
+        Ok(())
     }
 
     #[test]
@@ -2072,7 +2079,7 @@ mod tests {
     }
 
     #[test]
-    fn simple_config_applies_bitnet_architecture_defaults() {
+    fn simple_config_applies_bitnet_architecture_defaults() -> super::Result<()> {
         let data = build_metadata_only_gguf(vec![
             ("general.architecture", GgufValue::String("bitnet".to_string())),
             (
@@ -2089,10 +2096,10 @@ mod tests {
             ("bitnet-b1.58.feed_forward_length", GgufValue::U32(16)),
             ("bitnet-b1.58.rope.freq_base", GgufValue::F32(500_000.0)),
             ("bitnet-b1.58.attention.layer_norm_rms_epsilon", GgufValue::F32(1.0e-5)),
-        ]);
-        let reader = GgufReader::new(&data).expect("metadata-only gguf reader");
+        ])?;
+        let reader = GgufReader::new(&data)?;
 
-        let config = extract_config_from_gguf(&reader).expect("extract config");
+        let config = extract_config_from_gguf(&reader)?;
 
         assert_eq!(config.model.norm_type, NormType::RmsNorm);
         assert_eq!(config.model.activation_type, ActivationType::Relu2);
@@ -2102,5 +2109,6 @@ mod tests {
         assert_eq!(config.model.num_heads, 2);
         assert_eq!(config.model.num_key_value_heads, 1);
         assert_eq!(config.model.intermediate_size, 16);
+        Ok(())
     }
 }

--- a/crates/bitnet-tokenizers/src/hf_tokenizer.rs
+++ b/crates/bitnet-tokenizers/src/hf_tokenizer.rs
@@ -178,29 +178,31 @@ mod tests {
     use super::*;
     use crate::Tokenizer;
 
-    fn fixture_tokenizer() -> HfTokenizer {
+    fn fixture_tokenizer() -> AnyhowResult<HfTokenizer> {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../tests/fixtures/tokenizers/valid_tokenizer_a.json");
-        HfTokenizer::from_file(&path).expect("fixture tokenizer should load")
+        HfTokenizer::from_file(&path)
     }
 
     #[test]
-    fn embedded_special_prompt_does_not_get_post_processor_bos() {
-        let tokenizer = fixture_tokenizer();
+    fn embedded_special_prompt_does_not_get_post_processor_bos() -> AnyhowResult<()> {
+        let tokenizer = fixture_tokenizer()?;
 
-        let ids = tokenizer.encode("<s>▁t", false, true).expect("encode should succeed");
+        let ids = tokenizer.encode("<s>▁t", false, true)?;
 
         assert_eq!(ids.first().copied(), Some(1), "embedded BOS should be parsed");
         assert_ne!(ids.get(1).copied(), Some(1), "post-processor BOS must not be injected");
+        Ok(())
     }
 
     #[test]
-    fn explicit_bos_policy_still_prepends_single_bos() {
-        let tokenizer = fixture_tokenizer();
+    fn explicit_bos_policy_still_prepends_single_bos() -> AnyhowResult<()> {
+        let tokenizer = fixture_tokenizer()?;
 
-        let ids = tokenizer.encode("▁t", true, true).expect("encode should succeed");
+        let ids = tokenizer.encode("▁t", true, true)?;
 
         assert_eq!(ids.first().copied(), Some(1), "explicit BOS should be prepended");
         assert_ne!(ids.get(1).copied(), Some(1), "explicit BOS should not duplicate");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- replace the exact no-panic Policy failures in GGUF simple, GGUF loader, and HF tokenizer tests with Result propagation
- keep the changes test-only and avoid touching runtime loader/tokenizer/model behavior
- unblock #5783 and other Rust PRs selected by the policy lane

## Scope
- test-only cleanup in crates/bitnet-models/src/gguf_simple.rs
- test-only cleanup in crates/bitnet-models/src/formats/gguf/loader.rs
- test-only cleanup in crates/bitnet-tokenizers/src/hf_tokenizer.rs

## Claim boundary
- no runtime behavior change
- no tokenizer, prompt, model math, backend, speed, server, hardware, or product-readiness claim

## Validation
- PASS: tk cargo fmt -p bitnet-models -p bitnet-tokenizers -- --check
- PASS: tk git diff --check
- PASS: exact old Policy strings no longer match in the touched files; remaining xpect sites are pre-existing baseline identities not reported by the failing Policy logs
- GAP: tk cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports timed out locally after 10 minutes; hosted Policy should be treated as authoritative

## Follow-up / supersedes
- unblocks #5783 Policy/PR Gate once merged or once #5783 is refreshed