### PR TITLE
Fix CLI no-default QK256 receipt checks

### DIFF
--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -4178,7 +4178,9 @@ cases:
     fn cpu_answer_receipt_rejects_missing_qk256_hot_path_counters() {
         let mut receipt =
             strict_answer_receipt_fixture("cpu", "cpu-rust", "cpu", "i2_s-avx2-reference");
-        receipt.as_object_mut().unwrap().remove("qk256_hot_path");
+        if let Some(receipt) = receipt.as_object_mut() {
+            receipt.remove("qk256_hot_path");
+        }
 
         let failed = answer_receipt_failed_rules(&receipt, "cpu");
 

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -7641,7 +7641,6 @@ fn qk256_dispatch_coverage_receipt(
     })
 }
 
-#[cfg(feature = "full-cli")]
 fn qk256_cpu_hot_path_receipt(
     counters: &bitnet_qk256_dispatch::Qk256CpuHotPathCounters,
 ) -> serde_json::Value {


### PR DESCRIPTION
## Summary
- remove a new no-panic-policy unwrap in answer corpus receipt tests
- expose qk256_cpu_hot_path_receipt to no-default CLI builds that already call it

## Validation
- cargo fmt --all -- --check
- CARGO_INCREMENTAL=0 cargo check --locked -p bitnet-cli --no-default-features
- git diff --check

Note: local target/debug/xtask check-no-panic-family was stopped after 32 minutes with no output on this machine; the same policy scanner completed in seconds in CI and will gate this PR.