### PR TITLE
docs(i2s): sync I2S-DOCS-000 merge

### DIFF
--- a/docs/tracking/campaigns/i2s/active.toml
+++ b/docs/tracking/campaigns/i2s/active.toml
@@ -21,7 +21,9 @@ hard_constraints = [
 [[work_item]]
 id = "I2S-DOCS-000"
 title = "docs(i2s): add I2_S source map and implementation plan"
-status = "ready"
+status = "merged"
+pr = 5880
+merge_sha = "603b87839ae0d59b101c01bf9262be7ae9ca3601"
 branch = "codex/document-i2_s-productization-plan"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/i2s/events/2026-05-19T065500Z-I2S-DOCS-000-merged.toml
+++ b/docs/tracking/campaigns/i2s/events/2026-05-19T065500Z-I2S-DOCS-000-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-19T06:55:00Z"
+campaign = "i2s"
+item = "I2S-DOCS-000"
+event = "merged"
+pr = 5880
+merge_sha = "603b87839ae0d59b101c01bf9262be7ae9ca3601"
+actor = "codex"
+
+notes = [
+  "Merged the docs-only I2_S source map, campaign manifest, proposal, plan, and initial contract specs.",
+  "The merge establishes the I2_S productization control plane without runtime code changes.",
+  "No scaled math, backend parity, strict artifact, receipt, or performance claim is made.",
+]

--- a/docs/tracking/campaigns/i2s/generated/status.md
+++ b/docs/tracking/campaigns/i2s/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| I2S-DOCS-000 | ready | TBD | `codex/document-i2_s-productization-plan` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the I2_S source map, campaign manifest, implementation plan, proposal, and initial contract specs without changing runtime code or making kernel, backend, artifact, receipt, or performance claims. |
+| I2S-DOCS-000 | merged | #5880 | `codex/document-i2_s-productization-plan` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the I2_S source map, campaign manifest, implementation plan, proposal, and initial contract specs without changing runtime code or making kernel, backend, artifact, receipt, or performance claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -35,7 +35,7 @@
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | falcon-e-family | FE-000 | TBD | ready | FE-001 | Do not commit model binaries. |
 | falcon3-family | F3-000 | TBD | ready | none | Do not commit model binaries. |
-| i2s | I2S-DOCS-000 | TBD | ready | none | Do not change runtime code in docs-only I2_S tracker slices. |
+| i2s | I2S-DOCS-000 | #5880 | merged | none | Do not change runtime code in docs-only I2_S tracker slices. |
 | intel-258v-platform | LNL258V-OP-006 | #5749 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | proposed | A770-004 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-012 | #5634 | merged | none | Device-node detection is not inference. |


### PR DESCRIPTION
## Summary
- mark I2S-DOCS-000 merged after #5880
- record merge SHA 603b87839ae0d59b101c01bf9262be7ae9ca3601
- regenerate I2S/global dashboards so the docs-only source-map item leaves ready state

## Validation
- cargo run -p xtask --no-default-features -- campaign generate
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated campaign tracking metadata to record completion of documentation-focused work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/5883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->