### PR TITLE
test(a770): remove no-panic debt from policy fixtures

### DIFF
--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -678,8 +678,9 @@ mod tests {
     }
 
     #[test]
-    fn intel_a770_opencl_request_preserves_identity_when_opencl_available() {
-        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps()).unwrap();
+    fn intel_a770_opencl_request_preserves_identity_when_opencl_available()
+    -> Result<(), BackendSelectionError> {
+        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps())?;
 
         assert_eq!(result.selected, KernelBackend::OpenCL);
         assert_eq!(result.requested_backend(), "intel-a770-opencl");
@@ -692,6 +693,7 @@ mod tests {
         assert!(summary.contains("selected_backend=intel-a770-opencl"), "got: {summary}");
         assert!(summary.contains("runtime_api=opencl"), "got: {summary}");
         assert!(summary.contains("fallback_used=false"), "got: {summary}");
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-device-probe/src/intel_arc.rs
+++ b/crates/bitnet-device-probe/src/intel_arc.rs
@@ -666,7 +666,8 @@ mod tests {
     // ── A770 runtime probe ─────────────────────────────────────────────
 
     #[test]
-    fn opencl_a770_identity_selects_native_lane_without_execution_claim() {
+    fn opencl_a770_identity_selects_native_lane_without_execution_claim()
+    -> Result<(), serde_json::Error> {
         let opencl = OpenClRuntimeProbe {
             runtime_available: true,
             devices: vec![OpenClRuntimeDevice {
@@ -697,7 +698,7 @@ mod tests {
         assert!(!probe.fallback_used);
         assert!(probe.identity_evidence.iter().any(|entry| entry.starts_with("opencl:")));
 
-        let value = serde_json::to_value(&probe).expect("probe serializes");
+        let value = serde_json::to_value(&probe)?;
         assert_eq!(value["proof_stage"], "runtime_detected");
         assert_eq!(value["requested_backend"], INTEL_ARC_A770_REQUESTED_BACKEND);
         assert_eq!(value["selected_backend"], INTEL_ARC_A770_OPENCL_BACKEND);
@@ -707,6 +708,7 @@ mod tests {
         assert_eq!(value["qk256_decode"], false);
         assert_eq!(value["fallback_used"], false);
         assert_eq!(value["rebar_status"], "not_probed");
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- convert two test-only no-panic findings from unwrap/expect to fallible tests
- keep behavior unchanged; this is policy/test hygiene only
- unblock the hosted Policy failure observed on #5976

## Validation
- rtk cargo fmt -p bitnet-common -p bitnet-device-probe -- --check
- rtk git diff --check
- focused cargo tests timed out locally after 300s while building; hosted CI is the authoritative proof path