### PR TITLE
docs(spec): define PR disposition and closure law

### DIFF
--- a/docs/adr/BITNET-ADR-0006-pr-closure-creates-backlog.md
+++ b/docs/adr/BITNET-ADR-0006-pr-closure-creates-backlog.md
@@ -1,0 +1,81 @@
+# BITNET-ADR-0006: PR Closure Creates Backlog Unless Disposed
+
+- **Status:** Accepted
+- **Date:** 2026-05-19
+- **Linked proposal/spec:**
+  [BITNET-SPEC-PR-QUEUE-DISPOSITION](../specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+
+## Context
+
+BitNet-rs uses PRs as durable work records. A PR can contain implementation,
+review comments, CI history, evidence links, diagnostic tooling, and branch
+state that is not fully captured in generated dashboards or chat.
+
+During queue burn-down, older PRs can be stale, behind `main`, stacked on closed
+parents, diagnostic, noisy, or inconvenient. Those are routing states. Treating
+them as close reasons hides work and creates invisible backlog: the underlying
+behavior, evidence, or tooling still needs a disposition, but the queue no
+longer shows it.
+
+## Decision
+
+Closing a PR is valid backlog reduction only when the work is merged,
+duplicated, superseded by a linked landed successor, clean-ported by a linked
+landed successor, captured as historical-only evidence in a committed report or
+ledger, or explicitly rejected after content audit as having no unique durable
+value.
+
+If future work remains, the PR must not close without a live successor PR or a
+tracking issue.
+
+The following are invalid close reasons:
+
+```text
+old
+stale
+behind main
+root closed
+parent closed
+needs restack
+not based on main
+diagnostic-only
+noisy
+inconvenient
+```
+
+Original PR identity is useful work product. The default action is to preserve
+that identity by rebasing, restacking, retargeting, or merging from current
+`main` where feasible. Replacement PRs are allowed only when the original branch
+cannot be safely updated, scope must be narrowed, consolidation is explicit, the
+source links to the successor, and the source remains open until the successor
+lands unless a tracking issue exists.
+
+## Consequences
+
+- Queue size may remain larger while work is being classified truthfully.
+- Agents must review PR content before closing or replacing it.
+- Wrong base and closed-parent stacks route to restack, retarget, or successor
+  review rather than closure.
+- Clean ports close source PRs only after the successor lands.
+- Diagnostic PRs require durable/transient classification before closure.
+- Bulk close, bulk reopen, bulk recreate, and bulk restack remain outside the
+  normal autonomous burn-down model unless explicitly approved.
+
+## Alternatives Considered
+
+- **Close stale PRs and mine them later as source material.** Rejected because
+  it loses review history, hides remaining work, and makes future agents infer
+  intent from archaeology.
+- **Always create replacement PRs for old stacks.** Rejected because PR
+  identity, comments, evidence, and CI history are durable assets.
+- **Keep every PR open forever.** Rejected because duplicates, landed
+  successors, historical-only evidence, and audited no-value changes can be
+  closed truthfully.
+
+## How To Revert
+
+Reverting this ADR requires replacing it with another durable operating
+decision that prevents queue closure from hiding unlanded work. Existing PRs and
+comments remain evidence for what happened even if future policy changes the
+allowed disposition categories.
+

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -47,6 +47,11 @@ Roadmap
 - Public support claims belong in `docs/status/`, hardware matrices, model
   artifact gates, and receipts.
 - Policy exceptions and CI routing belong in `policy/*.toml`.
+- PR queue disposition rules belong in
+  `docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md`,
+  `docs/adr/BITNET-ADR-0006-pr-closure-creates-backlog.md`,
+  `docs/tracking/PR_QUEUE_DISPOSITION.md`, and
+  `policy/pr-dispositions.toml`.
 
 ## Rules
 
@@ -58,6 +63,8 @@ Roadmap
 6. Generated status is updated by tools, not by hand.
 7. Public claims require support-tier, hardware, model-artifact, or receipt proof.
 8. Policy exceptions require owner, reason, coverage, and review date.
+9. Closing a PR is a disposition event, not backlog reduction, unless the close
+   reason is valid under the PR queue disposition spec and policy ledger.
 
 ## Required headers
 

--- a/docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md
+++ b/docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md
@@ -1,0 +1,181 @@
+# BITNET-SPEC-PR-QUEUE-DISPOSITION: PR Queue Disposition And Closure Law
+
+Status: proposed
+Owner: release/ci
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs:
+[BITNET-SPEC-0001](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md)
+Linked ADRs:
+[BITNET-ADR-0006](../adr/BITNET-ADR-0006-pr-closure-creates-backlog.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: `policy/pr-dispositions.toml`
+
+## Purpose
+
+BitNet-rs PR queue work must not reduce visible backlog by hiding useful work.
+Closing a PR is a disposition event, not proof that the work no longer exists.
+This spec defines valid close reasons, invalid close reasons, routing states,
+tracking requirements, and acceptance examples for stale, restacked, diagnostic,
+and successor PRs.
+
+This spec does not define today's queue order. Plans and campaign active
+manifests own sequencing. This spec defines the rule that survives the current
+queue.
+
+## Source-Of-Truth Authorities
+
+PR disposition truth lives in:
+
+- this spec;
+- [PR closure creates backlog ADR](../adr/BITNET-ADR-0006-pr-closure-creates-backlog.md);
+- `policy/pr-dispositions.toml`;
+- [PR Queue Disposition](../tracking/PR_QUEUE_DISPOSITION.md);
+- PR bodies, comments, and linked issues that record the actual disposition.
+
+Generated campaign dashboards may summarize PR state, but they do not create a
+close reason. If a generated dashboard conflicts with this spec, repair the
+source manifest or generator.
+
+## Valid Close Reasons
+
+A PR close counts as backlog reduction only when the close comment or linked
+record proves one of these reasons:
+
+- the PR merged;
+- the PR is an exact duplicate of work that remains available elsewhere;
+- the PR is superseded by a linked successor that already landed;
+- the PR was clean-ported and the port already landed;
+- the PR is historical-only evidence and that evidence was captured in a
+  committed report or ledger;
+- content audit found no unique durable value and records the audit result.
+
+Any close that leaves future work behind must link a live successor PR or a
+tracking issue before the source PR closes.
+
+## Invalid Close Reasons
+
+The following are not close reasons:
+
+- old;
+- stale;
+- behind `main`;
+- root or parent closed;
+- needs restack;
+- not based on `main`;
+- diagnostic-only;
+- noisy;
+- inconvenient.
+
+These facts may change routing. They do not prove that the underlying work has
+no value.
+
+## Routing States
+
+Routing states tell maintainers and agents what action is allowed next:
+
+| Routing state | Meaning | Allowed action |
+| --- | --- | --- |
+| stale stack | Direct merge is unsafe | Rebase, restack, retarget, or successor-port |
+| needs restack | Branch shape is outdated | Refresh the same PR when feasible |
+| closed parent | Stack ancestry is broken | Review the child content on its own merits |
+| diagnostic-only | Evidence or tooling is diagnostic | Classify durable vs transient value |
+| wrong base | Base branch is wrong | Retarget or rebase where safe |
+
+None of these states permits closure by itself.
+
+## PR Identity Preservation
+
+Original PR identity is useful work product. Review comments, CI history, body
+text, source branch, and linked evidence are assets.
+
+Default action is to preserve the PR identity by rebasing, restacking,
+retargeting, or merging from current `main` when that is feasible and safe.
+
+A replacement PR is allowed only when:
+
+- the original branch cannot be safely updated;
+- scope must be narrowed for review;
+- consolidation is explicit;
+- the source PR links to the successor;
+- the source remains open until the successor lands, unless a tracking issue
+  exists for the remaining work.
+
+## Diagnostic PRs
+
+Diagnostic PRs are not disposable by default. A diagnostic PR has durable value
+when it contains reusable trace instrumentation, reference-runner tooling,
+comparator logic, receipt schema fields, focused regression tests, final
+synthesis reports, or runtime/model correctness signals.
+
+Durable diagnostic content must be merged as-is when valid, restacked when the
+base is wrong, clean-ported when the original cannot be made usable, or linked
+to a landed successor before closure.
+
+Transient diagnostic evidence may remain closed only when captured by a
+committed report, ledger, or newer landed synthesis.
+
+## Acceptance Examples
+
+| Case | Required disposition |
+| --- | --- |
+| PR targets a stale base but is otherwise valid | Rebase or restack the same PR |
+| PR was wrongly closed but still has durable value | Reopen the same PR |
+| Clean port landed on current `main` | Close the source PR with successor link |
+| Future work remains and no successor exists | Create or link a tracking issue before close |
+| Diagnostic PR has durable tooling | Keep open, port, or merge; do not close as old |
+| PR has no unique durable value after audit | Close with audit note and evidence links |
+
+## Close Comment Requirements
+
+A close comment or linked disposition record must include:
+
+```text
+disposition:
+reason:
+source_pr:
+landed_pr:
+landed_commit:
+duplicate_of:
+historical_report:
+tracking_issue:
+audit_summary:
+remaining_work:
+```
+
+Fields that do not apply may be `n/a`, but at least one valid close reason must
+be populated.
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+git diff --check
+```
+
+Future enforcement should live behind:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-pr-dispositions
+```
+
+The future checker should fail if a PR close comment lacks a valid close reason,
+landed successor, duplicate link, historical report link, audit record, or
+tracking issue when future work remains.
+
+## Non-Goals
+
+- Do not encode today's exact PR queue.
+- Do not encode current open PR order.
+- Do not encode temporary CI failures.
+- Do not encode one agent's command transcript.
+- Do not require CI for archaeology.
+- Do not convert stale, diagnostic, or non-main PRs into disposable source
+  material by default.
+

--- a/docs/tracking/PR_QUEUE_DISPOSITION.md
+++ b/docs/tracking/PR_QUEUE_DISPOSITION.md
@@ -1,0 +1,78 @@
+# PR Queue Disposition
+
+Status: proposed
+Owner: release/ci
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs:
+[BITNET-SPEC-PR-QUEUE-DISPOSITION](../specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+Linked ADRs:
+[BITNET-ADR-0006](../adr/BITNET-ADR-0006-pr-closure-creates-backlog.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: `policy/pr-dispositions.toml`
+
+## Operator Rule
+
+Closing a PR is not backlog reduction unless the work is merged, duplicated,
+superseded by a linked landed successor, clean-ported by a linked landed
+successor, captured as historical-only evidence, or explicitly rejected after a
+content audit as having no unique durable value.
+
+If future work remains, create or link a tracking issue or keep a live successor
+PR before closing the source PR.
+
+## Do Not Close Because
+
+- old;
+- stale;
+- behind `main`;
+- root or parent closed;
+- needs restack;
+- not based on `main`;
+- diagnostic-only;
+- noisy;
+- inconvenient.
+
+These are routing states, not close reasons.
+
+## Default Routing
+
+| State | Next action |
+| --- | --- |
+| Valid PR on stale base | Rebase or restack the same PR |
+| Wrongly closed valid PR | Reopen the same PR |
+| Original branch cannot be made usable | Create explicit successor and link source |
+| Successor has landed | Close source with successor PR and commit link |
+| Durable diagnostic tooling exists | Keep open, port, or merge |
+| Transient evidence only | Close only after committed report or ledger capture |
+
+## Close Comment Template
+
+```text
+disposition:
+reason:
+source_pr:
+landed_pr:
+landed_commit:
+duplicate_of:
+historical_report:
+tracking_issue:
+audit_summary:
+remaining_work:
+```
+
+Use `n/a` only when a field does not apply. Do not leave `reason`,
+`audit_summary`, or `remaining_work` ambiguous.
+
+## Review Checklist
+
+- The close reason is valid under `policy/pr-dispositions.toml`.
+- Any successor PR has landed before the source closes.
+- Any duplicate or historical-only claim links the durable evidence.
+- Any future work has a live successor PR or tracking issue.
+- Diagnostic content was classified as durable or transient.
+- The close comment records the disposition in a form future agents can audit.
+

--- a/policy/pr-dispositions.toml
+++ b/policy/pr-dispositions.toml
@@ -1,0 +1,72 @@
+schema_version = "1.0"
+policy = "pr-dispositions"
+owner = "release/ci"
+status = "active"
+updated = "2026-05-19"
+
+# PR closure is a disposition event. A close reduces backlog only when one of
+# the valid close reasons is documented with the required links or evidence.
+
+[valid_close_reasons]
+merged = true
+duplicate = true
+superseded_by_landed_successor = true
+ported_successor_landed = true
+historical_evidence_captured = true
+no_unique_durable_value_after_audit = true
+
+[invalid_close_reasons]
+old = true
+stale = true
+behind_main = true
+root_closed = true
+parent_closed = true
+needs_restack = true
+not_based_on_main = true
+diagnostic_only = true
+noisy = true
+inconvenient = true
+
+[routing_states]
+stale_stack = "route_to_restack_or_successor_review"
+needs_restack = "route_to_restack"
+closed_parent = "review_child_content_on_own_merits"
+diagnostic_only = "classify_durable_or_transient_value"
+wrong_base = "retarget_or_rebase_where_safe"
+
+[requires_tracking_issue]
+close_with_intent_to_reopen = true
+close_with_intent_to_port = true
+close_with_intent_to_restack = true
+close_with_future_work_remaining = true
+
+[successor_rules]
+source_pr_may_close_before_successor_lands = false
+source_pr_requires_successor_link = true
+successor_must_be_landed_for_superseded_close = true
+tracking_issue_may_hold_remaining_future_work = true
+
+[identity_preservation]
+default_action = "preserve_original_pr_identity"
+replacement_pr_requires_explicit_consolidation = true
+replacement_pr_requires_source_link = true
+replacement_pr_requires_scope_reason = true
+
+[bulk_actions]
+bulk_close_allowed = false
+bulk_reopen_allowed = false
+bulk_recreate_allowed = false
+bulk_restack_allowed_without_approval = false
+
+[close_comment_fields]
+disposition = true
+reason = true
+source_pr = true
+landed_pr = true
+landed_commit = true
+duplicate_of = true
+historical_report = true
+tracking_issue = true
+audit_summary = true
+remaining_work = true
+


### PR DESCRIPTION
## Summary
- add BITNET-SPEC-PR-QUEUE-DISPOSITION for valid close reasons, invalid close reasons, routing states, PR identity preservation, and diagnostic PR handling
- add BITNET-ADR-0006 recording the durable decision that closure creates backlog unless disposed
- add policy/pr-dispositions.toml plus docs/tracking/PR_QUEUE_DISPOSITION.md and link the rule from SPEC_SYSTEM

## Validation
- PASS: git diff --check
- PASS: python -c tomllib parse for policy/pr-dispositions.toml
- BLOCKED locally: cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports timed out after 300s before xtask completed
- BLOCKED locally: cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports timed out after 300s before xtask completed

## Notes
The xtask commands enter the local tokenizer/sentencepiece build path in this Windows checkout; no repo-local cargo/rustc/xtask process was left running after the timeouts.