### PR TITLE
ci-core: package-select build test surface

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -322,12 +322,104 @@ jobs:
           shared-key: ci-core-ubuntu
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Plan package selection
+        id: package-plan
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        env:
+          CHANGED_FILES: ${{ needs.classify-changes.outputs.changed_files }}
+          EVENT_NAME: ${{ github.event_name }}
+          LABELS_JSON: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.labels.*.name) || '[]' }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/ci
+          printf '%s\n' "$CHANGED_FILES" > target/ci/changed-files.txt
+          cargo run --locked -p xtask --no-default-features -- ci plan \
+            --changed-file target/ci/changed-files.txt \
+            --labels-json "$LABELS_JSON" \
+            --json-out target/ci/ci-plan.json \
+            --print
+
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          from pathlib import Path
+
+          plan = json.loads(Path("target/ci/ci-plan.json").read_text(encoding="utf-8"))
+          packages = plan.get("packages", {})
+          selected = list(dict.fromkeys(packages.get("selected", [])))
+
+          cpu_feature_packages = {
+              "bitnet",
+              "bitnet-common",
+              "bitnet-models",
+              "bitnet-tokenizers",
+              "bitnet-quantization",
+              "bitnet-kernels",
+              "bitnet-inference",
+              "bitnet-bdd-grid-core",
+              "bitnet-bdd-grid",
+              "bitnet-feature-contract",
+              "bitnet-testing-policy-core",
+              "bitnet-testing-scenarios-core",
+              "bitnet-runtime-feature-flags-core",
+              "bitnet-runtime-feature-flags",
+              "bitnet-startup-contract-core",
+              "bitnet-startup-contract-diagnostics",
+              "bitnet-startup-contract-guard",
+              "bitnet-runtime-context-core",
+              "bitnet-testing-scenarios-profile-core",
+              "bitnet-runtime-profile-contract-core",
+              "bitnet-testing-policy-runtime",
+              "bitnet-testing-policy-tests",
+              "bitnet-testing-policy-kit",
+              "bitnet-testing-profile",
+              "bitnet-testing-policy-contract",
+              "bitnet-testing-policy-interop",
+          }
+          default_feature_packages = {
+              "bitnet-prompt-templates",
+              "bitnet-receipts",
+              "bitnet-sampling",
+          }
+          no_feature_packages = {
+              "bitnet-logits",
+              "bitnet-gguf",
+              "bitnet-generation",
+              "bitnet-device-probe",
+              "bitnet-engine-core",
+          }
+          supported = cpu_feature_packages | default_feature_packages | no_feature_packages
+          unsupported = [package for package in selected if package not in supported]
+          broad = bool(packages.get("broad_sweep_required")) or bool(unsupported)
+          if os.environ.get("EVENT_NAME") != "pull_request" and not selected:
+              broad = True
+
+          def args(names):
+              return " ".join(f"-p {name}" for name in names)
+
+          print(f"broad_sweep_required={str(broad).lower()}")
+          print(f"selection_reason={packages.get('selection_reason', '')}")
+          print(f"selected_packages_csv={','.join(selected)}")
+          print(f"unsupported_packages_csv={','.join(unsupported)}")
+          print(f"cpu_package_args={args([p for p in selected if p in cpu_feature_packages])}")
+          print(f"default_package_args={args([p for p in selected if p in default_feature_packages])}")
+          print(f"no_feature_package_args={args([p for p in selected if p in no_feature_packages])}")
+          print(f"run_inference_golden={str(broad or 'bitnet-inference' in selected).lower()}")
+          print(f"run_avx2_quantization={str(broad or 'bitnet-quantization' in selected).lower()}")
+          print(f"run_avx2_kernels={str(broad or 'bitnet-kernels' in selected).lower()}")
+          PY
+
+          echo "Package selection:"
+          echo "  broad: $(grep '^broad_sweep_required=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-)"
+          echo "  selected: $(grep '^selected_packages_csv=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-)"
+          echo "  unsupported: $(grep '^unsupported_packages_csv=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-)"
+
       - name: Check formatting
         if: needs.classify-changes.outputs.no_rust_inputs != 'true'
         run: cargo fmt --all -- --check
 
       - name: Build core libs (CPU features)
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required == 'true'
         run: |
           cargo build --locked \
             -p bitnet-common \
@@ -338,15 +430,40 @@ jobs:
             --no-default-features --features cpu
 
       - name: Build SRP microcrates
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required == 'true'
         run: |
           cargo build --locked \
             -p bitnet-prompt-templates \
             -p bitnet-receipts \
             -p bitnet-sampling
 
+      - name: Build selected packages
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required != 'true'
+        env:
+          CPU_PACKAGE_ARGS: ${{ steps.package-plan.outputs.cpu_package_args }}
+          DEFAULT_PACKAGE_ARGS: ${{ steps.package-plan.outputs.default_package_args }}
+          NO_FEATURE_PACKAGE_ARGS: ${{ steps.package-plan.outputs.no_feature_package_args }}
+        run: |
+          set -euo pipefail
+          ran=false
+          if [ -n "$CPU_PACKAGE_ARGS" ]; then
+            cargo build --locked $CPU_PACKAGE_ARGS --no-default-features --features cpu
+            ran=true
+          fi
+          if [ -n "$DEFAULT_PACKAGE_ARGS" ]; then
+            cargo build --locked $DEFAULT_PACKAGE_ARGS
+            ran=true
+          fi
+          if [ -n "$NO_FEATURE_PACKAGE_ARGS" ]; then
+            cargo build --locked $NO_FEATURE_PACKAGE_ARGS --no-default-features
+            ran=true
+          fi
+          if [ "$ran" != "true" ]; then
+            echo "No selected packages to build."
+          fi
+
       - name: "Run unit tests: core libs"
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required == 'true'
         run: |
           cargo test --locked \
             -p bitnet-common \
@@ -359,7 +476,7 @@ jobs:
             -- --nocapture
 
       - name: "Run unit tests: SRP microcrates"
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required == 'true'
         run: |
           cargo test --locked \
             -p bitnet-prompt-templates \
@@ -374,14 +491,14 @@ jobs:
             --no-default-features
 
       - name: "Run tests: inference golden path"
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required == 'true'
         run: |
           cargo test --locked \
             -p bitnet-inference --test cpu_golden_path \
             --no-default-features --features cpu
 
       - name: "Run unit tests: policy / BDD crates"
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required == 'true'
         run: |
           cargo test --locked \
             -p bitnet-bdd-grid-core \
@@ -405,8 +522,40 @@ jobs:
             -p bitnet-testing-policy-interop \
             --no-default-features --features cpu
 
+      - name: "Run unit tests: selected packages"
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required != 'true'
+        env:
+          CPU_PACKAGE_ARGS: ${{ steps.package-plan.outputs.cpu_package_args }}
+          DEFAULT_PACKAGE_ARGS: ${{ steps.package-plan.outputs.default_package_args }}
+          NO_FEATURE_PACKAGE_ARGS: ${{ steps.package-plan.outputs.no_feature_package_args }}
+        run: |
+          set -euo pipefail
+          ran=false
+          if [ -n "$CPU_PACKAGE_ARGS" ]; then
+            cargo test --locked $CPU_PACKAGE_ARGS --lib --no-default-features --features cpu -- --nocapture
+            ran=true
+          fi
+          if [ -n "$DEFAULT_PACKAGE_ARGS" ]; then
+            cargo test --locked $DEFAULT_PACKAGE_ARGS
+            ran=true
+          fi
+          if [ -n "$NO_FEATURE_PACKAGE_ARGS" ]; then
+            cargo test --locked $NO_FEATURE_PACKAGE_ARGS --no-default-features
+            ran=true
+          fi
+          if [ "$ran" != "true" ]; then
+            echo "No selected packages to test."
+          fi
+
+      - name: "Run tests: selected inference golden path"
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && steps.package-plan.outputs.broad_sweep_required != 'true' && steps.package-plan.outputs.run_inference_golden == 'true'
+        run: |
+          cargo test --locked \
+            -p bitnet-inference --test cpu_golden_path \
+            --no-default-features --features cpu
+
       - name: "Run unit tests: AVX2 quantization (x86_64 static +avx2)"
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && runner.os == 'Linux' && runner.arch == 'X64'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && runner.os == 'Linux' && runner.arch == 'X64' && steps.package-plan.outputs.run_avx2_quantization == 'true'
         env:
           RUSTFLAGS: "-D warnings -C target-feature=+avx2"
         run: |
@@ -417,7 +566,7 @@ jobs:
             -- --nocapture
 
       - name: "Run unit tests: AVX2 kernels (x86_64 static +avx2)"
-        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && runner.os == 'Linux' && runner.arch == 'X64'
+        if: needs.classify-changes.outputs.no_rust_inputs != 'true' && runner.os == 'Linux' && runner.arch == 'X64' && steps.package-plan.outputs.run_avx2_kernels == 'true'
         env:
           RUSTFLAGS: "-D warnings -C target-feature=+avx2"
         run: |

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -494,6 +494,13 @@ generated-dashboard freshness. Hardware receipt-only changes run changed-receipt
 JSON syntax checks inside CI Core. Pure docs and policy-docs changes rely on the
 dedicated docs, markdown, link, policy, and PR Gate lanes.
 
+For Rust-input PRs, CI Core uses `ci-plan.json` package selection for the
+Linux build/test surface. The selected package set is the union of changed
+workspace packages, direct dependents from `cargo metadata`, and risk-pack
+canaries. Manifest, toolchain, and shared-foundation changes still force the
+full core sweep because their blast radius is intentionally broader than a
+single package edge.
+
 ## Operating metric
 
 We optimize for:

--- a/docs/ci/pr-plan.md
+++ b/docs/ci/pr-plan.md
@@ -38,7 +38,10 @@ The JSON artifact uses `schema_version = 1` and keeps these top-level fields:
   "packages": {
     "changed": [],
     "direct_dependents": [],
-    "canaries": []
+    "canaries": [],
+    "selected": [],
+    "broad_sweep_required": false,
+    "selection_reason": "changed packages plus direct dependents and canaries"
   },
   "risk_packs": [],
   "labels": []
@@ -48,6 +51,12 @@ The JSON artifact uses `schema_version = 1` and keeps these top-level fields:
 `selected_lanes` entries include `id`, `name`, `estimated_lem`, `reason`, and
 `blocking`. `skipped_lanes` entries include `id`, `name`, `reason`, and
 `blocking`.
+
+`packages` is the CI Core package-selection contract. `changed` comes from
+changed workspace package paths, `direct_dependents` comes from `cargo metadata`,
+`canaries` comes from risk packs, and `selected` is the union used by CI Core
+when a broad sweep is not required. `broad_sweep_required=true` preserves the
+full core sweep for manifest, toolchain, and shared-foundation changes.
 
 ## Boundaries
 

--- a/docs/ci/routed-verification-rollout.md
+++ b/docs/ci/routed-verification-rollout.md
@@ -127,7 +127,10 @@ consuming it as an API:
   "packages": {
     "changed": [],
     "direct_dependents": [],
-    "canaries": []
+    "canaries": [],
+    "selected": [],
+    "broad_sweep_required": false,
+    "selection_reason": "changed packages plus direct dependents and canaries"
   },
   "risk_packs": [],
   "labels": []
@@ -431,9 +434,10 @@ unless a broad sweep is required.
 
 **Required behavior:**
 
-- Compute changed packages, direct dependents, canary packages, and
-  `broad_sweep_required`.
-- Run `cargo test` and `cargo clippy` on the selected package set.
+- Compute changed packages, direct dependents, canary packages, selected
+  packages, and `broad_sweep_required`.
+- Run CI Core build/test on the selected package set when a broad sweep is not
+  required.
 - Require broad sweep for manifest/toolchain/shared-foundation changes.
 - Summarize selected packages and reason.
 

--- a/tests/fixtures/ci-plan/quantization.txt
+++ b/tests/fixtures/ci-plan/quantization.txt
@@ -1,0 +1,1 @@
+crates/bitnet-quantization/src/i2s_qk256.rs

--- a/xtask/src/ci/plan.rs
+++ b/xtask/src/ci/plan.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Clone, Serialize)]
@@ -79,6 +79,9 @@ pub struct Packages {
     pub changed: Vec<String>,
     pub direct_dependents: Vec<String>,
     pub canaries: Vec<String>,
+    pub selected: Vec<String>,
+    pub broad_sweep_required: bool,
+    pub selection_reason: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -631,14 +634,176 @@ fn package_name_for_path(path: &str) -> Option<String> {
     match parts.next()? {
         "crates" => parts.next().map(str::to_string),
         "xtask" => Some("xtask".to_string()),
+        "xtask-build-helper" => Some("xtask-build-helper".to_string()),
         "crossval" => Some("bitnet-crossval".to_string()),
+        "tests" => Some("bitnet-tests".to_string()),
+        "tests-new" => Some("bitnet-tests-new".to_string()),
+        "tools" => parts.next().map(str::to_string),
+        "fuzz" => Some("bitnet-fuzz".to_string()),
+        "src" | "examples" | "benches" => Some("bitnet".to_string()),
+        "build.rs" => Some("bitnet".to_string()),
         _ => None,
     }
 }
 
-fn build_packages(changed: &[String], risk_packs: &[String]) -> Packages {
+#[derive(Debug, Clone)]
+struct WorkspacePackageGraph {
+    packages: BTreeSet<String>,
+    direct_dependents_by_dependency: BTreeMap<String, BTreeSet<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoMetadataPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadataPackage {
+    name: String,
+    manifest_path: PathBuf,
+    #[serde(default)]
+    dependencies: Vec<CargoMetadataDependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadataDependency {
+    path: Option<PathBuf>,
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/").trim_end_matches('/').to_ascii_lowercase()
+}
+
+fn workspace_package_graph() -> Result<WorkspacePackageGraph> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .context("running cargo metadata for CI package selection")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed while computing CI package selection: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let metadata: CargoMetadata =
+        serde_json::from_slice(&output.stdout).context("parsing cargo metadata")?;
+    let mut packages = BTreeSet::new();
+    let mut package_by_root = BTreeMap::new();
+    for package in &metadata.packages {
+        packages.insert(package.name.clone());
+        if let Some(root) = package.manifest_path.parent() {
+            package_by_root.insert(normalized_path_key(root), package.name.clone());
+        }
+    }
+
+    let mut direct_dependents_by_dependency: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for package in &metadata.packages {
+        for dep in &package.dependencies {
+            let Some(path) = dep.path.as_ref() else {
+                continue;
+            };
+            if let Some(dep_name) = package_by_root.get(&normalized_path_key(path)) {
+                if dep_name != &package.name {
+                    direct_dependents_by_dependency
+                        .entry(dep_name.clone())
+                        .or_default()
+                        .insert(package.name.clone());
+                }
+            }
+        }
+    }
+
+    Ok(WorkspacePackageGraph { packages, direct_dependents_by_dependency })
+}
+
+fn direct_dependents_for(
+    changed_packages: &BTreeSet<String>,
+    graph: Option<&WorkspacePackageGraph>,
+) -> BTreeSet<String> {
+    let Some(graph) = graph else {
+        return BTreeSet::new();
+    };
+    let mut out = BTreeSet::new();
+    for package in changed_packages {
+        if let Some(dependents) = graph.direct_dependents_by_dependency.get(package) {
+            out.extend(dependents.iter().filter(|dep| !changed_packages.contains(*dep)).cloned());
+        }
+    }
+    out
+}
+
+fn package_exists(package: &str, graph: Option<&WorkspacePackageGraph>) -> bool {
+    graph.map(|g| g.packages.contains(package)).unwrap_or(true)
+}
+
+fn broad_sweep_packages(graph: Option<&WorkspacePackageGraph>) -> Vec<String> {
+    [
+        "bitnet-common",
+        "bitnet-models",
+        "bitnet-tokenizers",
+        "bitnet-quantization",
+        "bitnet-kernels",
+        "bitnet-prompt-templates",
+        "bitnet-receipts",
+        "bitnet-sampling",
+        "bitnet-logits",
+        "bitnet-gguf",
+        "bitnet-generation",
+        "bitnet-device-probe",
+        "bitnet-engine-core",
+        "bitnet-bdd-grid-core",
+        "bitnet-bdd-grid",
+        "bitnet-feature-contract",
+        "bitnet-testing-policy-core",
+        "bitnet-testing-scenarios-core",
+        "bitnet-runtime-feature-flags-core",
+        "bitnet-runtime-feature-flags",
+        "bitnet-startup-contract-core",
+        "bitnet-startup-contract-diagnostics",
+        "bitnet-startup-contract-guard",
+        "bitnet-runtime-context-core",
+        "bitnet-testing-scenarios-profile-core",
+        "bitnet-runtime-profile-contract-core",
+        "bitnet-testing-policy-runtime",
+        "bitnet-testing-policy-tests",
+        "bitnet-testing-policy-kit",
+        "bitnet-testing-profile",
+        "bitnet-testing-policy-contract",
+        "bitnet-testing-policy-interop",
+        "bitnet-inference",
+    ]
+    .into_iter()
+    .filter(|package| package_exists(package, graph))
+    .map(str::to_string)
+    .collect()
+}
+
+fn broad_sweep_required(changed: &[String], changed_packages: &BTreeSet<String>) -> bool {
+    const SHARED_FOUNDATION_PACKAGES: &[&str] = &[
+        "bitnet",
+        "bitnet-common",
+        "bitnet-math",
+        "bitnet-simd",
+        "bitnet-kernels",
+        "xtask-build-helper",
+    ];
+
+    manifest_or_toolchain_changed(changed)
+        || changed.iter().any(|path| path.starts_with(".cargo/") || path == "build.rs")
+        || changed_packages
+            .iter()
+            .any(|package| SHARED_FOUNDATION_PACKAGES.contains(&package.as_str()))
+}
+
+fn build_packages(
+    changed: &[String],
+    risk_packs: &[String],
+    graph: Option<&WorkspacePackageGraph>,
+) -> Packages {
     let changed_packages: BTreeSet<String> =
         changed.iter().filter_map(|path| package_name_for_path(path)).collect();
+    let direct_dependents = direct_dependents_for(&changed_packages, graph);
     let risk_set: BTreeSet<&str> = risk_packs.iter().map(String::as_str).collect();
     let mut canaries = BTreeSet::new();
     if risk_set.contains("qk256") {
@@ -658,15 +823,59 @@ fn build_packages(changed: &[String], risk_packs: &[String]) -> Packages {
         canaries.insert("bitnet-bdd-grid".to_string());
     }
 
+    canaries.retain(|package| package_exists(package, graph));
+
+    let broad_sweep_required = broad_sweep_required(changed, &changed_packages);
+    let selected: BTreeSet<String> = if broad_sweep_required {
+        broad_sweep_packages(graph).into_iter().collect()
+    } else {
+        changed_packages
+            .iter()
+            .chain(direct_dependents.iter())
+            .chain(canaries.iter())
+            .filter(|package| package_exists(package, graph))
+            .cloned()
+            .collect()
+    };
+
+    let selection_reason = if broad_sweep_required {
+        "broad sweep required for manifest/toolchain/shared-foundation change"
+    } else if selected.is_empty() {
+        "no Rust package selection for changed files"
+    } else {
+        "changed packages plus direct dependents and canaries"
+    };
+
     Packages {
         changed: changed_packages.into_iter().collect(),
-        direct_dependents: Vec::new(),
+        direct_dependents: direct_dependents.into_iter().collect(),
         canaries: canaries.into_iter().collect(),
+        selected: selected.into_iter().collect(),
+        broad_sweep_required,
+        selection_reason: selection_reason.to_string(),
     }
 }
 
 /// Compute the plan from a list of changed files and labels.
+#[cfg(test)]
 pub fn build_plan(changed: &[String], labels: &[String]) -> Plan {
+    build_plan_with_package_graph(changed, labels, None)
+}
+
+fn build_plan_with_workspace_metadata(changed: &[String], labels: &[String]) -> Plan {
+    let graph = if changed.iter().any(|path| is_rust_input_path(path)) {
+        workspace_package_graph().ok()
+    } else {
+        None
+    };
+    build_plan_with_package_graph(changed, labels, graph.as_ref())
+}
+
+fn build_plan_with_package_graph(
+    changed: &[String],
+    labels: &[String],
+    graph: Option<&WorkspacePackageGraph>,
+) -> Plan {
     let touched = classify_areas(changed);
     let lanes = pick_lanes(&touched, labels, changed);
     let total: u64 = lanes.iter().map(|l| l.lem).sum();
@@ -674,7 +883,7 @@ pub fn build_plan(changed: &[String], labels: &[String]) -> Plan {
     let risk_packs = pick_risk_packs(changed);
     let (guard, override_labels_present) = guard_verdict(total, labels);
     let classification = build_classification(changed, &touched, labels);
-    let packages = build_packages(changed, &risk_packs);
+    let packages = build_packages(changed, &risk_packs, graph);
     let selected_lanes = selected_lanes(&lanes);
     let skipped_lanes = skipped_lanes(&lanes);
     Plan {
@@ -916,7 +1125,7 @@ pub fn run(
         changed_files(&base, &head)?
     };
 
-    let plan = build_plan(&changed, &labels);
+    let plan = build_plan_with_workspace_metadata(&changed, &labels);
 
     let json = serde_json::to_string_pretty(&plan)?;
     if print_stdout {
@@ -1104,6 +1313,50 @@ mod tests {
         assert!(value.get("labels").is_some());
         assert!(value.get("lanes").is_none());
         assert!(value.get("touched").is_none());
+        assert!(value.pointer("/packages/changed").is_some());
+        assert!(value.pointer("/packages/direct_dependents").is_some());
+        assert!(value.pointer("/packages/canaries").is_some());
+        assert!(value.pointer("/packages/selected").is_some());
+        assert!(value.pointer("/packages/broad_sweep_required").is_some());
+        assert!(value.pointer("/packages/selection_reason").is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn ci_plan_packages_select_changed_dependents_and_canaries() -> Result<()> {
+        let changed = fixture_lines("quantization.txt")?;
+        let graph = workspace_package_graph()?;
+        let plan = build_plan_with_package_graph(&changed, &[], Some(&graph));
+        let selected: BTreeSet<&str> = plan.packages.selected.iter().map(String::as_str).collect();
+
+        assert_eq!(plan.packages.changed, vec!["bitnet-quantization".to_string()]);
+        assert!(!plan.packages.broad_sweep_required);
+        assert!(selected.contains("bitnet-quantization"));
+        assert!(selected.contains("bitnet-models"));
+        assert!(
+            plan.packages.direct_dependents.iter().any(|package| package == "bitnet-models"),
+            "bitnet-models directly depends on bitnet-quantization"
+        );
+        assert!(
+            plan.packages.canaries.iter().any(|package| package == "bitnet-models"),
+            "qk256 risk pack keeps bitnet-models as a canary"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ci_plan_packages_manifest_requires_broad_sweep() -> Result<()> {
+        let changed = fixture_lines("manifest.txt")?;
+        let graph = workspace_package_graph()?;
+        let plan = build_plan_with_package_graph(&changed, &[], Some(&graph));
+
+        assert!(plan.packages.broad_sweep_required);
+        assert!(plan.packages.selected.iter().any(|package| package == "bitnet-common"));
+        assert!(plan.packages.selected.iter().any(|package| package == "bitnet-kernels"));
+        assert_eq!(
+            plan.packages.selection_reason,
+            "broad sweep required for manifest/toolchain/shared-foundation change"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- extend `ci-plan.json` package selection with `selected`, `broad_sweep_required`, and `selection_reason`
- compute direct dependents from `cargo metadata` for Rust-input CI plans
- route CI Core Linux build/test through selected packages when a broad sweep is not required
- fail closed when package selection cannot be proven, including metadata failures, unsupported packages, and unmapped Rust inputs
- update CI docs and add quantization package-selection fixture coverage

## Scope

- CI planning and CI Core routing only
- no branch protection changes
- no runtime behavior, model math, tokenizer, backend, server, hardware, or receipt behavior changes

## Claim boundary

- this PR only changes default CI package selection economics
- it does not weaken selected blocking lanes
- manifest, toolchain, shared-foundation, unsupported-package, and unmapped Rust-input cases keep or force the broad CI Core sweep
- no CUDA, OpenCL, AVX, A770, server, speed, throughput, residency, or model-readiness claim is promoted

## Validation

- `rtk cargo fmt -p xtask -- --check`
- `rtk python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci-core.yml').read_text(encoding='utf-8'))"`
- `rtk git diff --check origin/main`
- `rtk cargo metadata --locked --format-version 1 --no-deps`
- `rtk cargo test --target-dir target-ci-package-select -p xtask --no-default-features ci_plan_packages --locked` timed out locally after 15 minutes with no failure diagnostic while the Windows host had multiple long-running cargo jobs; hosted CI is the authority for the cargo test lane

## Generated files

- none

## Follow-up / supersedes

- supersedes no open PR directly
- follow-up CI economics work should make PR Gate consume the package plan signal, not add broad workflow routing in this PR
