### PR TITLE
loader(gguf): trim non-qk i2s padding

### DIFF
--- a/crates/bitnet-models/src/formats/gguf/loader/tensor_loading.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader/tensor_loading.rs
@@ -147,7 +147,26 @@ fn load_i2s_tensor(
         return load_qk256_tensor(info, data, candle_device, model_config);
     }
 
-    load_dequantized_i2s_tensor(info, data, candle_device, policy_plan)
+    let logical_size = flavor.logical_size_bytes(nelems);
+    if data.len() < logical_size {
+        return Err(BitNetError::Validation(format!(
+            "I2_S '{}': available bytes {} shorter than logical {} for {:?}",
+            info.name,
+            data.len(),
+            logical_size,
+            flavor
+        )));
+    }
+    let logical_data = &data[..logical_size];
+    if data.len() > logical_size {
+        tracing::debug!(
+            "I2_S '{}': trimming {} GGUF alignment padding bytes before decode",
+            info.name,
+            data.len() - logical_size
+        );
+    }
+
+    load_dequantized_i2s_tensor(info, logical_data, candle_device, policy_plan)
 }
 
 fn validate_i2s_can_be_quantized(info: &TensorInfo) -> Result<()> {

--- a/crates/bitnet-models/src/formats/gguf/types.rs
+++ b/crates/bitnet-models/src/formats/gguf/types.rs
@@ -834,6 +834,12 @@ impl I2SFlavor {
         }
     }
 
+    /// Get the logical tensor byte count for this flavor, excluding trailing
+    /// GGUF alignment padding between tensors.
+    pub fn logical_size_bytes(&self, nelems: usize) -> usize {
+        nelems.div_ceil(self.block_size()) * self.total_bytes_per_block()
+    }
+
     /// Convert to legacy I2SLayoutKind for backward compatibility
     pub fn to_layout_kind(&self) -> I2SLayoutKind {
         match self {
@@ -1323,5 +1329,31 @@ mod tests {
         assert_eq!(align_up(31, 32), 32);
         assert_eq!(align_up(32, 32), 32);
         assert_eq!(align_up(33, 32), 64);
+    }
+
+    #[test]
+    fn i2s_flavor_accepts_strict_gguf_alignment_padding() {
+        let nelems = 256 * 256;
+        let logical = I2SFlavor::GgmlQk256NoScale.logical_size_bytes(nelems);
+        let info = TensorInfo {
+            name: "blk.0.ffn_down.weight".to_string(),
+            shape: vec![256, 256],
+            tensor_type: GgufTensorType::I2_S,
+            offset: 0,
+            size: (logical + 32) as u64,
+        };
+
+        temp_env::with_var("BITNET_STRICT_MODE", Some("1"), || {
+            let flavor = detect_i2s_flavor(&info, false, nelems).expect("alignment padding");
+            assert_eq!(flavor, I2SFlavor::GgmlQk256NoScale);
+        });
+    }
+
+    #[test]
+    fn i2s_logical_size_excludes_padding() {
+        let nelems = 256 * 256;
+        assert_eq!(I2SFlavor::GgmlQk256NoScale.logical_size_bytes(nelems), 16_384);
+        assert_eq!(I2SFlavor::BitNet32F16.logical_size_bytes(nelems), 20_480);
+        assert_eq!(I2SFlavor::Split32WithSibling.logical_size_bytes(nelems), 16_384);
     }
 }


### PR DESCRIPTION
## Summary
- ports the still-useful part of #4753 onto the current refactored GGUF loader
- adds `I2SFlavor::logical_size_bytes` and strict-padding tests for I2_S byte accounting
- trims trailing GGUF alignment padding before non-QK I2_S dequantization while preserving the current QK256 trailer-scale path

## Source / disposition
- Source PR: #4753
- This is not a blind close or age-based replacement. #4753 remains the source of the useful strict-padding idea; this PR re-cuts the part that still fits current main after QK256 trailer-scale handling changed.

## Validation
- `cargo test --locked -p bitnet-models --lib i2s_logical_size_excludes_padding -- --nocapture`
- `cargo test --locked -p bitnet-models --lib i2s_flavor_accepts_strict_gguf_alignment_padding -- --nocapture`
- `cargo test --locked -p bitnet-models --lib i2s_ -- --nocapture`
- `cargo check --locked -p bitnet-models`
- `rustfmt --edition 2024 --check crates\bitnet-models\src\formats\gguf\types.rs crates\bitnet-models\src\formats\gguf\loader\tensor_loading.rs`
- `git diff --check`

## Claim boundary
- No runtime math promotion.
- No A770 semantic quality, reference parity, speed, residency, selected attention, resident KV, attention score residency, softmax residency, value-mix residency, full residency, or completion claim.
- QK256 keeps its current trailer-scale preservation path; this PR only trims padding before non-QK I2_S dequantization.