### PR TITLE
docs(a770): close out A770-003

### DIFF
--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -67,10 +67,11 @@ must_not_claim = [
 
 [[work_item]]
 id = "A770-003"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-a770/A770-003-backend-identity"
 pr = 5969
 head_sha = "f86bc087913a3c2251a8a97c730ac060b2ff7d18"
+merge_sha = "9deb49448c1884813a3d06d5ca6b2b73d1e7eda9"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-19T160303Z-A770-003-merged.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-19T160303Z-A770-003-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-19T16:03:03Z"
+campaign = "intel-a770"
+item = "A770-003"
+event = "merged"
+pr = 5969
+head_sha = "f86bc087913a3c2251a8a97c730ac060b2ff7d18"
+merge_sha = "9deb49448c1884813a3d06d5ca6b2b73d1e7eda9"
+branch = "codex/intel-a770/A770-003-backend-identity"
+actor = "codex"
+
+notes = [
+  "Merged PR #5969, preserving Intel Arc A770 OpenCL requested and selected backend identity through config and backend-selection surfaces.",
+  "The merged change is identity-only and does not add A770 kernels, BitNet inference execution, route promotion, or speedup claims.",
+  "A770-004 remains the next follow-on for explicit receipt fields and logging propagation.",
+]

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | A770-000 | merged | #5623 | `codex/intel-a770/A770-000-truth-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Reconcile active.toml, CAMPAIGN.md, route matrix, kernel matrix, claim ledger, and model contract so no full inference or trusted-partial A770 claim is present without committed claim-grade receipts. |
-| A770-003 | pr_open | #5969 | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+| A770-003 | merged | #5969 | `codex/intel-a770/A770-003-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
 | A770-004 | proposed | TBD | `codex/intel-a770/A770-004-runtime-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add A770 runtime probe evidence without promoting OpenCL execution or BitNet inference claims. |
 | A770-005 | proposed | TBD | `codex/intel-a770/A770-005-opencl-smoke` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run a tiny selected-device OpenCL smoke with fallback_used=false and CPU parity, without BitNet inference claims. |
 | A770-006 | proposed | TBD | `codex/intel-a770/A770-006-opencl-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add CPU/OpenCL parity for a minimal kernel or subgraph without promoting official BitNet QK256 inference. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| intel-a770 | A770-003 | #5969 | `codex/intel-a770/A770-003-backend-identity` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -419,7 +419,7 @@
 | intel-258v-platform | LNL258V-REG-008 | LNL258V-POWER-001, LNL258V-REG-007 | merged |
 | intel-258v-platform | LNL258V-POWER-001 | LNL258V-ROUTE-019, LNL258V-NPU-RESIDENT-002, LNL258V-BENCH-004 | merged |
 | intel-258v-platform | LNL258V-OP-006 | LNL258V-ROUTE-015 | merged |
-| intel-a770 | A770-003 | A770-000 | pr_open |
+| intel-a770 | A770-003 | A770-000 | merged |
 | intel-a770 | A770-004 | A770-003 | proposed |
 | intel-a770 | A770-005 | A770-004 | proposed |
 | intel-a770 | A770-006 | A770-005 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -37,7 +37,7 @@
 | falcon3-family | F3-000 | TBD | ready | none | Do not commit model binaries. |
 | i2s | I2S-DOCS-000 | #5880 | merged | none | Do not change runtime code in docs-only I2_S tracker slices. |
 | intel-258v-platform | LNL258V-POWER-006 | TBD | blocked | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-003 | #5969 | pr_open | A770-004 | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-004 | TBD | proposed | A770-005 | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-013 | #5903 | merged | none | Device-node detection is not inference. |
 | llama3-8b-158 | LLAMA3-158-000 | TBD | ready | LLAMA3-158-001 | Do not commit model binaries. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -37,7 +37,7 @@
 | falcon3-family | Falcon3 multi-size BitNet-family onboarding | F3-000 | Do not commit model binaries. |
 | i2s | I2_S productization | I2S-DOCS-000 | Do not change runtime code in docs-only I2_S tracker slices. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-POWER-006 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-a770 | Intel Arc A770 validation | A770-004 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-013 | Device-node detection is not inference. |
 | llama3-8b-158 | Llama3 8B 1.58 supported-model candidate | LLAMA3-158-000 | Do not commit model binaries. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary
- Mark A770-003 merged after #5969 landed.
- Record the #5969 implementation head SHA and merge SHA in the Intel A770 tracker.
- Add the A770-003 merged event and refresh generated tracking dashboards.

## Validation
- `target\debug\xtask.exe campaign check intel-a770`
- `target\debug\xtask.exe campaign generate --check`
- `git diff --check`

## Claim boundary
- Tracker closeout only.
- No A770 OpenCL execution claim.
- No OpenVINO GPU/native OpenCL equivalence claim.
- No BitNet inference-on-A770, QK256, speedup, or route promotion claim.