### PR TITLE
Fix A770 no-panic policy tests

### DIFF
--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -679,7 +679,11 @@ mod tests {
 
     #[test]
     fn intel_a770_opencl_request_preserves_identity_when_opencl_available() {
-        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps()).unwrap();
+        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps());
+        assert!(result.is_ok());
+        let Ok(result) = result else {
+            return;
+        };
 
         assert_eq!(result.selected, KernelBackend::OpenCL);
         assert_eq!(result.requested_backend(), "intel-a770-opencl");

--- a/crates/bitnet-device-probe/src/intel_arc.rs
+++ b/crates/bitnet-device-probe/src/intel_arc.rs
@@ -697,7 +697,11 @@ mod tests {
         assert!(!probe.fallback_used);
         assert!(probe.identity_evidence.iter().any(|entry| entry.starts_with("opencl:")));
 
-        let value = serde_json::to_value(&probe).expect("probe serializes");
+        let value = serde_json::to_value(&probe);
+        assert!(value.is_ok());
+        let Ok(value) = value else {
+            return;
+        };
         assert_eq!(value["proof_stage"], "runtime_detected");
         assert_eq!(value["requested_backend"], INTEL_ARC_A770_REQUESTED_BACKEND);
         assert_eq!(value["selected_backend"], INTEL_ARC_A770_OPENCL_BACKEND);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 /// Build metadata captured at compile time.
 pub mod build_info;
 mod constants;
-/// Convenient imports for common BitNet types and traits.
+/// Convenient imports for common `BitNet` types and traits.
 pub mod prelude;
 
 pub use build_info::*;

--- a/xtask/src/ci/plan.rs
+++ b/xtask/src/ci/plan.rs
@@ -759,13 +759,13 @@ fn workspace_package_graph() -> Result<WorkspacePackageGraph> {
             let Some(path) = dep.path.as_ref() else {
                 continue;
             };
-            if let Some(dep_name) = package_by_root.get(&normalized_path_key(path)) {
-                if dep_name != &package.name {
-                    direct_dependents_by_dependency
-                        .entry(dep_name.clone())
-                        .or_default()
-                        .insert(package.name.clone());
-                }
+            if let Some(dep_name) = package_by_root.get(&normalized_path_key(path))
+                && dep_name != &package.name
+            {
+                direct_dependents_by_dependency
+                    .entry(dep_name.clone())
+                    .or_default()
+                    .insert(package.name.clone());
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove new unwrap/expect usage in A770 tests while keeping the assertions
- keep A770 backend identity and runtime probe coverage unchanged

## Validation
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-common --no-default-features --lib intel_a770_opencl_request_preserves_identity_when_opencl_available
- cargo test --locked -p bitnet-device-probe --no-default-features --lib opencl_a770_identity_selects_native_lane_without_execution_claim
- git diff --check