### PR TITLE
test(cli): lock Qwen3 next_proof in model-status dashboard contract

### DIFF
--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -3951,6 +3951,10 @@ mod tests {
 
         let qwen3 = model_status_json_row_for(&value, "dense_qwen3_06b_q8_candidate")?;
         assert_eq!(qwen3["model_coverage_row"], "dense_qwen3_06b_q8_candidate");
+        assert_eq!(
+            qwen3["next_proof"],
+            "Qwen3 exact-profile server readiness is promoted only for the current-source non-streaming /v1/chat/completions RTX 5070 Ti shared-engine receipt at ci/hardware/windows-9950x3d-rtx5070ti/2026-05-19/server-strict-dense-qwen3-q8-smoke.json. Separate exact-profile performance comparator evidence is still required before any speed, benchmark-qualified, or full-residency promotion."
+        );
         assert_eq!(qwen3["category"], "supported");
         assert_eq!(qwen3["current_tier"], "product_cli_ready");
         assert_eq!(qwen3["requested_backend"], "nvidia-rtx-5070-ti-cuda");


### PR DESCRIPTION
### Motivation
- Prevent accidental drift of the user-facing support surface by locking the Qwen3 `next_proof` message in the stable model-status dashboard JSON contract so test failures catch unintended wording/claim changes.

### Description
- Add a strict assertion for `qwen3["next_proof"]` in `model_status_dashboard_json_shape_is_stable` inside `crates/bitnet-cli/src/model_cache.rs` to pin the expected dashboard text; no runtime/kernels/tokenizer/loader/server behavior or claim promotions were changed.

### Testing
- Ran `cargo fmt --all` and it completed successfully. 
- Ran `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard` and `receipts_explain`, both test suites passed. 
- Ran `cargo run --locked -p xtask --no-default-features -- check-model-coverage` and it passed. 
- Ran `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7149a9948333815f2dafb035fb5d)