### PR TITLE
docs(spec): define A770 diagnostic lineage handling

### DIFF
--- a/docs/adr/BITNET-ADR-0007-a770-diagnostics-are-lineage.md
+++ b/docs/adr/BITNET-ADR-0007-a770-diagnostics-are-lineage.md
@@ -1,0 +1,64 @@
+# BITNET-ADR-0007: A770 Diagnostics Are Lineage
+
+- **Status:** Accepted
+- **Date:** 2026-05-19
+- **Linked proposal/spec:**
+  [BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE](../specs/BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE.md)
+
+## Context
+
+The A770 branch chain contains diagnostic traces, reference-runner work,
+comparators, receipts, tests, and runtime correctness signals. Some entries are
+old, stacked, noisy, or based on closed parents. Those facts change routing, but
+they do not prove the content has no durable value.
+
+Treating diagnostic PRs as disposable source material loses review history,
+breaks successor accounting, and can convert unresolved runtime work into
+invisible backlog. Treating diagnostic evidence as product proof creates the
+opposite failure: unsupported A770 claims can leak from traces or one-off
+receipts.
+
+## Decision
+
+A770 diagnostic PRs are lineage records. Each PR must be classified on content:
+durable diagnostic content is preserved, restacked, clean-ported, merged, or
+linked to a landed successor before closure; transient evidence may close only
+when captured in committed reports, ledgers, newer landed synthesis, or an audit
+record.
+
+Bulk close, bulk reopen, bulk recreate, bulk restack, and one-for-one
+replacement waves are not normal A770 diagnostic handling. The stack is reviewed
+one narrow dependency slice at a time.
+
+Diagnostic lineage does not promote product claims. A diagnostic trace can prove
+diagnostic evidence, not quality, speed, residency, selected execution, or broad
+A770 support.
+
+## Consequences
+
+- A770 queue work stays slower but more truthful.
+- Closed ancestors must be audited before descendants are considered disposed.
+- Open descendants are not automatic replacements.
+- Successor PRs need exact enough landed content before source PRs close.
+- Runtime salvage can use diagnostic lineage as evidence, but claim promotion
+  still requires route-specific specs and receipts.
+- Generated dashboards summarize state; they do not decide lineage value.
+
+## Alternatives Considered
+
+- **Bulk-close old diagnostic PRs.** Rejected because stale, noisy, and closed
+  parent states are routing states, not value judgments.
+- **Bulk-recreate successors.** Rejected because replacement waves lose review
+  history and create duplicate CI churn.
+- **Treat every diagnostic PR as product proof.** Rejected because diagnostics
+  can improve visibility without proving execution, quality, speed, or
+  residency.
+- **Keep every diagnostic PR open forever.** Rejected because transient evidence,
+  duplicates, landed successors, and audited no-value content can close with a
+  real disposition.
+
+## How To Revert
+
+Reverting this ADR requires another durable operating decision that protects
+A770 diagnostic evidence from both false closure and false product promotion.
+Existing lineage links, successor records, and closure comments remain evidence.

--- a/docs/specs/BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE.md
+++ b/docs/specs/BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE.md
@@ -1,0 +1,161 @@
+# BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE: A770 Diagnostic Lineage Handling
+
+Status: proposed
+Owner: release/runtime
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs:
+[BITNET-SPEC-PR-QUEUE-DISPOSITION](BITNET-SPEC-PR-QUEUE-DISPOSITION.md),
+[A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+Linked ADRs:
+[BITNET-ADR-0007](../adr/BITNET-ADR-0007-a770-diagnostics-are-lineage.md)
+Linked plan:
+[A770 diagnostic lineage implementation plan](../../plans/a770-diagnostic-lineage/implementation-plan.md)
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: `policy/a770-diagnostic-lineage.toml`
+
+## Purpose
+
+The A770 diagnostic branch chain is lineage. It is not a disposable pile of old
+PRs, and it is not product proof by itself. This spec defines how to classify
+diagnostic content, preserve PR identity, close only with valid disposition, and
+avoid batch operations that hide useful runtime evidence.
+
+This spec governs operational handling of A770 diagnostic PRs. Runtime behavior,
+quality promotion, residency, performance, and user-facing support claims remain
+owned by the A770 claim-boundary specs, runtime salvage specs, support-tier
+surfaces, and receipts.
+
+## Source-Of-Truth Authorities
+
+A770 diagnostic lineage truth lives in:
+
+- this spec;
+- [A770 diagnostics are lineage ADR](../adr/BITNET-ADR-0007-a770-diagnostics-are-lineage.md);
+- [A770 diagnostic lineage plan](../../plans/a770-diagnostic-lineage/implementation-plan.md);
+- `policy/a770-diagnostic-lineage.toml`;
+- the general [PR queue disposition spec](BITNET-SPEC-PR-QUEUE-DISPOSITION.md);
+- PR bodies, comments, linked successor PRs, and tracking issues.
+
+Generated dashboards may summarize A770 PR state, but they do not decide
+whether diagnostic content is durable or transient.
+
+## Durable Diagnostic Content
+
+Diagnostic content is durable when it contains reusable or claim-relevant work,
+including:
+
+- trace instrumentation;
+- reference-runner tooling;
+- comparator logic;
+- receipt schema fields;
+- focused regression tests;
+- final synthesis reports;
+- runtime or model correctness signals.
+
+Durable diagnostic content must be handled by one of these dispositions:
+
+- merge the original PR as-is when the branch is valid and proof is current;
+- rebase, restack, retarget, or merge from current `main` when the base is
+  wrong but the PR identity remains usable;
+- clean-port the exact durable subset when the original branch cannot be made
+  usable;
+- keep the source PR open until a linked successor lands;
+- close only after a landed successor, duplicate, committed historical report,
+  audit rejection, or tracking issue satisfies the PR queue disposition spec.
+
+## Transient Diagnostic Content
+
+Diagnostic content is transient when it is only:
+
+- a one-off target-local observation;
+- intermediate evidence that a mismatch moved to another location;
+- a contradicted hypothesis already captured by newer proof;
+- a manual receipt without reusable code, schema, tooling, or synthesis.
+
+Transient evidence may remain closed only when captured by a committed report,
+ledger, newer landed synthesis, or audited disposition comment. A transient
+classification must explain why no durable code, schema, test, or runtime signal
+remains.
+
+## Forbidden Inferences
+
+The following inferences are invalid:
+
+- diagnostic-only means disposable;
+- root closed means descendants should close;
+- closed ancestor means source material by default;
+- open descendant means replacement by default;
+- stale stack means close;
+- needs restack means close;
+- wrong base means close;
+- diagnostic evidence means A770 support, quality, speed, or residency proof.
+
+Diagnostic evidence may justify a narrow runtime salvage review. It does not
+promote product claims without the applicable runtime, support-tier, receipt,
+and claim-boundary gates.
+
+## Frontier Model
+
+A770 diagnostic review moves through one narrow frontier at a time:
+
+| Frontier state | Meaning | Required action |
+| --- | --- | --- |
+| closed ancestor | Older branch or parent closed | Audit content before treating it as disposed |
+| open descendant | Later PR remains open | Compare exact content before treating it as successor |
+| stale base | PR cannot merge directly | Rebase/restack same PR where feasible |
+| successor candidate | Clean port or narrowed PR exists | Keep source open until successor lands |
+| historical evidence | No reusable durable value remains | Link committed report or ledger before close |
+
+A landed successor must be exact enough to close its source. "Inspired by" or
+"source material" is not enough.
+
+## Prohibited Batch Actions
+
+Agents must not process the A770 diagnostic stack as a bulk object:
+
+- no bulk close;
+- no bulk reopen;
+- no bulk recreate;
+- no bulk restack;
+- no one-for-one replacement wave;
+- no CI for archaeology.
+
+One dependency slice may be reviewed at a time after current-main merge
+candidates are drained. The default is to preserve the original PR identity and
+create a successor only when the original cannot be made usable.
+
+## Acceptance Examples
+
+| Case | Required handling |
+| --- | --- |
+| PR contains reusable comparator code but targets a stale stack | Restack or clean-port; do not close as stale |
+| PR only records a contradicted local mismatch and a newer synthesis landed | Link the synthesis and close as historical evidence captured |
+| Closed parent blocks direct merge of a valid child | Review child content on its own merits |
+| Descendant PR overlaps but lacks exact tests from the source | Keep source open or create tracking for missing tests |
+| Clean successor lands with exact durable content | Close source with successor link and landed commit |
+| A diagnostic trace improves visibility | Claim diagnostic evidence only, not A770 product readiness |
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+git diff --check
+```
+
+Future enforcement may be added to the PR disposition checker by loading
+`policy/a770-diagnostic-lineage.toml` and requiring an explicit durable or
+transient classification for A770 diagnostic closures.
+
+## Non-Goals
+
+- Do not encode today's exact A770 queue.
+- Do not claim A770 support, quality, speed, residency, or selected execution.
+- Do not port runtime fixes in this spec PR.
+- Do not replace the A770 runtime salvage spec.
+- Do not turn generated dashboard rows into hand-authored truth.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -348,6 +348,20 @@ truth, invocation counters, parity, and profile/sustained receipts.
 
 ## A770 BitNet Productization
 
+Use these artifacts before processing the A770 diagnostic branch chain or
+closing/replacing A770 diagnostic PRs:
+
+1. [A770 Diagnostic Lineage](BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE.md)
+   - Defines durable versus transient diagnostic content, lineage frontiers,
+     successor rules, forbidden batch actions, and the no-claim boundary for
+     diagnostic evidence.
+2. [A770 Diagnostic Lineage Plan](../../plans/a770-diagnostic-lineage/implementation-plan.md)
+   - Sequences lineage policy/checker work before narrow runtime salvage slices.
+
+Do not bulk-close, bulk-reopen, bulk-recreate, or treat diagnostic-only as
+disposable. Diagnostic lineage can route runtime salvage, but it does not prove
+A770 support, quality, speed, residency, or selected execution.
+
 Use these specs before implementing or claiming A770 BitNet product support:
 
 1. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)

--- a/plans/a770-diagnostic-lineage/implementation-plan.md
+++ b/plans/a770-diagnostic-lineage/implementation-plan.md
@@ -1,0 +1,132 @@
+# A770 Diagnostic Lineage Implementation Plan
+
+Status: proposed
+Owner: release/runtime
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs:
+[BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE](../../docs/specs/BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE.md),
+[BITNET-SPEC-PR-QUEUE-DISPOSITION](../../docs/specs/BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+Linked ADRs:
+[BITNET-ADR-0007](../../docs/adr/BITNET-ADR-0007-a770-diagnostics-are-lineage.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: `policy/a770-diagnostic-lineage.toml`
+
+## Goal
+
+Make A770 diagnostic queue handling durable and repeatable without treating the
+branch chain as a bulk close target or as product proof.
+
+## Scope
+
+This plan sequences operating-rule work only. It does not port runtime code,
+merge A770 runtime fixes, promote A770 support, or reorder today's live queue.
+
+## PR 1 - Lineage Spec, ADR, Plan, And Policy
+
+Purpose: encode the durable rule set before the next runtime salvage slice.
+
+Files:
+
+```text
+docs/specs/BITNET-SPEC-A770-DIAGNOSTIC-LINEAGE.md
+docs/adr/BITNET-ADR-0007-a770-diagnostics-are-lineage.md
+plans/a770-diagnostic-lineage/implementation-plan.md
+policy/a770-diagnostic-lineage.toml
+docs/specs/INDEX.md
+```
+
+Acceptance:
+
+```text
+durable diagnostic content is defined
+transient diagnostic content is defined
+bulk close/reopen/recreate/restack are forbidden by default
+closed ancestor and open descendant are lineage states, not dispositions
+diagnostic evidence cannot promote support, quality, speed, or residency claims
+```
+
+Verification:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+git diff --check
+```
+
+## PR 2 - Checker Integration
+
+Purpose: make the lineage policy machine-checkable after the spec has landed.
+
+Allowed implementation:
+
+```text
+load policy/a770-diagnostic-lineage.toml
+extend the PR disposition checker to require A770 durable/transient classification
+reject A770 close records that cite stale/closed-parent/diagnostic-only as close reasons
+require landed successor, duplicate, tracking issue, historical report, or audit record
+```
+
+Not allowed:
+
+```text
+query live GitHub by default
+rerun CI for archaeology
+bulk-write labels or close comments
+promote diagnostic evidence into support claims
+```
+
+## PR 3 - Optional Historical Report
+
+Purpose: capture any historical-only A770 diagnostic evidence that is safe to
+close without hiding future work.
+
+Allowed files:
+
+```text
+docs/tracking/a770-diagnostic-lineage/*.md
+docs/tracking/a770-diagnostic-lineage/*.toml
+```
+
+Acceptance:
+
+```text
+each closed item cites a valid disposition
+future work links to a live successor PR or issue
+durable runtime content is not demoted into source material
+no generated dashboard is hand-edited
+```
+
+## Runtime Salvage Boundary
+
+Runtime salvage starts only after current-main merge candidates are drained and
+this lineage rule is available. Pick one narrow dependency slice at a time.
+
+Candidate slices include tied `lm_head`, tokenizer duplicate specials,
+effective logits assertion, prompt prefill, I2S trailer scale, act-parallel
+QK256 layout, GGUF BPE tokenizer, activation quant oracle, and
+activation-quantized QK256 dispatch.
+
+Each runtime salvage PR must identify:
+
+```text
+source PR
+source commit
+current-main successor
+files changed
+runtime behavior changed
+tests proving behavior
+claim boundary
+source PR disposition
+```
+
+## Stop Rules
+
+- Do not process the A770 stack as a batch.
+- Do not close because old, stale, behind main, closed parent, or needs restack.
+- Do not create replacement PRs without source links and disposition rules.
+- Do not run CI for archaeology.
+- Do not claim A770 product support from diagnostic lineage.

--- a/policy/a770-diagnostic-lineage.toml
+++ b/policy/a770-diagnostic-lineage.toml
@@ -1,0 +1,73 @@
+schema_version = "1.0"
+policy = "a770-diagnostic-lineage"
+owner = "release/runtime"
+status = "active"
+updated = "2026-05-19"
+
+# A770 diagnostics are lineage records. Diagnostic evidence must be classified
+# before closure and must not promote product claims by itself.
+
+[classification]
+durable_content = [
+  "trace_instrumentation",
+  "reference_runner_tooling",
+  "comparator_logic",
+  "receipt_schema_fields",
+  "focused_regression_tests",
+  "final_synthesis_reports",
+  "runtime_correctness_signals",
+  "model_correctness_signals",
+]
+transient_content = [
+  "one_off_target_local_observation",
+  "intermediate_mismatch_location",
+  "contradicted_hypothesis_captured_later",
+  "manual_receipt_without_reusable_artifact",
+]
+
+[durable_disposition]
+merge_as_is_when_valid = true
+rebase_or_restack_same_pr_when_feasible = true
+clean_port_when_original_unusable = true
+close_only_after_landed_successor_or_valid_disposition = true
+
+[transient_disposition]
+requires_committed_report_or_ledger = true
+requires_newer_landed_synthesis_or_audit_record = true
+must_explain_no_durable_value = true
+
+[invalid_inferences]
+diagnostic_only_means_disposable = true
+root_closed_means_descendants_close = true
+closed_ancestor_means_source_material = true
+open_descendant_means_replacement = true
+stale_stack_means_close = true
+needs_restack_means_close = true
+wrong_base_means_close = true
+diagnostic_evidence_means_support_claim = true
+
+[frontier_model]
+closed_ancestor = "audit_content_before_disposition"
+open_descendant = "compare_exact_content_before_successor_claim"
+stale_base = "rebase_or_restack_same_pr_where_feasible"
+successor_candidate = "keep_source_open_until_successor_lands"
+historical_evidence = "link_committed_report_or_ledger_before_close"
+
+[bulk_actions]
+bulk_close_allowed = false
+bulk_reopen_allowed = false
+bulk_recreate_allowed = false
+bulk_restack_allowed_without_approval = false
+one_for_one_replacement_wave_allowed = false
+ci_for_archaeology_allowed = false
+
+[claim_boundaries]
+diagnostic_trace_claim = "diagnostic_evidence"
+forbidden_promotions = [
+  "support",
+  "quality",
+  "speed",
+  "residency",
+  "selected_execution",
+  "broad_a770_readiness",
+]


### PR DESCRIPTION
## Summary
- add the A770 diagnostic lineage spec and ADR
- add a PR-sized implementation plan and machine-readable lineage policy
- link the new lineage rules from the specs index

## Scope
- operational docs and policy only
- no runtime behavior changes
- no A770 support, quality, speed, residency, or selected-execution promotion

## Validation
- rtk git diff --check
- TOML parse check passed for policy/a770-diagnostic-lineage.toml
- linked-path existence check passed for spec, ADR, plan, and policy files

## Local validation gap
- rtk cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports timed out locally after 600s in the Windows build path; hosted CI is the proof path for xtask policy jobs