### PR TITLE
fix(bitnet): preserve K precision for attention scores

### DIFF
--- a/crates/bitnet-transformer/src/attention_forward.rs
+++ b/crates/bitnet-transformer/src/attention_forward.rs
@@ -7,9 +7,10 @@
 #[cfg(feature = "trace")]
 use super::BitNetError;
 use super::{
-    LayerKVCache, MultiHeadAttention, attention_f16_dot_input, dbg_finite, dbg_stats,
-    debug_attn_enabled, debug_attn_scale_enabled, debug_gqa_enabled, debug_rope_enabled,
-    qwen_trace_event, qwen_trace_layer_enabled, qwen_trace_tensor, trace_rms_enabled,
+    LayerKVCache, MultiHeadAttention, attention_f16_dot_input, attention_score_key_input,
+    dbg_finite, dbg_stats, debug_attn_enabled, debug_attn_scale_enabled, debug_gqa_enabled,
+    debug_rope_enabled, qwen_trace_event, qwen_trace_layer_enabled, qwen_trace_tensor,
+    trace_rms_enabled,
 };
 use bitnet_common::Result;
 use candle_core::{DType, Module, Tensor};
@@ -316,7 +317,7 @@ impl MultiHeadAttention {
         }
 
         let q_for_scores = attention_f16_dot_input(q)?;
-        let k_for_scores = attention_f16_dot_input(k_expanded)?;
+        let k_for_scores = attention_score_key_input(k_expanded)?;
         let scores = q_for_scores.matmul(&k_for_scores.transpose(2, 3)?)?;
 
         // Convert to fp32 for numerically stable computation

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -29,6 +29,10 @@ fn attention_f16_dot_input(tensor: &Tensor) -> Result<Tensor> {
     Ok(tensor.to_dtype(DType::F16)?.to_dtype(DType::F32)?)
 }
 
+fn attention_score_key_input(tensor: &Tensor) -> Result<Tensor> {
+    Ok(tensor.to_dtype(DType::F32)?)
+}
+
 /// Rotary Position Embedding
 pub struct RotaryEmbedding {
     sin: Tensor,
@@ -1783,19 +1787,32 @@ mod tests {
     }
 
     #[test]
-    fn attention_qk_both_use_f16_roundtrip_precision() -> Result<()> {
+    fn attention_score_key_input_preserves_f32_values() -> Result<()> {
+        let device = Device::Cpu;
+        let input =
+            Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
+
+        let output = attention_score_key_input(&input)?;
+        let values = output.flatten_all()?.to_vec1::<f32>()?;
+
+        assert_eq!(values, vec![1.0003, -2.0007, 3.1259, -4.2509]);
+        Ok(())
+    }
+
+    #[test]
+    fn attention_score_qk_inputs_match_reference_precision_contract() -> Result<()> {
         let device = Device::Cpu;
         let query =
             Tensor::from_slice(&[1.0003f32, -2.0007, 3.1259, -4.2509], (1, 1, 1, 4), &device)?;
         let key = Tensor::from_slice(&[5.0003f32, 6.0007, -7.1259, 8.2509], (1, 1, 1, 4), &device)?;
 
         let q_values = attention_f16_dot_input(&query)?.flatten_all()?.to_vec1::<f32>()?;
-        let k_values = attention_f16_dot_input(&key)?.flatten_all()?.to_vec1::<f32>()?;
+        let k_values = attention_score_key_input(&key)?.flatten_all()?.to_vec1::<f32>()?;
         let score = q_values.iter().zip(k_values.iter()).fold(0.0f32, |sum, (q, k)| sum + q * k);
 
         assert_eq!(q_values, vec![1.0, -2.0, 3.125, -4.25]);
-        assert_eq!(k_values, vec![5.0, 6.0, -7.125, 8.25]);
-        assert!(score.is_finite(), "attention score should be finite, got {score}");
+        assert_eq!(k_values, vec![5.0003, 6.0007, -7.1259, 8.2509]);
+        assert_eq!(score, -64.33586);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Port the durable runtime-correctness part of stacked diagnostic PR #5020 onto current `main`.

The change preserves K precision for attention score formation while keeping the already-pinned Q and value-mix behavior:

- Q score input still uses the F16 roundtrip.
- K score input now stays F32.
- Value-mix input still uses the F16 roundtrip.

## Scope

- `crates/bitnet-transformer/src/attention_forward.rs`
- `crates/bitnet-transformer/src/lib.rs`
- no generated files
- no branch-chain diagnostic reports

## Claim boundary

This is a shared CPU/A770 runtime correctness fix. It does not promote A770 semantic quality, selected attention, resident KV, attention score residency, softmax residency, value mix residency, full support residency, full device residency, performance, reference parity, completion, server readiness, or speed claims.

## Validation

- PASS: `cargo fmt --check -p bitnet-transformer`
- PASS: `cargo test --locked -p bitnet-transformer attention_score -- --nocapture`
- PASS: `cargo test --locked -p bitnet-transformer -- --nocapture`
- PASS: `cargo check --locked -p bitnet-transformer`
- PASS: `cargo check --locked -p bitnet-cli --no-default-features --features cpu`
- PASS: `cargo check --locked -p bitnet-cli --no-default-features --features opencl`
- PASS: `git diff --check`

## Generated files

None.

## Follow-up / supersedes

Supersedes stacked diagnostic PR #5020 after this clean port lands. The rest of the A770 diagnostic branch chain still needs lineage review before merge/close decisions.
