### PR TITLE
docs(spec): define PR disposition and closure law

### DIFF
--- a/docs/adr/0003-pr-closure-creates-backlog.md
+++ b/docs/adr/0003-pr-closure-creates-backlog.md
@@ -1,0 +1,31 @@
+# ADR-0003: PR closure creates backlog unless durable disposition conditions are met
+
+Status: Accepted
+Owner: BitNet maintainers
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs: docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: policy/pr-dispositions.toml
+
+## Context
+
+Past queue cleanup actions closed PRs for operational convenience (stale stack, parent closure, restack required) without proving that durable value was merged, superseded, or intentionally rejected after audit.
+
+## Decision
+
+Adopt closure law as a durable repo operating decision:
+
+- Closing is not backlog reduction unless the disposition satisfies explicit durable reasons.
+- Operational states (stale base, restack needed, parent closed) route to repair actions, not disposal.
+- If future work remains, closure requires successor link or tracking issue.
+
+## Consequences
+
+- Queue cleanup must preserve evidence lineage.
+- PR disposition comments must include durable reason and links.
+- Future automation can validate closure metadata against policy.

--- a/docs/adr/0004-preserve-pr-identity.md
+++ b/docs/adr/0004-preserve-pr-identity.md
@@ -1,0 +1,34 @@
+# ADR-0004: Preserve PR identity by default
+
+Status: Accepted
+Owner: BitNet maintainers
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs: docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md
+Linked ADRs: docs/adr/0003-pr-closure-creates-backlog.md
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: policy/pr-dispositions.toml
+
+## Context
+
+Review threads, CI history, receipts, and branch context are durable assets. Recreating PRs by default discards this context and inflates queue churn.
+
+## Decision
+
+Preserve original PR identity by default. Preferred action is rebase/restack/retarget existing PR.
+
+Replacement PR is allowed only when:
+
+1. original branch cannot be safely updated,
+2. scope must be narrowed, or
+3. explicit consolidation is planned.
+
+When replacement happens, source PR must link successor and stay open until successor lands unless a tracking issue exists.
+
+## Consequences
+
+- Less review context loss and less CI churn.
+- Clear lineage between source PRs and successor ports.

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -47,6 +47,7 @@ Roadmap
 - Public support claims belong in `docs/status/`, hardware matrices, model
   artifact gates, and receipts.
 - Policy exceptions and CI routing belong in `policy/*.toml`.
+- PR queue disposition and closure law belongs in `docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md` with machine-readable reasons in `policy/pr-dispositions.toml`.
 
 ## Rules
 

--- a/docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md
+++ b/docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md
@@ -1,0 +1,70 @@
+# BITNET-SPEC-PR-QUEUE-DISPOSITION
+
+Status: Draft
+Owner: BitNet maintainers
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs: docs/reference/SPEC_SYSTEM.md
+Linked ADRs: docs/adr/0003-pr-closure-creates-backlog.md, docs/adr/0004-preserve-pr-identity.md
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: policy/pr-dispositions.toml
+
+## Purpose
+
+Define durable disposition law for pull requests so queue burndown cannot reinterpret valuable work as disposable backlog reduction.
+
+## Required behavior
+
+### Closure does not equal backlog reduction
+
+Closing a PR counts as backlog reduction only when one of the following is true:
+
+1. PR is merged.
+2. PR is duplicate of another open/merged PR with explicit link.
+3. PR is superseded by a linked landed equivalent.
+4. PR was clean-ported and the successor port is landed.
+5. PR is historical-only and evidence is captured in a committed report or ledger.
+6. PR was explicitly rejected after content audit with no unique durable value.
+
+If future work remains, closure requires a linked tracking issue or live successor PR.
+
+### Invalid close reasons
+
+The following are invalid as stand-alone closure reasons:
+
+- old/stale age,
+- behind main,
+- parent/root closed,
+- needs restack,
+- not based on main,
+- diagnostic-only,
+- noisy,
+- inconvenient.
+
+### Routing states
+
+- stale stack means no direct merge, not mandatory close;
+- needs restack means repair path, not close;
+- parent/root closed does not force descendant closure;
+- diagnostic-only does not imply disposable work.
+
+### PR identity preservation
+
+Default action is to preserve PR identity and update the same PR through rebase/restack/retarget. Replacement PRs are allowed only when branch repair is unsafe, scope narrowing is required, or explicit consolidation is documented. Source PR must link successor and remain open until successor lands unless a tracking issue exists.
+
+## Acceptance examples
+
+1. PR targets stale base but valid content -> rebase/restack same PR.
+2. PR wrongly closed but still valid -> reopen same PR.
+3. Clean-port landed -> close source PR with successor link.
+4. Future work remains with no successor -> create tracking issue before close.
+5. Diagnostic PR includes durable tooling -> keep open, port, or merge; do not close as old.
+
+## Proof requirements
+
+- `cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports`
+- `cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports`
+- `git diff --check`

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -782,3 +782,17 @@ Use these artifacts before implementing or claiming TL2 route support:
 11. [TL2 CPU](BITNET-SPEC-TL2-CPU.md), [CUDA](BITNET-SPEC-TL2-CUDA.md), [Performance](BITNET-SPEC-TL2-PERFORMANCE.md), and [Status Surface](BITNET-SPEC-TL2-STATUS-SURFACE.md)
 
 TL2 is x86-first and separate from I2_S/QK256 and TL1 proof families.
+
+
+## PR Queue Disposition and Identity Preservation
+
+Use these artifacts before queue cleanup, restack, or closure decisions:
+
+1. [PR Queue Disposition Spec](BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+   - Defines valid/invalid closure reasons, required successor/issue links, and routing semantics for stale/restack states.
+2. [PR Closure Backlog ADR](../adr/0003-pr-closure-creates-backlog.md)
+   - Records durable decision that closure without durable disposition creates hidden backlog.
+3. [PR Identity Preservation ADR](../adr/0004-preserve-pr-identity.md)
+   - Makes rebase/restack/retarget the default over PR recreation.
+
+Do not treat stale age, parent closure, or restack needs as disposal reasons.

--- a/docs/tracking/PR_QUEUE_DISPOSITION.md
+++ b/docs/tracking/PR_QUEUE_DISPOSITION.md
@@ -1,0 +1,21 @@
+# PR Queue Disposition Tracker Notes
+
+This tracker note operationalizes `BITNET-SPEC-PR-QUEUE-DISPOSITION` for queue reviews.
+
+## Reviewer checklist
+
+1. Record one valid close reason from `policy/pr-dispositions.toml`.
+2. Add required evidence link:
+   - merged commit/PR,
+   - duplicate PR,
+   - landed successor,
+   - historical report/ledger, or
+   - content-audit note.
+3. If future work remains, link successor PR or tracking issue before close.
+4. Do not close for stale/restack/parent-closed states.
+
+## Routing reminders
+
+- stale stack -> restack/rebase.
+- invalid closure -> reopen and continue repair.
+- diagnostic with durable tooling -> keep open, port, or merge.

--- a/policy/pr-dispositions.toml
+++ b/policy/pr-dispositions.toml
@@ -1,0 +1,28 @@
+schema_version = "1.0"
+policy = "pr-dispositions"
+
+[valid_close_reasons]
+merged = true
+duplicate = true
+superseded_by_landed_successor = true
+ported_successor_landed = true
+historical_evidence_captured = true
+no_unique_durable_value_after_audit = true
+
+[invalid_close_reasons]
+old = true
+stale = true
+behind_main = true
+root_closed = true
+parent_closed = true
+needs_restack = true
+not_based_on_main = true
+diagnostic_only = true
+noisy = true
+inconvenient = true
+
+[requires_tracking_issue]
+close_with_intent_to_reopen = true
+close_with_intent_to_port = true
+close_with_intent_to_restack = true
+close_with_future_work_remaining = true


### PR DESCRIPTION
### Motivation

- Encode a durable repository rule that closing a PR is not backlog reduction unless explicit durable disposition criteria are met so valuable work is not discarded by operational cleanup.
- Preserve PR identity and review/CI history by making rebase/restack/retarget the default instead of recreating PRs, reducing churn and lost context.
- Provide a machine-readable policy shape to drive automation and checkers so closure decisions and CI write-actions can be validated programmatically.

### Description

- Add `docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md` to define valid/invalid close reasons, routing semantics for stale/restack states, PR identity preservation defaults, acceptance examples, and proof commands (including `xtask` invocations). 
- Add ADRs `docs/adr/0003-pr-closure-creates-backlog.md` and `docs/adr/0004-preserve-pr-identity.md`, add machine-readable policy `policy/pr-dispositions.toml`, and add reviewer runbook `docs/tracking/PR_QUEUE_DISPOSITION.md` to operationalize the spec. 
- Update `docs/specs/INDEX.md` and `docs/reference/SPEC_SYSTEM.md` to reference the new spec and policy, and commit the changes as the PR titled `docs(spec): define PR disposition and closure law`.

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports` which completed with no findings (passed). 
- Ran `cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports` which produced the policy report (completed with warnings/advisories in unrelated lint entries but the report generation succeeded). 
- Ran `git diff --check` which returned clean (no check failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c716e82b883338c4eb81e8a683ba6)