### PR TITLE
docs(qwen36): register governed Qwen3.6 family lane and candidate coverage rows

### DIFF
--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -957,6 +957,49 @@ claim_boundary = "1bitLLM large-family artifacts are diagnostic until artifact a
   dense_regular_llm_cuda_proof = false
 
 [[entry]]
+id = "bitnet_llama3_8b_158_diagnostic"
+model_class = "bitnet"
+family = "llama3_bitnet_b1_58"
+artifact_kind = "safetensors_candidate"
+contract_id = "hf1bitllm_llama3_8b_158_diagnostic"
+status = "diagnostic_only"
+current_tier = "registered"
+verifier_surface = "model coverage matrix only"
+tokenizer_authority = "pending_llama3_tokenizer_prompt_audit"
+prompt_authority = "pending_llama3_prompt_audit"
+cpu_reference = "reference_runner_and_layout_contract_required"
+accelerator_routes = []
+required_receipts = [
+  "artifact_inventory",
+  "tokenizer_prompt_authority",
+  "reference_runner_evidence",
+  "i2s_or_tl_layout_proof",
+]
+forbidden_claims = [
+  "official_microsoft_2b_proof_inheritance",
+  "cpu_answer_ready",
+  "accelerator_answer_ready",
+  "speedup",
+  "server_ready",
+]
+next_proof = "Exact artifact inventory, tokenizer/prompt audit, reference-runner evidence, and I2_S/TL layout proof before any CPU, accelerator, or answer-readiness claim."
+claim_boundary = "Llama3 8B 1.58-bit-family artifacts are diagnostic-only until artifact authority, tokenizer/prompt authority, reference behavior, and layout route contracts are pinned; no Microsoft 2B proof is inherited."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+[[entry]]
 id = "llama3_8b_158_100b_tokens_candidate"
 model_class = "bitnet"
 family = "llama3_bitnet_b1_58"

--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -1663,3 +1663,267 @@ claim_boundary = "x86 TL2 3B is a registered future route only and must not inhe
   full_residency_claim = false
   bitnet_packed_i2s_qk256_proof = false
   dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_27b_hf_reference_candidate"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "safetensors_vl_reference"
+contract_id = "qwen36_27b_hf_safetensors"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-27b"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_27b_text_quant_candidate"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "text_quant_candidate"
+contract_id = "qwen36_27b_text_quant_candidate"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-27b-text-quant"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_35b_a3b_hf_reference_candidate"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "safetensors_vl_reference"
+contract_id = "qwen36_35b_a3b_hf_safetensors"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-35b-a3b"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_35b_a3b_text_sidecar_candidate"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "safetensors_vl_reference"
+contract_id = "qwen36_35b_a3b_text_sidecar_candidate"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-35b-a3b-text-sidecar"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_plus_api_reference"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "hosted_api_reference"
+contract_id = "qwen36_plus_api_reference"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-plus-api"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_max_preview_api_reference"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "hosted_api_reference"
+contract_id = "qwen36_max_preview_api_reference"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-max-preview-api"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_ollama_reference_candidate"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "ollama_reference_candidate"
+contract_id = "qwen36_ollama_reference_candidate"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-ollama"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false
+
+
+[[entry]]
+id = "qwen36_mlx_reference_candidate"
+model_class = "dense_llm"
+family = "qwen3_6"
+artifact_kind = "mlx_reference_candidate"
+contract_id = "qwen36_mlx_reference_candidate"
+status = "registered_reference_candidate"
+current_tier = "registered"
+verifier_surface = "bitnet model verify qwen3.6-mlx"
+tokenizer_authority = "pending_processor_prompt_audit"
+prompt_authority = "pending_qwen36_chat_template_audit"
+cpu_reference = "pending_external_reference_good"
+accelerator_routes = []
+required_receipts = ["artifact_inventory","processor_tokenizer_prompt_authority","external_reference_good","architecture_inventory","memory_envelope"]
+forbidden_claims = ["bitnet_packed_i2s_qk256_proof","qwen2_5_proof_inheritance","qwen3_06b_proof_inheritance","native_rust_answer_ready","cuda_answer_ready","server_ready","speedup"]
+next_proof = "Record artifact inventory, processor/tokenizer/prompt authority, external reference corpus, architecture inventory, and memory envelope before any local runtime claim."
+claim_boundary = "Registered reference candidate only; not BitNet, not Qwen2.5/Qwen3 0.6B inheritance, and no native answer/backend/server/speed claims."
+
+  [entry.claims]
+  registered = true
+  structurally_valid = false
+  reference_good = false
+  cpu_answer_ready = false
+  accelerator_answer_ready = false
+  benchmark_qualified = false
+  product_cli_ready = false
+  server_ready = false
+  speedup_claim = false
+  full_residency_claim = false
+  bitnet_packed_i2s_qk256_proof = false
+  dense_regular_llm_cuda_proof = false

--- a/docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+++ b/docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
@@ -1,0 +1,19 @@
+# BITNET-PROP-0017-qwen36-modern-dense-model-family
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/qwen/qwen36/README.md
+++ b/docs/qwen/qwen36/README.md
@@ -1,0 +1,22 @@
+# Qwen3.6 Source Map
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: docs/specs/BITNET-SPEC-QWEN36-*
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: candidate registration only
+Policy impact: claim-boundary enforcement
+
+Qwen3.6 is tracked as a separate modern dense/multimodal/agentic family lane.
+
+## Claim boundary
+
+- Not a BitNet I2_S/TL lane.
+- Not inheriting Qwen2.5 or Qwen3 0.6B dense SLM proofs.
+- External engines (Transformers/vLLM/SGLang/Ollama/MLX/API) are reference-only until native receipts exist.
+- Initial status is registered candidate only.

--- a/docs/specs/BITNET-SPEC-QWEN36-ARCHITECTURE-INVENTORY.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-ARCHITECTURE-INVENTORY.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-ARCHITECTURE-INVENTORY
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-EXTERNAL-REFERENCE.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-EXTERNAL-REFERENCE.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-EXTERNAL-REFERENCE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-FAMILY-ARTIFACT-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-FAMILY-ARTIFACT-CONTRACT.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-FAMILY-ARTIFACT-CONTRACT
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-MEMORY-ENVELOPE.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-MEMORY-ENVELOPE.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-MEMORY-ENVELOPE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-MOE-35B-A3B.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-MOE-35B-A3B.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-MOE-35B-A3B
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-MULTIMODAL.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-MULTIMODAL.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-MULTIMODAL
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-PERFORMANCE.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-PERFORMANCE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-PROCESSOR-TOKENIZER-PROMPT.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-PROCESSOR-TOKENIZER-PROMPT.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-PROCESSOR-TOKENIZER-PROMPT
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-QUALITY.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-QUALITY
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-SERVER.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-SERVER.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-SERVER
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-STATUS-SURFACE.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-STATUS-SURFACE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/BITNET-SPEC-QWEN36-TEXT-ONLY-NATIVE.md
+++ b/docs/specs/BITNET-SPEC-QWEN36-TEXT-ONLY-NATIVE.md
@@ -1,0 +1,19 @@
+# BITNET-SPEC-QWEN36-TEXT-ONLY-NATIVE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered-only unless receipts prove otherwise
+Policy impact: strict no-overclaim boundaries
+
+This document defines the Qwen3.6 contract area named in the file title.
+
+## Core boundary
+
+Qwen3.6 is a separate modern dense/multimodal/agentic family lane. It is not BitNet proof, does not inherit Qwen2.5/Qwen3 0.6B proof, and external sidecar/API proof is not native Rust proof.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -695,3 +695,21 @@ Technical specification for implementing manual KV cache position tracking in th
 - `bitnet-cpp-ffi-sockets.md` - Socket 1/Socket 3 architecture
 - `dual-backend-crossval.md` - Cross-validation patterns
 - `cpp-setup.md` - C++ reference setup guide
+
+
+## Qwen3.6 Modern Dense/Multimodal Family
+
+Use these artifacts before implementing or claiming Qwen3.6 support:
+
+1. [Qwen3.6 Source Map](../qwen/qwen36/README.md)
+2. [Qwen3.6 Implementation Plan](../../plans/qwen36/implementation-plan.md)
+3. [Qwen3.6 Proposal](../proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md)
+4. [Artifact Contract](BITNET-SPEC-QWEN36-FAMILY-ARTIFACT-CONTRACT.md)
+5. [Processor/Tokenizer/Prompt](BITNET-SPEC-QWEN36-PROCESSOR-TOKENIZER-PROMPT.md)
+6. [Architecture Inventory](BITNET-SPEC-QWEN36-ARCHITECTURE-INVENTORY.md)
+7. [External Reference](BITNET-SPEC-QWEN36-EXTERNAL-REFERENCE.md)
+8. [Text-only Native](BITNET-SPEC-QWEN36-TEXT-ONLY-NATIVE.md)
+9. [MoE 35B-A3B](BITNET-SPEC-QWEN36-MOE-35B-A3B.md)
+10. [Multimodal](BITNET-SPEC-QWEN36-MULTIMODAL.md), [Memory Envelope](BITNET-SPEC-QWEN36-MEMORY-ENVELOPE.md), [Quality](BITNET-SPEC-QWEN36-QUALITY.md), [Performance](BITNET-SPEC-QWEN36-PERFORMANCE.md), [Server](BITNET-SPEC-QWEN36-SERVER.md), [Status Surface](BITNET-SPEC-QWEN36-STATUS-SURFACE.md)
+
+Qwen3.6 is a separate governed family lane: not BitNet proof, not inherited Qwen2.5/Qwen3 0.6B proof, and external sidecar/API evidence is not native Rust proof.

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -82,3 +82,7 @@ cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070t
 cargo run --locked -p xtask --no-default-features -- campaign generate --check
 git diff --check
 ```
+
+## Qwen3.6 Candidate Boundary
+
+Qwen3.6 rows are registered candidates only in the model coverage matrix. They do not currently prove dense CUDA execution, product CLI, server readiness, speedup, or full residency.

--- a/docs/tracking/campaigns/qwen36/CAMPAIGN.md
+++ b/docs/tracking/campaigns/qwen36/CAMPAIGN.md
@@ -1,0 +1,15 @@
+# Qwen3.6 Campaign
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: docs/specs/BITNET-SPEC-QWEN36-*
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: registered candidate rows only
+Policy impact: Qwen3.6 not BitNet; no inheritance; no overclaim from external engines
+
+This campaign governs Qwen3.6 as a separate modern dense/multimodal/agentic family lane.

--- a/docs/tracking/campaigns/qwen36/active.toml
+++ b/docs/tracking/campaigns/qwen36/active.toml
@@ -1,0 +1,13 @@
+schema = 1
+campaign = "qwen36"
+status = "active"
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+plan = "plans/qwen36/implementation-plan.md"
+source_map = "docs/qwen/qwen36/README.md"
+
+[work_item]
+id = "QWEN36-DOCS-000"
+title = "Register Qwen3.6 family governance lane"
+status = "ready"

--- a/docs/tracking/campaigns/qwen36/active.toml
+++ b/docs/tracking/campaigns/qwen36/active.toml
@@ -1,5 +1,5 @@
-schema = 1
-campaign = "qwen36"
+id = "qwen36"
+title = "Qwen3.6 governed model family"
 status = "active"
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
@@ -7,7 +7,64 @@ human_gate = "on_blocker_only"
 plan = "plans/qwen36/implementation-plan.md"
 source_map = "docs/qwen/qwen36/README.md"
 
-[work_item]
+objective = "Govern Qwen3.6 as a separate modern dense, multimodal, and agentic model-family lane with source-of-truth docs, spec placeholders, and registered-only candidate coverage rows before any native BitNet-rs runtime or quality claim."
+
+end_state = [
+  "Qwen3.6 source map, implementation plan, and proposal/spec placeholders exist.",
+  "Model coverage rows register Qwen3.6 candidates as reference-only or candidate-only with claim booleans false.",
+  "Future Qwen3.6 work cannot inherit BitNet, Qwen2.5, or Qwen3-0.6B proof claims.",
+]
+
+hard_constraints = [
+  "Qwen3.6 registration is not native BitNet-rs inference support.",
+  "External engine behavior is reference-only until native receipts exist.",
+  "Do not claim answer quality, server support, performance, GPU/NPU execution, Qwen3.5 support, or BitNet QK256 changes.",
+]
+
+[[work_item]]
 id = "QWEN36-DOCS-000"
-title = "Register Qwen3.6 family governance lane"
 status = "ready"
+branch = "codex/add-qwen3.6-as-a-governed-model-family"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Register the Qwen3.6 family governance lane as documentation and model-coverage scaffolding only. The slice must add the source map, implementation plan, proposal/spec placeholders, candidate coverage rows, and campaign tracker entry without claiming native runtime support, server inference, answer quality, performance, GPU/NPU execution, Qwen3.5 support, or BitNet QK256 changes."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check qwen36",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "cargo run --locked -p xtask --no-default-features -- check-model-coverage",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/model-artifacts/model-coverage-matrix.toml",
+  "docs/proposals/**",
+  "docs/qwen/qwen36/**",
+  "docs/specs/**",
+  "docs/status/**",
+  "docs/tracking/campaigns/qwen36/**",
+  "plans/qwen36/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "models/**",
+  "server inference",
+  "GPU, NPU, OpenVINO, or UHD 620 execution",
+  "Qwen3.5 support",
+  "BitNet QK256/I2_S kernels",
+]
+may_claim = [
+  "Qwen3.6 candidates are registered as governed reference-only or candidate-only rows.",
+  "The Qwen3.6 lane has a source map, plan, and spec placeholders for future proof work.",
+]
+must_not_claim = [
+  "Native BitNet-rs Qwen3.6 inference works.",
+  "Qwen3.6 answer quality is proven.",
+  "Qwen3.6 server support is available.",
+  "Qwen3.6 performance is measured.",
+  "GPU, NPU, OpenVINO, or UHD 620 execution is involved.",
+  "Qwen3.6 inherits BitNet, Qwen2.5, or Qwen3-0.6B proof claims.",
+  "Qwen3.5 support is in scope.",
+  "BitNet QK256/I2_S kernels are modified.",
+]

--- a/docs/tracking/campaigns/qwen36/generated/status.md
+++ b/docs/tracking/campaigns/qwen36/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Qwen3.6 governed model family Campaign Status
+
+- Campaign: `qwen36`
+- State: `active`
+- Objective: Govern Qwen3.6 as a separate modern dense, multimodal, and agentic model-family lane with source-of-truth docs, spec placeholders, and registered-only candidate coverage rows before any native BitNet-rs runtime or quality claim.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| QWEN36-DOCS-000 | ready | TBD | `codex/add-qwen3.6-as-a-governed-model-family` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Register the Qwen3.6 family governance lane as documentation and model-coverage scaffolding only. The slice must add the source map, implementation plan, proposal/spec placeholders, candidate coverage rows, and campaign tracker entry without claiming native runtime support, server inference, answer quality, performance, GPU/NPU execution, Qwen3.5 support, or BitNet QK256 changes. |
+
+## Hard Constraints
+
+- Qwen3.6 registration is not native BitNet-rs inference support.
+- External engine behavior is reference-only until native receipts exist.
+- Do not claim answer quality, server support, performance, GPU/NPU execution, Qwen3.5 support, or BitNet QK256 changes.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -43,6 +43,7 @@
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
 | official-bitnet-2b | OFFICIAL-2B-000 | TBD | ready | OFFICIAL-2B-001 | Do not commit model binaries. |
+| qwen36 | QWEN36-DOCS-000 | TBD | ready | none | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | SERVER-005 | #4490 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-050 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -43,6 +43,7 @@
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |
 | official-bitnet-2b | Official Microsoft BitNet 2B productization | OFFICIAL-2B-000 | Do not commit model binaries. |
+| qwen36 | Qwen3.6 governed model family | QWEN36-DOCS-000 | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | Server real inference | SERVER-005 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-050 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/plans/qwen36/README.md
+++ b/plans/qwen36/README.md
@@ -1,0 +1,15 @@
+# Qwen3.6 Plan Source Map
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: docs/specs/BITNET-SPEC-QWEN36-*
+Linked ADRs: n/a
+Linked plan: plans/qwen36/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: candidate registration only
+Policy impact: no overclaiming from external references
+
+This lane governs Qwen3.6 registration, artifact authority, prompt/processor authority, reference proofs, architecture inventory, and memory-envelope realism before native promotion.

--- a/plans/qwen36/implementation-plan.md
+++ b/plans/qwen36/implementation-plan.md
@@ -1,0 +1,31 @@
+# Qwen3.6 Implementation Plan
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md
+Linked specs: docs/specs/BITNET-SPEC-QWEN36-*
+Linked ADRs: n/a
+Linked plan: this file
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: candidate-only until proof receipts
+Policy impact: strict claim boundaries
+
+## Ordered phases
+
+1. Source map + campaign registration + model-coverage registered rows.
+2. Proposal and spec contracts for artifact/processor/architecture/reference/text-only/MoE/multimodal/memory/quality/performance/server/status.
+3. Artifact inventory receipts (27B and 35B-A3B), no native claims.
+4. External reference corpus receipts, no native claims.
+5. Architecture and memory-envelope inventory.
+6. Select one local quantized text-only candidate.
+7. Native structural loader → CPU sanity/blocker → CUDA route ladder.
+8. Exact-profile server/benchmark/promotion.
+
+## Required proof commands for this planning PR
+
+- `cargo run --locked -p xtask --no-default-features -- campaign check qwen36`
+- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
+- `cargo run --locked -p xtask --no-default-features -- check-model-coverage`
+- `git diff --check`


### PR DESCRIPTION
### Motivation

- Register Qwen3.6 as a separate modern dense / multimodal / agentic model-family lane and prevent accidental claim inheritance from BitNet/Qwen2.5/Qwen3 0.6B.
- Provide a source-of-truth plan and spec surface so future proofing (artifact inventory, tokenizer/processor authority, external references, architecture inventory, memory envelope, and route selection) proceeds without overclaiming native support.
- Add model-coverage rows that record Qwen3.6 variants as registered/reference-only candidates and explicitly keep all answer/backend/server/speed/BitNet-proof booleans false.

### Description

- Added Qwen3.6 source map and campaign scaffolding at `docs/qwen/qwen36/README.md`, `plans/qwen36/implementation-plan.md`, and `docs/tracking/campaigns/qwen36/active.toml` plus `CAMPAIGN.md` to drive the PR-by-PR rollout.
- Added a proposal `docs/proposals/BITNET-PROP-0017-qwen36-modern-dense-model-family.md` and a suite of Qwen3.6 spec contract placeholders under `docs/specs/` (artifact, tokenizer/processor/prompt, architecture, external-reference, text-only native, MoE, multimodal, memory envelope, quality, performance, server, status).
- Updated `docs/specs/INDEX.md` to include the Qwen3.6 source-of-truth chain and appended a CUDA status note in `docs/status/CUDA_CAPABILITY_MATRIX.md` clarifying Qwen3.6 is candidate-only.
- Inserted registered-only model coverage rows into `ci/model-artifacts/model-coverage-matrix.toml` for the requested Qwen3.6 entries (for example `qwen36_27b_hf_reference_candidate`, `qwen36_27b_text_quant_candidate`, `qwen36_35b_a3b_hf_reference_candidate`, `qwen36_35b_a3b_text_sidecar_candidate`, `qwen36_plus_api_reference`, `qwen36_max_preview_api_reference`, `qwen36_ollama_reference_candidate`, and `qwen36_mlx_reference_candidate`) with explicit forbidden-claim booleans.
- Normalized the existing generated-docs-only `bitnet_llama3_8b_158_diagnostic` coverage row into the TOML source matrix with diagnostic-only status and all answer/backend/server/speed/residency/proof booleans false.

### Claim boundary

- Documentation/model-coverage scaffolding only.
- No native Qwen3.6 runtime, answer quality, server, accelerator, speed, residency, or BitNet QK256/I2_S claim.
- The added Llama3 diagnostic matrix row is source-matrix normalization only and does not promote Llama3 answer/backend/server/speed/readiness claims.

### Testing

- Hosted `Doctor + Generated Dashboards` passed.
- Hosted `PR Plan` passed.
- Hosted `PR Gate Success` passed.
- Hosted `Lint + Link Check + Rustdoc`, markdown lint, link check, guards, CI core, build/test fast path, clippy, and docs checks passed.
- Local audit checked the PR diff for promoted readiness/proof booleans and found no added `*_ready = true`, `speedup_claim = true`, `full_residency_claim = true`, `reference_good = true`, `structurally_valid = true`, `benchmark_qualified = true`, `bitnet_packed_i2s_qk256_proof = true`, or `dense_regular_llm_cuda_proof = true` entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0e661b5483339b228a2f37517b11)