### PR TITLE
ci: honor acknowledged PR size skips in PR gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -110,10 +110,20 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           HEAD_SHA: ${{ steps.head.outputs.sha }}
+          LABELS: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.labels.*.name) || '[]' }}
         run: |
           set -euo pipefail
 
           test -f ci-plan.json
+
+          labels="${LABELS:-[]}"
+          if [ "$labels" = "null" ]; then
+            labels="[]"
+          fi
+          pr_size_acknowledged=false
+          if printf '%s' "$labels" | jq -e 'index("mechanical-change") or index("ai-native")' >/dev/null; then
+            pr_size_acknowledged=true
+          fi
 
           echo "Selected blocking lanes from ci-plan.json:"
           jq -r '.selected_lanes[] | select(.blocking == true) | "  - \(.id): \(.name)"' ci-plan.json
@@ -127,7 +137,12 @@ jobs:
             [ -n "$lane_id" ] || continue
             case "$lane_id" in
               always-on-guards)
-                required_jobs+=("Guards" "Check PR Size")
+                required_jobs+=("Guards")
+                if [ "$pr_size_acknowledged" = "true" ]; then
+                  echo "Check PR Size is intentionally skipped by PR label; not adding it as a required upstream lane."
+                else
+                  required_jobs+=("Check PR Size")
+                fi
                 ;;
               bdd-grid-check)
                 required_jobs+=("BDD Grid Check")

--- a/docs/ci/pr-gate-success.md
+++ b/docs/ci/pr-gate-success.md
@@ -23,7 +23,10 @@ Common selected blocking lanes map to these upstream checks:
   **Minimum Supported Rust Version**.
 * **`gpu-native`** -> the five **`native-check (...)`** GPU-matrix compile
   checks.
-* **`always-on-guards`** -> **Guards** and **Check PR Size**.
+* **`always-on-guards`** -> **Guards** and **Check PR Size**. If the PR has
+  `mechanical-change` or `ai-native`, **PR Size Guard** intentionally skips
+  **Check PR Size**; in that acknowledged-large-PR case, **PR Gate Success**
+  requires **Guards** but does not wait for **Check PR Size**.
 
 Lanes that are **not** required by `PR Gate Success`:
 
@@ -87,6 +90,11 @@ any selected upstream lane plus rollup and status propagation cushion.
 | Selected blocking         | Pending after 55 minutes | `failure` |
 | Selected advisory         | Any status            | Reported, not blocking |
 | Unselected                | `skipped` or missing  | Allowed |
+
+Exception: **Check PR Size** may be omitted from the required upstream set when
+the PR carries `mechanical-change` or `ai-native`, because
+`.github/workflows/pr-size-guard.yml` deliberately skips that job for
+acknowledged large PRs.
 
 If `ci-plan.json` selects a blocking lane that PR Gate does not know how to map
 to check names, the gate fails closed. That makes route/schema drift visible


### PR DESCRIPTION
## Summary

- Updates PR Gate so `always-on-guards` still requires `Guards`, but does not require `Check PR Size` when the PR has `mechanical-change` or `ai-native`.
- Documents the acknowledged-large-PR exception in `docs/ci/pr-gate-success.md`.

## Why

`PR Size Guard` intentionally skips `Check PR Size` for `mechanical-change` and `ai-native` PRs. PR Gate was still treating that intentional skip as a required-lane failure, which blocks acknowledged large diagnostic/tooling PRs even after Policy, Guards, and CI Core pass.

## Validation

- PASS: `git diff --check`
- PASS: YAML parse for `.github/workflows/pr-gate.yml` via PyYAML

## Claim boundary

CI routing only. No runtime, model, backend, hardware, A770, residency, performance, or product-readiness claim changes.