### PR TITLE
docs(tl2): add TL2 source map, campaign scaffolding, and initial TL2 spec set

### DIFF
--- a/ci/model-artifacts/model-kernel-compatibility.toml
+++ b/ci/model-artifacts/model-kernel-compatibility.toml
@@ -7,6 +7,7 @@ source_url = "https://github.com/microsoft/BitNet/blob/main/README.md"
 source_map = "docs/bitnet/official-2b/README.md"
 i2s_source_map = "docs/bitnet/i2s/README.md"
 claim_boundary = "Upstream model/kernel support is a precondition for answer_ready, reference_authority, backend_parity, and speedup claims. Unsupported combinations may only be used for diagnostic runs, artifact inspection, or unsupported-path receipts."
+tl2_boundary_note = "TL2 x86 route evidence is tracked separately from I2_S/QK256 and TL1; listed support is not automatic answer proof."
 
 proof_claims_rejected_when_unsupported = [
   "answer_ready",

--- a/docs/bitnet/tl2/README.md
+++ b/docs/bitnet/tl2/README.md
@@ -1,0 +1,15 @@
+# TL2 Source Map
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md, docs/specs/BITNET-SPEC-TL2-LAYOUT.md, docs/specs/BITNET-SPEC-TL2-SCALAR-ORACLE.md, docs/specs/BITNET-SPEC-TL2-X86-AVX.md, docs/specs/BITNET-SPEC-TL2-ARTIFACT-GATE.md, docs/specs/BITNET-SPEC-TL2-MODEL-COMPATIBILITY.md, docs/specs/BITNET-SPEC-TL2-REFERENCE-QUALITY.md, docs/specs/BITNET-SPEC-TL2-CPU.md, docs/specs/BITNET-SPEC-TL2-CUDA.md, docs/specs/BITNET-SPEC-TL2-PERFORMANCE.md, docs/specs/BITNET-SPEC-TL2-STATUS-SURFACE.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: TL2 remains registered/candidate until route-specific proof passes
+Policy impact: none
+
+TL2 is a separate route family and must not inherit I2_S/QK256 or TL1 proof.

--- a/docs/proposals/BITNET-PROP-0018-tl2-productization.md
+++ b/docs/proposals/BITNET-PROP-0018-tl2-productization.md
@@ -1,0 +1,15 @@
+# BITNET-PROP-0018 TL2 Productization
+
+Status: proposed
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: no immediate promotion
+Policy impact: none
+
+TL2 is an x86-first table-lookup BitNet route that remains separate from I2_S/QK256 and TL1.

--- a/docs/specs/BITNET-SPEC-TL2-ARTIFACT-GATE.md
+++ b/docs/specs/BITNET-SPEC-TL2-ARTIFACT-GATE.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-ARTIFACT-GATE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines artifact authority lanes and blocks answer claims without tokenizer/prompt authority and reference-good output.

--- a/docs/specs/BITNET-SPEC-TL2-CPU.md
+++ b/docs/specs/BITNET-SPEC-TL2-CPU.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-CPU
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-SCALAR-ORACLE.md, docs/specs/BITNET-SPEC-TL2-REFERENCE-QUALITY.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines strict scalar/AVX2/AVX512 x86 proof ladder with `fallback_used=false` for strict answer receipts.

--- a/docs/specs/BITNET-SPEC-TL2-CUDA.md
+++ b/docs/specs/BITNET-SPEC-TL2-CUDA.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-CUDA
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-CPU.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines CUDA TL2 as optional post-CPU-proof route with no inherited QK256/dense proof.

--- a/docs/specs/BITNET-SPEC-TL2-LAYOUT.md
+++ b/docs/specs/BITNET-SPEC-TL2-LAYOUT.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-LAYOUT
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: self
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines canonical TL2 tensor layout and requires reconciliation across quantization-support.md, tl2.rs, tl_lut.rs, and archived analysis before runtime proof.

--- a/docs/specs/BITNET-SPEC-TL2-MODEL-COMPATIBILITY.md
+++ b/docs/specs/BITNET-SPEC-TL2-MODEL-COMPATIBILITY.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-MODEL-COMPATIBILITY
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Tracks per-model TL2 x86 and ARM statuses with explicit unsupported_upstream ARM boundary.

--- a/docs/specs/BITNET-SPEC-TL2-PERFORMANCE.md
+++ b/docs/specs/BITNET-SPEC-TL2-PERFORMANCE.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-PERFORMANCE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-CPU.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines exact-profile benchmark fields and forbids speedup claims before review.

--- a/docs/specs/BITNET-SPEC-TL2-REFERENCE-QUALITY.md
+++ b/docs/specs/BITNET-SPEC-TL2-REFERENCE-QUALITY.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-REFERENCE-QUALITY
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ARTIFACT-GATE.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines minimum deterministic reference corpus and receipt structure for `reference_good=true`.

--- a/docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+++ b/docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
@@ -1,0 +1,17 @@
+# BITNET-SPEC-TL2-ROUTE-CONTRACT
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: self
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Route IDs: tl2_artifact_inventory, tl2_layout_fixture, tl2_scalar_reference, tl2_avx2_reference, tl2_avx512_reference, tl2_x86_cpu_answer, tl2_cuda_candidate, tl2_warm_session, tl2_benchmark_profile.
+
+Strict `--route tl2 --strict` must fail closed when artifact or kernel is unavailable.

--- a/docs/specs/BITNET-SPEC-TL2-SCALAR-ORACLE.md
+++ b/docs/specs/BITNET-SPEC-TL2-SCALAR-ORACLE.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-SCALAR-ORACLE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-LAYOUT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines scalar TL2 oracle kernel IDs `tl2-scalar-reference-gemv` and `tl2-scalar-reference-gemm` with fixture classes and rejection rules for wrong-route I2_S/TL1 paths.

--- a/docs/specs/BITNET-SPEC-TL2-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-TL2-STATUS-SURFACE.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-STATUS-SURFACE
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines `bitnet model status --route tl2`, `bitnet model verify --route tl2`, and `bitnet receipts explain --latest` TL2 status requirements.

--- a/docs/specs/BITNET-SPEC-TL2-X86-AVX.md
+++ b/docs/specs/BITNET-SPEC-TL2-X86-AVX.md
@@ -1,0 +1,15 @@
+# BITNET-SPEC-TL2-X86-AVX
+
+Status: draft
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-SCALAR-ORACLE.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none
+
+Defines AVX2/AVX-512 TL2 reference kernels and parity requirements against scalar oracle before any answer promotion.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -696,7 +696,6 @@ Technical specification for implementing manual KV cache position tracking in th
 - `dual-backend-crossval.md` - Cross-validation patterns
 - `cpp-setup.md` - C++ reference setup guide
 
-
 ## Qwen3.6 Modern Dense/Multimodal Family
 
 Use these artifacts before implementing or claiming Qwen3.6 support:
@@ -713,3 +712,21 @@ Use these artifacts before implementing or claiming Qwen3.6 support:
 10. [Multimodal](BITNET-SPEC-QWEN36-MULTIMODAL.md), [Memory Envelope](BITNET-SPEC-QWEN36-MEMORY-ENVELOPE.md), [Quality](BITNET-SPEC-QWEN36-QUALITY.md), [Performance](BITNET-SPEC-QWEN36-PERFORMANCE.md), [Server](BITNET-SPEC-QWEN36-SERVER.md), [Status Surface](BITNET-SPEC-QWEN36-STATUS-SURFACE.md)
 
 Qwen3.6 is a separate governed family lane: not BitNet proof, not inherited Qwen2.5/Qwen3 0.6B proof, and external sidecar/API evidence is not native Rust proof.
+
+## TL2 Productization
+
+Use these artifacts before implementing or claiming TL2 route support:
+
+1. [TL2 Source Map](../bitnet/tl2/README.md)
+2. [TL2 Implementation Plan](../../plans/tl2/implementation-plan.md)
+3. [TL2 Productization Proposal](../proposals/BITNET-PROP-0018-tl2-productization.md)
+4. [TL2 Route Contract](BITNET-SPEC-TL2-ROUTE-CONTRACT.md)
+5. [TL2 Layout](BITNET-SPEC-TL2-LAYOUT.md)
+6. [TL2 Scalar Oracle](BITNET-SPEC-TL2-SCALAR-ORACLE.md)
+7. [TL2 X86 AVX](BITNET-SPEC-TL2-X86-AVX.md)
+8. [TL2 Artifact Gate](BITNET-SPEC-TL2-ARTIFACT-GATE.md)
+9. [TL2 Model Compatibility](BITNET-SPEC-TL2-MODEL-COMPATIBILITY.md)
+10. [TL2 Reference Quality](BITNET-SPEC-TL2-REFERENCE-QUALITY.md)
+11. [TL2 CPU](BITNET-SPEC-TL2-CPU.md), [CUDA](BITNET-SPEC-TL2-CUDA.md), [Performance](BITNET-SPEC-TL2-PERFORMANCE.md), and [Status Surface](BITNET-SPEC-TL2-STATUS-SURFACE.md)
+
+TL2 is x86-first and separate from I2_S/QK256 and TL1 proof families.

--- a/docs/status/BITNET_CAPABILITY_MATRIX.md
+++ b/docs/status/BITNET_CAPABILITY_MATRIX.md
@@ -32,3 +32,10 @@ human-facing map for the official 2B rows.
 4. Quality, performance, residency, server, and status-surface contracts.
 5. Route-specific receipts before any promotion beyond the current I2_S/QK256
    bounded product CLI state.
+
+
+## TL2 source-of-truth
+
+- TL2 x86 remains `registered`/candidate until artifact, layout, scalar oracle, reference-good, and strict CPU receipts pass.
+- ARM TL2 remains `unsupported_upstream` for tracked families.
+- TL2 does not inherit I2_S/QK256 or TL1 proof.

--- a/docs/tracking/campaigns/tl2/CAMPAIGN.md
+++ b/docs/tracking/campaigns/tl2/CAMPAIGN.md
@@ -1,0 +1,13 @@
+# TL2 Campaign
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: none

--- a/docs/tracking/campaigns/tl2/active.toml
+++ b/docs/tracking/campaigns/tl2/active.toml
@@ -1,5 +1,70 @@
-schema = 1
-campaign = "tl2"
+id = "tl2"
+title = "TL2 x86 table lookup route"
 status = "active"
-updated = "2026-05-19"
-linked_plan = "plans/tl2/implementation-plan.md"
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+plan = "plans/tl2/implementation-plan.md"
+source_map = "docs/bitnet/tl2/README.md"
+
+objective = "Govern TL2 as a distinct x86-first table-lookup proof family with source-of-truth docs, draft specs, and campaign scaffolding before any runtime, model, or benchmark claim."
+
+end_state = [
+  "TL2 source map, implementation plan, proposal, and initial spec set exist.",
+  "TL2 proof work is sequenced through route contract, layout, scalar oracle, artifact gate, CPU, CUDA, reference-quality, and performance slices.",
+  "TL2 cannot inherit I2_S/QK256 or TL1 proof claims.",
+]
+
+hard_constraints = [
+  "TL2 registration is not native BitNet-rs inference support.",
+  "Do not edit runtime code, kernels, model binaries, server inference, GPU/NPU execution, or BitNet QK256/I2_S kernels.",
+  "Do not claim answer quality, performance, CPU/CUDA parity, or model compatibility until follow-up receipts prove them.",
+]
+
+[[work_item]]
+id = "TL2-DOCS-000"
+status = "ready"
+branch = "codex/define-tl2-as-x86-table-lookup-route"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Register the TL2 x86 table-lookup route as documentation and tracker scaffolding only. The slice must add the source map, proposal, draft spec set, implementation plan, campaign tracker entry, and status/index links without claiming native runtime support, model compatibility, answer quality, performance, CPU/CUDA proof, server support, GPU/NPU execution, TL1 proof inheritance, or BitNet QK256/I2_S changes."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign check tl2",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "cargo run --locked -p xtask --no-default-features -- check-model-coverage",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/model-artifacts/model-kernel-compatibility.toml",
+  "docs/bitnet/tl2/**",
+  "docs/proposals/**",
+  "docs/specs/**",
+  "docs/status/**",
+  "docs/tracking/campaigns/tl2/**",
+  "plans/native-rust-inference/bitnet-tl2.md",
+  "plans/tl2/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "models/**",
+  "server inference",
+  "GPU, NPU, OpenVINO, or UHD 620 execution",
+  "TL1 proof inheritance",
+  "BitNet QK256/I2_S kernels",
+]
+may_claim = [
+  "TL2 route scaffolding and draft proof contracts exist.",
+  "Future TL2 work has a source map, plan, and tracker lane.",
+]
+must_not_claim = [
+  "Native BitNet-rs TL2 inference works.",
+  "TL2 answer quality is proven.",
+  "TL2 CPU, CUDA, or server support is available.",
+  "TL2 performance is measured.",
+  "GPU, NPU, OpenVINO, or UHD 620 execution is involved.",
+  "TL2 inherits I2_S/QK256 or TL1 proof claims.",
+  "BitNet QK256/I2_S kernels are modified.",
+]

--- a/docs/tracking/campaigns/tl2/active.toml
+++ b/docs/tracking/campaigns/tl2/active.toml
@@ -1,0 +1,5 @@
+schema = 1
+campaign = "tl2"
+status = "active"
+updated = "2026-05-19"
+linked_plan = "plans/tl2/implementation-plan.md"

--- a/docs/tracking/campaigns/tl2/generated/status.md
+++ b/docs/tracking/campaigns/tl2/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# TL2 x86 table lookup route Campaign Status
+
+- Campaign: `tl2`
+- State: `active`
+- Objective: Govern TL2 as a distinct x86-first table-lookup proof family with source-of-truth docs, draft specs, and campaign scaffolding before any runtime, model, or benchmark claim.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| TL2-DOCS-000 | ready | TBD | `codex/define-tl2-as-x86-table-lookup-route` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Register the TL2 x86 table-lookup route as documentation and tracker scaffolding only. The slice must add the source map, proposal, draft spec set, implementation plan, campaign tracker entry, and status/index links without claiming native runtime support, model compatibility, answer quality, performance, CPU/CUDA proof, server support, GPU/NPU execution, TL1 proof inheritance, or BitNet QK256/I2_S changes. |
+
+## Hard Constraints
+
+- TL2 registration is not native BitNet-rs inference support.
+- Do not edit runtime code, kernels, model binaries, server inference, GPU/NPU execution, or BitNet QK256/I2_S kernels.
+- Do not claim answer quality, performance, CPU/CUDA parity, or model compatibility until follow-up receipts prove them.

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -46,5 +46,6 @@
 | qwen36 | QWEN36-DOCS-000 | TBD | ready | none | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | SERVER-005 | #4490 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-021 | #5133 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
+| tl2 | TL2-DOCS-000 | TBD | ready | none | TL2 registration is not native BitNet-rs inference support. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -46,5 +46,6 @@
 | qwen36 | Qwen3.6 governed model family | QWEN36-DOCS-000 | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | Server real inference | SERVER-005 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-021 | Do not edit BitNet QK256/I2_S kernels. |
+| tl2 | TL2 x86 table lookup route | TL2-DOCS-000 | TL2 registration is not native BitNet-rs inference support. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |

--- a/plans/native-rust-inference/bitnet-tl2.md
+++ b/plans/native-rust-inference/bitnet-tl2.md
@@ -41,3 +41,8 @@ git diff --check
 ### Rollback
 
 Remove diagnostic lane additions and keep existing registered state.
+
+
+## Update 2026-05-19
+
+TL2 now has dedicated source-of-truth docs under `docs/bitnet/tl2/` and `plans/tl2/`.

--- a/plans/tl2/README.md
+++ b/plans/tl2/README.md
@@ -1,0 +1,13 @@
+# TL2 Plan Index
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: plans/tl2/implementation-plan.md
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none (planning only)
+Policy impact: none

--- a/plans/tl2/implementation-plan.md
+++ b/plans/tl2/implementation-plan.md
@@ -1,0 +1,22 @@
+# TL2 Implementation Plan
+
+Status: active
+Owner: BitNet-rs contributors
+Created: 2026-05-19
+Linked proposal: docs/proposals/BITNET-PROP-0018-tl2-productization.md
+Linked specs: docs/specs/BITNET-SPEC-TL2-ROUTE-CONTRACT.md, docs/specs/BITNET-SPEC-TL2-LAYOUT.md, docs/specs/BITNET-SPEC-TL2-SCALAR-ORACLE.md, docs/specs/BITNET-SPEC-TL2-X86-AVX.md, docs/specs/BITNET-SPEC-TL2-ARTIFACT-GATE.md, docs/specs/BITNET-SPEC-TL2-MODEL-COMPATIBILITY.md, docs/specs/BITNET-SPEC-TL2-REFERENCE-QUALITY.md, docs/specs/BITNET-SPEC-TL2-CPU.md, docs/specs/BITNET-SPEC-TL2-CUDA.md, docs/specs/BITNET-SPEC-TL2-PERFORMANCE.md, docs/specs/BITNET-SPEC-TL2-STATUS-SURFACE.md
+Linked ADRs: docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md
+Linked plan: self
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none until proof gates pass
+Policy impact: none
+
+## Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check tl2
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```


### PR DESCRIPTION
### Motivation

- Establish TL2 as an x86-first, separate route family that must not inherit I2_S/QK256 or TL1 proof, and provide a repository source-of-truth for the TL2 productization ladder. 
- Provide the spec/plan scaffolding required before any runtime/model-level TL2 proof (layout reconciliation, scalar oracle, artifact gate, CPU/AVX/CUDA proof, and benchmark promotion).

### Description

- Add TL2 source-map and human-facing entry: `docs/bitnet/tl2/README.md`. 
- Add campaign and plan scaffolding under `plans/tl2/` and `docs/tracking/campaigns/tl2/` with `implementation-plan.md` and `active.toml` to sequence PRs and proof commands. 
- Add proposal and initial draft TL2 spec set: `docs/proposals/BITNET-PROP-0018-tl2-productization.md` and `docs/specs/BITNET-SPEC-TL2-*.md` (route-contract, layout, scalar-oracle, x86-avx, artifact-gate, model-compatibility, reference-quality, cpu, cuda, performance, status-surface). 
- Update index/status/compatibility surfaces to link the new TL2 artifacts: `docs/specs/INDEX.md`, `docs/status/BITNET_CAPABILITY_MATRIX.md`, `plans/native-rust-inference/bitnet-tl2.md`, and add a TL2 clarification to `ci/model-artifacts/model-kernel-compatibility.toml`.

### Testing

- Started `cargo run --locked -p xtask --no-default-features -- campaign check tl2`; compilation began but the run did not finish within the session time window. 
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check` and `cargo run --locked -p xtask --no-default-features -- check-model-coverage` were attempted but blocked behind the cargo/artifact lock created by the in-progress build. 
- Proof commands to run after the build completes include `cargo run --locked -p xtask --no-default-features -- campaign check tl2`, `cargo run --locked -p xtask --no-default-features -- campaign generate --check`, `cargo run --locked -p xtask --no-default-features -- check-model-coverage`, and `git diff --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1c440e248333b5c77e41025689c0)