### PR TITLE
fix(ci): remove duplicate locked flags in model gates

### DIFF
--- a/.github/workflows/model-gates.yml
+++ b/.github/workflows/model-gates.yml
@@ -77,12 +77,12 @@ jobs:
       - name: Build xtask
         run: |
           echo "🔨 Building xtask..."
-          cargo build --locked -p xtask --release --locked
+          cargo build --locked -p xtask --release
 
       - name: Build bitnet-cli (CPU)
         run: |
           echo "🔨 Building bitnet-cli with CPU features..."
-          cargo build --locked -p bitnet-cli --release --no-default-features --features cpu,full-cli --locked
+          cargo build --locked -p bitnet-cli --release --no-default-features --features cpu,full-cli
 
       - name: Run benchmark and write receipt
         run: |
@@ -91,7 +91,7 @@ jobs:
           echo "This runs a tiny deterministic inference benchmark (128 tokens)"
           echo "and writes a receipt with measured tokens/sec and real kernel IDs."
           echo ""
-          cargo run --locked -p xtask --locked -- benchmark --model tests/models/mini.gguf --tokens 128
+          cargo run --locked -p xtask -- benchmark --model tests/models/mini.gguf --tokens 128
 
       - name: Display receipt
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Verify receipt (strict)
         run: |
           echo "🔍 Verifying receipt against quality gates..."
-          cargo run --locked -p xtask --locked -- verify-receipt --path ci/inference.json
+          cargo run --locked -p xtask -- verify-receipt --path ci/inference.json
 
       - name: Upload receipt artifact
         if: always()


### PR DESCRIPTION
## Summary
- remove duplicate `--locked` flags from the model-gates Cargo invocations
- keep one `--locked` on each build/run command so the existing workflow guard remains satisfied
- unblock CPU Receipt Gate failures like `the argument '--locked' cannot be used multiple times`

## Claim boundary
- CI workflow-only fix
- no runtime, model, receipt schema, hardware, A770, server, or performance behavior change

## Validation
- `rg -n "\bcargo\s+(build|run|test|bench|clippy)\b.*--locked.*--locked" .github\workflows\model-gates.yml` => no matches
- workflow locked-guard equivalent over `.github/workflows` => `locked_guard=ok`
- `git diff --check`