### PR TITLE
ci: route mapped Rust inputs to core

### DIFF
--- a/xtask/src/ci/plan.rs
+++ b/xtask/src/ci/plan.rs
@@ -161,7 +161,16 @@ fn area_patterns() -> Vec<(&'static str, Vec<&'static str>)> {
             vec![
                 r"^crates/",
                 r"^tests/",
+                r"^tests-new/",
+                r"^tools/",
                 r"^xtask/",
+                r"^xtask-build-helper/",
+                r"^src/",
+                r"^examples/",
+                r"^benches/",
+                r"^scripts/.*\.rs$",
+                r"^build\.rs$",
+                r"^Makefile$",
                 r"^Cargo\.(toml|lock)$",
                 r"^rust-toolchain\.toml$",
             ],
@@ -1315,6 +1324,11 @@ mod tests {
             "scripts/off-workspace-helper.rs",
         ] {
             assert!(is_rust_input_path(path), "{path} should run Rust CI planning");
+            let plan = build_plan(&s(&[path]), &[]);
+            assert!(
+                plan.selected_lanes.iter().any(|lane| lane.id == "ci-core-build-test"),
+                "{path} should select CI Core"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- follow up #5925 after it merged before the review fix landed
- route root, helper, tests-new, tools, examples, benches, build.rs, Makefile, and script Rust paths through the same `rust_core` area classifier used to select CI Core
- extend the regression so mapped Rust-input paths must select `ci-core-build-test`, not merely avoid `no_rust_inputs`

## Why
#5925 correctly expanded `is_rust_input_path`, but `pick_lanes` still depends on `classify_areas(...)[rust_core]`. Without this follow-up, paths like `src/lib.rs`, `tools/...`, or `scripts/*.rs` could be classified as Rust inputs for package planning while failing to select the blocking CI Core lane.

## Claim boundary
- CI planner logic and regression coverage only.
- No runtime, model, tokenizer, backend, kernel, GPU/NPU/A770/OpenCL/CUDA-route, speed, residency, server, product-readiness, or dependency claim.

## Validation
Local:
- `rtk cargo fmt -p xtask -- --check` - passed
- `rtk git diff --check origin/main...HEAD` - passed

Attempted before opening this follow-up:
- `rtk cargo test --locked -p xtask --bin xtask ci::plan` with `CARGO_TARGET_DIR=target/codex-5925` - did not reach test result locally; failed/stalled during heavy Windows compile after kernel warnings
- `rtk cargo test --locked -p xtask --no-default-features --bin xtask package_mapped_paths_are_rust_inputs -- --exact` with `CARGO_TARGET_DIR=target/codex-5925` - timed out after 15 minutes locally

Hosted CI is the merge proof for the xtask regression.