### PR TITLE
Fix OpenCL fake-runtime clippy guard

### DIFF
--- a/crates/bitnet-kernels/src/device_features.rs
+++ b/crates/bitnet-kernels/src/device_features.rs
@@ -179,14 +179,12 @@ pub fn opencl_available_runtime() -> bool {
         .map(|v| v == "1" || v.to_lowercase() == "true")
         .unwrap_or(false);
 
-    if !strict_mode {
-        if let Ok(fake) = env::var("BITNET_GPU_FAKE") {
-            if fake.eq_ignore_ascii_case("opencl") {
-                return true;
-            }
-            if fake.eq_ignore_ascii_case("none") {
-                return false;
-            }
+    if !strict_mode && let Ok(fake) = env::var("BITNET_GPU_FAKE") {
+        if fake.eq_ignore_ascii_case("opencl") {
+            return true;
+        }
+        if fake.eq_ignore_ascii_case("none") {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- collapse the OpenCL fake-runtime strict-mode guard per clippy
- keep BITNET_GPU_FAKE=opencl/none behavior unchanged

## Validation
- cargo fmt --all -- --check
- cargo clippy --locked -p bitnet-kernels --features opencl -- -D warnings
- git diff --check HEAD~1..HEAD