### PR TITLE
docs(spec): define status support schemas

### DIFF
--- a/docs/specs/BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md
+++ b/docs/specs/BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md
@@ -1,0 +1,213 @@
+# BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE
+
+Status: proposed
+Linked proposal:
+[BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs:
+[BITNET-SPEC-0013](BITNET-SPEC-0013-model-onboarding-proof-ladder.md),
+[BITNET-SPEC-0014](BITNET-SPEC-0014-runtime-performance-contract.md)
+Linked ADRs:
+[BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Applies to: `bitnet model status --format json`, receipt explanation
+summaries, support bundles, model coverage rows, status dashboards
+
+## Purpose
+
+`bitnet model status` is the front door for verified local inference. It must
+show what is supported, what route would run, what backend is selected, which
+proof family applies, and which claims remain false. It must not collapse model
+loading, answer quality, CUDA execution, performance, and server readiness into
+one vague "works" state.
+
+This spec defines the stable readiness/status surface that user-facing status,
+receipt explanation, and support bundles must preserve.
+
+## Source-Of-Truth Authorities
+
+The status surface summarizes existing authorities:
+
+- `ci/model-artifacts/model-coverage-matrix.toml`;
+- [Model Coverage Matrix](../model-artifacts/MODEL_COVERAGE_MATRIX.md);
+- [Model Onboarding Proof Ladder](BITNET-SPEC-0013-model-onboarding-proof-ladder.md);
+- [Runtime Performance Contract](BITNET-SPEC-0014-runtime-performance-contract.md);
+- [Proof-family ADR](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md);
+- `ci/hardware/**` receipts;
+- campaign active manifests and events under `docs/tracking/campaigns/**`.
+
+If a status row disagrees with the model coverage matrix, repair the status row
+or the matrix before promoting the user-facing claim. If a status row disagrees
+with a receipt, the receipt remains evidence for what happened and the status
+row remains the supported claim state.
+
+## Top-Level JSON Contract
+
+`bitnet model status --device <device> --format json` must emit a stable object
+with at least these fields:
+
+```text
+schema_version
+device
+requested_backend
+selected_backend
+source
+note
+models
+```
+
+`schema_version` changes only when a breaking shape change is intentionally
+accepted. `requested_backend` records the user's input. `selected_backend`
+records the strict backend label that status rows use for proof, or `null` when
+the device cannot be mapped to a supported status surface.
+
+## Model Row Contract
+
+Each row in `models` must include the support and claim fields required for
+automated support:
+
+```text
+id
+model_coverage_row
+display_name
+model_class
+route
+selected_route
+requested_backend
+selected_backend
+tier
+current_tier
+status
+category
+fallback_used
+cpu_answer_ready
+accelerator_answer_ready
+benchmark_qualified
+product_cli_ready
+speedup_claim
+server_ready
+full_residency_claim
+bitnet_packed_i2s_qk256_proof
+dense_regular_llm_cuda_proof
+ask
+one_token
+short_decode
+warm_session
+benchmark
+server
+server_ready_scope
+server_scope
+server_endpoint
+server_streaming
+server_smoke
+server_reason
+claim_boundary
+next_proof
+```
+
+`tier` and `current_tier` are aliases for the same model coverage tier. New
+fields may be added, but existing fields must not be removed or repurposed
+without a schema-version bump and migration note.
+
+## Tier And Readiness Semantics
+
+Readiness booleans are not interchangeable:
+
+- `cpu_answer_ready=true` means the CPU answer gate passed for that row.
+- `accelerator_answer_ready=true` means the exact accelerator/backend/route
+  proof passed without hidden fallback.
+- `product_cli_ready=true` means normal user CLI paths are accepted for the row.
+- `benchmark_qualified=true` means a benchmark review accepted the exact
+  profile. It does not imply global speedup.
+- `server_ready=true` means the server profile in the row was accepted. It does
+  not imply streaming, concurrency, or broad readiness unless the row says so.
+
+`category` is a display grouping, not a proof tier. `status` is a user-facing
+summary, not an authority that overrides `current_tier` or claim booleans.
+
+## Unknown, False, And Smoke Semantics
+
+The status surface must distinguish unknown from false:
+
+- `null` means the row has no selected route, fallback result, or readiness
+  scope to report.
+- `false` means the repo has explicitly not accepted that claim.
+- `server_smoke=true` means bounded smoke evidence exists.
+- `server_ready=false` with `server_smoke=true` means smoke evidence is not
+  broad readiness.
+
+Status renderers must not translate `null` to `false` when the distinction
+matters for support, and must not translate smoke evidence to readiness.
+
+## Proof-Family Boundaries
+
+The status surface must preserve proof-family booleans:
+
+- `bitnet_packed_i2s_qk256_proof=true` applies only to the exact BitNet
+  packed I2_S/QK256 row and route.
+- `dense_regular_llm_cuda_proof=true` applies only to the exact dense model row
+  and route.
+- A dense proof must never satisfy a BitNet QK256 proof.
+- A BitNet QK256 proof must never satisfy a dense SLM proof.
+- Qwen2.5 proof must never satisfy Qwen3, SmolLM2, Llama, Gemma, or Phi rows.
+
+Any row that is product CLI-ready or server-ready must still show unrelated
+proof-family booleans as `false`.
+
+## Required Parity Across Surfaces
+
+The following surfaces must agree for the same model coverage row:
+
+```text
+bitnet model status --device <device> --format json
+bitnet receipts explain <receipt> --format json
+bitnet support bundle --latest --device <device> --format json
+```
+
+They must preserve:
+
+```text
+model_coverage_row
+current_tier
+selected_backend
+selected_route
+fallback_used
+product_cli_ready
+server_ready
+server_ready_scope
+speedup_claim
+full_residency_claim
+bitnet_packed_i2s_qk256_proof
+dense_regular_llm_cuda_proof
+next_proof
+```
+
+Receipt explanation may report `null` when the receipt lacks information; model
+status remains the current claim state from the matrix.
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+## Non-Goals
+
+- Do not promote any model tier or claim in this spec.
+- Do not change runtime math, kernels, tokenizer, loader, server behavior, or
+  model coverage rows.
+- Do not make `server_smoke` imply `server_ready`.
+- Do not make one proof family imply another proof family.
+- Do not require model downloads or hardware runs to validate this docs-only
+  contract.
+
+## Related Policy Or Manifest Sources
+
+- `ci/model-artifacts/model-coverage-matrix.toml`
+- `docs/status/CUDA_CAPABILITY_MATRIX.md`
+- `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+- `docs/tracking/generated/*`
+- `policy/docs-source-of-truth.toml`

--- a/docs/specs/BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md
+++ b/docs/specs/BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md
@@ -1,0 +1,176 @@
+# BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA
+
+Status: proposed
+Linked proposal:
+[BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs:
+[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md),
+[BITNET-SPEC-0013](BITNET-SPEC-0013-model-onboarding-proof-ladder.md),
+[BITNET-SPEC-0014](BITNET-SPEC-0014-runtime-performance-contract.md)
+Linked ADRs:
+[BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Applies to: `bitnet receipts explain <receipt> --format json`,
+`bitnet receipts explain --latest --format json`, receipt support summaries
+
+## Purpose
+
+`bitnet receipts explain` turns a raw receipt into a stable support summary. It
+must explain what happened in the run and link that run to the current model
+coverage row without inventing unsupported claims.
+
+This spec defines the normalized JSON schema for receipt explanation.
+
+## Source-Of-Truth Authorities
+
+Receipt explanation summarizes:
+
+- the receipt JSON selected by the command;
+- `ci/model-artifacts/model-coverage-matrix.toml`;
+- [Model readiness/status surface](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md);
+- [Runtime Performance Contract](BITNET-SPEC-0014-runtime-performance-contract.md);
+- [Proof-family ADR](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md).
+
+The raw receipt is evidence for what happened. The model coverage row is the
+current support claim. Receipt explanation must show both when they differ.
+
+## Top-Level JSON Contract
+
+`bitnet receipts explain <receipt> --format json` must emit an object with at
+least these fields:
+
+```text
+schema_version
+path
+model_coverage_row
+current_tier
+selected_backend
+selected_route
+fallback_used
+product_cli_ready
+server_ready
+server_ready_scope
+speedup_claim
+full_residency_claim
+bitnet_packed_i2s_qk256_proof
+dense_regular_llm_cuda_proof
+artifact_kind
+claim
+model
+model_coverage
+backend
+execution_plan
+kernels
+quality
+timing
+residency
+benchmark_qualification
+openvino
+claim_limits
+```
+
+The flat aliases exist for support automation. The nested objects preserve
+diagnostic detail.
+
+## Latest Resolution
+
+With `--latest`, the command may search the default receipt directory or a
+provided directory for the newest JSON receipt. The returned `path` must be the
+receipt that was actually explained. `--latest` must not run inference, produce
+a new receipt, or silently select non-JSON artifacts.
+
+If latest resolution fails, the command must fail with an actionable path or
+receipt-discovery message rather than returning an empty success object.
+
+## Flat Alias Semantics
+
+The flat aliases must be filled from the best available source:
+
+1. explicit receipt fields;
+2. normalized receipt subobjects such as `backend`, `execution_plan`, or
+   `claim_boundary`;
+3. the linked model coverage row;
+4. `null` when unknown.
+
+They must not default unknown claims to `true`. A missing receipt field may be
+`null`; an explicitly unaccepted model-coverage claim remains `false`.
+
+## Required Nested Objects
+
+The nested objects must preserve these responsibilities:
+
+| Object | Owns |
+| --- | --- |
+| `model_coverage` | row, tier, route, product/server/speed/residency/proof booleans, warnings |
+| `backend` | requested backend, selected backend, runtime API, fallback status/reason |
+| `execution_plan` | selected route, model family, profile, route-specific claims |
+| `quality` | quality gate pass/fail, blocker, answer/UTF-8 status when present |
+| `timing` | phase timing and throughput fields when present |
+| `residency` | residency, transfer, VRAM, and workspace reuse evidence when present |
+| `benchmark_qualification` | accepted/rejected/not-reviewed benchmark decision |
+| `claim_limits` | forbidden claims and promotion warnings |
+
+Receipts from older lanes may leave some nested fields empty, but the object
+shape must remain stable.
+
+## Proof-Family And Promotion Warnings
+
+Receipt explanation must warn when users might infer the wrong proof family:
+
+- BitNet QK256 proof is not dense SLM CUDA proof.
+- Dense regular-LLM CUDA proof is not BitNet packed I2_S/QK256 proof.
+- Qwen2.5 proof is not Qwen3 proof.
+- Server smoke is not broad server readiness.
+- Benchmark evidence is not speedup unless the exact profile was accepted.
+
+Warnings may be nested under `model_coverage.warnings` or `claim_limits`, but
+the JSON must keep proof-family booleans explicit at the top level.
+
+## Unknown, False, And Conflict Semantics
+
+Receipt explanation must preserve three states:
+
+- `null`: the receipt or matrix did not provide this fact.
+- `false`: the claim is explicitly not accepted.
+- `true`: the claim is explicitly accepted for the row or receipt scope.
+
+If the raw receipt says a claim was not made but the model coverage row has an
+accepted exact-profile claim, explanation may show the accepted row claim, but
+it must preserve the receipt's raw claim boundary in nested detail or warnings.
+
+## Required Rows For Contract Tests
+
+Schema contract tests must cover at least:
+
+- official BitNet 2B I2_S/QK256;
+- Qwen2.5 0.5B Q8_0 dense CUDA;
+- Qwen3 0.6B Q8_0 dense CUDA;
+- SmolLM2 360M structurally valid blocker row.
+
+The tests must assert `model_coverage_row`, `current_tier`,
+`selected_backend`, `selected_route`, `fallback_used`, `server_ready`,
+`server_ready_scope`, `speedup_claim`, `full_residency_claim`,
+`bitnet_packed_i2s_qk256_proof`, and `dense_regular_llm_cuda_proof`.
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+git diff --check
+```
+
+## Non-Goals
+
+- Do not require receipt explanation to run inference or benchmarks.
+- Do not promote model, server, speedup, residency, or proof-family claims.
+- Do not make the receipt schema a replacement for raw immutable receipts.
+- Do not hide conflicts between raw receipt claims and current model coverage.
+
+## Related Policy Or Manifest Sources
+
+- `ci/model-artifacts/model-coverage-matrix.toml`
+- `ci/hardware/**`
+- `docs/tracking/campaigns/**`
+- `policy/docs-source-of-truth.toml`

--- a/docs/specs/BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md
+++ b/docs/specs/BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md
@@ -1,0 +1,186 @@
+# BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA
+
+Status: proposed
+Linked proposal:
+[BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs:
+[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md),
+[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md)
+Linked ADRs:
+[BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Applies to: `bitnet support bundle --latest --device <device> --format json`,
+GitHub CUDA support issues, receipt triage docs
+
+## Purpose
+
+The support bundle is the pasteable issue artifact for proof-carrying local
+inference. It combines model status, latest receipt explanation, binary/build
+identity, and runtime identity into one JSON object without running inference
+or promoting claims.
+
+This spec defines the support bundle schema and support semantics.
+
+## Source-Of-Truth Authorities
+
+The support bundle composes existing surfaces:
+
+- `bitnet model status --device <device> --format json`;
+- `bitnet receipts explain <receipt> --format json`;
+- `ci/model-artifacts/model-coverage-matrix.toml`;
+- [Model readiness/status surface](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md);
+- [Receipt explain schema](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md);
+- [CUDA receipt triage guide](../tutorials/cuda-receipt-triage.md);
+- `.github/ISSUE_TEMPLATE/cuda-support.yml`.
+
+The bundle is a support envelope. It is not a receipt and is not proof by
+itself.
+
+## Top-Level JSON Contract
+
+`bitnet support bundle --latest --device <device> --format json` must emit an
+object with at least these fields:
+
+```text
+schema_version
+kind
+created_utc
+device
+summary
+binary
+runtime
+model_status
+latest_receipt
+```
+
+`kind` must identify the object as a support bundle. `created_utc` records when
+the bundle was assembled. `device` records the requested device label.
+
+## Summary Contract
+
+`summary` is the issue-triage front panel. It must include:
+
+```text
+model_coverage_row
+current_tier
+selected_backend
+selected_route
+fallback_used
+quality_gate
+server_ready
+server_ready_scope
+speedup_claim
+full_residency_claim
+bitnet_packed_i2s_qk256_proof
+dense_regular_llm_cuda_proof
+next_proof
+receipt_path
+```
+
+`summary` must be derived from `latest_receipt` and the corresponding
+`model_status` row when possible. It must not use stale docs prose or free-form
+string matching when the structured surfaces provide a value.
+
+## Binary Identity
+
+`binary` must include:
+
+```text
+name
+crate_version
+git_commit
+git_commit_source
+build_timestamp
+rustc_version
+target_triple
+```
+
+Unknown build fields may be `null`. They must not be replaced by placeholder
+values that look authoritative.
+
+## Runtime Identity
+
+`runtime` should include runtime identity when the latest receipt contains it:
+
+```text
+selected_backend
+runtime_api
+device_name
+driver_version
+cuda_runtime_version
+cuda_driver_version
+source
+```
+
+Runtime identity may be `null` on CPU-only or older receipts. A missing CUDA
+driver/runtime field must not be interpreted as CPU fallback, CUDA failure, or
+successful CUDA proof.
+
+## Embedded Status And Receipt Objects
+
+`model_status` must preserve the full model status dashboard shape from
+[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md).
+
+`latest_receipt` must preserve the full receipt explanation shape from
+[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md).
+
+The bundle may add fields in future versions, but it must not remove these
+embedded objects without a schema-version bump.
+
+## No New Inference
+
+Support bundle generation must be read-only:
+
+- it may read the model coverage matrix;
+- it may read a receipt path or resolve `--latest`;
+- it may inspect build/runtime identity already available locally;
+- it must not download models;
+- it must not run ask, chat, bench, serve, or hardware probes;
+- it must not create a new inference receipt.
+
+This keeps support collection cheap and safe for users filing issues.
+
+## Proof-Family And Claim Boundaries
+
+The bundle must preserve the same hard boundaries as status and receipt
+explanation:
+
+- `speedup_claim=false` remains false unless an exact-profile benchmark review
+  accepted it.
+- `full_residency_claim=false` remains false unless per-phase residency proof
+  accepted it.
+- Exact-profile server readiness must show its scope.
+- Dense CUDA proof must not satisfy BitNet packed I2_S/QK256 proof.
+- BitNet QK256 proof must not satisfy dense SLM proof.
+- Qwen2.5 proof must not satisfy Qwen3 proof.
+
+## Issue Template Contract
+
+CUDA support issue templates should ask for the support bundle JSON before
+free-form environment prose. If the command fails, the template should ask for
+the failed command, stderr, and any available receipt path.
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli support_bundle
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
+git diff --check
+```
+
+## Non-Goals
+
+- Do not make the support bundle an immutable receipt.
+- Do not run inference, model verification, benchmarks, server requests, or
+  hardware probes while assembling a bundle.
+- Do not promote any model, server, speedup, residency, or proof-family claim.
+- Do not require CUDA-only runtime fields for non-CUDA support bundles.
+
+## Related Policy Or Manifest Sources
+
+- `ci/model-artifacts/model-coverage-matrix.toml`
+- `docs/tutorials/cuda-receipt-triage.md`
+- `.github/ISSUE_TEMPLATE/cuda-support.yml`
+- `docs/tracking/campaigns/nvidia-5070ti/active.toml`

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,5 +1,27 @@
 # Specs Index
 
+## Common Local Inference Status Contracts
+
+Use these specs before changing the machine-readable support surfaces for
+model readiness, receipt explanation, or support bundles:
+
+1. [Model Readiness Status Surface](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md)
+   - Defines the stable `bitnet model status --format json` dashboard fields,
+     tier semantics, readiness booleans, backend/route/fallback provenance, and
+     proof-family booleans.
+2. [Receipt Explain Schema](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md)
+   - Defines the normalized `bitnet receipts explain --format json` shape,
+     flat support aliases, nested diagnostic objects, unknown-vs-false
+     semantics, and promotion warnings.
+3. [Support Bundle Schema](BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md)
+   - Defines `bitnet support bundle --latest --device <device> --format json`
+     as a read-only issue artifact that embeds model status and receipt
+     explanation without promoting claims.
+
+Do not remove or repurpose support JSON fields without a schema-version bump.
+Do not let status, receipt explanation, or support bundles infer speedup,
+residency, broad server readiness, or cross-family proof.
+
 ## TL1 ARM-First Table-Lookup Route
 
 Use these artifacts before implementing or claiming TL1 support:


### PR DESCRIPTION
## Summary
- Add durable specs for model-status JSON, receipt-explain JSON, and support-bundle JSON contracts.
- Define required fields, unknown-vs-false semantics, proof-family non-inheritance, and read-only support bundle behavior.
- Add the specs to docs/specs/INDEX.md.

## Validation
- rtk git diff --check
- rtk git diff --cached --check
- rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
- rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
- rtk cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli support_bundle

## Validation gap
- rtk cargo run --locked -p xtask --no-default-features -- check-model-coverage timed out after 300s and the spawned validation cargo processes were stopped.

No runtime, model coverage, server, kernel, tokenizer, loader, or claim-booleans changes.