### PR TITLE
docs(spec): define PR write-action CI economics

### DIFF
--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -32,6 +32,27 @@ Rollout PRs must use the PR body sections from the rollout document so every
 change records default LEM before/after, lanes removed from default, preserved
 verification, boundaries, and validation.
 
+## PR burn-down write-action law
+
+Queue burn-down has its own CI economics rule:
+[PR Write-Action CI Economics](../specs/BITNET-SPEC-PR-CI-ECONOMICS.md).
+The machine-readable policy is `policy/pr-ci-actions.toml`.
+
+Closing, reopening, rebasing, pushing, retargeting, labeling, recreating, and
+rerunning workflows are write actions. They can trigger CI, status churn, review
+churn, or branch-protection recomputation. During PR queue recovery, do
+read-only archaeology first and write only when the current disposition, merge,
+or proof decision requires it.
+
+The default rules are:
+
+- no bulk write without explicit approval;
+- no CI for archaeology;
+- CI only for approved merge candidates, approved clean ports, branch refreshes
+  needed for current proof, failed required-check reruns with evidence, or other
+  required proof;
+- close/reopen/recreate actions must satisfy the PR queue disposition law.
+
 ## Cost target
 
 For ordinary PRs, our operating target is:

--- a/docs/specs/BITNET-SPEC-PR-CI-ECONOMICS.md
+++ b/docs/specs/BITNET-SPEC-PR-CI-ECONOMICS.md
@@ -1,0 +1,142 @@
+# BITNET-SPEC-PR-CI-ECONOMICS: PR Write-Action CI Economics
+
+Status: proposed
+Owner: release/ci
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs:
+[BITNET-SPEC-PR-QUEUE-DISPOSITION](BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+Linked ADRs:
+[BITNET-ADR-0006](../adr/BITNET-ADR-0006-pr-closure-creates-backlog.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: `policy/pr-ci-actions.toml`
+
+## Purpose
+
+PR queue work can burn CI without changing code. Closing, reopening, rebasing,
+pushing, retargeting, labeling, recreating, and rerunning workflows are write
+actions. Many of them can trigger webhooks, status recomputation, workflow
+selection, reviewer notifications, or branch-protection recalculation.
+
+This spec defines when PR write actions are allowed during burn-down and when CI
+spend is justified. The rule is simple: no CI for archaeology. Hosted CI should
+be spent on approved merge candidates, approved clean ports, branch refreshes
+needed to prove those candidates, and required proof.
+
+## Source-Of-Truth Authorities
+
+PR CI economics truth lives in:
+
+- this spec;
+- [CI Cost and Verification Policy](../ci/cost-and-verification-policy.md);
+- `policy/pr-ci-actions.toml`;
+- [PR queue disposition spec](BITNET-SPEC-PR-QUEUE-DISPOSITION.md);
+- PR bodies and comments that explain why a write action was necessary.
+
+Workflow files implement routing. They do not make bulk write actions safe by
+default.
+
+## Write Actions
+
+These actions are writes and must be treated as potentially CI-relevant:
+
+| Action | Risk | Required condition |
+| --- | --- | --- |
+| close PR | Hides backlog and may trigger state churn | Valid disposition under PR queue spec |
+| reopen PR | Re-enters queue and may retrigger checks | Reason and intended next action |
+| push branch | Triggers CI on the PR branch | Merge candidate, clean port, or required proof |
+| rebase/merge main | Triggers CI on refreshed branch | Needed for current merge/proof decision |
+| retarget PR | Changes review and merge context | Explicit base correction or lane decision |
+| label PR | May select optional workflows | Label must match real risk/proof need |
+| rerun workflow | Spends CI again | Failed required check, known flake, or fixed input |
+| recreate PR | Loses identity and triggers CI | Allowed only under PR disposition successor rules |
+
+Bulk versions of these actions require explicit approval unless the policy file
+marks a narrower safe case. The default is no bulk close, no bulk reopen, no
+bulk recreate, and no one-for-one replacement wave.
+
+## Read-Only Queue Work
+
+Read-only archaeology is allowed and should be preferred before writes:
+
+```text
+gh pr view
+gh pr diff
+gh api reads
+existing reports
+existing CI logs
+local git show/log/diff
+```
+
+Read-only review can classify a PR, find a successor, identify a stale stack, or
+decide that a branch is a merge candidate. It should not be followed by a write
+unless one of the required conditions is true.
+
+## Allowed CI Spend During Burn-Down
+
+CI spend is allowed for:
+
+- approved merge candidates;
+- approved clean ports;
+- branch refreshes needed to prove a merge candidate;
+- focused proof required by the selected spec or plan;
+- reruns of failed required checks when the failure is plausibly flaky or the
+  input has changed;
+- reviewer or branch-protection requirements for the current PR.
+
+CI spend is not allowed for:
+
+- archaeology without a merge or proof decision;
+- bulk close or reopen waves;
+- recreating valid PRs to reduce visible queue size;
+- refreshing stale stacks only to inspect them;
+- rerunning optional workflows without a proof need;
+- label changes that select expensive lanes without matching risk.
+
+## Rerun Rules
+
+Rerunning a workflow must name one of these reasons:
+
+- required check failed and the log points to an infrastructure or flake class;
+- PR input changed after a fix or restack;
+- branch protection requires a fresh check on the current head;
+- the selected plan requires the proof and the previous receipt is stale.
+
+Do not rerun a workflow simply because a historical PR has old red checks.
+
+## Acceptance Examples
+
+| Case | Required handling |
+| --- | --- |
+| PR is a current-main merge candidate | Refresh if needed, run required CI, merge when green |
+| PR is stale but content may be durable | Review read-only first; restack only if it becomes a candidate |
+| PR will close because a successor landed | Close with disposition; no workflow rerun needed |
+| PR has future work and no successor | Create/link tracking before close; do not rerun CI |
+| Optional hardware label would select expensive lanes | Apply only when the proof requires hardware |
+| Historical PR has red checks from months ago | Do not rerun for archaeology |
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+git diff --check
+```
+
+Future enforcement may load `policy/pr-ci-actions.toml` in a PR action checker
+and fail close/reopen/recreate records that lack the required disposition,
+reason, approval, or proof context.
+
+## Non-Goals
+
+- Do not encode today's exact open PR order.
+- Do not change workflow routing in this spec PR.
+- Do not disable required CI for real merge candidates.
+- Do not treat optional pending jobs as required gates unless branch protection
+  or the selected plan says so.
+- Do not use CI spend as a substitute for content audit.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -22,6 +22,22 @@ Do not remove or repurpose support JSON fields without a schema-version bump.
 Do not let status, receipt explanation, or support bundles infer speedup,
 residency, broad server readiness, or cross-family proof.
 
+## PR Queue And CI Operations
+
+Use these specs before closing, replacing, restacking, or otherwise writing to
+PR queue state:
+
+1. [PR Queue Disposition](BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+   - Defines valid close reasons, invalid close reasons, routing states,
+     successor requirements, and PR identity preservation.
+2. [PR Write-Action CI Economics](BITNET-SPEC-PR-CI-ECONOMICS.md)
+   - Defines queue write actions, no-CI-for-archaeology, bulk-write limits,
+     rerun rules, and allowed CI spend during burn-down.
+
+Wrong base, stale stack, closed parent, and needs-restack are routing states,
+not close reasons. Queue writes should follow content review and should spend
+CI only on current merge candidates, clean ports, or required proof.
+
 ## TL1 ARM-First Table-Lookup Route
 
 Use these artifacts before implementing or claiming TL1 support:

--- a/policy/pr-ci-actions.toml
+++ b/policy/pr-ci-actions.toml
@@ -1,0 +1,65 @@
+schema_version = "1.0"
+policy = "pr-ci-actions"
+owner = "release/ci"
+status = "active"
+updated = "2026-05-19"
+
+# PR queue writes can trigger CI, status churn, or review churn. Read first;
+# write only when the current disposition, merge, or proof decision requires it.
+
+[write_actions]
+close_pr = { requires_disposition = true, may_trigger_ci = true }
+reopen_pr = { requires_reason = true, may_trigger_ci = true }
+push_branch = { requires_merge_candidate = true, may_trigger_ci = true }
+merge_main_or_rebase = { requires_current_proof_need = true, may_trigger_ci = true }
+retarget_pr = { requires_base_correction = true, may_trigger_ci = true }
+label_pr = { requires_risk_or_proof_match = true, may_trigger_ci = true }
+rerun_workflow = { requires_failed_required_check_or_changed_input = true, may_trigger_ci = true }
+recreate_pr = { requires_successor_policy = true, may_trigger_ci = true }
+
+[bulk_actions]
+bulk_label = { requires_approval = true }
+bulk_close = { allowed = false }
+bulk_reopen = { allowed = false }
+bulk_recreate = { allowed = false }
+bulk_restack = { allowed_without_approval = false }
+one_for_one_replacement_wave = { allowed = false }
+
+[classification]
+read_only_tools = [
+  "gh pr view",
+  "gh pr diff",
+  "gh api",
+  "existing reports",
+  "existing ci logs",
+  "git show",
+  "git log",
+  "git diff",
+]
+allowed_ci_spend = [
+  "approved_merge_candidate",
+  "approved_clean_port",
+  "branch_refresh_for_current_merge_candidate",
+  "focused_required_proof",
+  "failed_required_check_rerun_with_flake_or_infra_evidence",
+  "fresh_check_required_by_branch_protection",
+]
+disallowed_ci_spend = [
+  "archaeology_without_merge_decision",
+  "bulk_queue_write",
+  "visible_queue_size_reduction",
+  "optional_workflow_rerun_without_proof_need",
+  "expensive_label_without_matching_risk",
+]
+
+[rerun_reasons]
+required_check_failed_with_flake_or_infra_evidence = true
+input_changed_after_fix_or_restack = true
+fresh_check_required_by_branch_protection = true
+selected_plan_requires_current_proof = true
+historical_red_check_only = false
+
+[merge_candidate_rules]
+hosted_required_checks_must_pass = true
+branch_must_be_mergeable = true
+optional_pending_rows_do_not_block_unless_required = true


### PR DESCRIPTION
## Summary

- Adds the PR write-action CI economics spec.
- Adds machine-readable `policy/pr-ci-actions.toml`.
- Links the rule from the CI cost policy and specs index.

## Scope

- Docs and policy only.
- No workflow changes.
- No branch-protection changes.
- No runtime behavior changes.

## Claim boundary

This is a CI economics/source-of-truth policy PR. It does not change workflow routing, branch protection, runtime behavior, model math, backend support, proof claims, speed, residency, server readiness, or hardware/model support status.

## Validation

- PASS: `git diff --check origin/main..HEAD`
- PASS: TOML parse check for `policy/pr-ci-actions.toml`
- PASS: linked-path existence check for the new spec, policy file, PR queue disposition spec, and ADR link
- HOSTED PASS: PR Gate, PR Plan, Policy, Guards, Link Checker, Markdownlint, Docs Automation, CI Core, and compatibility route checks

## Generated files

None.

## Follow-up / supersedes

- Supersedes no open PR.
- Future workflow changes must be separate implementation PRs.
