### PR TITLE
test(a770): remove no-panic policy debt

### DIFF
--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -679,7 +679,9 @@ mod tests {
 
     #[test]
     fn intel_a770_opencl_request_preserves_identity_when_opencl_available() {
-        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps()).unwrap();
+        let result = select_backend(BackendRequest::IntelA770OpenCl, &opencl_caps());
+        assert!(result.is_ok(), "expected A770 OpenCL selection, got {result:?}");
+        let result = if let Ok(result) = result { result } else { return };
 
         assert_eq!(result.selected, KernelBackend::OpenCL);
         assert_eq!(result.requested_backend(), "intel-a770-opencl");

--- a/crates/bitnet-device-probe/src/intel_arc.rs
+++ b/crates/bitnet-device-probe/src/intel_arc.rs
@@ -697,7 +697,9 @@ mod tests {
         assert!(!probe.fallback_used);
         assert!(probe.identity_evidence.iter().any(|entry| entry.starts_with("opencl:")));
 
-        let value = serde_json::to_value(&probe).expect("probe serializes");
+        let value = serde_json::to_value(&probe);
+        assert!(value.is_ok(), "probe serializes: {value:?}");
+        let value = if let Ok(value) = value { value } else { return };
         assert_eq!(value["proof_stage"], "runtime_detected");
         assert_eq!(value["requested_backend"], INTEL_ARC_A770_REQUESTED_BACKEND);
         assert_eq!(value["selected_backend"], INTEL_ARC_A770_OPENCL_BACKEND);


### PR DESCRIPTION
## Summary
- replace two A770 test-only unwrap/expect calls with explicit result checks
- keep runtime behavior and A770 claim state unchanged

## Validation
- rtk cargo test --locked -p bitnet-common --no-default-features intel_a770_opencl_request_preserves_identity_when_opencl_available
- rtk cargo test --locked -p bitnet-device-probe --no-default-features opencl_a770_identity_selects_native_lane_without_execution_claim
- rtk cargo check --locked -p bitnet-common --no-default-features
- rtk cargo check --locked -p bitnet-device-probe --no-default-features
- rtk proxy cargo fmt -p bitnet-common -p bitnet-device-probe -- --check
- rtk git diff --check