### PR TITLE
fix(policy): remove new no-panic test debt

### DIFF
--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -4178,7 +4178,7 @@ cases:
     fn cpu_answer_receipt_rejects_missing_qk256_hot_path_counters() {
         let mut receipt =
             strict_answer_receipt_fixture("cpu", "cpu-rust", "cpu", "i2_s-avx2-reference");
-        receipt.as_object_mut().unwrap().remove("qk256_hot_path");
+        let _ = receipt.as_object_mut().and_then(|object| object.remove("qk256_hot_path"));
 
         let failed = answer_receipt_failed_rules(&receipt, "cpu");
 


### PR DESCRIPTION
## Summary

Fixes the current no-panic Policy blocker seen on merge commits by removing one new test-only `unwrap()` finding in the answer-corpus QK256 hot-path fixture.

## Scope

- Replaces one test-only `unwrap()` with non-panicking object removal for the QK256 hot-path missing-counter fixture.
- The earlier server `Clippy (OneAPI)` cleanup was superseded by #5962 and is no longer part of this PR.

## Claim boundary

No runtime routing, model math, tokenizer, backend selection, hardware support, server readiness, speed, throughput, residency, CUDA, OpenCL, OneAPI, AVX, or BitNet QK256 claim is promoted.

## Validation

- `cargo fmt -p bitnet-cli -- --check`
- `git diff --check`
- `Select-String -Path crates\bitnet-cli\src\commands\answer_corpus.rs -Pattern "as_object_mut\(\)\.unwrap\(\).*qk256_hot_path"` returned 0 matches.
- Local gap: `CARGO_TARGET_DIR=target/codex-ci-blockers cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports` timed out twice on this Windows workspace; hosted Policy is the merge proof for the no-panic lane.
- Local gap: `CARGO_TARGET_DIR=target/codex-ci-blockers cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cpu_answer_receipt_rejects_missing_qk256_hot_path_counters -- --nocapture` timed out waiting behind a separate Rust build lock; the code change is the exact hosted no-panic finding.

## Generated files

None.

## Follow-up / supersedes

Unblocks PRs whose merge commits currently fail no-panic Policy, including #5952.
