### PR TITLE
ci(pr-gate): honor size guard exemption labels

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -121,13 +121,22 @@ jobs:
           echo "Selected advisory lanes from ci-plan.json (reported, not gating):"
           jq -r '.selected_lanes[] | select(.blocking == false) | "  - \(.id): \(.name)"' ci-plan.json
 
+          size_guard_exempt=false
+          if jq -e '.labels[]? | select(. == "ai-native" or . == "mechanical-change")' ci-plan.json >/dev/null; then
+            size_guard_exempt=true
+            echo "PR size guard exemption label present; Check PR Size may be skipped."
+          fi
+
           required_jobs=()
           unknown_lanes=()
           while IFS= read -r lane_id; do
             [ -n "$lane_id" ] || continue
             case "$lane_id" in
               always-on-guards)
-                required_jobs+=("Guards" "Check PR Size")
+                required_jobs+=("Guards")
+                if [ "$size_guard_exempt" != "true" ]; then
+                  required_jobs+=("Check PR Size")
+                fi
                 ;;
               bdd-grid-check)
                 required_jobs+=("BDD Grid Check")

--- a/docs/ci/pr-gate-success.md
+++ b/docs/ci/pr-gate-success.md
@@ -23,7 +23,9 @@ Common selected blocking lanes map to these upstream checks:
   **Minimum Supported Rust Version**.
 * **`gpu-native`** -> the five **`native-check (...)`** GPU-matrix compile
   checks.
-* **`always-on-guards`** -> **Guards** and **Check PR Size**.
+* **`always-on-guards`** -> **Guards** and **Check PR Size**, except that
+  **Check PR Size** is not required when `mechanical-change` or `ai-native`
+  intentionally exempts the upstream size guard.
 
 Lanes that are **not** required by `PR Gate Success`:
 
@@ -83,7 +85,7 @@ any selected upstream lane plus rollup and status propagation cushion.
 | ------------------------- | --------------------- | ----------------------- |
 | Selected blocking         | `success`             | `success` when all selected blocking checks pass |
 | Selected blocking         | `failure`, `cancelled`, or `timed_out` | `failure` |
-| Selected blocking         | `skipped`             | `failure` |
+| Selected blocking         | `skipped`             | `failure`, except for the documented `Check PR Size` exemption labels |
 | Selected blocking         | Pending after 55 minutes | `failure` |
 | Selected advisory         | Any status            | Reported, not blocking |
 | Unselected                | `skipped` or missing  | Allowed |


### PR DESCRIPTION
## Summary

- Make `PR Gate Success` honor the existing PR-size exemption labels used by `pr-size-guard.yml`.
- Keep `always-on-guards` requiring `Guards`, but stop requiring `Check PR Size` when `ai-native` or `mechanical-change` intentionally causes that upstream check to skip.
- Update the PR Gate docs so skipped size checks remain failures except for the documented exemption labels.

## Validation

- PASS: `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/pr-gate.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- PASS: `git diff --check`
- BLOCKED/LOCAL ENV: `cargo run --locked -p xtask --no-default-features -- lint-workflows` timed out locally while compiling xtask dependencies; no BitNet cargo/rustc process remained afterward. Hosted `Lint Workflows / check-yaml` is the authority for this PR.

## Queue context

This fixes the #5946 false-red pattern where `ai-native` correctly skips `Check PR Size`, but `PR Gate Success` still required that skipped check.