### PR TITLE
refactor(bitnet): split root module into SRP-focused submodules

### DIFF
--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,22 @@
+use bitnet_build_info_core::BuildMetadata;
+
+const METADATA: BuildMetadata = BuildMetadata::from_env(
+    option_env!("VERGEN_GIT_SHA"),
+    None,
+    option_env!("VERGEN_BUILD_TIMESTAMP"),
+    option_env!("VERGEN_RUSTC_SEMVER"),
+    option_env!("VERGEN_CARGO_TARGET_TRIPLE"),
+    None,
+);
+
+/// Git commit hash at build time
+pub const GIT_HASH: &str = METADATA.git_sha;
+
+/// Build timestamp
+pub const BUILD_TIMESTAMP: &str = METADATA.build_timestamp;
+
+/// Target triple
+pub const TARGET: &str = METADATA.cargo_target_triple;
+
+/// Rust version used for build
+pub const RUSTC_VERSION: &str = METADATA.rustc_semver;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,5 @@
+/// Library version information
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Minimum supported Rust version
+pub const MSRV: &str = "1.92.0";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,10 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-mod build_info;
+/// Build metadata captured at compile time.
+pub mod build_info;
 mod constants;
+/// Convenient prelude for common imports.
 pub mod prelude;
 
 pub use build_info::*;
@@ -94,6 +96,10 @@ mod tests {
     #[test]
     fn test_build_info() {
         // These should not panic
+        let _ = build_info::GIT_HASH;
+        let _ = build_info::BUILD_TIMESTAMP;
+        let _ = build_info::TARGET;
+        let _ = build_info::RUSTC_VERSION;
         let _ = GIT_HASH;
         let _ = BUILD_TIMESTAMP;
         let _ = TARGET;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,13 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
+mod build_info;
+mod constants;
+pub mod prelude;
+
+pub use build_info::*;
+pub use constants::{MSRV, VERSION};
+
 // Re-export core functionality
 pub use bitnet_common as common;
 pub use bitnet_models as models;
@@ -64,53 +71,6 @@ pub use bitnet_tokenizers as tokenizers;
 #[cfg(feature = "kernels")]
 #[cfg_attr(docsrs, doc(cfg(feature = "kernels")))]
 pub use bitnet_kernels as kernels;
-
-/// Convenient prelude for common imports
-pub mod prelude {
-    pub use crate::common::{
-        BitNetConfig, BitNetError, Device, GenerationConfig, QuantizationType,
-    };
-    pub use crate::models::{BitNetModel, ModelLoader};
-    pub use crate::quantization::Quantize;
-
-    #[cfg(feature = "inference")]
-    pub use crate::inference::InferenceEngine;
-
-    #[cfg(feature = "tokenizers")]
-    pub use crate::tokenizers::Tokenizer;
-}
-
-/// Library version information
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Minimum supported Rust version
-pub const MSRV: &str = "1.92.0";
-
-/// Build information
-pub mod build_info {
-    use bitnet_build_info_core::BuildMetadata;
-
-    const METADATA: BuildMetadata = BuildMetadata::from_env(
-        option_env!("VERGEN_GIT_SHA"),
-        None,
-        option_env!("VERGEN_BUILD_TIMESTAMP"),
-        option_env!("VERGEN_RUSTC_SEMVER"),
-        option_env!("VERGEN_CARGO_TARGET_TRIPLE"),
-        None,
-    );
-
-    /// Git commit hash at build time
-    pub const GIT_HASH: &str = METADATA.git_sha;
-
-    /// Build timestamp
-    pub const BUILD_TIMESTAMP: &str = METADATA.build_timestamp;
-
-    /// Target triple
-    pub const TARGET: &str = METADATA.cargo_target_triple;
-
-    /// Rust version used for build
-    pub const RUSTC_VERSION: &str = METADATA.rustc_semver;
-}
 
 #[cfg(test)]
 mod tests {
@@ -134,10 +94,10 @@ mod tests {
     #[test]
     fn test_build_info() {
         // These should not panic
-        let _ = build_info::GIT_HASH;
-        let _ = build_info::BUILD_TIMESTAMP;
-        let _ = build_info::TARGET;
-        let _ = build_info::RUSTC_VERSION;
+        let _ = GIT_HASH;
+        let _ = BUILD_TIMESTAMP;
+        let _ = TARGET;
+        let _ = RUSTC_VERSION;
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,9 @@
 //! - [`bitnet_common`]: Shared types, config, error types
 //! - [`bitnet_models`]: GGUF / `SafeTensors` model loading
 //! - [`bitnet_quantization`]: `I2_S`, `TL1`, `TL2` quantization
-//! - [`bitnet_kernels`]: AVX2 / AVX-512 / NEON / CUDA compute kernels
-//! - [`bitnet_inference`]: Autoregressive generation engine
-//! - [`bitnet_tokenizers`]: Universal tokenizer with auto-discovery
+//! - `bitnet_kernels`: AVX2 / AVX-512 / NEON / CUDA compute kernels
+//! - `bitnet_inference`: Autoregressive generation engine
+//! - `bitnet_tokenizers`: Universal tokenizer with auto-discovery
 //!
 //! ## Quick Start
 //!
@@ -50,6 +50,7 @@
 
 mod build_info;
 mod constants;
+/// Convenient imports for common BitNet types and traits.
 pub mod prelude;
 
 pub use build_info::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,10 @@
+/// Convenient prelude for common imports
+pub use crate::common::{BitNetConfig, BitNetError, Device, GenerationConfig, QuantizationType};
+pub use crate::models::{BitNetModel, ModelLoader};
+pub use crate::quantization::Quantize;
+
+#[cfg(feature = "inference")]
+pub use crate::inference::InferenceEngine;
+
+#[cfg(feature = "tokenizers")]
+pub use crate::tokenizers::Tokenizer;


### PR DESCRIPTION
### Motivation
- Reduce cognitive load in `src/lib.rs` by moving distinct responsibilities into smaller, single-responsibility modules.
- Improve maintainability and testability by isolating build metadata, constants, and prelude exports.
- Keep the public crate API surface stable while making internals clearer and easier to extend.

### Description
- Extracted build metadata into `src/build_info.rs` and kept `pub mod build_info` public so the existing `bitnet::build_info::*` path remains valid.
- Extracted version and MSRV constants into `src/constants.rs` and re-exported `MSRV` and `VERSION` from `src/lib.rs`.
- Moved the convenient prelude exports into `src/prelude.rs` and exposed the module via `pub mod prelude;` in `src/lib.rs`.
- Updated `src/lib.rs` to wire the new modules with `mod`/`pub mod` and `pub use` while preserving existing feature-gated re-exports and tests that reference the re-exported symbols.
- Added a regression assertion that `build_info::GIT_HASH`, `build_info::BUILD_TIMESTAMP`, `build_info::TARGET`, and `build_info::RUSTC_VERSION` remain reachable through the historical module path.

### Claim Boundary
- Behavior-preserving root crate refactor only.
- No runtime, model, tokenizer, backend, receipt, performance, hardware, route, support-tier, or readiness claim.
- No generated dashboard or tracker change.

### Testing
- PASS: `rustfmt --edition 2024 --check src/lib.rs src/build_info.rs src/constants.rs src/prelude.rs`
- PASS: `CARGO_TARGET_DIR=target/codex-pr5940-bitnet-lib cargo check --locked -p bitnet --lib --quiet`
- PASS: `git diff --check`
- INCONCLUSIVE: `CARGO_TARGET_DIR=target/codex-pr5940-bitnet-lib cargo test --locked -p bitnet --lib --quiet` timed out locally rather than producing a test failure. Hosted checks should remain the merge authority for the full lib test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1303fe008333ac3c43d3d9813d85)