### PR TITLE
ci(pr-gate): paginate check-run polling

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -203,8 +203,9 @@ jobs:
           missing="${required_jobs[*]}"
 
           while [ $SECONDS -lt $deadline ]; do
-            payload=$(gh api -H 'Accept: application/vnd.github+json' \
-              "${api}?per_page=100" || true)
+            payload=$(gh api --paginate -H 'Accept: application/vnd.github+json' \
+              "${api}?per_page=100" --jq '.check_runs[]' \
+              | jq -s '{check_runs: .}' || true)
             if [ -z "$payload" ]; then
               echo "Empty API response; retrying"
               sleep 30


### PR DESCRIPTION
## Summary
- make PR Gate poll all check-run pages for the head SHA instead of only the first 100 check runs
- preserve the existing required-job mapping and success/failure rules
- fixes the current failure mode where rerun-heavy PRs can leave required jobs invisible to PR Gate even after they succeed

## Scope
- .github/workflows/pr-gate.yml only
- no CI lane routing change
- no branch protection change
- no runtime/model code

## Claim boundary
- CI gate reliability only
- does not weaken required checks or mark skipped selected lanes as successful

## Validation
- PASS: tk git diff --check
- REVIEW: diff is one shell command change from single-page gh api to paginated gh api --paginate normalized back to {check_runs: [...]} for the existing jq consumers

## Follow-up / supersedes
- unblocks #5791 PR Gate on rerun-heavy check sets