### PR TITLE
fix(bitnet): use embedded GGUF BPE tokenizer metadata

### DIFF
--- a/crates/bitnet-tokenizers/src/gguf_loader.rs
+++ b/crates/bitnet-tokenizers/src/gguf_loader.rs
@@ -281,7 +281,8 @@ impl RustTokenizer {
     ) -> Result<(tokenizers::Tokenizer, ahash::AHashMap<String, u32>, usize)> {
         use ahash::AHashMap;
         use tokenizers::{
-            decoders::byte_level::ByteLevel, models::bpe::BPE, pre_tokenizers::byte_level,
+            AddedToken, decoders::byte_level::ByteLevel, models::bpe::BPE,
+            pre_tokenizers::byte_level,
         };
 
         // Load vocabulary array from metadata
@@ -297,6 +298,11 @@ impl RustTokenizer {
         // Build GGUF piece-to-ID mapping (authoritative token IDs from model)
         let piece_to_gguf_id: AHashMap<String, u32> =
             vocab_strings.iter().enumerate().map(|(i, tok)| (tok.clone(), i as u32)).collect();
+        let special_tokens = vocab_strings
+            .iter()
+            .filter(|tok| is_gguf_control_token(tok))
+            .map(|tok| AddedToken::from(tok.clone(), true).normalized(false))
+            .collect::<Vec<_>>();
 
         // Convert to AHashMap<String, u32> for HuggingFace BPE builder
         // NOTE: HuggingFace will assign its own IDs, we'll remap them in encode()
@@ -338,19 +344,21 @@ impl RustTokenizer {
             .context("BPE tokenizer construction failed - vocab or merges may be invalid")?;
 
         // Create tokenizer with ByteLevel pre-tokenizer and decoder (GPT-2 style)
-        // NOTE: add_prefix_space=true ensures first token is treated like subsequent tokens
-        // (llama.cpp GPT-2 behavior: pretend there is a space before the first token)
-        //
-        // CRITICAL: Both pre-tokenizer AND decoder need add_prefix_space(true) to match llama.cpp
+        // GGUF BPE vocabularies already carry explicit leading-space pieces (for example
+        // `ĠWhat`). Do not synthesize a prefix space; llama.cpp's default GGUF path maps
+        // initial text like `What` to the non-prefixed `What` token.
         let mut tokenizer = tokenizers::Tokenizer::new(bpe);
         tokenizer.with_pre_tokenizer(Some(
-            byte_level::ByteLevel::default().add_prefix_space(true).trim_offsets(false), // Preserve byte offsets for accurate decoding
+            byte_level::ByteLevel::default().add_prefix_space(false).trim_offsets(false), // Preserve byte offsets for accurate decoding
         ));
         tokenizer.with_decoder(Some(
             ByteLevel::default()
-                .add_prefix_space(true) // Match pre-tokenizer configuration
+                .add_prefix_space(false) // Match pre-tokenizer configuration
                 .trim_offsets(false),
         ));
+        if !special_tokens.is_empty() {
+            tokenizer.add_special_tokens(&special_tokens);
+        }
 
         Ok((tokenizer, piece_to_gguf_id, real_vocab_size))
     }
@@ -626,6 +634,11 @@ impl RustTokenizer {
     pub fn add_bos_hint(&self) -> Option<bool> {
         self.add_bos_hint
     }
+}
+
+fn is_gguf_control_token(token: &str) -> bool {
+    (token.starts_with("<|") && token.ends_with("|>"))
+        || (token.starts_with('<') && token.ends_with('>') && !token.contains(' '))
 }
 
 // Implement the Tokenizer trait for RustTokenizer

--- a/crates/bitnet-tokenizers/src/loader.rs
+++ b/crates/bitnet-tokenizers/src/loader.rs
@@ -134,6 +134,12 @@ pub fn load_tokenizer_from_gguf(
 pub fn load_tokenizer_from_gguf_reader(
     reader: &bitnet_models::GgufReader,
 ) -> Result<Arc<dyn Tokenizer + Send + Sync>> {
+    if reader.get_string_metadata("tokenizer.ggml.model").is_some() {
+        let tokenizer = crate::gguf_loader::RustTokenizer::from_gguf(reader)
+            .context("Failed to load GGUF tokenizer metadata")?;
+        return Ok(Arc::new(tokenizer));
+    }
+
     if let Some(bytes) = reader.get_bin_or_u8_array("tokenizer.ggml.model") {
         let bos = reader.get_u32_metadata("tokenizer.ggml.bos_token_id");
         let eos = reader.get_u32_metadata("tokenizer.ggml.eos_token_id");
@@ -141,4 +147,102 @@ pub fn load_tokenizer_from_gguf_reader(
     }
 
     Err(anyhow::anyhow!("GGUF missing tokenizer.ggml.model"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitnet_models::GgufReader;
+
+    fn write_string(buf: &mut Vec<u8>, value: &str) {
+        buf.extend(&(value.len() as u64).to_le_bytes());
+        buf.extend(value.as_bytes());
+    }
+
+    fn write_string_kv(buf: &mut Vec<u8>, key: &str, value: &str) {
+        write_string(buf, key);
+        buf.extend(&8u32.to_le_bytes());
+        write_string(buf, value);
+    }
+
+    fn write_u32_kv(buf: &mut Vec<u8>, key: &str, value: u32) {
+        write_string(buf, key);
+        buf.extend(&4u32.to_le_bytes());
+        buf.extend(&value.to_le_bytes());
+    }
+
+    fn write_string_array_kv(buf: &mut Vec<u8>, key: &str, values: &[&str]) {
+        write_string(buf, key);
+        buf.extend(&9u32.to_le_bytes());
+        buf.extend(&8u32.to_le_bytes());
+        buf.extend(&(values.len() as u64).to_le_bytes());
+        for value in values {
+            write_string(buf, value);
+        }
+    }
+
+    fn minimal_bpe_gguf() -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend(&3u32.to_le_bytes());
+        buf.extend(&0u64.to_le_bytes());
+        buf.extend(&6u64.to_le_bytes());
+        buf.extend(&32u32.to_le_bytes());
+        buf.extend(&0u64.to_le_bytes());
+
+        write_string_kv(&mut buf, "tokenizer.ggml.model", "gpt2");
+        write_string_array_kv(
+            &mut buf,
+            "tokenizer.ggml.tokens",
+            &["a", "b", "ab", "<|eot_id|>", "\u{0120}", "\u{0120}a"],
+        );
+        write_string_array_kv(&mut buf, "tokenizer.ggml.merges", &["a b", "\u{0120} a"]);
+        write_u32_kv(&mut buf, "tokenizer.ggml.bos_token_id", 0);
+        write_u32_kv(&mut buf, "tokenizer.ggml.eos_token_id", 1);
+        write_u32_kv(&mut buf, "tokenizer.ggml.eot_token_id", 3);
+
+        let data_offset = buf.len().div_ceil(32) * 32;
+        buf.resize(data_offset, 0);
+        buf[28..36].copy_from_slice(&(data_offset as u64).to_le_bytes());
+        buf
+    }
+
+    #[test]
+    fn gguf_reader_loader_accepts_string_model_bpe_metadata() {
+        let bytes = minimal_bpe_gguf();
+        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let tokenizer = load_tokenizer_from_gguf_reader(&reader)
+            .expect("GGUF BPE tokenizer metadata should load");
+
+        assert_eq!(tokenizer.vocab_size(), 6);
+        assert_eq!(tokenizer.bos_token_id(), Some(0));
+        assert_eq!(tokenizer.eos_token_id(), Some(1));
+    }
+
+    #[test]
+    fn gguf_reader_loader_parses_bpe_special_tokens_when_enabled() {
+        let bytes = minimal_bpe_gguf();
+        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let tokenizer = load_tokenizer_from_gguf_reader(&reader)
+            .expect("GGUF BPE tokenizer metadata should load");
+
+        let ids = tokenizer
+            .encode("<|eot_id|>", false, true)
+            .expect("parse_special should encode known GGUF special token");
+
+        assert_eq!(ids, vec![3]);
+        assert_eq!(tokenizer.token_to_id("<|eot_id|>"), Some(3));
+    }
+
+    #[test]
+    fn gguf_reader_loader_does_not_synthesize_prefix_space() {
+        let bytes = minimal_bpe_gguf();
+        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let tokenizer = load_tokenizer_from_gguf_reader(&reader)
+            .expect("GGUF BPE tokenizer metadata should load");
+
+        let ids = tokenizer.encode("a", false, false).expect("a should encode");
+
+        assert_eq!(ids, vec![0]);
+    }
 }

--- a/crates/bitnet-tokenizers/src/loader.rs
+++ b/crates/bitnet-tokenizers/src/loader.rs
@@ -208,41 +208,44 @@ mod tests {
     }
 
     #[test]
-    fn gguf_reader_loader_accepts_string_model_bpe_metadata() {
+    fn gguf_reader_loader_accepts_string_model_bpe_metadata() -> Result<()> {
         let bytes = minimal_bpe_gguf();
-        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let reader = GgufReader::new(&bytes).context("minimal BPE GGUF should parse")?;
         let tokenizer = load_tokenizer_from_gguf_reader(&reader)
-            .expect("GGUF BPE tokenizer metadata should load");
+            .context("GGUF BPE tokenizer metadata should load")?;
 
         assert_eq!(tokenizer.vocab_size(), 6);
         assert_eq!(tokenizer.bos_token_id(), Some(0));
         assert_eq!(tokenizer.eos_token_id(), Some(1));
+        Ok(())
     }
 
     #[test]
-    fn gguf_reader_loader_parses_bpe_special_tokens_when_enabled() {
+    fn gguf_reader_loader_parses_bpe_special_tokens_when_enabled() -> Result<()> {
         let bytes = minimal_bpe_gguf();
-        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let reader = GgufReader::new(&bytes).context("minimal BPE GGUF should parse")?;
         let tokenizer = load_tokenizer_from_gguf_reader(&reader)
-            .expect("GGUF BPE tokenizer metadata should load");
+            .context("GGUF BPE tokenizer metadata should load")?;
 
         let ids = tokenizer
             .encode("<|eot_id|>", false, true)
-            .expect("parse_special should encode known GGUF special token");
+            .context("parse_special should encode known GGUF special token")?;
 
         assert_eq!(ids, vec![3]);
         assert_eq!(tokenizer.token_to_id("<|eot_id|>"), Some(3));
+        Ok(())
     }
 
     #[test]
-    fn gguf_reader_loader_does_not_synthesize_prefix_space() {
+    fn gguf_reader_loader_does_not_synthesize_prefix_space() -> Result<()> {
         let bytes = minimal_bpe_gguf();
-        let reader = GgufReader::new(&bytes).expect("minimal BPE GGUF should parse");
+        let reader = GgufReader::new(&bytes).context("minimal BPE GGUF should parse")?;
         let tokenizer = load_tokenizer_from_gguf_reader(&reader)
-            .expect("GGUF BPE tokenizer metadata should load");
+            .context("GGUF BPE tokenizer metadata should load")?;
 
-        let ids = tokenizer.encode("a", false, false).expect("a should encode");
+        let ids = tokenizer.encode("a", false, false).context("a should encode")?;
 
         assert_eq!(ids, vec![0]);
+        Ok(())
     }
 }

--- a/xtask/src/bitnet_reference_plan.rs
+++ b/xtask/src/bitnet_reference_plan.rs
@@ -20,6 +20,14 @@ const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "a770_semantic_quality_proven",
 ];
 
+struct PlanTokenizer {
+    tokenizer: std::sync::Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>,
+    source: String,
+    path: Option<String>,
+    contract_path: Option<String>,
+    rust_cli_tokenizer_arg: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct ReferencePlanArgs<'a> {
     pub model_contract: &'a Path,
@@ -131,13 +139,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
         .map(path_to_string)
         .or_else(|| str_at(&contract, "/local_path").map(ToOwned::to_owned))
         .context("model path missing; pass --model or set /local_path in the model contract")?;
-    let tokenizer_path = args
-        .tokenizer
-        .map(path_to_string)
-        .or_else(|| str_at(&contract, "/tokenizer/path").map(ToOwned::to_owned))
-        .context(
-            "tokenizer path missing; pass --tokenizer or set /tokenizer/path in the model contract",
-        )?;
+    let plan_tokenizer = resolve_plan_tokenizer(&model_path, args.tokenizer, &contract)?;
     let template = args
         .prompt_template
         .parse::<TemplateType>()
@@ -145,9 +147,8 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
     let rendered_prompt = template.apply(args.prompt, args.system_prompt);
     let add_bos = template.should_add_bos();
     let parse_special = template.parse_special();
-    let tokenizer = bitnet_tokenizers::load_tokenizer(Path::new(&tokenizer_path))
-        .with_context(|| format!("loading tokenizer {tokenizer_path}"))?;
-    let token_ids = tokenizer
+    let token_ids = plan_tokenizer
+        .tokenizer
         .encode(&rendered_prompt, add_bos, parse_special)
         .with_context(|| "tokenizing rendered prompt with contract tokenizer")?;
 
@@ -161,7 +162,9 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
     if !Path::new(&model_path).exists() {
         blocked_reasons.push("model_file_missing");
     }
-    if !Path::new(&tokenizer_path).exists() {
+    if let Some(path) = plan_tokenizer.path.as_deref()
+        && !Path::new(path).exists()
+    {
         blocked_reasons.push("tokenizer_file_missing");
     }
 
@@ -195,13 +198,23 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "model_id": str_at(&contract, "/model_id").unwrap_or("unknown-model"),
             "model_path": model_path,
             "model_exists": Path::new(&model_path).exists(),
-            "tokenizer_path": tokenizer_path,
-            "tokenizer_exists": Path::new(&tokenizer_path).exists(),
+            "tokenizer_path": plan_tokenizer.path.as_deref(),
+            "tokenizer_source": plan_tokenizer.source.as_str(),
+            "tokenizer_exists": plan_tokenizer
+                .path
+                .as_deref()
+                .is_some_and(|path| Path::new(path).exists()),
+            "contract_tokenizer_path": plan_tokenizer.contract_path.as_deref(),
+            "contract_tokenizer_exists": plan_tokenizer
+                .contract_path
+                .as_deref()
+                .is_some_and(|path| Path::new(path).exists()),
             "weights_sha256": str_at(&contract, "/sha256").unwrap_or(""),
             "tokenizer_sha256": str_at(&contract, "/tokenizer/sha256").unwrap_or(""),
         },
         "prompt_identity": {
             "prompt_template": args.prompt_template,
+            "tokenizer_source": plan_tokenizer.source.as_str(),
             "system_prompt_present": args.system_prompt.is_some(),
             "rendered_prompt_sha256": sha256_text(&rendered_prompt),
             "prompt_token_ids_sha256": sha256_token_ids(&token_ids)?,
@@ -229,7 +242,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "cpu_argv": rust_cli_argv(
                 "cpu",
                 &model_path,
-                &tokenizer_path,
+                plan_tokenizer.rust_cli_tokenizer_arg.as_deref(),
                 args.prompt_template,
                 args.system_prompt,
                 args.prompt,
@@ -239,7 +252,7 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
             "a770_argv": rust_cli_argv(
                 "intel-arc-a770-opencl",
                 &model_path,
-                &tokenizer_path,
+                plan_tokenizer.rust_cli_tokenizer_arg.as_deref(),
                 args.prompt_template,
                 args.system_prompt,
                 args.prompt,
@@ -254,6 +267,60 @@ fn build_report(args: &ReferencePlanArgs<'_>) -> Result<Value> {
         },
         "not_claims": CRITICAL_NOT_CLAIMS,
     }))
+}
+
+fn resolve_plan_tokenizer(
+    model_path: &str,
+    tokenizer_override: Option<&Path>,
+    contract: &Value,
+) -> Result<PlanTokenizer> {
+    let contract_path = str_at(contract, "/tokenizer/path").map(ToOwned::to_owned);
+    if let Some(path) = tokenizer_override {
+        let path_string = path_to_string(path);
+        let tokenizer = bitnet_tokenizers::load_tokenizer(path)
+            .with_context(|| format!("loading explicit tokenizer {path_string}"))?;
+        return Ok(PlanTokenizer {
+            tokenizer,
+            source: "explicit".to_string(),
+            path: Some(path_string.clone()),
+            contract_path,
+            rust_cli_tokenizer_arg: Some(path_string),
+        });
+    }
+
+    let model = Path::new(model_path);
+    if model.extension().and_then(|ext| ext.to_str()) == Some("gguf")
+        && let Ok(resolution) = bitnet_tokenizers::auto::resolve_tokenizer(model, None, true)
+    {
+        let source = resolution.source.as_str().to_string();
+        let path = resolution.path.as_deref().map(path_to_string);
+        let rust_cli_tokenizer_arg =
+            if resolution.source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
+                None
+            } else {
+                path.clone()
+            };
+        return Ok(PlanTokenizer {
+            tokenizer: resolution.tokenizer,
+            source,
+            path,
+            contract_path,
+            rust_cli_tokenizer_arg,
+        });
+    }
+
+    let tokenizer_path = contract_path.clone().context(
+        "tokenizer path missing; pass --tokenizer or set /tokenizer/path in the model contract",
+    )?;
+    let tokenizer = bitnet_tokenizers::load_tokenizer(Path::new(&tokenizer_path))
+        .with_context(|| format!("loading contract tokenizer {tokenizer_path}"))?;
+    Ok(PlanTokenizer {
+        tokenizer,
+        source: "contract_tokenizer".to_string(),
+        path: Some(tokenizer_path.clone()),
+        contract_path,
+        rust_cli_tokenizer_arg: Some(tokenizer_path),
+    })
 }
 
 #[derive(Debug)]
@@ -317,7 +384,7 @@ fn executable_names() -> &'static [&'static str] {
 fn rust_cli_argv(
     device: &str,
     model: &str,
-    tokenizer: &str,
+    tokenizer: Option<&str>,
     prompt_template: &str,
     system_prompt: Option<&str>,
     prompt: &str,
@@ -341,13 +408,15 @@ fn rust_cli_argv(
         device.to_string(),
         "--model".to_string(),
         model.to_string(),
-        "--tokenizer".to_string(),
-        tokenizer.to_string(),
         "--model-format".to_string(),
         "gguf".to_string(),
         "--prompt-template".to_string(),
         prompt_template.to_string(),
     ];
+    if let Some(tokenizer) = tokenizer {
+        argv.push("--tokenizer".to_string());
+        argv.push(tokenizer.to_string());
+    }
     if let Some(system_prompt) = system_prompt {
         argv.push("--system-prompt".to_string());
         argv.push(system_prompt.to_string());
@@ -428,11 +497,11 @@ mod tests {
 
     #[test]
     fn rust_cli_argv_keeps_a770_and_cpu_feature_routes_separate() {
-        let cpu = rust_cli_argv("cpu", "m.gguf", "tok.json", "raw", None, "x", 1, "cpu.json");
+        let cpu = rust_cli_argv("cpu", "m.gguf", Some("tok.json"), "raw", None, "x", 1, "cpu.json");
         let a770 = rust_cli_argv(
             "intel-arc-a770-opencl",
             "m.gguf",
-            "tok.json",
+            Some("tok.json"),
             "raw",
             None,
             "x",
@@ -442,6 +511,23 @@ mod tests {
         assert!(cpu.windows(2).any(|args| args == ["--features", "cpu"]));
         assert!(a770.windows(2).any(|args| args == ["--features", "opencl"]));
         assert!(a770.windows(2).any(|args| args == ["--device", "intel-arc-a770-opencl"]));
+    }
+
+    #[test]
+    fn rust_cli_argv_can_use_embedded_gguf_tokenizer() {
+        let argv = rust_cli_argv(
+            "cpu",
+            "m.gguf",
+            None,
+            "llama3-chat",
+            None,
+            "What is 2+2?",
+            1,
+            "cpu.json",
+        );
+
+        assert!(!argv.iter().any(|arg| arg == "--tokenizer"));
+        assert!(argv.iter().any(|arg| arg == "--strict-tokenizer"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Port the durable embedded-GGUF BPE tokenizer behavior from stacked diagnostic PR #4845 onto current `main`.
- Load string-valued `tokenizer.ggml.model` GGUF metadata through the Rust GGUF tokenizer path.
- Register GGUF control tokens as special tokens and stop synthesizing a prefix space for GGUF BPE tokenization.
- Let `xtask bitnet-reference-plan` prefer authoritative embedded GGUF tokenizer metadata and omit `--tokenizer` from generated Rust commands when that embedded path is selected.

## Scope

- `crates/bitnet-tokenizers/src/gguf_loader.rs`
- `crates/bitnet-tokenizers/src/loader.rs`
- `xtask/src/bitnet_reference_plan.rs`

This is a clean current-main port. It intentionally does not merge the old stacked diagnostic branch.

## Claim boundary

- Improves tokenizer authority and reference-plan prompt-token evidence.
- Does not prove semantic quality, reference logit parity, A770 performance, completion, residency, server readiness, or product support.
- Does not change model math, kernel routing, CUDA/OpenCL execution, or claim booleans.
- Does not pull predecessor first-token diagnostic/reference-logit features from the old branch chain.

## Validation

Passed locally:

- `cargo fmt -p bitnet-tokenizers -p xtask -- --check`
- `cargo check --locked -p bitnet-tokenizers --no-default-features` (passed before branch refresh; timed out after rebase in the local `sentencepiece-sys` build-script class)
- `Select-String -Path crates/bitnet-tokenizers/src/loader.rs -Pattern '\.expect\(|unwrap\('`
- `git diff --check`
- `git diff --cached --check`
- `git rebase origin/main`
- `git push --force-with-lease`

Local timeout, needs hosted CI:

- `cargo test --locked -p bitnet-tokenizers --lib loader::tests -- --nocapture`
- `cargo test --locked -p bitnet-tokenizers --no-default-features --lib loader::tests -- --nocapture`
- `cargo check --locked -p xtask --no-default-features`
- `cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports`

Those commands timed out locally on Windows while stuck in `sentencepiece-sys` build-script startup before the edited tests/code executed. Hosted Policy initially found panic-family calls in the new tokenizer tests; the follow-up commit converts those tests to `Result<()>` and removes the new `expect` calls. A later PR Gate run failed because it selected `compatibility-tokenizer` while `Tokenizer Compatibility Tests` was skipped; the branch was rebased onto current `origin/main` and force-with-lease pushed to pick up current CI routing fixes. The replacement PR should not merge until hosted CI supplies the missing compile/test/no-panic/gate signal or the timeout is otherwise resolved.

## Generated files

None.

## Follow-up / supersedes

- Supersedes #4845 after this replacement PR merges.
- Keep #4845 open until this PR is green and merged.
