### PR TITLE
fix(cli): import Command for Windows mac helpers

### DIFF
--- a/crates/bitnet-cli/src/mac.rs
+++ b/crates/bitnet-cli/src/mac.rs
@@ -10,7 +10,6 @@ use std::io::{self, BufRead, IsTerminal, Read, Write};
 #[cfg(unix)]
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
-#[cfg(unix)]
 use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};


### PR DESCRIPTION
## Summary

Fixes a Windows compile break in `bitnet-cli` by making the existing `std::process::Command` import available on all platforms. The affected Apple M4 helper functions already compile on Windows, but their `Command::new` calls were hidden behind a Unix-only import.

## Scope

- One import guard in `crates/bitnet-cli/src/mac.rs`.
- No workflow routing, runtime behavior, model math, backend selection, server, speed, throughput, accelerator, NPU, CUDA, AVX, or BitNet QK256 claim changes.

## Claim boundary

Unchanged. This is compile plumbing only.

## Validation

- `rtk git diff --check`
- `rtk cargo fmt -p bitnet-cli -- --check`
- `rtk proxy cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet`

## Generated files

None.

## Follow-up / supersedes

Unblocks focused `bitnet-cli` validation on Windows for PRs such as `#5920`.
