### PR TITLE
docs(tl1): add TL1 source map and implementation plan

### DIFF
--- a/ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
+++ b/ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
@@ -1,6 +1,6 @@
 schema = 1
 artifact_kind = "apple_silicon_macbook_bitnet_candidate_matrix"
-updated = "2026-05-12"
+updated = "2026-05-19"
 work_item = "MB-AS-003"
 machine_lane = "apple-m3-macbook-air"
 claim_boundary = "Candidate planning only. No candidate is accepted for Apple local-answer claims until the MacBook lane records source, size, SHA256, tokenizer authority, coherent reference-runner output, and cleanup status. Dense Qwen evidence does not prove BitNet quality."
@@ -16,6 +16,7 @@ storage_policy = [
 required_reference_prompt_suite = "ci/quality/bitnet-answer-corpus.yaml"
 shared_answer_gate = "docs/model-artifacts/ANSWER_ARTIFACT_GATE.md"
 compatibility_ledger = "ci/model-artifacts/model-kernel-compatibility.toml"
+tl1_campaign = "docs/tracking/campaigns/tl1/CAMPAIGN.md"
 
 [[candidate]]
 id = "microsoft_bitnet_b158_2b_4t_i2s"

--- a/ci/model-artifacts/model-kernel-compatibility.toml
+++ b/ci/model-artifacts/model-kernel-compatibility.toml
@@ -6,7 +6,7 @@ source = "microsoft/BitNet README supported model table"
 source_url = "https://github.com/microsoft/BitNet/blob/main/README.md"
 source_map = "docs/bitnet/official-2b/README.md"
 i2s_source_map = "docs/bitnet/i2s/README.md"
-claim_boundary = "Upstream model/kernel support is a precondition for answer_ready, reference_authority, backend_parity, and speedup claims. Unsupported combinations may only be used for diagnostic runs, artifact inspection, or unsupported-path receipts."
+claim_boundary = "Upstream model/kernel support is a precondition for answer_ready, reference_authority, backend_parity, and speedup claims. Unsupported combinations may only be used for diagnostic runs, artifact inspection, or unsupported-path receipts. TL1 is a distinct route family and must not inherit I2_S/QK256 or TL2 proof."
 tl2_boundary_note = "TL2 x86 route evidence is tracked separately from I2_S/QK256 and TL1; listed support is not automatic answer proof."
 
 proof_claims_rejected_when_unsupported = [

--- a/docs/apple-silicon/bitnet-candidate-matrix.md
+++ b/docs/apple-silicon/bitnet-candidate-matrix.md
@@ -109,3 +109,12 @@ Apple answer, benchmark, Metal, or server claim may be made until artifact
 inventory, TL1 conversion/runner authority, tokenizer/prompt authority,
 reference-good output, TL1 scalar/NEON fixtures, and strict Apple receipts pass
 with `fallback=false`.
+
+## TL1 route boundary
+
+TL1 is an ARM-first table-lookup route tracked by `docs/bitnet/tl1/README.md`,
+`plans/tl1/implementation-plan.md`, and
+`docs/tracking/campaigns/tl1/CAMPAIGN.md`. Apple candidate planning must treat
+TL1 as distinct from `I2_S`/QK256 and distinct from TL2; no TL1 answer/backend
+claim is valid before TL1 layout authority, scalar oracle, artifact authority,
+and reference-good output are proven.

--- a/docs/bitnet/tl1/README.md
+++ b/docs/bitnet/tl1/README.md
@@ -1,0 +1,40 @@
+# TL1 Source Map
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0016-tl1-productization.md (planned)
+Linked specs: docs/specs/BITNET-SPEC-TL1-ROUTE-CONTRACT.md (planned)
+Linked ADRs: n/a
+Linked plan: plans/tl1/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: planning only
+Policy impact: none
+
+## Purpose
+
+This source map establishes TL1 as an ARM-first BitNet table-lookup route with
+its own route identity, artifact authority, layout proof, scalar oracle,
+backend proof, answer quality receipts, and benchmark promotion ladder.
+
+## Route boundary
+
+- TL1 is a separate route family from `I2_S`/QK256.
+- TL1 is a separate route family from TL2.
+- For currently tracked families, x86 TL1 remains
+  `unsupported_upstream` in the compatibility ledger.
+- ARM TL1 support listings are candidate inputs, not proof of answer readiness.
+
+## Authority stack for TL1 lane
+
+1. Proposal: `docs/proposals/BITNET-PROP-0016-tl1-productization.md`.
+2. Specs: `docs/specs/BITNET-SPEC-TL1-*.md`.
+3. Plan: `plans/tl1/implementation-plan.md`.
+4. Active campaign goal: `docs/tracking/campaigns/tl1/active.toml`.
+5. Compatibility ledger: `ci/model-artifacts/model-kernel-compatibility.toml`.
+
+## Current claim boundary
+
+TL1 remains planning/specification-only in this PR. No answer/backend/speed
+promotion is introduced by this source map.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,5 +1,18 @@
 # Specs Index
 
+## TL1 ARM-First Table-Lookup Route
+
+Use these artifacts before implementing or claiming TL1 support:
+
+1. [TL1 Source Map](../bitnet/tl1/README.md)
+   - Defines TL1 as an ARM-first route with explicit non-inheritance boundaries from `I2_S`/QK256 and TL2.
+2. [TL1 Implementation Plan](../../plans/tl1/implementation-plan.md)
+   - Sequences docs/spec setup, layout/scalar proof, artifact authority, Apple CPU/NEON proof, and benchmark promotion.
+3. [TL1 Campaign](../tracking/campaigns/tl1/CAMPAIGN.md)
+   - Tracks the active work item and proof commands.
+
+Do not treat upstream listed ARM TL1 support as answer/backend/speed proof. x86 TL1 remains `unsupported_upstream` for currently tracked families unless the compatibility ledger changes with new upstream evidence.
+
 ## I2_S/QK256 Productization
 
 Use these artifacts before implementing or claiming new I2_S route capabilities:

--- a/docs/tracking/campaigns/tl1/CAMPAIGN.md
+++ b/docs/tracking/campaigns/tl1/CAMPAIGN.md
@@ -1,0 +1,40 @@
+# TL1 Campaign
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0016-tl1-productization.md (planned)
+Linked specs: docs/specs/BITNET-SPEC-TL1-ROUTE-CONTRACT.md (planned)
+Linked ADRs: n/a
+Linked plan: plans/tl1/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: planning only
+Policy impact: none
+
+## Campaign thesis
+
+TL1 is an ARM-first BitNet table-lookup route that must be productized as its
+own lane instead of inheriting proof from `I2_S`/QK256 or TL2.
+
+## Current work item
+
+- `TL1-PLAN-000`: docs/source-of-truth bootstrap only.
+- No runtime, answer, backend, or speed promotion in this item.
+
+## Route boundaries
+
+- TL1 is not `I2_S`/QK256.
+- TL1 is not TL2.
+- x86 TL1 remains `unsupported_upstream` for tracked model families unless the
+  upstream support table changes and the compatibility ledger is updated.
+- ARM TL1 support listings require per-artifact, per-route, and per-backend
+  proof before claims.
+
+## Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check tl1
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```

--- a/docs/tracking/campaigns/tl1/active.toml
+++ b/docs/tracking/campaigns/tl1/active.toml
@@ -1,0 +1,41 @@
+schema = 1
+campaign = "tl1"
+status = "active"
+updated = "2026-05-19"
+owner = "bitnet-rs contributors"
+
+linked_plan = "plans/tl1/implementation-plan.md"
+linked_source_map = "docs/bitnet/tl1/README.md"
+linked_specs_index = "docs/specs/INDEX.md"
+compatibility_ledger = "ci/model-artifacts/model-kernel-compatibility.toml"
+
+[work_item]
+id = "TL1-PLAN-000"
+title = "docs(tl1): add TL1 source map and implementation plan"
+status = "ready"
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+scope = [
+  "docs/bitnet/tl1/README.md",
+  "plans/tl1/README.md",
+  "plans/tl1/implementation-plan.md",
+  "docs/tracking/campaigns/tl1/active.toml",
+  "docs/tracking/campaigns/tl1/CAMPAIGN.md",
+  "docs/specs/INDEX.md",
+  "ci/model-artifacts/model-kernel-compatibility.toml",
+  "docs/apple-silicon/bitnet-candidate-matrix.md",
+  "ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml",
+]
+proof = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check tl1",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+
+[boundaries]
+arm_first_tl1 = true
+x86_tl1_unsupported_upstream_for_tracked_families = true
+tl1_not_i2s_qk256 = true
+tl1_not_tl2 = true
+no_promotion_in_this_item = true

--- a/docs/tracking/campaigns/tl1/active.toml
+++ b/docs/tracking/campaigns/tl1/active.toml
@@ -1,41 +1,69 @@
-schema = 1
-campaign = "tl1"
+id = "tl1"
+title = "TL1 ARM table lookup route"
 status = "active"
-updated = "2026-05-19"
-owner = "bitnet-rs contributors"
-
-linked_plan = "plans/tl1/implementation-plan.md"
-linked_source_map = "docs/bitnet/tl1/README.md"
-linked_specs_index = "docs/specs/INDEX.md"
-compatibility_ledger = "ci/model-artifacts/model-kernel-compatibility.toml"
-
-[work_item]
-id = "TL1-PLAN-000"
-title = "docs(tl1): add TL1 source map and implementation plan"
-status = "ready"
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
-scope = [
-  "docs/bitnet/tl1/README.md",
-  "plans/tl1/README.md",
-  "plans/tl1/implementation-plan.md",
-  "docs/tracking/campaigns/tl1/active.toml",
-  "docs/tracking/campaigns/tl1/CAMPAIGN.md",
-  "docs/specs/INDEX.md",
-  "ci/model-artifacts/model-kernel-compatibility.toml",
-  "docs/apple-silicon/bitnet-candidate-matrix.md",
-  "ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml",
-]
-proof = [
-  "cargo run --locked -p xtask --no-default-features -- campaign check tl1",
-  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
-  "git diff --check",
+plan = "plans/tl1/implementation-plan.md"
+source_map = "docs/bitnet/tl1/README.md"
+
+objective = "Govern TL1 as an ARM-first table-lookup proof family with source-of-truth docs, an implementation plan, and compatibility-ledger boundaries before any runtime, kernel, artifact, or answer-quality claim."
+
+end_state = [
+  "TL1 source map, implementation plan, campaign tracker, and compatibility references exist.",
+  "TL1 is explicitly separated from I2_S/QK256 and TL2 proof families.",
+  "Future TL1 work has a route, layout, scalar, artifact, answer-quality, and promotion ladder.",
 ]
 
-[boundaries]
-arm_first_tl1 = true
-x86_tl1_unsupported_upstream_for_tracked_families = true
-tl1_not_i2s_qk256 = true
-tl1_not_tl2 = true
-no_promotion_in_this_item = true
+hard_constraints = [
+  "TL1 registration is not native BitNet-rs inference support.",
+  "Do not edit runtime code, kernels, model binaries, server inference, GPU/NPU execution, or BitNet QK256/I2_S kernels.",
+  "Do not claim answer quality, performance, CPU/Metal proof, or model compatibility until follow-up receipts prove them.",
+]
+
+[[work_item]]
+id = "TL1-PLAN-000"
+status = "ready"
+branch = "codex/add-tl1-as-arm-first-route"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Register the TL1 ARM-first table-lookup route as documentation and tracker scaffolding only. The slice must add the source map, implementation plan, campaign tracker entry, compatibility-ledger references, and status/index links without claiming native runtime support, model compatibility, answer quality, performance, CPU/Metal proof, server support, GPU/NPU execution, TL2 proof inheritance, or BitNet QK256/I2_S changes."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check tl1",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "cargo run --locked -p xtask --no-default-features -- check-model-coverage",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml",
+  "ci/model-artifacts/model-kernel-compatibility.toml",
+  "docs/apple-silicon/bitnet-candidate-matrix.md",
+  "docs/bitnet/tl1/README.md",
+  "docs/specs/INDEX.md",
+  "docs/tracking/campaigns/tl1/**",
+  "plans/tl1/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "models/**",
+  "server inference",
+  "GPU, NPU, OpenVINO, or UHD 620 execution",
+  "TL2 proof inheritance",
+  "BitNet QK256/I2_S kernels",
+]
+may_claim = [
+  "TL1 route scaffolding and proof-family boundaries exist.",
+  "Future TL1 work has a source map, plan, and tracker lane.",
+]
+must_not_claim = [
+  "Native BitNet-rs TL1 inference works.",
+  "TL1 answer quality is proven.",
+  "TL1 CPU, Metal, or server support is available.",
+  "TL1 performance is measured.",
+  "GPU, NPU, OpenVINO, or UHD 620 execution is involved.",
+  "TL1 inherits I2_S/QK256 or TL2 proof claims.",
+  "BitNet QK256/I2_S kernels are modified.",
+]

--- a/docs/tracking/campaigns/tl1/generated/status.md
+++ b/docs/tracking/campaigns/tl1/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# TL1 ARM table lookup route Campaign Status
+
+- Campaign: `tl1`
+- State: `active`
+- Objective: Govern TL1 as an ARM-first table-lookup proof family with source-of-truth docs, an implementation plan, and compatibility-ledger boundaries before any runtime, kernel, artifact, or answer-quality claim.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| TL1-PLAN-000 | ready | TBD | `codex/add-tl1-as-arm-first-route` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Register the TL1 ARM-first table-lookup route as documentation and tracker scaffolding only. The slice must add the source map, implementation plan, campaign tracker entry, compatibility-ledger references, and status/index links without claiming native runtime support, model compatibility, answer quality, performance, CPU/Metal proof, server support, GPU/NPU execution, TL2 proof inheritance, or BitNet QK256/I2_S changes. |
+
+## Hard Constraints
+
+- TL1 registration is not native BitNet-rs inference support.
+- Do not edit runtime code, kernels, model binaries, server inference, GPU/NPU execution, or BitNet QK256/I2_S kernels.
+- Do not claim answer quality, performance, CPU/Metal proof, or model compatibility until follow-up receipts prove them.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -46,6 +46,7 @@
 | qwen36 | QWEN36-DOCS-000 | TBD | ready | none | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | SERVER-005 | #4490 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-021 | #5133 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
+| tl1 | TL1-PLAN-000 | TBD | ready | none | TL1 registration is not native BitNet-rs inference support. |
 | tl2 | TL2-DOCS-000 | TBD | ready | none | TL2 registration is not native BitNet-rs inference support. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -46,6 +46,7 @@
 | qwen36 | Qwen3.6 governed model family | QWEN36-DOCS-000 | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | Server real inference | SERVER-005 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-021 | Do not edit BitNet QK256/I2_S kernels. |
+| tl1 | TL1 ARM table lookup route | TL1-PLAN-000 | TL1 registration is not native BitNet-rs inference support. |
 | tl2 | TL2 x86 table lookup route | TL2-DOCS-000 | TL2 registration is not native BitNet-rs inference support. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |

--- a/plans/tl1/README.md
+++ b/plans/tl1/README.md
@@ -1,0 +1,20 @@
+# TL1 Plan Lane
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0016-tl1-productization.md (planned)
+Linked specs: docs/specs/BITNET-SPEC-TL1-ROUTE-CONTRACT.md (planned)
+Linked ADRs: n/a
+Linked plan: plans/tl1/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: planning only
+Policy impact: none
+
+This lane sequences TL1 work as an ARM-first route from source-of-truth docs
+through layout/scalar/backend proof, then artifact/reference authority, Apple
+CPU/NEON receipts, and exact-profile benchmark promotion.
+
+Use `plans/tl1/implementation-plan.md` for PR-sized work items and proof
+commands.

--- a/plans/tl1/implementation-plan.md
+++ b/plans/tl1/implementation-plan.md
@@ -1,0 +1,51 @@
+# TL1 Implementation Plan
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0016-tl1-productization.md (planned)
+Linked specs: docs/specs/BITNET-SPEC-TL1-ROUTE-CONTRACT.md (planned), docs/specs/BITNET-SPEC-TL1-LAYOUT.md (planned)
+Linked ADRs: n/a
+Linked plan: this document
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: planning only
+Policy impact: none
+
+## Objective
+
+Make TL1 a first-class ARM table-lookup route with explicit route identity,
+artifact authority, scalar-correctness proof, ARM NEON parity, Apple
+CPU/NEON answer receipts, and exact-profile benchmark promotion.
+
+## Work items
+
+1. **TL1-PLAN-000 (docs source map and campaign setup)**
+   - Add TL1 source map, plan lane, campaign manifest, and campaign summary.
+   - Clarify ARM-first TL1 and x86 `unsupported_upstream` boundaries.
+2. **TL1-SPEC-001 (proposal + route/layout specs)**
+3. **TL1-SPEC-002 (scalar + ARM NEON specs)**
+4. **TL1-SPEC-003 (artifact/model/quality specs)**
+5. **TL1-SPEC-004 (Apple/performance/status specs)**
+6. **TL1-LAYOUT-005 (layout reconciliation report)**
+7. **TL1-FIXTURE-006 (synthetic TL1 fixture corpus)**
+8. **TL1-SCALAR-007 (scalar oracle implementation)**
+9. **TL1-SELECT-008 (selection/fallback metadata)**
+10. **TL1-ARTIFACT-009+ (artifact/reference/loader/backend/benchmark/status PRs)**
+
+## Proof commands
+
+Run for docs/spec PRs in this lane:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check tl1
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+Runtime PRs may add narrower cargo test/bench commands per linked specs.
+
+## Claim boundary
+
+No TL1 runtime claim is valid until layout authority, scalar oracle,
+artifact authority, and reference-good output are proven.


### PR DESCRIPTION
## Summary

- Add TL1 source-map, plan, and campaign tracker scaffolding for the ARM-first table-lookup route.
- Link TL1 from the Apple candidate matrix, spec index, and model-kernel compatibility ledger.
- Keep TL1 explicitly separate from I2_S/QK256 and TL2 proof families.

## Scope

- Documentation, campaign tracking, and generated tracker status only.
- No runtime, kernel, model binary, tokenizer, server, GPU/NPU/OpenVINO execution, BitNet QK256/I2_S, benchmark, or generated-token behavior changes.

## Claim boundary

TL1 remains planning/source-of-truth only. This PR does not claim native BitNet-rs TL1 inference, model compatibility, answer quality, CPU/Metal proof, server readiness, performance, or residency.

## Validation

Local:
- `git diff --check origin/main..HEAD`

Hosted:
- `Doctor + Generated Dashboards`
- `CI Core Success`
- `Markdownlint`
- `Link Checker`
- `Docs Automation`
- `PR Gate Success`
- `PR Plan`
- `RIPR PR Evidence`

## Generated files

- `docs/tracking/campaigns/tl1/generated/status.md`
- `docs/tracking/generated/global-dashboard.md`
- `docs/tracking/generated/lane-dashboard.md`

## Follow-up / supersedes

- No superseded PRs.
- Follow-up TL1 work remains gated by the route/layout/scalar/artifact/quality proof ladder in `plans/tl1/implementation-plan.md`.
