### PR TITLE
server: accept Qwen3 dense smoke receipts

### DIFF
--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -316,10 +316,31 @@ fn validate_dense_qwen_server_shared_engine_receipt(
     receipt: &Value,
     model_identity: &Value,
 ) -> Result<()> {
-    require_string_eq(model_identity, "model_id", QWEN25_05B_INSTRUCT_Q8_0_MODEL_ID)?;
-    require_string_eq(model_identity, "model_sha256", QWEN25_05B_INSTRUCT_Q8_0_MODEL_SHA256)?;
-    require_string_eq(receipt, "model_sha256", QWEN25_05B_INSTRUCT_Q8_0_MODEL_SHA256)?;
-    require_string_eq(receipt, "model_coverage_row", "dense_qwen25_05b_q8_cuda")?;
+    let (model_id, model_sha256, model_coverage_row) = match required_string(
+        model_identity,
+        "model_id",
+    )? {
+        QWEN25_05B_INSTRUCT_Q8_0_MODEL_ID => (
+            QWEN25_05B_INSTRUCT_Q8_0_MODEL_ID,
+            QWEN25_05B_INSTRUCT_Q8_0_MODEL_SHA256,
+            "dense_qwen25_05b_q8_cuda",
+        ),
+        QWEN3_06B_INSTRUCT_Q8_0_MODEL_ID => (
+            QWEN3_06B_INSTRUCT_Q8_0_MODEL_ID,
+            QWEN3_06B_INSTRUCT_Q8_0_MODEL_SHA256,
+            "dense_qwen3_06b_q8_candidate",
+        ),
+        model_id => {
+            return Err(anyhow!(
+                "dense server shared-engine receipt model_id `{model_id}` is not an accepted exact-profile dense Qwen model"
+            ));
+        }
+    };
+
+    require_string_eq(model_identity, "model_id", model_id)?;
+    require_string_eq(model_identity, "model_sha256", model_sha256)?;
+    require_string_eq(receipt, "model_sha256", model_sha256)?;
+    require_string_eq(receipt, "model_coverage_row", model_coverage_row)?;
     require_string_eq(receipt, "model_coverage_tier", "product_cli_ready")?;
     require_bool_eq(receipt, "dense_regular_llm_cuda_inference_claimed", true)?;
     require_bool_eq(receipt, "bitnet_packed_i2s_qk256_proof", false)?;

--- a/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
+++ b/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
@@ -102,6 +102,22 @@ fn server_shared_engine_chat_completion_receipt() -> Value {
     })
 }
 
+fn qwen3_server_shared_engine_chat_completion_receipt() -> Value {
+    let mut receipt = server_shared_engine_chat_completion_receipt();
+    receipt["model_identity"]["model_id"] = json!("qwen3-0.6b-instruct-q8_0");
+    receipt["model_identity"]["requested_model"] = json!("qwen3-0.6b-instruct-q8_0");
+    receipt["model_identity"]["active_model_path"] =
+        json!("models/qwen3-0.6b-instruct-q8_0/Qwen3-0.6B-Q8_0.gguf");
+    receipt["model_identity"]["model_sha256"] =
+        json!("9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031");
+    receipt["requested_model"] = json!("qwen3-0.6b-instruct-q8_0");
+    receipt["active_model_path"] = json!("models/qwen3-0.6b-instruct-q8_0/Qwen3-0.6B-Q8_0.gguf");
+    receipt["model_sha256"] =
+        json!("9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031");
+    receipt["model_coverage_row"] = json!("dense_qwen3_06b_q8_candidate");
+    receipt
+}
+
 fn bitnet_qk256_server_smoke_receipt() -> Value {
     json!({
         "receipt_kind": "server_shared_engine_chat_completion",
@@ -295,6 +311,19 @@ fn server_shared_engine_chat_completion_receipt_validates() {
 }
 
 #[test]
+fn qwen3_server_shared_engine_chat_completion_receipt_validates_without_readiness_claim() {
+    let receipt = qwen3_server_shared_engine_chat_completion_receipt();
+
+    assert!(validate_server_shared_engine_chat_completion_receipt_json(&receipt).is_ok());
+    assert_eq!(receipt["model_coverage_row"], "dense_qwen3_06b_q8_candidate");
+    assert_eq!(receipt["server_ready_claimed"], false);
+    assert_eq!(receipt["speedup_claim"], false);
+    assert_eq!(receipt["full_cuda_residency_claimed"], false);
+    assert_eq!(receipt["dense_regular_llm_cuda_inference_claimed"], true);
+    assert_eq!(receipt["bitnet_packed_i2s_qk256_proof"], false);
+}
+
+#[test]
 fn bitnet_qk256_server_smoke_receipt_validates() {
     let receipt = bitnet_qk256_server_smoke_receipt();
 
@@ -446,14 +475,18 @@ fn server_shared_engine_chat_completion_receipt_rejects_inconsistent_model_ident
 
 #[test]
 fn server_shared_engine_chat_completion_receipt_rejects_wrong_dense_model_scope() {
+    let mut receipt = qwen3_server_shared_engine_chat_completion_receipt();
+    receipt["model_coverage_row"] = json!("dense_qwen25_05b_q8_cuda");
+
+    assert!(validate_server_shared_engine_chat_completion_receipt_json(&receipt).is_err());
+}
+
+#[test]
+fn server_shared_engine_chat_completion_receipt_rejects_unknown_dense_model_scope() {
     let mut receipt = server_shared_engine_chat_completion_receipt();
-    receipt["model_identity"]["model_id"] = json!("qwen3-0.6b-instruct-q8_0");
-    receipt["model_identity"]["requested_model"] = json!("qwen3-0.6b-instruct-q8_0");
-    receipt["requested_model"] = json!("qwen3-0.6b-instruct-q8_0");
-    receipt["model_identity"]["model_sha256"] =
-        json!("9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031");
-    receipt["model_sha256"] =
-        json!("9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031");
+    receipt["model_identity"]["model_id"] = json!("smollm2-360m-instruct");
+    receipt["model_identity"]["requested_model"] = json!("smollm2-360m-instruct");
+    receipt["requested_model"] = json!("smollm2-360m-instruct");
     receipt["model_coverage_row"] = json!("dense_qwen3_06b_q8_candidate");
 
     assert!(validate_server_shared_engine_chat_completion_receipt_json(&receipt).is_err());

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -81,6 +81,9 @@ use monitoring::{
 const DENSE_QWEN25_Q8_MODEL_ID: &str = "qwen2.5-0.5b-instruct-q8_0";
 const DENSE_QWEN25_Q8_MODEL_SHA256: &str =
     "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e";
+const DENSE_QWEN3_Q8_MODEL_ID: &str = "qwen3-0.6b-instruct-q8_0";
+const DENSE_QWEN3_Q8_MODEL_SHA256: &str =
+    "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031";
 const BITNET_QK256_MODEL_ID: &str = "microsoft-bitnet-b1.58-2B-4T-i2s";
 const BITNET_QK256_MODEL_SHA256: &str =
     "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162";
@@ -1400,7 +1403,7 @@ fn server_receipt_route(
     active_model: &model_manager::ModelMetadata,
 ) -> String {
     if matches!(configured_device, DeviceConfig::NvidiaRtx5070TiCuda)
-        && is_dense_qwen25_q8_model(request, active_model)
+        && dense_qwen_server_coverage_for_request(request, active_model).is_some()
     {
         DENSE_QWEN_ROUTE.to_string()
     } else if matches!(configured_device, DeviceConfig::NvidiaRtx5070TiCuda)
@@ -1417,12 +1420,10 @@ fn server_receipt_model_coverage(
     request: &ChatCompletionRequest,
     active_model: &model_manager::ModelMetadata,
 ) -> Option<ServerReceiptModelCoverage> {
-    if route == DENSE_QWEN_ROUTE && is_dense_qwen25_q8_model(request, active_model) {
-        return Some(ServerReceiptModelCoverage {
-            row: "dense_qwen25_05b_q8_cuda",
-            tier: "product_cli_ready",
-            route: DENSE_QWEN_ROUTE,
-        });
+    if route == DENSE_QWEN_ROUTE {
+        if let Some(coverage) = dense_qwen_server_coverage_for_request(request, active_model) {
+            return Some(coverage);
+        }
     }
     if route == BITNET_QK256_ROUTE && is_official_bitnet_qk256_model(request, active_model) {
         return Some(ServerReceiptModelCoverage {
@@ -1459,6 +1460,19 @@ fn server_model_coverage_for_active_model(
         && active_model
             .model_sha256
             .as_deref()
+            .is_some_and(|sha256| sha256.eq_ignore_ascii_case(DENSE_QWEN3_Q8_MODEL_SHA256))
+    {
+        return Some(ServerReceiptModelCoverage {
+            row: "dense_qwen3_06b_q8_candidate",
+            tier: "product_cli_ready",
+            route: DENSE_QWEN_ROUTE,
+        });
+    }
+
+    if active_model_device_is_cuda(active_model)
+        && active_model
+            .model_sha256
+            .as_deref()
             .is_some_and(|sha256| sha256.eq_ignore_ascii_case(BITNET_QK256_MODEL_SHA256))
     {
         return Some(ServerReceiptModelCoverage {
@@ -1471,16 +1485,36 @@ fn server_model_coverage_for_active_model(
     None
 }
 
-fn is_dense_qwen25_q8_model(
+fn dense_qwen_server_coverage_for_request(
     request: &ChatCompletionRequest,
     active_model: &model_manager::ModelMetadata,
-) -> bool {
-    request.model == DENSE_QWEN25_Q8_MODEL_ID
-        && active_model_device_is_cuda(active_model)
-        && active_model
-            .model_sha256
-            .as_deref()
-            .is_some_and(|sha256| sha256.eq_ignore_ascii_case(DENSE_QWEN25_Q8_MODEL_SHA256))
+) -> Option<ServerReceiptModelCoverage> {
+    if !active_model_device_is_cuda(active_model) {
+        return None;
+    }
+    let sha256 = active_model.model_sha256.as_deref()?;
+
+    if request.model == DENSE_QWEN25_Q8_MODEL_ID
+        && sha256.eq_ignore_ascii_case(DENSE_QWEN25_Q8_MODEL_SHA256)
+    {
+        return Some(ServerReceiptModelCoverage {
+            row: "dense_qwen25_05b_q8_cuda",
+            tier: "product_cli_ready",
+            route: DENSE_QWEN_ROUTE,
+        });
+    }
+
+    if request.model == DENSE_QWEN3_Q8_MODEL_ID
+        && sha256.eq_ignore_ascii_case(DENSE_QWEN3_Q8_MODEL_SHA256)
+    {
+        return Some(ServerReceiptModelCoverage {
+            row: "dense_qwen3_06b_q8_candidate",
+            tier: "product_cli_ready",
+            route: DENSE_QWEN_ROUTE,
+        });
+    }
+
+    None
 }
 
 fn is_official_bitnet_qk256_model(
@@ -2076,6 +2110,49 @@ mod tests {
         )
     }
 
+    fn qwen3_server_receipt(request_id: &str) -> super::ServerSharedEngineReceipt {
+        let request = ChatCompletionRequest {
+            model: "qwen3-0.6b-instruct-q8_0".to_string(),
+            messages: vec![ChatCompletionMessage {
+                role: "user".to_string(),
+                content: "Say OK.".to_string(),
+            }],
+            max_tokens: Some(2),
+            temperature: Some(0.0),
+            top_p: Some(1.0),
+            stream: Some(false),
+        };
+        let usage =
+            ChatCompletionUsage { prompt_tokens: 15, completion_tokens: 1, total_tokens: 16 };
+        let metadata = ModelMetadata {
+            model_id: "qwen3-0.6b-instruct-q8_0".to_string(),
+            model_path: "models/Qwen3-0.6B-Q8_0.gguf".to_string(),
+            model_sha256: Some(
+                "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031".to_string(),
+            ),
+            device: "Cuda(0)".to_string(),
+            quantization_type: "Q8_0".to_string(),
+            loaded_at: SystemTime::UNIX_EPOCH,
+            size_mb: 620,
+            parameters: 600_000_000,
+            context_length: 32_768,
+            inference_count: 0,
+            avg_tokens_per_second: 0.0,
+        };
+
+        build_server_shared_engine_receipt(
+            request_id,
+            &request,
+            &metadata,
+            &DeviceConfig::NvidiaRtx5070TiCuda,
+            "chatml",
+            &usage,
+            "OK",
+            31,
+            None,
+        )
+    }
+
     #[tokio::test]
     async fn server_receipt_store_exports_latest_and_by_id() {
         let store = ServerReceiptStore::default();
@@ -2292,6 +2369,53 @@ mod tests {
     }
 
     #[test]
+    fn server_readiness_links_qwen3_model_coverage_without_server_claims()
+    -> Result<(), &'static str> {
+        let response = build_server_readiness_response(
+            ModelMemoryStats {
+                total_models: 1,
+                total_size_mb: 620,
+                active_model_id: Some("model-1".to_string()),
+                cache_size_limit: 3,
+                memory_limit_gb: Some(16.0),
+            },
+            Some(ModelMetadata {
+                model_id: "model-1".to_string(),
+                model_path: "models/Qwen3-0.6B-Q8_0.gguf".to_string(),
+                model_sha256: Some(
+                    "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031".to_string(),
+                ),
+                device: "Cuda(0)".to_string(),
+                quantization_type: "Q8_0".to_string(),
+                loaded_at: SystemTime::UNIX_EPOCH,
+                size_mb: 620,
+                parameters: 600_000_000,
+                context_length: 32_768,
+                inference_count: 0,
+                avg_tokens_per_second: 0.0,
+            }),
+            true,
+            "nvidia-rtx-5070-ti-cuda".to_string(),
+            &DeviceConfig::NvidiaRtx5070TiCuda,
+            false,
+            Vec::new(),
+            Some("nvidia-rtx-5070-ti-cuda".to_string()),
+        );
+
+        let active_model = response.model.active_model.as_ref().ok_or("active model")?;
+        assert_eq!(
+            active_model.model_coverage_row.as_deref(),
+            Some("dense_qwen3_06b_q8_candidate")
+        );
+        assert_eq!(active_model.model_coverage_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(active_model.selected_route.as_deref(), Some("dense_regular_llm_cuda"));
+        assert!(!response.claim_boundary.server_ready_claimed);
+        assert!(!response.claim_boundary.speedup_claim);
+        assert!(!response.claim_boundary.full_cuda_residency_claimed);
+        Ok(())
+    }
+
+    #[test]
     fn server_shared_engine_renders_qwen_chatml_prompt() {
         let request = ChatCompletionRequest {
             model: "qwen2.5-0.5b-instruct-q8_0".to_string(),
@@ -2490,6 +2614,36 @@ mod tests {
         assert_eq!(metadata.latest_receipt_path, "/receipts/latest");
         assert_eq!(metadata.readiness_path, "/readiness");
         assert_eq!(metadata.model_coverage_row.as_deref(), Some("dense_qwen25_05b_q8_cuda"));
+        assert_eq!(metadata.model_coverage_tier.as_deref(), Some("product_cli_ready"));
+        assert_eq!(metadata.selected_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(metadata.selected_route, "dense_regular_llm_cuda");
+        assert!(!metadata.fallback_used);
+    }
+
+    #[test]
+    fn server_shared_engine_receipt_records_qwen3_dense_smoke_boundary() {
+        let receipt = qwen3_server_receipt("qwen3-request-1");
+
+        assert_eq!(receipt.selected_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(receipt.runtime_api, "cuda");
+        assert_eq!(receipt.model_identity.model_id, "qwen3-0.6b-instruct-q8_0");
+        assert_eq!(receipt.requested_backend, "nvidia-rtx-5070-ti-cuda");
+        assert_eq!(receipt.selected_route, "dense_regular_llm_cuda");
+        assert_eq!(receipt.model_coverage_row.as_deref(), Some("dense_qwen3_06b_q8_candidate"));
+        assert_eq!(receipt.model_coverage_tier.as_deref(), Some("product_cli_ready"));
+        assert!(!receipt.fallback_used);
+        assert!(receipt.generated_text_non_empty);
+        assert!(receipt.quality_gate.passed);
+        assert!(receipt.server_smoke_response_claimed);
+        assert!(!receipt.server_ready_claimed);
+        assert!(!receipt.speedup_claim);
+        assert!(!receipt.full_cuda_residency_claimed);
+        assert!(receipt.dense_regular_llm_cuda_inference_claimed);
+        assert!(!receipt.bitnet_packed_i2s_qk256_proof);
+
+        let metadata = ChatCompletionResponseMetadata::from_receipt(&receipt);
+        assert_eq!(metadata.receipt_id, "qwen3-request-1");
+        assert_eq!(metadata.model_coverage_row.as_deref(), Some("dense_qwen3_06b_q8_candidate"));
         assert_eq!(metadata.model_coverage_tier.as_deref(), Some("product_cli_ready"));
         assert_eq!(metadata.selected_backend, "nvidia-rtx-5070-ti-cuda");
         assert_eq!(metadata.selected_route, "dense_regular_llm_cuda");


### PR DESCRIPTION
## Summary

- accept exact Qwen3 0.6B Q8_0 dense CUDA server-smoke receipts in the shared-engine receipt validator
- map exact Qwen3 artifact evidence to `dense_qwen3_06b_q8_candidate` when the selected server route is `dense_regular_llm_cuda`
- add server/readiness/receipt tests proving Qwen3 smoke evidence does not promote server readiness, speedup, full residency, Qwen2.5 inheritance, or BitNet QK256 proof

## Scope

- receipt validation and server shared-engine metadata only
- exact Qwen3 Q8_0 artifact SHA and dense CUDA route only
- no live server receipt is added in this PR
- no tokenizer, prompt, model math, kernel, backend dispatch, performance, or residency implementation change

## Claim boundary

- Qwen3 remains `product_cli_ready` only because current main already contains the ask/chat user-path promotion review and committed receipts
- this PR records server smoke compatibility only
- `server_ready_claimed=false`
- `speedup_claim=false`
- `full_cuda_residency_claimed=false`
- `bitnet_packed_i2s_qk256_proof=false`
- Qwen2.5 receipts do not prove Qwen3, and Qwen3 dense CUDA receipts do not prove BitNet QK256

## Validation

- `rtk cargo fmt -p bitnet-server -p bitnet-receipts-core -- --check`
- `rtk git diff --check origin/main...HEAD`
- hosted CI is the authority for cargo test lanes because this Windows host currently has unrelated long-running cargo jobs

## Generated files

- none

## Follow-up / supersedes

- follows the Qwen3 ask/chat product CLI promotion receipts already on main
- does not supersede any diagnostic branch-chain PR
