### PR TITLE
cuda: record Qwen logits transfer blocker

### DIFF
--- a/crates/bitnet-cli/src/commands/dense_gguf_linear_parity/mod.rs
+++ b/crates/bitnet-cli/src/commands/dense_gguf_linear_parity/mod.rs
@@ -6421,6 +6421,69 @@ fn dense_logits_top_k(logits: &[f32], top_k: usize) -> Result<Vec<DenseGgufLogit
         .collect())
 }
 
+fn dense_qwen_logits_transfer_reduction_json(
+    logits_len: usize,
+    generated_tokens: u64,
+    observed_top_k: usize,
+    actual_device_to_host_bytes: u64,
+) -> Result<Value> {
+    if logits_len == 0 {
+        bail!("dense Qwen logits transfer reduction requires a non-empty logits vector");
+    }
+    if generated_tokens == 0 {
+        bail!("dense Qwen logits transfer reduction requires generated tokens");
+    }
+    if observed_top_k == 0 {
+        bail!("dense Qwen logits transfer reduction requires top-k evidence");
+    }
+
+    let full_logits_bytes_per_step =
+        checked_u64_mul(logits_len as u64, 4, "full logits bytes per step")?;
+    let full_logits_download_bytes = checked_u64_mul(
+        full_logits_bytes_per_step,
+        generated_tokens,
+        "full logits download bytes",
+    )?;
+    if actual_device_to_host_bytes != full_logits_download_bytes {
+        bail!(
+            "dense Qwen current transfer accounting must match full logits download bytes until device top-k transfer lands"
+        );
+    }
+
+    let top_k_result_bytes_per_step_floor =
+        checked_u64_mul(observed_top_k as u64, 12, "top-k result bytes per step floor")?;
+    let top_k_result_bytes_total_floor = checked_u64_mul(
+        top_k_result_bytes_per_step_floor,
+        generated_tokens,
+        "top-k result bytes total floor",
+    )?;
+    let selected_token_bytes_total_floor =
+        checked_u64_mul(4, generated_tokens, "selected-token bytes total floor")?;
+
+    Ok(json!({
+        "schema": 1,
+        "scope": "dense_qwen_logits_top_k_transfer",
+        "transfer_mode": "full_logits_download_cpu_sampler",
+        "sampling_location": "cpu",
+        "requested_top_k": observed_top_k as u64,
+        "generated_tokens_count": generated_tokens,
+        "logits_vector_length": logits_len as u64,
+        "logits_element_bytes": 4_u64,
+        "full_logits_bytes_per_step": full_logits_bytes_per_step,
+        "full_logits_download_bytes": full_logits_download_bytes,
+        "actual_device_to_host_bytes": actual_device_to_host_bytes,
+        "top_k_result_bytes_per_step_floor": top_k_result_bytes_per_step_floor,
+        "top_k_result_bytes_total_floor": top_k_result_bytes_total_floor,
+        "selected_token_bytes_total_floor": selected_token_bytes_total_floor,
+        "device_to_host_bytes_reduced": false,
+        "bytes_saved_vs_full_logits": 0_u64,
+        "selected_token_equality_preserved": true,
+        "top_k_evidence_preserved": true,
+        "quality_receipts_unchanged": true,
+        "reduction_blocker": "cpu_sampler_requires_full_logits_until_device_top_k_sampler"
+    }))
+}
+
 fn dense_final_norm_descriptor(
     inspection: &DenseGgufDescriptorInspection,
 ) -> Result<&DenseGgufTensorDescriptor> {
@@ -11215,6 +11278,20 @@ fn dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(
     let stats_h2d = model_bytes;
     let stats_d2h = logits_transfer_bytes;
     let stats_launches = runtime_invocations;
+    let observed_top_k = cuda
+        .steps
+        .first()
+        .map(|step| step.top_k.len())
+        .ok_or_else(|| anyhow!("dense Qwen short-decode receipt requires top-k steps"))?;
+    if observed_top_k == 0 || cuda.steps.iter().any(|step| step.top_k.len() != observed_top_k) {
+        bail!("dense Qwen short-decode receipt requires uniform non-empty top-k evidence");
+    }
+    let logits_transfer_reduction = dense_qwen_logits_transfer_reduction_json(
+        cuda.logits_len,
+        generated_count_u64,
+        observed_top_k,
+        stats_d2h,
+    )?;
     let top_k_all_match = cpu.top_k_steps_sha256 == cuda.top_k_steps_sha256;
     let first_top_k_divergence = first_top_k_divergence_index(&cpu.steps, &cuda.steps);
     let step_json = dense_qwen_short_decode_steps_json(cpu, cuda);
@@ -11359,6 +11436,7 @@ fn dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(
             "chat_claimed": false
         },
         "kernel_stats": kernel_stats,
+        "logits_transfer_reduction": logits_transfer_reduction,
         "kernel_coverage": {
             "schema": 1,
             "route": DENSE_REGULAR_LLM_CUDA_ARTIFACT_KIND,
@@ -11620,6 +11698,28 @@ fn dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(
     let stats_h2d = model_bytes;
     let stats_d2h = logits_transfer_bytes;
     let stats_launches = runtime_invocations;
+    let observed_top_k = cuda
+        .turns
+        .iter()
+        .flat_map(|turn| turn.steps.iter())
+        .next()
+        .map(|step| step.top_k.len())
+        .ok_or_else(|| anyhow!("dense Qwen warm-session receipt requires top-k steps"))?;
+    if observed_top_k == 0
+        || cuda
+            .turns
+            .iter()
+            .flat_map(|turn| turn.steps.iter())
+            .any(|step| step.top_k.len() != observed_top_k)
+    {
+        bail!("dense Qwen warm-session receipt requires uniform non-empty top-k evidence");
+    }
+    let logits_transfer_reduction = dense_qwen_logits_transfer_reduction_json(
+        logits_len,
+        generated_tokens_total,
+        observed_top_k,
+        stats_d2h,
+    )?;
 
     let cpu_generated_all = cpu
         .turns
@@ -11909,6 +12009,7 @@ fn dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(
             "chat_claimed": false
         },
         "kernel_stats": kernel_stats,
+        "logits_transfer_reduction": logits_transfer_reduction,
         "kernel_coverage": {
             "schema": 1,
             "route": DENSE_REGULAR_LLM_CUDA_ARTIFACT_KIND,

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -5393,6 +5393,85 @@ fn validate_dense_qwen_transfer_timing(timing: &Value, transfer: &Value) -> Resu
     Ok(())
 }
 
+fn validate_dense_qwen_logits_transfer_reduction(
+    receipt: &Value,
+    stats_d2h: u64,
+    generated_tokens: u64,
+) -> Result<()> {
+    let Some(reduction) = receipt.get("logits_transfer_reduction") else {
+        return Ok(());
+    };
+    if !reduction.is_object() {
+        return Err(anyhow!("logits_transfer_reduction must be an object when present"));
+    }
+
+    require_u64_eq(reduction, "schema", 1)?;
+    require_string_eq(reduction, "scope", "dense_qwen_logits_top_k_transfer")?;
+    require_string_non_empty(reduction, "transfer_mode")?;
+    require_string_non_empty(reduction, "sampling_location")?;
+    require_positive_u64(reduction, "requested_top_k")?;
+    require_u64_eq(reduction, "generated_tokens_count", generated_tokens)?;
+    require_positive_u64(reduction, "logits_vector_length")?;
+    require_positive_u64(reduction, "logits_element_bytes")?;
+    let full_logits_bytes_per_step = required_u64(reduction, "full_logits_bytes_per_step")?;
+    let full_logits_download_bytes = required_u64(reduction, "full_logits_download_bytes")?;
+    if full_logits_bytes_per_step == 0 || full_logits_download_bytes == 0 {
+        return Err(anyhow!("logits_transfer_reduction full logits byte counts must be positive"));
+    }
+    let expected_full_bytes = full_logits_bytes_per_step
+        .checked_mul(generated_tokens)
+        .ok_or_else(|| anyhow!("logits_transfer_reduction full logits byte count overflows"))?;
+    if full_logits_download_bytes != expected_full_bytes {
+        return Err(anyhow!(
+            "logits_transfer_reduction.full_logits_download_bytes must equal full_logits_bytes_per_step * generated_tokens_count"
+        ));
+    }
+    let actual_device_to_host_bytes = required_u64(reduction, "actual_device_to_host_bytes")?;
+    if actual_device_to_host_bytes != stats_d2h {
+        return Err(anyhow!(
+            "logits_transfer_reduction.actual_device_to_host_bytes must match measured device_to_host_bytes"
+        ));
+    }
+    require_positive_u64(reduction, "top_k_result_bytes_per_step_floor")?;
+    require_positive_u64(reduction, "top_k_result_bytes_total_floor")?;
+    require_positive_u64(reduction, "selected_token_bytes_total_floor")?;
+    require_bool_eq(reduction, "selected_token_equality_preserved", true)?;
+    require_bool_eq(reduction, "top_k_evidence_preserved", true)?;
+    require_bool_eq(reduction, "quality_receipts_unchanged", true)?;
+
+    let reduced = object_field(reduction, "device_to_host_bytes_reduced")?
+        .as_bool()
+        .ok_or_else(|| anyhow!("field `device_to_host_bytes_reduced` must be a bool"))?;
+    let bytes_saved = required_u64(reduction, "bytes_saved_vs_full_logits")?;
+    if reduced {
+        if actual_device_to_host_bytes >= full_logits_download_bytes {
+            return Err(anyhow!(
+                "logits_transfer_reduction.device_to_host_bytes_reduced requires actual_device_to_host_bytes < full_logits_download_bytes"
+            ));
+        }
+        if bytes_saved != full_logits_download_bytes - actual_device_to_host_bytes {
+            return Err(anyhow!(
+                "logits_transfer_reduction.bytes_saved_vs_full_logits must equal the measured D2H reduction"
+            ));
+        }
+    } else {
+        require_string_eq(reduction, "transfer_mode", "full_logits_download_cpu_sampler")?;
+        require_string_non_empty(reduction, "reduction_blocker")?;
+        if actual_device_to_host_bytes != full_logits_download_bytes {
+            return Err(anyhow!(
+                "logits_transfer_reduction non-reduced receipts must account for full logits D2H bytes"
+            ));
+        }
+        if bytes_saved != 0 {
+            return Err(anyhow!(
+                "logits_transfer_reduction.bytes_saved_vs_full_logits must be 0 when device_to_host_bytes_reduced is false"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Validate the exact dense Qwen model identities allowed in runtime CUDA proofs.
 fn require_verified_dense_qwen_runtime_model(model: &Value) -> Result<()> {
     let id = required_string(model, "id")?;
@@ -5957,6 +6036,7 @@ pub fn validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(
     require_u64_eq(transfer, "kernel_invocations", stats_invocations)?;
     require_u64_eq(transfer, "kernel_launches", stats_launches)?;
     validate_dense_qwen_transfer_timing(timing, transfer)?;
+    validate_dense_qwen_logits_transfer_reduction(receipt, stats_d2h, requested)?;
 
     let claim_boundary = object_field(receipt, "claim_boundary")?;
     require_bool_eq(claim_boundary, "dense_regular_llm_cuda_claimed", true)?;
@@ -6365,6 +6445,7 @@ pub fn validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(
     require_u64_eq(transfer, "kernel_invocations", stats_invocations)?;
     require_u64_eq(transfer, "kernel_launches", stats_launches)?;
     validate_dense_qwen_transfer_timing(timing, transfer)?;
+    validate_dense_qwen_logits_transfer_reduction(receipt, stats_d2h, turns_count * requested)?;
 
     let claim_boundary = object_field(receipt, "claim_boundary")?;
     require_bool_eq(claim_boundary, "dense_regular_llm_cuda_claimed", true)?;

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -5409,14 +5409,30 @@ fn validate_dense_qwen_logits_transfer_reduction(
     require_string_eq(reduction, "scope", "dense_qwen_logits_top_k_transfer")?;
     require_string_non_empty(reduction, "transfer_mode")?;
     require_string_non_empty(reduction, "sampling_location")?;
-    require_positive_u64(reduction, "requested_top_k")?;
+    let requested_top_k = required_u64(reduction, "requested_top_k")?;
+    if requested_top_k == 0 {
+        return Err(anyhow!("logits_transfer_reduction.requested_top_k must be positive"));
+    }
     require_u64_eq(reduction, "generated_tokens_count", generated_tokens)?;
-    require_positive_u64(reduction, "logits_vector_length")?;
-    require_positive_u64(reduction, "logits_element_bytes")?;
+    let logits_vector_length = required_u64(reduction, "logits_vector_length")?;
+    let logits_element_bytes = required_u64(reduction, "logits_element_bytes")?;
+    if logits_vector_length == 0 || logits_element_bytes == 0 {
+        return Err(anyhow!(
+            "logits_transfer_reduction logits vector length and element bytes must be positive"
+        ));
+    }
     let full_logits_bytes_per_step = required_u64(reduction, "full_logits_bytes_per_step")?;
     let full_logits_download_bytes = required_u64(reduction, "full_logits_download_bytes")?;
     if full_logits_bytes_per_step == 0 || full_logits_download_bytes == 0 {
         return Err(anyhow!("logits_transfer_reduction full logits byte counts must be positive"));
+    }
+    let expected_full_logits_bytes_per_step = logits_vector_length
+        .checked_mul(logits_element_bytes)
+        .ok_or_else(|| anyhow!("logits_transfer_reduction logits byte count overflows"))?;
+    if full_logits_bytes_per_step != expected_full_logits_bytes_per_step {
+        return Err(anyhow!(
+            "logits_transfer_reduction.full_logits_bytes_per_step must equal logits_vector_length * logits_element_bytes"
+        ));
     }
     let expected_full_bytes = full_logits_bytes_per_step
         .checked_mul(generated_tokens)
@@ -5432,9 +5448,43 @@ fn validate_dense_qwen_logits_transfer_reduction(
             "logits_transfer_reduction.actual_device_to_host_bytes must match measured device_to_host_bytes"
         ));
     }
-    require_positive_u64(reduction, "top_k_result_bytes_per_step_floor")?;
-    require_positive_u64(reduction, "top_k_result_bytes_total_floor")?;
-    require_positive_u64(reduction, "selected_token_bytes_total_floor")?;
+    let top_k_result_bytes_per_step_floor =
+        required_u64(reduction, "top_k_result_bytes_per_step_floor")?;
+    let top_k_result_bytes_total_floor = required_u64(reduction, "top_k_result_bytes_total_floor")?;
+    let selected_token_bytes_total_floor =
+        required_u64(reduction, "selected_token_bytes_total_floor")?;
+    if top_k_result_bytes_per_step_floor == 0
+        || top_k_result_bytes_total_floor == 0
+        || selected_token_bytes_total_floor == 0
+    {
+        return Err(anyhow!(
+            "logits_transfer_reduction preserved-evidence byte floors must be positive"
+        ));
+    }
+    let expected_top_k_bytes_per_step = requested_top_k
+        .checked_mul(12)
+        .ok_or_else(|| anyhow!("logits_transfer_reduction top-k byte floor overflows"))?;
+    if top_k_result_bytes_per_step_floor != expected_top_k_bytes_per_step {
+        return Err(anyhow!(
+            "logits_transfer_reduction.top_k_result_bytes_per_step_floor must equal requested_top_k * 12"
+        ));
+    }
+    let expected_top_k_bytes_total = top_k_result_bytes_per_step_floor
+        .checked_mul(generated_tokens)
+        .ok_or_else(|| anyhow!("logits_transfer_reduction top-k byte total overflows"))?;
+    if top_k_result_bytes_total_floor != expected_top_k_bytes_total {
+        return Err(anyhow!(
+            "logits_transfer_reduction.top_k_result_bytes_total_floor must equal top_k_result_bytes_per_step_floor * generated_tokens_count"
+        ));
+    }
+    let expected_selected_token_bytes_total = 4_u64
+        .checked_mul(generated_tokens)
+        .ok_or_else(|| anyhow!("logits_transfer_reduction selected-token byte floor overflows"))?;
+    if selected_token_bytes_total_floor != expected_selected_token_bytes_total {
+        return Err(anyhow!(
+            "logits_transfer_reduction.selected_token_bytes_total_floor must equal 4 * generated_tokens_count"
+        ));
+    }
     require_bool_eq(reduction, "selected_token_equality_preserved", true)?;
     require_bool_eq(reduction, "top_k_evidence_preserved", true)?;
     require_bool_eq(reduction, "quality_receipts_unchanged", true)?;

--- a/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
+++ b/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
@@ -1979,35 +1979,58 @@ fn dense_gguf_qwen_short_decode_rejects_missing_transfer_timing_source_fields() 
 }
 
 #[test]
-fn dense_gguf_qwen_short_decode_accepts_legacy_receipt_without_transfer_reduction_section() {
+fn dense_gguf_qwen_short_decode_accepts_legacy_receipt_without_transfer_reduction_section()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
-    receipt.as_object_mut().unwrap().remove("logits_transfer_reduction");
+    let receipt_object = receipt.as_object_mut().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "receipt must be an object")
+    })?;
+    receipt_object.remove("logits_transfer_reduction");
 
-    validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt).unwrap();
+    validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt)?;
+    Ok(())
 }
 
 #[test]
-fn dense_gguf_qwen_short_decode_rejects_unearned_transfer_reduction_claim() {
+fn dense_gguf_qwen_short_decode_rejects_unearned_transfer_reduction_claim()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
     receipt["logits_transfer_reduction"]["device_to_host_bytes_reduced"] = json!(true);
 
-    let err = validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt)
-        .unwrap_err()
-        .to_string();
+    let err = match validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted an unearned transfer-reduction claim",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
 
     assert!(err.contains("device_to_host_bytes_reduced"), "unexpected error: {err}");
+    Ok(())
 }
 
 #[test]
-fn dense_gguf_qwen_short_decode_requires_reduction_blocker_when_full_logits_download_remains() {
+fn dense_gguf_qwen_short_decode_requires_reduction_blocker_when_full_logits_download_remains()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
     receipt["logits_transfer_reduction"]["reduction_blocker"] = Value::Null;
 
-    let err = validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt)
-        .unwrap_err()
-        .to_string();
+    let err = match validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted a full-logits receipt without a reduction blocker",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
 
     assert!(err.contains("reduction_blocker"), "unexpected error: {err}");
+    Ok(())
 }
 
 #[test]
@@ -2112,35 +2135,58 @@ fn dense_gguf_qwen_warm_session_rejects_missing_transfer_timing_source_fields() 
 }
 
 #[test]
-fn dense_gguf_qwen_warm_session_accepts_legacy_receipt_without_transfer_reduction_section() {
+fn dense_gguf_qwen_warm_session_accepts_legacy_receipt_without_transfer_reduction_section()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
-    receipt.as_object_mut().unwrap().remove("logits_transfer_reduction");
+    let receipt_object = receipt.as_object_mut().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "receipt must be an object")
+    })?;
+    receipt_object.remove("logits_transfer_reduction");
 
-    validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt).unwrap();
+    validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt)?;
+    Ok(())
 }
 
 #[test]
-fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_byte_mismatch() {
+fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_byte_mismatch()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
     receipt["logits_transfer_reduction"]["actual_device_to_host_bytes"] = json!(128);
 
-    let err = validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt)
-        .unwrap_err()
-        .to_string();
+    let err = match validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted mismatched transfer byte accounting",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
 
     assert!(err.contains("actual_device_to_host_bytes"), "unexpected error: {err}");
+    Ok(())
 }
 
 #[test]
-fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_without_top_k_evidence() {
+fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_without_top_k_evidence()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
     receipt["logits_transfer_reduction"]["top_k_evidence_preserved"] = json!(false);
 
-    let err = validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt)
-        .unwrap_err()
-        .to_string();
+    let err = match validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted transfer reduction without top-k evidence",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
 
     assert!(err.contains("top_k_evidence_preserved"), "unexpected error: {err}");
+    Ok(())
 }
 
 #[test]

--- a/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
+++ b/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
@@ -1979,6 +1979,38 @@ fn dense_gguf_qwen_short_decode_rejects_missing_transfer_timing_source_fields() 
 }
 
 #[test]
+fn dense_gguf_qwen_short_decode_accepts_legacy_receipt_without_transfer_reduction_section() {
+    let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
+    receipt.as_object_mut().unwrap().remove("logits_transfer_reduction");
+
+    validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt).unwrap();
+}
+
+#[test]
+fn dense_gguf_qwen_short_decode_rejects_unearned_transfer_reduction_claim() {
+    let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
+    receipt["logits_transfer_reduction"]["device_to_host_bytes_reduced"] = json!(true);
+
+    let err = validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("device_to_host_bytes_reduced"), "unexpected error: {err}");
+}
+
+#[test]
+fn dense_gguf_qwen_short_decode_requires_reduction_blocker_when_full_logits_download_remains() {
+    let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
+    receipt["logits_transfer_reduction"]["reduction_blocker"] = Value::Null;
+
+    let err = validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("reduction_blocker"), "unexpected error: {err}");
+}
+
+#[test]
 fn dense_gguf_qwen_short_decode_rejects_chat_speedup_full_residency_and_bitnet_claims() {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
     receipt["claim_boundary"]["qwen_chat_cuda_claimed"] = json!(true);
@@ -2077,6 +2109,38 @@ fn dense_gguf_qwen_warm_session_rejects_missing_transfer_timing_source_fields() 
         .to_string();
 
     assert!(err.contains("transfer_timing_status"), "unexpected error: {err}");
+}
+
+#[test]
+fn dense_gguf_qwen_warm_session_accepts_legacy_receipt_without_transfer_reduction_section() {
+    let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
+    receipt.as_object_mut().unwrap().remove("logits_transfer_reduction");
+
+    validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt).unwrap();
+}
+
+#[test]
+fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_byte_mismatch() {
+    let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
+    receipt["logits_transfer_reduction"]["actual_device_to_host_bytes"] = json!(128);
+
+    let err = validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("actual_device_to_host_bytes"), "unexpected error: {err}");
+}
+
+#[test]
+fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_without_top_k_evidence() {
+    let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
+    receipt["logits_transfer_reduction"]["top_k_evidence_preserved"] = json!(false);
+
+    let err = validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt)
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("top_k_evidence_preserved"), "unexpected error: {err}");
 }
 
 #[test]
@@ -4182,7 +4246,7 @@ fn valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt() -> Value {
                 "cuda_logits_top_k_sha256": format!("{:064x}", 50 + index),
                 "cpu_logits_sha256": format!("{:064x}", 70 + index),
                 "cuda_logits_sha256": format!("{:064x}", 80 + index),
-                "logits_vector_length": 151936,
+                "logits_vector_length": 32,
                 "cpu_top_k": [
                     {"rank": 1, "token_id": *token, "value": 1.0},
                     {"rank": 2, "token_id": 3, "value": 0.5}
@@ -4286,6 +4350,28 @@ fn valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt() -> Value {
             "kernel_time_ms": 0.0
         }
     ]);
+    receipt["logits_transfer_reduction"] = json!({
+        "schema": 1,
+        "scope": "dense_qwen_logits_top_k_transfer",
+        "transfer_mode": "full_logits_download_cpu_sampler",
+        "sampling_location": "cpu",
+        "requested_top_k": 2,
+        "generated_tokens_count": 8,
+        "logits_vector_length": 32,
+        "logits_element_bytes": 4,
+        "full_logits_bytes_per_step": 128,
+        "full_logits_download_bytes": 1024,
+        "actual_device_to_host_bytes": 1024,
+        "top_k_result_bytes_per_step_floor": 24,
+        "top_k_result_bytes_total_floor": 192,
+        "selected_token_bytes_total_floor": 32,
+        "device_to_host_bytes_reduced": false,
+        "bytes_saved_vs_full_logits": 0,
+        "selected_token_equality_preserved": true,
+        "top_k_evidence_preserved": true,
+        "quality_receipts_unchanged": true,
+        "reduction_blocker": "cpu_sampler_requires_full_logits_until_device_top_k_sampler"
+    });
     receipt["kernel_coverage"] = json!({
         "schema": 1,
         "route": "dense_regular_llm_cuda",
@@ -4440,7 +4526,7 @@ fn valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt() -> Value {
                         "cuda_logits_top_k_sha256": format!("{:064x}", 130 + turn_index * 10 + index),
                         "cpu_logits_sha256": format!("{:064x}", 170 + turn_index * 10 + index),
                         "cuda_logits_sha256": format!("{:064x}", 200 + turn_index * 10 + index),
-                        "logits_vector_length": 151936,
+                        "logits_vector_length": 32,
                         "cpu_top_k": [
                             {"rank": 1, "token_id": *token, "value": 1.0},
                             {"rank": 2, "token_id": 3, "value": 0.5}
@@ -4574,6 +4660,28 @@ fn valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt() -> Value {
             "kernel_time_ms": 0.0
         }
     ]);
+    receipt["logits_transfer_reduction"] = json!({
+        "schema": 1,
+        "scope": "dense_qwen_logits_top_k_transfer",
+        "transfer_mode": "full_logits_download_cpu_sampler",
+        "sampling_location": "cpu",
+        "requested_top_k": 2,
+        "generated_tokens_count": 24,
+        "logits_vector_length": 32,
+        "logits_element_bytes": 4,
+        "full_logits_bytes_per_step": 128,
+        "full_logits_download_bytes": 3072,
+        "actual_device_to_host_bytes": 3072,
+        "top_k_result_bytes_per_step_floor": 24,
+        "top_k_result_bytes_total_floor": 576,
+        "selected_token_bytes_total_floor": 96,
+        "device_to_host_bytes_reduced": false,
+        "bytes_saved_vs_full_logits": 0,
+        "selected_token_equality_preserved": true,
+        "top_k_evidence_preserved": true,
+        "quality_receipts_unchanged": true,
+        "reduction_blocker": "cpu_sampler_requires_full_logits_until_device_top_k_sampler"
+    });
     receipt["kernel_coverage"] = json!({
         "schema": 1,
         "route": "dense_regular_llm_cuda",

--- a/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
+++ b/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
@@ -2034,6 +2034,28 @@ fn dense_gguf_qwen_short_decode_requires_reduction_blocker_when_full_logits_down
 }
 
 #[test]
+fn dense_gguf_qwen_short_decode_rejects_malformed_full_logits_byte_accounting()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
+    receipt["logits_transfer_reduction"]["full_logits_bytes_per_step"] = json!(64);
+    receipt["logits_transfer_reduction"]["full_logits_download_bytes"] = json!(512);
+
+    let err = match validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted inconsistent full-logits byte accounting",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
+
+    assert!(err.contains("full_logits_bytes_per_step"), "unexpected error: {err}");
+    Ok(())
+}
+
+#[test]
 fn dense_gguf_qwen_short_decode_rejects_chat_speedup_full_residency_and_bitnet_claims() {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
     receipt["claim_boundary"]["qwen_chat_cuda_claimed"] = json!(true);
@@ -2186,6 +2208,27 @@ fn dense_gguf_qwen_warm_session_rejects_transfer_reduction_without_top_k_evidenc
     };
 
     assert!(err.contains("top_k_evidence_preserved"), "unexpected error: {err}");
+    Ok(())
+}
+
+#[test]
+fn dense_gguf_qwen_warm_session_rejects_malformed_top_k_floor_accounting()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut receipt = valid_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt();
+    receipt["logits_transfer_reduction"]["top_k_result_bytes_total_floor"] = json!(24);
+
+    let err = match validate_dense_gguf_qwen_warm_session_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted inconsistent top-k floor accounting",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
+
+    assert!(err.contains("top_k_result_bytes_total_floor"), "unexpected error: {err}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add `logits_transfer_reduction` to dense Qwen short-decode and warm-session receipts
- record the current full-logits D2H accounting and the blocker for top-k-only device transfer
- validate future transfer-reduction claims fail closed unless measured D2H bytes drop while selected-token and top-k evidence stays preserved
- keep the new receipt section optional so legacy receipts remain accepted

## Scope
- dense Qwen receipt emission in `bitnet-cli`
- dense Qwen receipt validation in `bitnet-receipts-core`
- focused receipt validator coverage in `bitnet-receipts`

## Claim boundary
- `device_to_host_bytes_reduced` remains `false` for the current CPU sampler path
- speedup, full residency, server readiness, broad dense GGUF, Qwen3, and BitNet QK256 proof are not promoted
- this PR records a blocker for future transfer reduction; it does not implement device top-k sampling

## Validation
- `cargo fmt -p bitnet-cli -p bitnet-receipts-core -p bitnet-receipts -- --check`
- `cargo test --locked -p bitnet-receipts --test cuda_receipt_validation dense_gguf_qwen_short_decode`
- `cargo test --locked -p bitnet-receipts --test cuda_receipt_validation dense_gguf_qwen_warm_session`
- `cargo test --locked -p bitnet-receipts --test cuda_receipt_validation`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli`
- `git diff --check origin/main..HEAD`

Local policy repro attempted and timed out before a finding:
- `cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports`
- `cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error`

The branch was updated to remove the new panic-family helpers from the added tests before rerunning CI.

## Generated files
- none

## Receipts
- adds `logits_transfer_reduction` with schema, transfer mode, D2H byte accounting, top-k evidence preservation, quality preservation, and explicit reduction blocker fields

## What this does not claim
- no speedup claim
- no full residency claim
- no server readiness claim
- no broad dense GGUF claim
- no Qwen3 promotion
- no BitNet QK256 proof

## Follow-up / supersedes
- follow-up device top-k transfer work must flip `device_to_host_bytes_reduced` only with lower measured D2H bytes and preserved selected-token/top-k evidence
- supersedes: none
