### PR TITLE
ci(pr-plan): fail closed for package selection

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -390,7 +390,7 @@ jobs:
           }
           supported = cpu_feature_packages | default_feature_packages | no_feature_packages
           unsupported = [package for package in selected if package not in supported]
-          broad = bool(packages.get("broad_sweep_required")) or bool(unsupported)
+          broad = bool(packages.get("broad_sweep_required")) or bool(unsupported) or not selected
           if os.environ.get("EVENT_NAME") != "pull_request" and not selected:
               broad = True
 

--- a/xtask/src/ci/plan.rs
+++ b/xtask/src/ci/plan.rs
@@ -791,6 +791,7 @@ fn broad_sweep_required(changed: &[String], changed_packages: &BTreeSet<String>)
 
     manifest_or_toolchain_changed(changed)
         || changed.iter().any(|path| path.starts_with(".cargo/") || path == "build.rs")
+        || (changed.iter().any(|path| is_rust_input_path(path)) && changed_packages.is_empty())
         || changed_packages
             .iter()
             .any(|package| SHARED_FOUNDATION_PACKAGES.contains(&package.as_str()))
@@ -862,13 +863,13 @@ pub fn build_plan(changed: &[String], labels: &[String]) -> Plan {
     build_plan_with_package_graph(changed, labels, None)
 }
 
-fn build_plan_with_workspace_metadata(changed: &[String], labels: &[String]) -> Plan {
+fn build_plan_with_workspace_metadata(changed: &[String], labels: &[String]) -> Result<Plan> {
     let graph = if changed.iter().any(|path| is_rust_input_path(path)) {
-        workspace_package_graph().ok()
+        Some(workspace_package_graph()?)
     } else {
         None
     };
-    build_plan_with_package_graph(changed, labels, graph.as_ref())
+    Ok(build_plan_with_package_graph(changed, labels, graph.as_ref()))
 }
 
 fn build_plan_with_package_graph(
@@ -1125,7 +1126,7 @@ pub fn run(
         changed_files(&base, &head)?
     };
 
-    let plan = build_plan_with_workspace_metadata(&changed, &labels);
+    let plan = build_plan_with_workspace_metadata(&changed, &labels)?;
 
     let json = serde_json::to_string_pretty(&plan)?;
     if print_stdout {
@@ -1353,6 +1354,25 @@ mod tests {
         assert!(plan.packages.broad_sweep_required);
         assert!(plan.packages.selected.iter().any(|package| package == "bitnet-common"));
         assert!(plan.packages.selected.iter().any(|package| package == "bitnet-kernels"));
+        assert_eq!(
+            plan.packages.selection_reason,
+            "broad sweep required for manifest/toolchain/shared-foundation change"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ci_plan_packages_unmapped_rust_input_requires_broad_sweep() -> Result<()> {
+        let graph = workspace_package_graph()?;
+        let plan = build_plan_with_package_graph(
+            &s(&["scripts/off-workspace-helper.rs"]),
+            &[],
+            Some(&graph),
+        );
+
+        assert!(plan.packages.changed.is_empty());
+        assert!(plan.packages.broad_sweep_required);
+        assert!(plan.packages.selected.iter().any(|package| package == "bitnet-common"));
         assert_eq!(
             plan.packages.selection_reason,
             "broad sweep required for manifest/toolchain/shared-foundation change"


### PR DESCRIPTION
## Summary

- fail closed when CI package selection cannot prove a safe narrow package set
- require `cargo metadata` success for Rust-input package selection instead of silently dropping direct dependents
- force a broad CI Core sweep for unmapped Rust inputs and empty selected package sets
- add regression coverage for an unmapped Rust input path

## Scope

- CI planning and CI Core routing only
- no branch protection changes
- no runtime behavior, model math, tokenizer, backend, server, hardware, or receipt behavior changes

## Claim boundary

- this PR tightens the package-scoped CI selection introduced by #5805
- it preserves the broad sweep when narrow package selection is uncertain
- no CUDA, OpenCL, AVX, A770, server, speed, throughput, residency, or model-readiness claim is promoted

## Validation

- `rtk cargo fmt -p xtask -- --check`
- `rtk python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci-core.yml').read_text(encoding='utf-8'))"`
- `rtk git diff --check origin/main...HEAD`
- `rtk cargo metadata --locked --format-version 1 --no-deps`
- `rtk cargo test --target-dir target-ci-package-select -p xtask --no-default-features ci_plan_packages --locked` was attempted before this follow-up branch and timed out locally after 15 minutes with no failure diagnostic while the Windows host had multiple long-running cargo jobs; hosted CI is the authority for the cargo test lane

## Generated files

- none

## Follow-up / supersedes

- follows #5805
- supersedes no open PR directly
