### PR TITLE
test(bitnet): remove dense fixture no-panic debt

### DIFF
--- a/crates/bitnet-models/src/dense_gguf_linear_fixture.rs
+++ b/crates/bitnet-models/src/dense_gguf_linear_fixture.rs
@@ -567,17 +567,16 @@ mod tests {
     use crate::formats::gguf::GgufValue;
 
     #[test]
-    fn qwen_q8_attention_q_fixture_dequantizes_and_computes_cpu_reference() {
+    fn qwen_q8_attention_q_fixture_dequantizes_and_computes_cpu_reference() -> Result<()> {
         let data = build_qwen_gguf(vec![(
             "blk.0.attn_q.weight",
             vec![4, 3],
             GgufTensorType::Q8_0,
             q8_0_blob(0.5, &(1..=12).collect::<Vec<_>>()),
         )]);
-        let reader = GgufReader::new(&data).expect("parse qwen q8 fixture");
+        let reader = GgufReader::new(&data)?;
 
-        let fixture = extract_dense_gguf_linear_fixture(&reader, DenseGgufTensorRole::AttentionQ)
-            .expect("extract linear fixture");
+        let fixture = extract_dense_gguf_linear_fixture(&reader, DenseGgufTensorRole::AttentionQ)?;
 
         assert_eq!(fixture.summary.artifact_kind, DENSE_GGUF_LINEAR_FIXTURE_ARTIFACT_KIND);
         assert_eq!(fixture.summary.model_family, "qwen");
@@ -599,28 +598,27 @@ mod tests {
                 fixture.summary.matrix_rows,
                 fixture.summary.matrix_cols,
                 &fixture.cpu_reference_input
-            )
-            .unwrap()
+            )?
         );
         assert!(fixture.summary.values_materialized_as_f32);
         assert!(fixture.summary.cpu_reference_computed);
         assert!(!fixture.summary.cpu_cuda_parity_claimed);
         assert!(!fixture.summary.dense_gguf_inference_claimed);
         assert!(!fixture.summary.bitnet_packed_i2s_qk256_proof);
+        Ok(())
     }
 
     #[test]
-    fn qwen_q8_sidecar_matvec_matches_eager_f32_fixture() {
+    fn qwen_q8_sidecar_matvec_matches_eager_f32_fixture() -> Result<()> {
         let data = build_qwen_gguf(vec![(
             "blk.0.ffn_down.weight",
             vec![4, 3],
             GgufTensorType::Q8_0,
             q8_0_blob(0.25, &(1..=12).collect::<Vec<_>>()),
         )]);
-        let reader = GgufReader::new(&data).expect("parse qwen q8 fixture");
+        let reader = GgufReader::new(&data)?;
 
-        let sidecar = extract_dense_gguf_q8_linear_sidecar(&reader, DenseGgufTensorRole::MlpDown)
-            .expect("extract q8 sidecar");
+        let sidecar = extract_dense_gguf_q8_linear_sidecar(&reader, DenseGgufTensorRole::MlpDown)?;
 
         assert_eq!(sidecar.summary.artifact_kind, DENSE_GGUF_Q8_LINEAR_SIDECAR_ARTIFACT_KIND);
         assert_eq!(sidecar.summary.tensor_name, "blk.0.ffn_down.weight");
@@ -636,10 +634,11 @@ mod tests {
         assert!(!sidecar.summary.dense_runtime_replaced);
         assert_eq!(sidecar.summary.max_abs_diff_vs_eager_f32, 0.0);
         assert_eq!(sidecar.fused_output, sidecar.eager_output);
+        Ok(())
     }
 
     #[test]
-    fn qwen_q8_sidecar_rejects_non_q8_fixture() {
+    fn qwen_q8_sidecar_rejects_non_q8_fixture() -> Result<()> {
         let values: Vec<f32> = (0..12).map(|idx| idx as f32 / 8.0).collect();
         let data = build_qwen_gguf(vec![(
             "blk.0.ffn_up.weight",
@@ -647,17 +646,23 @@ mod tests {
             GgufTensorType::F16,
             f16_blob(&values),
         )]);
-        let reader = GgufReader::new(&data).expect("parse qwen f16 fixture");
+        let reader = GgufReader::new(&data)?;
 
-        let err = extract_dense_gguf_q8_linear_sidecar(&reader, DenseGgufTensorRole::MlpUp)
-            .unwrap_err()
-            .to_string();
+        let err = match extract_dense_gguf_q8_linear_sidecar(&reader, DenseGgufTensorRole::MlpUp) {
+            Ok(_) => {
+                return Err(BitNetError::Validation(
+                    "expected non-Q8 fixture to be rejected".to_string(),
+                ));
+            }
+            Err(err) => err.to_string(),
+        };
 
         assert!(err.contains("requires tensor type q8_0"), "unexpected error: {err}");
+        Ok(())
     }
 
     #[test]
-    fn qwen_f16_mlp_up_fixture_materializes_cpu_reference() {
+    fn qwen_f16_mlp_up_fixture_materializes_cpu_reference() -> Result<()> {
         let values: Vec<f32> = (0..12).map(|idx| idx as f32 / 8.0).collect();
         let data = build_qwen_gguf(vec![(
             "blk.0.ffn_up.weight",
@@ -665,16 +670,16 @@ mod tests {
             GgufTensorType::F16,
             f16_blob(&values),
         )]);
-        let reader = GgufReader::new(&data).expect("parse qwen f16 fixture");
+        let reader = GgufReader::new(&data)?;
 
-        let fixture = extract_dense_gguf_linear_fixture(&reader, DenseGgufTensorRole::MlpUp)
-            .expect("extract f16 fixture");
+        let fixture = extract_dense_gguf_linear_fixture(&reader, DenseGgufTensorRole::MlpUp)?;
 
         assert_eq!(fixture.summary.tensor_type, "f16");
         assert_eq!(fixture.summary.matrix_rows, 3);
         assert_eq!(fixture.summary.matrix_cols, 4);
         assert_eq!(fixture.summary.value_count, 12);
         assert_eq!(fixture.cpu_reference_output.len(), 3);
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-models/tests/qk256_property_tests.rs
+++ b/crates/bitnet-models/tests/qk256_property_tests.rs
@@ -150,7 +150,10 @@ proptest! {
         input in random_input_vector(QK256_BLOCK),
     ) {
         let packed_vec = pack_qk256_row_codes(&codes, QK256_BLOCK);
-        let packed: [u8; QK256_PACKED_BYTES] = packed_vec.try_into().unwrap();
+        let packed: [u8; QK256_PACKED_BYTES] = packed_vec
+            .as_slice()
+            .try_into()
+            .map_err(|_| TestCaseError::fail("packed QK256 row length mismatch"))?;
 
         // Compute QK256 result
         let qk256_result = gemv_qk256_row(&packed, &input, QK256_BLOCK);
@@ -179,7 +182,10 @@ proptest! {
         cols in 1usize..=255, // Tail only (< QK256_BLOCK)
     ) {
         let packed_vec = pack_qk256_row_codes(&codes, QK256_BLOCK);
-        let packed: [u8; QK256_PACKED_BYTES] = packed_vec.try_into().unwrap();
+        let packed: [u8; QK256_PACKED_BYTES] = packed_vec
+            .as_slice()
+            .try_into()
+            .map_err(|_| TestCaseError::fail("packed QK256 row length mismatch"))?;
 
         // Compute QK256 result with limited cols
         let qk256_result = gemv_qk256_row(&packed, &input, cols);


### PR DESCRIPTION
## Summary

- replace new dense GGUF fixture test `expect`/`unwrap_err` calls with `Result` propagation and explicit error handling
- replace the new QK256 property-test `unwrap` calls with `TestCaseError`
- unblock the no-panic family policy gate without changing runtime/model behavior

## Claim boundary

Test/policy debt cleanup only. No runtime math, tokenizer, backend, model-support, A770, residency, speed, or product-readiness claim is promoted.

## Validation

- PASS: `rustfmt --edition 2024 --check --config skip_children=true crates/bitnet-models/src/dense_gguf_linear_fixture.rs crates/bitnet-models/tests/qk256_property_tests.rs`
- PASS: `git diff --check HEAD~1..HEAD`
- GAP: `cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target\codex-no-panic-reports` timed out locally after 5 minutes with no failure output; the two cargo processes from that run were stopped
- Pending: hosted Policy/no-panic gate on head `c75b180f3`