### PR TITLE
refactor: split bitnet lib into SRP-focused submodules

### DIFF
--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,24 @@
+//! Build-time metadata constants.
+
+use bitnet_build_info_core::BuildMetadata;
+
+const METADATA: BuildMetadata = BuildMetadata::from_env(
+    option_env!("VERGEN_GIT_SHA"),
+    None,
+    option_env!("VERGEN_BUILD_TIMESTAMP"),
+    option_env!("VERGEN_RUSTC_SEMVER"),
+    option_env!("VERGEN_CARGO_TARGET_TRIPLE"),
+    None,
+);
+
+/// Git commit hash at build time.
+pub const GIT_HASH: &str = METADATA.git_sha;
+
+/// Build timestamp.
+pub const BUILD_TIMESTAMP: &str = METADATA.build_timestamp;
+
+/// Target triple.
+pub const TARGET: &str = METADATA.cargo_target_triple;
+
+/// Rust version used for build.
+pub const RUSTC_VERSION: &str = METADATA.rustc_semver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,19 +66,7 @@ pub use bitnet_tokenizers as tokenizers;
 pub use bitnet_kernels as kernels;
 
 /// Convenient prelude for common imports
-pub mod prelude {
-    pub use crate::common::{
-        BitNetConfig, BitNetError, Device, GenerationConfig, QuantizationType,
-    };
-    pub use crate::models::{BitNetModel, ModelLoader};
-    pub use crate::quantization::Quantize;
-
-    #[cfg(feature = "inference")]
-    pub use crate::inference::InferenceEngine;
-
-    #[cfg(feature = "tokenizers")]
-    pub use crate::tokenizers::Tokenizer;
-}
+pub mod prelude;
 
 /// Library version information
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -87,30 +75,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const MSRV: &str = "1.92.0";
 
 /// Build information
-pub mod build_info {
-    use bitnet_build_info_core::BuildMetadata;
-
-    const METADATA: BuildMetadata = BuildMetadata::from_env(
-        option_env!("VERGEN_GIT_SHA"),
-        None,
-        option_env!("VERGEN_BUILD_TIMESTAMP"),
-        option_env!("VERGEN_RUSTC_SEMVER"),
-        option_env!("VERGEN_CARGO_TARGET_TRIPLE"),
-        None,
-    );
-
-    /// Git commit hash at build time
-    pub const GIT_HASH: &str = METADATA.git_sha;
-
-    /// Build timestamp
-    pub const BUILD_TIMESTAMP: &str = METADATA.build_timestamp;
-
-    /// Target triple
-    pub const TARGET: &str = METADATA.cargo_target_triple;
-
-    /// Rust version used for build
-    pub const RUSTC_VERSION: &str = METADATA.rustc_semver;
-}
+pub mod build_info;
 
 #[cfg(test)]
 mod tests {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,11 @@
+//! Convenient prelude for common imports.
+
+pub use crate::common::{BitNetConfig, BitNetError, Device, GenerationConfig, QuantizationType};
+pub use crate::models::{BitNetModel, ModelLoader};
+pub use crate::quantization::Quantize;
+
+#[cfg(feature = "inference")]
+pub use crate::inference::InferenceEngine;
+
+#[cfg(feature = "tokenizers")]
+pub use crate::tokenizers::Tokenizer;


### PR DESCRIPTION
### Motivation
- Reduce responsibility concentration in `src/lib.rs` by extracting distinct concerns into single-responsibility modules.
- Improve maintainability and testability for the prelude exports and build-time metadata.

### Description
- Move prelude exports out of `src/lib.rs` into a new `src/prelude.rs` and re-export it from `src/lib.rs` via `pub mod prelude;`.
- Move build metadata constants out of `src/lib.rs` into a new `src/build_info.rs` and re-export it from `src/lib.rs` via `pub mod build_info;`.
- Preserve the public API surface so existing callers (`use crate::prelude::*`, `build_info::GIT_HASH`, etc.) continue to work unchanged.

### Testing
- Ran `cargo test -p bitnet --lib`; compilation progressed through workspace crates with no failures observed during the run window but the full test run did not complete in this environment.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1303fe008333ac3c43d3d9813d85)