### PR TITLE
docs(qwen36): close out QWEN36-DOCS-000

### DIFF
--- a/docs/tracking/campaigns/qwen36/active.toml
+++ b/docs/tracking/campaigns/qwen36/active.toml
@@ -23,7 +23,10 @@ hard_constraints = [
 
 [[work_item]]
 id = "QWEN36-DOCS-000"
-status = "ready"
+status = "merged"
+pr = 5892
+head_sha = "f9fd728e3ac76ba853c7c0165641bcd238eff20f"
+merge_sha = "a2b374225d01908e96a5858d0268b8116b928da2"
 branch = "codex/add-qwen3.6-as-a-governed-model-family"
 stackable = false
 review_mode = "codex_premerge"
@@ -44,6 +47,7 @@ allowed_paths = [
   "docs/specs/**",
   "docs/status/**",
   "docs/tracking/campaigns/qwen36/**",
+  "docs/tracking/generated/**",
   "plans/qwen36/**",
 ]
 forbidden_paths = [

--- a/docs/tracking/campaigns/qwen36/events/2026-05-19T090602Z-QWEN36-DOCS-000-merged.toml
+++ b/docs/tracking/campaigns/qwen36/events/2026-05-19T090602Z-QWEN36-DOCS-000-merged.toml
@@ -1,0 +1,32 @@
+schema_version = "1.0"
+campaign = "qwen36"
+item = "QWEN36-DOCS-000"
+event = "merged"
+timestamp = "2026-05-19T09:06:02Z"
+actor = "codex"
+pr = 5892
+head_sha = "f9fd728e3ac76ba853c7c0165641bcd238eff20f"
+merge_sha = "a2b374225d01908e96a5858d0268b8116b928da2"
+branch = "codex/add-qwen3.6-as-a-governed-model-family"
+
+summary = "Merged #5892 with Qwen3.6 governed-family documentation, proposal/spec placeholders, implementation plan, source map, and registered-only model coverage rows."
+
+artifacts = [
+  "https://github.com/EffortlessMetrics/BitNet-rs/pull/5892",
+  "ci/model-artifacts/model-coverage-matrix.toml",
+  "docs/qwen/qwen36/README.md",
+  "plans/qwen36/implementation-plan.md",
+  "docs/tracking/campaigns/qwen36/active.toml",
+  "docs/tracking/campaigns/qwen36/generated/status.md",
+  "docs/tracking/generated/global-dashboard.md",
+]
+
+notes = [
+  "QWEN36-DOCS-000 is documentation and coverage scaffolding only.",
+  "Qwen3.6 remains governed as reference-only or candidate-only until native BitNet-rs receipts exist.",
+  "No native runtime support, answer quality, server support, performance, GPU/NPU/OpenVINO/UHD 620 execution, Qwen3.5 support, BitNet QK256/I2_S kernel change, or proof inheritance claim is made.",
+]
+
+validation = [
+  "Hosted PR #5892 merged on 2026-05-19 with merge commit a2b374225d01908e96a5858d0268b8116b928da2.",
+]

--- a/docs/tracking/campaigns/qwen36/generated/status.md
+++ b/docs/tracking/campaigns/qwen36/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| QWEN36-DOCS-000 | ready | TBD | `codex/add-qwen3.6-as-a-governed-model-family` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Register the Qwen3.6 family governance lane as documentation and model-coverage scaffolding only. The slice must add the source map, implementation plan, proposal/spec placeholders, candidate coverage rows, and campaign tracker entry without claiming native runtime support, server inference, answer quality, performance, GPU/NPU execution, Qwen3.5 support, or BitNet QK256 changes. |
+| QWEN36-DOCS-000 | merged | #5892 | `codex/add-qwen3.6-as-a-governed-model-family` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Register the Qwen3.6 family governance lane as documentation and model-coverage scaffolding only. The slice must add the source map, implementation plan, proposal/spec placeholders, candidate coverage rows, and campaign tracker entry without claiming native runtime support, server inference, answer quality, performance, GPU/NPU execution, Qwen3.5 support, or BitNet QK256 changes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -43,7 +43,7 @@
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
 | official-bitnet-2b | OFFICIAL-2B-000 | TBD | ready | OFFICIAL-2B-001 | Do not commit model binaries. |
-| qwen36 | QWEN36-DOCS-000 | TBD | ready | none | Qwen3.6 registration is not native BitNet-rs inference support. |
+| qwen36 | QWEN36-DOCS-000 | #5892 | merged | none | Qwen3.6 registration is not native BitNet-rs inference support. |
 | server-real-inference | SERVER-005 | #4490 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-021 | #5133 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tl1 | TL1-PLAN-000 | TBD | ready | none | TL1 registration is not native BitNet-rs inference support. |


### PR DESCRIPTION
## Summary
- mark `QWEN36-DOCS-000` merged with #5892 head and merge SHAs
- add the required merged event for the qwen36 campaign tracker
- refresh qwen36 and global generated campaign dashboards

## Claim boundary
- tracker closeout only
- no runtime support, answer quality, server support, performance, GPU/NPU/OpenVINO/UHD 620 execution, Qwen3.5 support, or BitNet QK256/I2_S claim

## Validation
- `cargo run --locked -p xtask --no-default-features -- campaign check qwen36`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- check-model-coverage`
- `git diff --check`