### PR TITLE
feat(a770): preserve OpenCL backend identity

### DIFF
--- a/crates/bitnet-cli-config-core/src/lib.rs
+++ b/crates/bitnet-cli-config-core/src/lib.rs
@@ -27,6 +27,7 @@ pub const SUPPORTED_DEVICE_LABELS: &[&str] = &[
     "intel-npu-openvino",
     "nvidia-rtx-5070-ti-cuda",
     "nvidia-rtx-5070-ti-wgpu",
+    "intel-a770-opencl",
     "metal",
     "mpsgraph",
     "apple-m4-metal",
@@ -39,7 +40,7 @@ pub const SUPPORTED_DEVICE_LABELS: &[&str] = &[
 ];
 
 /// Stable help text for supported package-level device/backend labels.
-pub const SUPPORTED_DEVICE_LABELS_TEXT: &str = "cpu, cuda, gpu, vulkan, opencl, ocl, hip, rocm, oneapi, npu, npu:<index>, intel-npu, intel-npu:<index>, openvino-npu, intel-npu-openvino, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, apple-m3-air-metal, apple-m3-air-mpsgraph, apple-m3-air-cpu-neon, auto";
+pub const SUPPORTED_DEVICE_LABELS_TEXT: &str = "cpu, cuda, gpu, vulkan, opencl, ocl, hip, rocm, oneapi, npu, npu:<index>, intel-npu, intel-npu:<index>, openvino-npu, intel-npu-openvino, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, intel-a770-opencl, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, apple-m3-air-metal, apple-m3-air-mpsgraph, apple-m3-air-cpu-neon, auto";
 
 /// Stable help text for Apple M4 proof-lane labels.
 pub const APPLE_M4_DEVICE_LABELS_TEXT: &str = "apple-m4-metal = native Metal proof lane, apple-m4-mpsgraph = MPSGraph graph/reference lane, apple-m4-cpu-neon = Apple CPU/NEON fallback/parity lane";
@@ -48,7 +49,7 @@ pub const APPLE_M4_DEVICE_LABELS_TEXT: &str = "apple-m4-metal = native Metal pro
 pub const APPLE_M3_AIR_DEVICE_LABELS_TEXT: &str = "apple-m3-air-metal = strict request identity for future M3 MacBook Air Metal receipts, apple-m3-air-mpsgraph = strict request identity for future M3 MacBook Air MPSGraph/reference receipts, apple-m3-air-cpu-neon = M3 MacBook Air Apple CPU/NEON lane";
 
 /// Top-level `--device` help for package-level backend labels.
-pub const DEVICE_HELP: &str = "Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, apple-m3-air-metal, apple-m3-air-mpsgraph, apple-m3-air-cpu-neon, auto). Apple M4 and M3 Air labels are distinct proof lanes";
+pub const DEVICE_HELP: &str = "Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, intel-a770-opencl, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, apple-m3-air-metal, apple-m3-air-mpsgraph, apple-m3-air-cpu-neon, auto). Apple M4 and M3 Air labels are distinct proof lanes";
 
 /// Help for legacy full-cli commands that do not emit Apple proof receipts.
 pub const LEGACY_RUNTIME_DEVICE_HELP: &str = "Device for this legacy command (cpu, cuda/gpu aliases, auto). Use `bitnet run` for receipt-backed Apple proof labels";
@@ -246,6 +247,7 @@ pub fn is_supported_device_label(label: &str) -> bool {
             | "intel-npu-openvino"
             | "nvidia-rtx-5070-ti-cuda"
             | "nvidia-rtx-5070-ti-wgpu"
+            | "intel-a770-opencl"
             | "metal"
             | "mpsgraph"
             | "apple-m4-metal"
@@ -313,8 +315,9 @@ impl ConfigBuilder {
 mod tests {
     use super::{
         APPLE_M3_AIR_DEVICE_LABELS_TEXT, APPLE_M4_DEVICE_LABELS_TEXT, CliConfig, ConfigBuilder,
-        LoggingConfig, PerformanceConfig, SUPPORTED_DEVICE_LABELS, invalid_device_message,
-        is_supported_device_label, unsupported_legacy_command_device_message,
+        DEVICE_HELP, LoggingConfig, PerformanceConfig, SUPPORTED_DEVICE_LABELS,
+        SUPPORTED_DEVICE_LABELS_TEXT, invalid_device_message, is_supported_device_label,
+        unsupported_legacy_command_device_message,
     };
     use std::path::PathBuf;
 
@@ -919,6 +922,18 @@ memory_optimization = true
             },
         )?;
         assert!(format!("{err}").contains("Invalid device"));
+        Ok(())
+    }
+
+    #[test]
+    fn validation_accepts_intel_a770_opencl_proof_lane_label() -> anyhow::Result<()> {
+        let config =
+            CliConfig { default_device: "intel-a770-opencl".to_string(), ..CliConfig::default() };
+
+        config.validate()?;
+        assert!(is_supported_device_label("intel-a770-opencl"));
+        assert!(SUPPORTED_DEVICE_LABELS_TEXT.contains("intel-a770-opencl"));
+        assert!(DEVICE_HELP.contains("intel-a770-opencl"));
         Ok(())
     }
 

--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -58,6 +58,8 @@ pub enum BackendRequest {
     Hip,
     /// Require Intel oneAPI specifically.
     OneApi,
+    /// Require the Intel Arc A770 native OpenCL proof lane.
+    IntelA770OpenCl,
     /// Require Intel NPU identity without treating it as GPU, Metal, or CPU fallback.
     IntelNpu,
     /// Require Intel NPU through the OpenVINO runtime.
@@ -92,6 +94,7 @@ impl BackendRequest {
             "nvidia-rtx-5070-ti-wgpu" => Some(BackendRequest::NvidiaRtx5070TiWgpu),
             "hip" | "rocm" => Some(BackendRequest::Hip),
             "oneapi" => Some(BackendRequest::OneApi),
+            "intel-a770-opencl" | "a770-opencl" => Some(BackendRequest::IntelA770OpenCl),
             "npu" | "intel-npu" => Some(BackendRequest::IntelNpu),
             "openvino-npu" | "intel-npu-openvino" => Some(BackendRequest::OpenVinoNpu),
             "metal" => Some(BackendRequest::Metal),
@@ -118,6 +121,7 @@ impl fmt::Display for BackendRequest {
             BackendRequest::NvidiaRtx5070TiWgpu => write!(f, "nvidia-rtx-5070-ti-wgpu"),
             BackendRequest::Hip => write!(f, "hip"),
             BackendRequest::OneApi => write!(f, "oneapi"),
+            BackendRequest::IntelA770OpenCl => write!(f, "intel-a770-opencl"),
             BackendRequest::IntelNpu => write!(f, "intel-npu"),
             BackendRequest::OpenVinoNpu => write!(f, "openvino-npu"),
             BackendRequest::Metal => write!(f, "metal"),
@@ -176,6 +180,9 @@ impl BackendSelectionResult {
             (BackendRequest::NvidiaRtx5070TiCuda, KernelBackend::Cuda) => {
                 "nvidia-rtx-5070-ti-cuda".to_string()
             }
+            (BackendRequest::IntelA770OpenCl, KernelBackend::OpenCL) => {
+                "intel-a770-opencl".to_string()
+            }
             _ => self.selected.to_string(),
         }
     }
@@ -186,7 +193,7 @@ impl BackendSelectionResult {
             "cuda" | "nvidia-rtx-5070-ti-cuda" => "cuda",
             "hip" => "hip",
             "oneapi" => "oneapi",
-            "opencl" => "opencl",
+            "opencl" | "intel-a770-opencl" => "opencl",
             "apple-m4-metal" | "apple-m3-air-metal" | "metal" => "metal",
             "apple-m4-mpsgraph" | "apple-m3-air-mpsgraph" | "mpsgraph" => "mpsgraph",
             _ => "cpu",
@@ -202,6 +209,7 @@ impl BackendSelectionResult {
             BackendRequest::Cuda => self.selected != KernelBackend::Cuda,
             BackendRequest::Hip => self.selected != KernelBackend::Hip,
             BackendRequest::OneApi => self.selected != KernelBackend::OneApi,
+            BackendRequest::IntelA770OpenCl => self.requested_backend() != self.selected_backend(),
             BackendRequest::NvidiaRtx5070TiCuda
             | BackendRequest::NvidiaRtx5070TiWgpu
             | BackendRequest::IntelNpu
@@ -344,6 +352,22 @@ pub fn select_backend(
                 });
             }
         }
+        BackendRequest::IntelA770OpenCl => {
+            // The A770 lane is strict and label-preserving. Device verification
+            // and kernel proof land in later work items; CPU fallback is never
+            // OpenCL proof.
+            if caps.opencl_compiled && caps.opencl_runtime {
+                (
+                    KernelBackend::OpenCL,
+                    "Intel Arc A770 OpenCL backend requested; OpenCL runtime available".to_string(),
+                )
+            } else {
+                return Err(BackendSelectionError::RequestedUnavailable {
+                    requested: request,
+                    available: detected.clone(),
+                });
+            }
+        }
         BackendRequest::IntelNpu | BackendRequest::OpenVinoNpu => {
             // NPU-002 preserves the requested identity only. Runtime probing and
             // OpenVINO graph execution land later, so CPU/GPU fallback is never
@@ -471,6 +495,22 @@ mod tests {
         }
     }
 
+    fn opencl_caps() -> KernelCapabilities {
+        KernelCapabilities {
+            cpu_rust: true,
+            cuda_compiled: false,
+            cuda_runtime: false,
+            hip_compiled: false,
+            hip_runtime: false,
+            oneapi_compiled: false,
+            oneapi_runtime: false,
+            opencl_compiled: true,
+            opencl_runtime: true,
+            cpp_ffi: false,
+            simd_level: SimdLevel::Avx2,
+        }
+    }
+
     #[test]
     fn auto_selects_cpu_when_only_cpu() {
         let result = select_backend(BackendRequest::Auto, &cpu_only_caps()).unwrap();
@@ -574,6 +614,21 @@ mod tests {
     }
 
     #[test]
+    fn intel_a770_opencl_label_parses_without_aliasing_generic_gpu() {
+        assert_eq!(
+            BackendRequest::from_label("intel-a770-opencl"),
+            Some(BackendRequest::IntelA770OpenCl)
+        );
+        assert_eq!(
+            BackendRequest::from_label("a770-opencl"),
+            Some(BackendRequest::IntelA770OpenCl)
+        );
+        assert_ne!(BackendRequest::from_label("intel-a770-opencl"), Some(BackendRequest::Gpu));
+        assert_ne!(BackendRequest::from_label("intel-a770-opencl"), Some(BackendRequest::OneApi));
+        assert_eq!(BackendRequest::IntelA770OpenCl.to_string(), "intel-a770-opencl");
+    }
+
+    #[test]
     fn intel_npu_labels_parse_without_aliasing() {
         assert_eq!(BackendRequest::from_label("npu"), Some(BackendRequest::IntelNpu));
         assert_eq!(BackendRequest::from_label("intel-npu"), Some(BackendRequest::IntelNpu));
@@ -620,6 +675,31 @@ mod tests {
 
         assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
         assert!(err.to_string().contains("nvidia-rtx-5070-ti-wgpu"));
+    }
+
+    #[test]
+    fn intel_a770_opencl_request_preserves_identity_when_opencl_available() {
+        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps()).unwrap();
+
+        assert_eq!(result.selected, KernelBackend::OpenCL);
+        assert_eq!(result.requested_backend(), "intel-a770-opencl");
+        assert_eq!(result.selected_backend(), "intel-a770-opencl");
+        assert_eq!(result.runtime_api(), "opencl");
+        assert!(!result.fallback_used());
+
+        let summary = result.identity_summary();
+        assert!(summary.contains("requested_backend=intel-a770-opencl"), "got: {summary}");
+        assert!(summary.contains("selected_backend=intel-a770-opencl"), "got: {summary}");
+        assert!(summary.contains("runtime_api=opencl"), "got: {summary}");
+        assert!(summary.contains("fallback_used=false"), "got: {summary}");
+    }
+
+    #[test]
+    fn intel_a770_opencl_request_is_strict_without_opencl_runtime() {
+        let err = select_backend(BackendRequest::IntelA770OpenCl, &cpu_only_caps()).unwrap_err();
+
+        assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
+        assert!(err.to_string().contains("intel-a770-opencl"));
     }
 
     #[test]

--- a/crates/bitnet-device-config-core/src/backend.rs
+++ b/crates/bitnet-device-config-core/src/backend.rs
@@ -14,6 +14,7 @@ impl DeviceConfig {
             DeviceConfig::OpenVinoNpu => BackendRequest::OpenVinoNpu,
             DeviceConfig::NvidiaRtx5070TiCuda => BackendRequest::NvidiaRtx5070TiCuda,
             DeviceConfig::NvidiaRtx5070TiWgpu => BackendRequest::NvidiaRtx5070TiWgpu,
+            DeviceConfig::IntelA770OpenCl => BackendRequest::IntelA770OpenCl,
             DeviceConfig::Metal => BackendRequest::Metal,
             DeviceConfig::MpsGraph => BackendRequest::MpsGraph,
             DeviceConfig::AppleM4Metal => BackendRequest::AppleM4Metal,

--- a/crates/bitnet-device-config-core/src/config.rs
+++ b/crates/bitnet-device-config-core/src/config.rs
@@ -18,6 +18,8 @@ pub enum DeviceConfig {
     NvidiaRtx5070TiCuda,
     /// Preserve the RTX 5070 Ti WGPU reference-lane backend identity.
     NvidiaRtx5070TiWgpu,
+    /// Preserve the Intel Arc A770 native OpenCL proof-lane backend identity.
+    IntelA770OpenCl,
     /// Preserve a native Metal backend identity.
     Metal,
     /// Preserve an MPSGraph graph/reference backend identity.

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -33,6 +33,7 @@ mod tests {
             parse_device("nvidia-rtx-5070-ti-wgpu"),
             Some(DeviceConfig::NvidiaRtx5070TiWgpu)
         );
+        assert_eq!(parse_device("intel-a770-opencl"), Some(DeviceConfig::IntelA770OpenCl));
         assert_eq!(parse_device("metal"), Some(DeviceConfig::Metal));
         assert_eq!(parse_device("mpsgraph"), Some(DeviceConfig::MpsGraph));
         assert_eq!(parse_device("apple-m4-metal"), Some(DeviceConfig::AppleM4Metal));
@@ -94,6 +95,20 @@ mod tests {
         assert_ne!(rtx_cuda.backend_label(), generic_cuda.backend_label());
         assert_ne!(rtx_wgpu.backend_label(), generic_gpu.backend_label());
         assert_ne!(rtx_wgpu.backend_label(), generic_cuda.backend_label());
+    }
+
+    #[test]
+    fn intel_a770_opencl_backend_label_does_not_alias_generic_gpu_or_oneapi() {
+        let generic_gpu = DeviceConfig::Gpu(0);
+        let generic_opencl_alias = DeviceConfig::Gpu(0);
+        let a770 = DeviceConfig::IntelA770OpenCl;
+
+        assert_eq!(a770.backend_label(), "intel-a770-opencl");
+        assert_eq!(a770.backend_request().to_string(), "intel-a770-opencl");
+        assert_eq!(a770.resolve(), bitnet_common::Device::OpenCL(0));
+        assert_ne!(a770.backend_label(), generic_gpu.backend_label());
+        assert_ne!(a770.backend_label(), generic_opencl_alias.backend_label());
+        assert_ne!(a770.backend_request(), bitnet_common::BackendRequest::OneApi);
     }
 
     #[test]
@@ -214,6 +229,7 @@ mod tests {
             DeviceConfig::OpenVinoNpu,
             DeviceConfig::NvidiaRtx5070TiCuda,
             DeviceConfig::NvidiaRtx5070TiWgpu,
+            DeviceConfig::IntelA770OpenCl,
             DeviceConfig::Metal,
             DeviceConfig::MpsGraph,
             DeviceConfig::AppleM4Metal,

--- a/crates/bitnet-device-config-core/src/parse.rs
+++ b/crates/bitnet-device-config-core/src/parse.rs
@@ -15,6 +15,7 @@ impl FromStr for DeviceConfig {
             "openvino-npu" | "intel-npu-openvino" => Ok(DeviceConfig::OpenVinoNpu),
             "nvidia-rtx-5070-ti-cuda" => Ok(DeviceConfig::NvidiaRtx5070TiCuda),
             "nvidia-rtx-5070-ti-wgpu" => Ok(DeviceConfig::NvidiaRtx5070TiWgpu),
+            "intel-a770-opencl" | "a770-opencl" => Ok(DeviceConfig::IntelA770OpenCl),
             "metal" => Ok(DeviceConfig::Metal),
             "mpsgraph" => Ok(DeviceConfig::MpsGraph),
             "apple-m4-metal" => Ok(DeviceConfig::AppleM4Metal),

--- a/crates/bitnet-device-config-core/src/resolve.rs
+++ b/crates/bitnet-device-config-core/src/resolve.rs
@@ -14,6 +14,7 @@ impl DeviceConfig {
             DeviceConfig::NvidiaRtx5070TiCuda => Device::Cuda(0),
             // WGPU is a reference-lane identity; execution lands in a later item.
             DeviceConfig::NvidiaRtx5070TiWgpu => Device::Cpu,
+            DeviceConfig::IntelA770OpenCl => Device::OpenCL(0),
             DeviceConfig::Metal | DeviceConfig::AppleM4Metal => Device::Metal,
             // M3 Air Metal is an identity-only request until a receipt-backed runtime item lands.
             DeviceConfig::AppleM3AirMetal => Device::Cpu,

--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -415,12 +415,12 @@ pub fn select_backend(
             }
         }
         Device::OpenCL(_) => {
-            if bitnet_kernels::device_features::oneapi_available_runtime() {
+            if bitnet_kernels::device_features::opencl_available_runtime() {
                 info!(
                     "OpenCL selected; compute kernels dispatched via KernelManager, tensor ops on CPU"
                 );
             } else {
-                warn!("OpenCL requested but oneapi runtime not available, falling back to CPU");
+                warn!("OpenCL requested but OpenCL runtime not available, falling back to CPU");
             }
             // OpenCL compute kernels are dispatched via KernelManager inside
             // quantized linear layers; the high-level backend uses CPU tensors.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -67,7 +67,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "A770-003"
-status = "proposed"
+status = "in_progress"
 branch = "codex/intel-a770/A770-003-backend-identity"
 stackable = false
 review_mode = "codex_premerge"
@@ -80,6 +80,7 @@ commands = [
   "cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu",
 ]
 allowed_paths = [
+  "crates/bitnet-common/src/backend_selection.rs",
   "crates/bitnet-common/src/types.rs",
   "crates/bitnet-device-config-core/src/lib.rs",
   "crates/bitnet-inference/src/backends.rs",

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -67,8 +67,10 @@ must_not_claim = [
 
 [[work_item]]
 id = "A770-003"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/intel-a770/A770-003-backend-identity"
+pr = 5969
+head_sha = "f86bc087913a3c2251a8a97c730ac060b2ff7d18"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-19T155517Z-A770-003-in-progress.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-19T155517Z-A770-003-in-progress.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-19T15:55:17Z"
+campaign = "intel-a770"
+item = "A770-003"
+event = "in_progress"
+branch = "codex/intel-a770/A770-003-backend-identity"
+actor = "codex"
+
+notes = [
+  "Started A770-003 to preserve Intel Arc A770 OpenCL requested and selected backend identity without adding kernels or inference claims.",
+  "The patch scope is backend/config/logging identity only: labels, request parsing, strict selection, and receipt-facing selected backend identity.",
+  "The item scope now includes crates/bitnet-common/src/backend_selection.rs because BackendRequest and selection identity live there in the current code layout.",
+  "No A770 OpenCL execution, BitNet inference, packed QK256, speedup, or route promotion claim is made.",
+]

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-19T160157Z-A770-003-pr-open.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-19T160157Z-A770-003-pr-open.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-19T16:01:57Z"
+campaign = "intel-a770"
+item = "A770-003"
+event = "pr_open"
+pr = 5969
+head_sha = "f86bc087913a3c2251a8a97c730ac060b2ff7d18"
+branch = "codex/intel-a770/A770-003-backend-identity"
+actor = "codex"
+
+notes = [
+  "Opened PR #5969 to preserve Intel Arc A770 OpenCL requested and selected backend identity through config and backend-selection surfaces.",
+  "The PR keeps A770 OpenCL strict and label-preserving without adding kernels or inference claims.",
+  "No A770 OpenCL execution, OpenVINO GPU/native OpenCL equivalence, BitNet inference-on-A770, speedup, route promotion, or QK256 behavior claim is made.",
+]

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | A770-000 | merged | #5623 | `codex/intel-a770/A770-000-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Reconcile active.toml, CAMPAIGN.md, route matrix, kernel matrix, claim ledger, and model contract so no full inference or trusted-partial A770 claim is present without committed claim-grade receipts. |
-| A770-003 | proposed | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-003 | in_progress | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
 | A770-004 | proposed | TBD | `codex/intel-a770/A770-004-runtime-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add A770 runtime probe evidence without promoting OpenCL execution or BitNet inference claims. |
 | A770-005 | proposed | TBD | `codex/intel-a770/A770-005-opencl-smoke` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run a tiny selected-device OpenCL smoke with fallback_used=false and CPU parity, without BitNet inference claims. |
 | A770-006 | proposed | TBD | `codex/intel-a770/A770-006-opencl-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add CPU/OpenCL parity for a minimal kernel or subgraph without promoting official BitNet QK256 inference. |

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | A770-000 | merged | #5623 | `codex/intel-a770/A770-000-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Reconcile active.toml, CAMPAIGN.md, route matrix, kernel matrix, claim ledger, and model contract so no full inference or trusted-partial A770 claim is present without committed claim-grade receipts. |
-| A770-003 | in_progress | TBD | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-003 | pr_open | #5969 | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
 | A770-004 | proposed | TBD | `codex/intel-a770/A770-004-runtime-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add A770 runtime probe evidence without promoting OpenCL execution or BitNet inference claims. |
 | A770-005 | proposed | TBD | `codex/intel-a770/A770-005-opencl-smoke` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run a tiny selected-device OpenCL smoke with fallback_used=false and CPU parity, without BitNet inference claims. |
 | A770-006 | proposed | TBD | `codex/intel-a770/A770-006-opencl-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add CPU/OpenCL parity for a minimal kernel or subgraph without promoting official BitNet QK256 inference. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,3 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| intel-a770 | A770-003 | #5969 | `codex/intel-a770/A770-003-backend-identity` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -419,7 +419,7 @@
 | intel-258v-platform | LNL258V-REG-008 | LNL258V-POWER-001, LNL258V-REG-007 | merged |
 | intel-258v-platform | LNL258V-POWER-001 | LNL258V-ROUTE-019, LNL258V-NPU-RESIDENT-002, LNL258V-BENCH-004 | merged |
 | intel-258v-platform | LNL258V-OP-006 | LNL258V-ROUTE-015 | merged |
-| intel-a770 | A770-003 | A770-000 | in_progress |
+| intel-a770 | A770-003 | A770-000 | pr_open |
 | intel-a770 | A770-004 | A770-003 | proposed |
 | intel-a770 | A770-005 | A770-004 | proposed |
 | intel-a770 | A770-006 | A770-005 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -419,7 +419,7 @@
 | intel-258v-platform | LNL258V-REG-008 | LNL258V-POWER-001, LNL258V-REG-007 | merged |
 | intel-258v-platform | LNL258V-POWER-001 | LNL258V-ROUTE-019, LNL258V-NPU-RESIDENT-002, LNL258V-BENCH-004 | merged |
 | intel-258v-platform | LNL258V-OP-006 | LNL258V-ROUTE-015 | merged |
-| intel-a770 | A770-003 | A770-000 | proposed |
+| intel-a770 | A770-003 | A770-000 | in_progress |
 | intel-a770 | A770-004 | A770-003 | proposed |
 | intel-a770 | A770-005 | A770-004 | proposed |
 | intel-a770 | A770-006 | A770-005 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -37,7 +37,7 @@
 | falcon3-family | F3-000 | TBD | ready | none | Do not commit model binaries. |
 | i2s | I2S-DOCS-000 | #5880 | merged | none | Do not change runtime code in docs-only I2_S tracker slices. |
 | intel-258v-platform | LNL258V-POWER-006 | TBD | blocked | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | in_progress | A770-004 | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-003 | #5969 | pr_open | A770-004 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-013 | #5903 | merged | none | Device-node detection is not inference. |
 | llama3-8b-158 | LLAMA3-158-000 | TBD | ready | LLAMA3-158-001 | Do not commit model binaries. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -37,7 +37,7 @@
 | falcon3-family | F3-000 | TBD | ready | none | Do not commit model binaries. |
 | i2s | I2S-DOCS-000 | #5880 | merged | none | Do not change runtime code in docs-only I2_S tracker slices. |
 | intel-258v-platform | LNL258V-POWER-006 | TBD | blocked | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | TBD | proposed | A770-004 | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-003 | TBD | in_progress | A770-004 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-013 | #5903 | merged | none | Device-node detection is not inference. |
 | llama3-8b-158 | LLAMA3-158-000 | TBD | ready | LLAMA3-158-001 | Do not commit model binaries. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary
- Add the `intel-a770-opencl` proof-lane label through CLI config and device-config parsing/resolution.
- Preserve requested/selected backend identity for A770 OpenCL when OpenCL is compiled and the runtime is available.
- Fix the OpenCL backend runtime probe warning to use OpenCL availability instead of oneAPI availability.
- Mark A770-003 in progress and regenerate tracking dashboards; tracker scope now names `backend_selection.rs` because the current BackendRequest implementation lives there.

## Validation
- `rustfmt --check --config skip_children=true,newline_style=Unix --edition 2024 crates\bitnet-common\src\backend_selection.rs crates\bitnet-device-config-core\src\config.rs crates\bitnet-device-config-core\src\parse.rs crates\bitnet-device-config-core\src\backend.rs crates\bitnet-device-config-core\src\resolve.rs crates\bitnet-device-config-core\src\lib.rs crates\bitnet-cli-config-core\src\lib.rs crates\bitnet-inference\src\backends.rs`
- `cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu`
- `cargo test --locked -p bitnet-common --no-default-features --features cpu backend_selection -- --nocapture`
- `cargo test --locked -p bitnet-cli-config-core validation_accepts_intel_a770_opencl_proof_lane_label -- --nocapture`
- `cargo check --locked -p bitnet-inference --no-default-features --features cpu`
- `target\debug\xtask.exe campaign check intel-a770`
- `target\debug\xtask.exe campaign generate --check`
- `git diff --check`

## Host validation caveats
- `cargo fmt --all -- --check` failed locally with Windows `os error 206` path-length/tooling failure; direct rustfmt over touched Rust files passed.
- `cargo run --locked -p xtask --no-default-features -- campaign generate` hit local MSVC PDB/link and temporary disk-space issues; the existing `target\debug\xtask.exe` was used for campaign generation/checks after workspace-local incremental artifacts were cleaned.
- Full `cargo test --locked -p bitnet-inference --no-default-features --features cpu` timed out locally; focused `cargo check` for the touched inference crate passed.

## Claim boundary
- No A770 OpenCL execution claim.
- No OpenVINO GPU/native OpenCL equivalence claim.
- No BitNet inference-on-A770 claim.
- No kernel, QK256, packed math, speedup, route promotion, GPU/NPU promotion, dense SLM, or server behavior change.