### PR TITLE
refactor: split qk256 CPU hot-path helpers into SRP submodule

### DIFF
--- a/crates/bitnet-qk256-dispatch/src/cpu_hot_path.rs
+++ b/crates/bitnet-qk256-dispatch/src/cpu_hot_path.rs
@@ -1,0 +1,48 @@
+pub(crate) fn requested_cpu_kernel_label() -> Option<String> {
+    std::env::var("BITNET_CPU_KERNEL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn selected_cpu_hot_path_label(
+    f32_scalar: u64,
+    f32_avx2: u64,
+    scaled_scalar: u64,
+    scaled_avx2: u64,
+) -> Option<String> {
+    let mut labels = Vec::new();
+    if f32_scalar > 0 {
+        labels.push("qk256-f32-scalar-gemv");
+    }
+    if f32_avx2 > 0 {
+        labels.push("qk256-f32-avx2-gemv");
+    }
+    if scaled_scalar > 0 {
+        labels.push("qk256-i2s-i8s-scaled-scalar-gemv");
+    }
+    if scaled_avx2 > 0 {
+        labels.push("qk256-i2s-i8s-scaled-avx2-gemv");
+    }
+    match labels.as_slice() {
+        [] => None,
+        [single] => Some((*single).to_string()),
+        _ => Some("mixed-qk256-cpu-hot-paths".to_string()),
+    }
+}
+
+pub(crate) fn qk256_execution_path_label(
+    f32_scalar: u64,
+    f32_avx2: u64,
+    scaled_scalar: u64,
+    scaled_avx2: u64,
+) -> &'static str {
+    let no_scale = f32_scalar + f32_avx2;
+    let scaled = scaled_scalar + scaled_avx2;
+    match (no_scale > 0, scaled > 0) {
+        (true, true) => "mixed_scaled_and_no_scale",
+        (true, false) => "no_scale_f32",
+        (false, true) => "scaled_i2s_i8s",
+        (false, false) => "not_observed",
+    }
+}

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -18,6 +18,8 @@ use candle_core::Tensor;
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+mod cpu_hot_path;
+
 const NOT_CLAIMED_OPENCL_QK256: &[&str] = &[
     "a770_qk256_opencl_execution",
     "a770_qk256_opencl_performance",
@@ -202,68 +204,19 @@ pub fn qk256_cpu_hot_path_counters() -> Qk256CpuHotPathCounters {
         qk256_flat_bytes_extracted_count: QK256_FLAT_BYTES_EXTRACTED_COUNT.load(Ordering::Relaxed),
         input_rows_materialized_count: QK256_INPUT_ROWS_MATERIALIZED_COUNT.load(Ordering::Relaxed),
         output_rows_allocated_count: QK256_OUTPUT_ROWS_ALLOCATED_COUNT.load(Ordering::Relaxed),
-        requested_kernel: requested_cpu_kernel_label(),
-        selected_kernel: selected_cpu_hot_path_label(
+        requested_kernel: cpu_hot_path::requested_cpu_kernel_label(),
+        selected_kernel: cpu_hot_path::selected_cpu_hot_path_label(
             f32_scalar,
             f32_avx2,
             scaled_scalar,
             scaled_avx2,
         ),
-        qk256_execution_path: qk256_execution_path_label(
+        qk256_execution_path: cpu_hot_path::qk256_execution_path_label(
             f32_scalar,
             f32_avx2,
             scaled_scalar,
             scaled_avx2,
         ),
-    }
-}
-
-fn requested_cpu_kernel_label() -> Option<String> {
-    std::env::var("BITNET_CPU_KERNEL")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn selected_cpu_hot_path_label(
-    f32_scalar: u64,
-    f32_avx2: u64,
-    scaled_scalar: u64,
-    scaled_avx2: u64,
-) -> Option<String> {
-    let mut labels = Vec::new();
-    if f32_scalar > 0 {
-        labels.push("qk256-f32-scalar-gemv");
-    }
-    if f32_avx2 > 0 {
-        labels.push("qk256-f32-avx2-gemv");
-    }
-    if scaled_scalar > 0 {
-        labels.push("qk256-i2s-i8s-scaled-scalar-gemv");
-    }
-    if scaled_avx2 > 0 {
-        labels.push("qk256-i2s-i8s-scaled-avx2-gemv");
-    }
-    match labels.as_slice() {
-        [] => None,
-        [single] => Some((*single).to_string()),
-        _ => Some("mixed-qk256-cpu-hot-paths".to_string()),
-    }
-}
-
-fn qk256_execution_path_label(
-    f32_scalar: u64,
-    f32_avx2: u64,
-    scaled_scalar: u64,
-    scaled_avx2: u64,
-) -> &'static str {
-    let no_scale = f32_scalar + f32_avx2;
-    let scaled = scaled_scalar + scaled_avx2;
-    match (no_scale > 0, scaled > 0) {
-        (true, true) => "mixed_scaled_and_no_scale",
-        (true, false) => "no_scale_f32",
-        (false, true) => "scaled_i2s_i8s",
-        (false, false) => "not_observed",
     }
 }
 


### PR DESCRIPTION
### Motivation

- Improve single-responsibility separation inside the `bitnet-qk256-dispatch` crate by isolating CPU hot-path label and execution-path logic from the larger `lib.rs` file.
- Make the environment-parsing and label-selection helpers easier to test, reason about, and reuse without changing public behavior or proof/receipt semantics.

### Description

- Added a new internal submodule file `crates/bitnet-qk256-dispatch/src/cpu_hot_path.rs` containing `requested_cpu_kernel_label`, `selected_cpu_hot_path_label`, and `qk256_execution_path_label` helper functions.
- Updated `crates/bitnet-qk256-dispatch/src/lib.rs` to declare `mod cpu_hot_path;` and to call `cpu_hot_path::requested_cpu_kernel_label`, `cpu_hot_path::selected_cpu_hot_path_label`, and `cpu_hot_path::qk256_execution_path_label` instead of inlining those functions.
- Removed the previous inline helper implementations from `lib.rs` so the label/env parsing logic now lives in the focused SRP submodule while coverage counters and snapshots remain in `lib.rs`.
- This is a behavior-preserving internal refactor with no public API changes.

### Testing

- Ran `cargo fmt --all -- --check` and it passed.
- Ran `cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests` and all tests passed (17 passed).
- Ran `cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256 --lib` and all tests passed (33 passed).
- Ran `cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu` and all unit/integration tests passed.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1303fe008333ac3c43d3d9813d85)