### PR TITLE
fix(ci): clear cpu feature clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 /// Build metadata captured at compile time.
 pub mod build_info;
 mod constants;
-/// Convenient imports for common BitNet types and traits.
+/// Convenient imports for common `BitNet` types and traits.
 pub mod prelude;
 
 pub use build_info::*;

--- a/xtask/src/ci/plan.rs
+++ b/xtask/src/ci/plan.rs
@@ -759,13 +759,13 @@ fn workspace_package_graph() -> Result<WorkspacePackageGraph> {
             let Some(path) = dep.path.as_ref() else {
                 continue;
             };
-            if let Some(dep_name) = package_by_root.get(&normalized_path_key(path)) {
-                if dep_name != &package.name {
-                    direct_dependents_by_dependency
-                        .entry(dep_name.clone())
-                        .or_default()
-                        .insert(package.name.clone());
-                }
+            if let Some(dep_name) = package_by_root.get(&normalized_path_key(path))
+                && dep_name != &package.name
+            {
+                direct_dependents_by_dependency
+                    .entry(dep_name.clone())
+                    .or_default()
+                    .insert(package.name.clone());
             }
         }
     }


### PR DESCRIPTION
## Summary
- backtick `BitNet` in the root crate prelude docs to satisfy `clippy::doc_markdown`
- collapse the nested dependency graph `if` in `xtask` to satisfy `clippy::collapsible_if`

## Validation
- `rustfmt --edition 2024 --check src\\lib.rs xtask\\src\\ci\\plan.rs`
- `git diff --check`
- `cargo clippy --locked -p bitnet --lib --no-default-features --features cpu -- -D warnings`
- `CMAKE_GENERATOR=Ninja cargo clippy --locked -p xtask --bin xtask --no-default-features -- -D warnings`

Full workspace CPU clippy was attempted locally with `CMAKE_GENERATOR=Ninja`; the host ran out of disk writing `target\\debug` artifacts (`os error 112`) after passing the previously failing warning locations. GitHub Linux CI remains the authoritative full-workspace gate.