### PR TITLE
test(receipts): remove cli m4 no-panic debt

### DIFF
--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -1432,8 +1432,9 @@ fn mac_ask_help_documents_positional_question() {
 }
 
 #[test]
-fn mac_ask_accepts_positional_question_and_progress_flags_before_cache_lookup() {
-    let dir = tempfile::tempdir().expect("tempdir");
+fn mac_ask_accepts_positional_question_and_progress_flags_before_cache_lookup()
+-> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
     let cache = dir.path().join("models");
     let cache_str = cache.to_string_lossy().into_owned();
 
@@ -1453,6 +1454,7 @@ fn mac_ask_accepts_positional_question_and_progress_flags_before_cache_lookup() 
         .stderr(predicate::str::contains("bitnet mac models --cache-dir"))
         .stderr(predicate::str::contains("Disk guidance:"))
         .stderr(predicate::str::contains("unexpected argument").not());
+    Ok(())
 }
 
 #[test]
@@ -2235,7 +2237,10 @@ fn mac_receipts_check_rejects_bitnet_serve_gate_missing_fallback_state()
 
     let mut receipt_json: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&gate_receipt)?)?;
-    receipt_json.as_object_mut().unwrap().remove("fallback_used");
+    receipt_json
+        .as_object_mut()
+        .ok_or_else(|| "gate receipt must be a JSON object".to_string())?
+        .remove("fallback_used");
     std::fs::write(&gate_receipt, serde_json::to_vec_pretty(&receipt_json)?)?;
 
     bitnet()
@@ -3999,8 +4004,9 @@ fn mac_receipts_check_accepts_golden_smoke_receipt() -> Result<(), Box<dyn std::
 }
 
 #[test]
-fn mac_receipts_check_accepts_bitnet_warm_session_receipt() {
-    let dir = tempfile::tempdir().expect("tempdir");
+fn mac_receipts_check_accepts_bitnet_warm_session_receipt() -> Result<(), Box<dyn std::error::Error>>
+{
+    let dir = tempfile::tempdir()?;
     let receipt_path = dir.path().join("bitnet-warm.json");
     let prompt = "Answer with a single digit: 2+2=";
     let prompts = serde_json::json!([
@@ -4168,10 +4174,8 @@ fn mac_receipts_check_accepts_bitnet_warm_session_receipt() {
             "bitnet_quality_claimed": false,
             "broad_performance_claim": false,
             "speedup_claim": false
-        }))
-        .expect("json"),
-    )
-    .expect("write receipt");
+        }))?,
+    )?;
     let receipt_str = receipt_path.to_string_lossy().into_owned();
 
     bitnet()
@@ -4181,6 +4185,7 @@ fn mac_receipts_check_accepts_bitnet_warm_session_receipt() {
         .stdout(predicate::str::contains("bitnet_apple_m4_warm_session"))
         .stdout(predicate::str::contains("\"prompt_count\": 3"))
         .stdout(predicate::str::contains("\"passed\": true"));
+    Ok(())
 }
 
 #[test]
@@ -4810,14 +4815,17 @@ fn mac_receipts_check_accepts_dense_slm_quality_corpus_gate() {
 }
 
 #[test]
-fn mac_receipts_check_rejects_warm_session_missing_generated_token_ids() {
-    let dir = tempfile::tempdir().expect("tempdir");
+fn mac_receipts_check_rejects_warm_session_missing_generated_token_ids()
+-> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
     let receipt_path = dir.path().join("warm-missing-generated-ids.json");
     let mut receipt = dense_quality_warm_session_receipt();
-    receipt["prompts"][0].as_object_mut().unwrap().remove("generated_token_ids");
-    receipt["prompts"][0].as_object_mut().unwrap().remove("tokens");
-    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt).expect("json"))
-        .expect("write receipt");
+    let prompt = receipt["prompts"][0]
+        .as_object_mut()
+        .ok_or_else(|| "prompt receipt entry must be a JSON object".to_string())?;
+    prompt.remove("generated_token_ids");
+    prompt.remove("tokens");
+    std::fs::write(&receipt_path, serde_json::to_vec_pretty(&receipt)?)?;
     let receipt_str = receipt_path.to_string_lossy().into_owned();
 
     bitnet()
@@ -4825,6 +4833,7 @@ fn mac_receipts_check_rejects_warm_session_missing_generated_token_ids() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("generated token IDs"));
+    Ok(())
 }
 
 #[test]

--- a/crates/bitnet-receipts/tests/m4_run_identity_validation.rs
+++ b/crates/bitnet-receipts/tests/m4_run_identity_validation.rs
@@ -104,8 +104,8 @@ fn accepts_m4_excellence_receipt_family_contracts() {
         ("bitnet_apple_m4_mac_ask_failure", "bitnet_failure", "mac ask"),
     ] {
         let receipt = receipt_for_family(artifact_kind, evidence_family, command_class);
-        validate_m4_run_identity_contract_json(&receipt)
-            .unwrap_or_else(|err| panic!("{artifact_kind} should validate: {err}"));
+        let validation = validate_m4_run_identity_contract_json(&receipt);
+        assert!(validation.is_ok(), "{artifact_kind} should validate: {validation:?}");
     }
 }
 
@@ -145,7 +145,11 @@ fn rejects_invalid_model_sha() {
 #[test]
 fn rejects_missing_tokenizer_authority() {
     let mut receipt = valid_receipt();
-    receipt["run_identity"]["tokenizer"].as_object_mut().unwrap().remove("authority");
+    let tokenizer = receipt["run_identity"]["tokenizer"].as_object_mut();
+    assert!(tokenizer.is_some(), "tokenizer identity must be an object");
+    if let Some(tokenizer) = tokenizer {
+        tokenizer.remove("authority");
+    }
     refresh_run_identity_digest(&mut receipt);
 
     let err = validate_m4_run_identity_contract_json(&receipt).unwrap_err().to_string();
@@ -155,7 +159,11 @@ fn rejects_missing_tokenizer_authority() {
 #[test]
 fn rejects_missing_tokenizer_sha() {
     let mut receipt = valid_receipt();
-    receipt["run_identity"]["tokenizer"].as_object_mut().unwrap().remove("sha256");
+    let tokenizer = receipt["run_identity"]["tokenizer"].as_object_mut();
+    assert!(tokenizer.is_some(), "tokenizer identity must be an object");
+    if let Some(tokenizer) = tokenizer {
+        tokenizer.remove("sha256");
+    }
     refresh_run_identity_digest(&mut receipt);
 
     let err = validate_m4_run_identity_contract_json(&receipt).unwrap_err().to_string();
@@ -175,7 +183,11 @@ fn rejects_backend_mismatch() {
 #[test]
 fn rejects_missing_identity_fallback_state() {
     let mut receipt = valid_receipt();
-    receipt["run_identity"]["backend"].as_object_mut().unwrap().remove("fallback_used");
+    let backend = receipt["run_identity"]["backend"].as_object_mut();
+    assert!(backend.is_some(), "backend identity must be an object");
+    if let Some(backend) = backend {
+        backend.remove("fallback_used");
+    }
     refresh_run_identity_digest(&mut receipt);
 
     let err = validate_m4_run_identity_contract_json(&receipt).unwrap_err().to_string();


### PR DESCRIPTION
## Summary

Removes the no-panic-family debt that hosted Policy reported on #5817. This is split out so the QK256 fallback-scale port does not carry unrelated test cleanup.

- Converts the newly reported CLI/M4 receipt test `expect`/`unwrap` sites to `Result` propagation or checked object mutation.
- Replaces the direct `panic!` validation helper with an `assert!` on the validation result.
- Leaves runtime behavior unchanged.

## Validation

- PASS: `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_ask_accepts_positional_question_and_progress_flags_before_cache_lookup -- --nocapture`
- PASS: `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_receipts_check_accepts_bitnet_warm_session_receipt -- --nocapture`
- PASS: `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_receipts_check_rejects_warm_session_missing_generated_token_ids -- --nocapture`
- PASS: `cargo test --locked -p bitnet-receipts --test m4_run_identity_validation -- --nocapture`
- PASS: `rustfmt --edition 2024 --check crates\bitnet-cli\tests\cli_arg_tests.rs crates\bitnet-receipts\tests\m4_run_identity_validation.rs`
- PASS: `git diff --check`

## Local note

`cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target\codex-no-panic-cli-m4-receipt-tests` timed out locally after 10 minutes without failure output. The two cargo processes from that run were stopped. Hosted Policy is the authoritative no-panic signal for this PR.

## Claim boundary

Test-policy cleanup only. No runtime, model, A770, quality, speed, residency, or completion claim changes.