### PR TITLE
docs(spec): harden support bundle contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/cuda-support.yml
+++ b/.github/ISSUE_TEMPLATE/cuda-support.yml
@@ -28,7 +28,8 @@ body:
             "selected_backend": "nvidia-rtx-5070-ti-cuda",
             "selected_route": "...",
             "fallback_used": false,
-            "speedup_claim": false
+            "speedup_claim": false,
+            "claim_boundary": "..."
           }
         }
       render: json

--- a/crates/bitnet-cli/src/commands/support.rs
+++ b/crates/bitnet-cli/src/commands/support.rs
@@ -76,6 +76,7 @@ struct SupportBundleSummary {
     bitnet_packed_i2s_qk256_proof: Option<bool>,
     dense_regular_llm_cuda_proof: Option<bool>,
     next_proof: Option<String>,
+    claim_boundary: Option<String>,
     receipt_path: String,
 }
 
@@ -176,6 +177,7 @@ fn support_summary(
         bitnet_packed_i2s_qk256_proof: receipt.bitnet_packed_i2s_qk256_proof,
         dense_regular_llm_cuda_proof: receipt.dense_regular_llm_cuda_proof,
         next_proof,
+        claim_boundary: receipt.model_coverage.claim_boundary.clone(),
         receipt_path: receipt.path.clone(),
     }
 }
@@ -422,6 +424,12 @@ mod tests {
                 .context("support summary next_proof must be a string")?
                 .contains("exact-profile dense Qwen server readiness")
         );
+        assert!(
+            value["summary"]["claim_boundary"]
+                .as_str()
+                .context("support summary claim_boundary must be a string")?
+                .contains("do not satisfy BitNet packed I2_S/QK256 proof")
+        );
         assert_eq!(value["runtime"]["runtime_api"], "cuda");
         assert_eq!(value["runtime"]["driver_version"], "test-driver");
         assert_eq!(value["runtime"]["cuda_runtime_version"], "test-cuda-runtime");
@@ -442,6 +450,97 @@ mod tests {
                 && model["dense_regular_llm_cuda_proof"] == true
                 && model["bitnet_packed_i2s_qk256_proof"] == false
         }));
+        Ok(())
+    }
+
+    #[test]
+    fn cuda_support_issue_template_requires_bundle_json_and_claim_boundaries() -> Result<()> {
+        let template_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join(".github")
+            .join("ISSUE_TEMPLATE")
+            .join("cuda-support.yml");
+        let template: serde_yaml::Value = serde_yaml::from_slice(
+            &fs::read(&template_path)
+                .with_context(|| format!("read {}", template_path.display()))?,
+        )?;
+
+        assert_eq!(template["name"].as_str(), Some("CUDA Support"));
+        let labels = template["labels"]
+            .as_sequence()
+            .context("cuda support issue labels must be a sequence")?;
+        assert!(labels.iter().any(|label| label.as_str() == Some("support")));
+        assert!(labels.iter().any(|label| label.as_str() == Some("cuda")));
+
+        let body =
+            template["body"].as_sequence().context("cuda support issue body must be a sequence")?;
+        let support_bundle_index = body
+            .iter()
+            .position(|item| item["id"].as_str() == Some("support-bundle"))
+            .context("cuda support issue template must include support-bundle field")?;
+        let issue_index = body
+            .iter()
+            .position(|item| item["id"].as_str() == Some("issue"))
+            .context("cuda support issue template must include issue field")?;
+        assert!(
+            support_bundle_index < issue_index,
+            "support bundle must be requested before free-form issue prose"
+        );
+
+        let support_bundle = &body[support_bundle_index];
+        assert_eq!(support_bundle["type"].as_str(), Some("textarea"));
+        assert_eq!(support_bundle["attributes"]["render"].as_str(), Some("json"));
+        assert_eq!(support_bundle["validations"]["required"].as_bool(), Some(true));
+        let description = support_bundle["attributes"]["description"]
+            .as_str()
+            .context("support-bundle description must be a string")?;
+        assert!(description.contains(
+            "bitnet support bundle --latest --device nvidia-rtx-5070-ti-cuda --format json"
+        ));
+        let placeholder = support_bundle["attributes"]["placeholder"]
+            .as_str()
+            .context("support-bundle placeholder must be a string")?;
+        for required_fragment in [
+            "\"kind\": \"bitnet_support_bundle\"",
+            "\"selected_backend\": \"nvidia-rtx-5070-ti-cuda\"",
+            "\"selected_route\":",
+            "\"fallback_used\": false",
+            "\"speedup_claim\": false",
+            "\"claim_boundary\":",
+        ] {
+            assert!(
+                placeholder.contains(required_fragment),
+                "support-bundle placeholder missing {required_fragment}"
+            );
+        }
+
+        let claim_boundaries = body
+            .iter()
+            .find(|item| item["id"].as_str() == Some("claim-boundaries"))
+            .context("cuda support issue template must include claim-boundaries")?;
+        let options = claim_boundaries["attributes"]["options"]
+            .as_sequence()
+            .context("claim boundary options must be a sequence")?;
+        let option_labels = options
+            .iter()
+            .filter_map(|option| option["label"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        for required_boundary in [
+            "selected backend is `nvidia-rtx-5070-ti-cuda`, not generic `cuda`",
+            "`fallback_used=false`",
+            "`speedup_claim=false`",
+            "Qwen2.5 exact-profile server readiness is not being treated as broad dense GGUF server readiness",
+            "Dense CUDA proof is not being treated as BitNet I2_S/QK256 proof",
+            "Qwen2.5 evidence is not being treated as Qwen3 evidence",
+        ] {
+            assert!(
+                option_labels.contains(required_boundary),
+                "claim boundary checklist missing {required_boundary}"
+            );
+        }
+
         Ok(())
     }
 }

--- a/docs/specs/BITNET-SPEC-CUDA-SUPPORT-ISSUE.md
+++ b/docs/specs/BITNET-SPEC-CUDA-SUPPORT-ISSUE.md
@@ -1,0 +1,98 @@
+# BITNET-SPEC-CUDA-SUPPORT-ISSUE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-19
+Linked proposal:
+[BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs:
+[BITNET-SPEC-SUPPORT-BUNDLE](BITNET-SPEC-SUPPORT-BUNDLE.md),
+[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md),
+[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md)
+Linked ADRs:
+[BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: CUDA support issues must preserve existing claim boundaries
+Policy impact: none
+
+## Purpose
+
+CUDA support issues must be receipt-backed. A user should paste one support
+bundle before writing free-form environment prose so triage can route by
+structured proof instead of by inference history or guesswork.
+
+The governed template is:
+
+```text
+.github/ISSUE_TEMPLATE/cuda-support.yml
+```
+
+## Required First Artifact
+
+The template must ask for JSON from:
+
+```powershell
+bitnet support bundle --latest --device nvidia-rtx-5070-ti-cuda --format json
+```
+
+The support-bundle field must:
+
+- appear before the free-form issue description;
+- be required;
+- render as JSON;
+- show `kind = bitnet_support_bundle`;
+- show `selected_backend = nvidia-rtx-5070-ti-cuda`;
+- show `selected_route`;
+- show `fallback_used`;
+- show `speedup_claim`;
+- show `claim_boundary`.
+
+## Claim Boundary Checklist
+
+The template must preserve these review boundaries:
+
+```text
+selected backend is nvidia-rtx-5070-ti-cuda, not generic cuda
+fallback_used=false is required for strict selected-backend proof
+speedup_claim=false unless exact-profile benchmark proof accepts speedup
+Qwen2.5 exact-profile server readiness is not broad dense GGUF server readiness
+dense CUDA proof is not BitNet I2_S/QK256 proof
+Qwen2.5 evidence is not Qwen3 evidence
+```
+
+Checkboxes are allowed as user-facing reminders, but triage must still use the
+support-bundle JSON and receipt explanation as the authority.
+
+## Fallback Path
+
+If the support-bundle command fails, issue triage should request:
+
+```text
+failed command
+stderr
+receipt path, if available
+operating system
+GPU model
+driver/runtime versions
+```
+
+This fallback is for support collection only. It must not become proof of
+selected CUDA execution, speedup, full residency, server readiness, or answer
+quality.
+
+## Non-Goals
+
+- Do not ask users to paste unrelated logs before the support bundle.
+- Do not infer broad CUDA support from one device label.
+- Do not infer Qwen3, BitNet packed I2_S/QK256, speedup, or full residency
+  from dense Qwen2.5 CUDA support evidence.
+- Do not require private paths, secrets, tokens, credentials, or model files.
+
+## Proof Commands
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cuda_support_issue_template
+git diff --check
+```

--- a/docs/specs/BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md
+++ b/docs/specs/BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md
@@ -1,186 +1,26 @@
 # BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA
 
 Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-19
 Linked proposal:
 [BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
 Linked specs:
-[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md),
-[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md)
+[BITNET-SPEC-SUPPORT-BUNDLE](BITNET-SPEC-SUPPORT-BUNDLE.md)
 Linked ADRs:
 [BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
-Applies to: `bitnet support bundle --latest --device <device> --format json`,
-GitHub CUDA support issues, receipt triage docs
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: compatibility pointer only
+Policy impact: none
 
-## Purpose
+## Compatibility Pointer
 
-The support bundle is the pasteable issue artifact for proof-carrying local
-inference. It combines model status, latest receipt explanation, binary/build
-identity, and runtime identity into one JSON object without running inference
-or promoting claims.
+This stable URL is retained for older references to the support-bundle schema.
+The current support-bundle contract is:
 
-This spec defines the support bundle schema and support semantics.
+[BITNET-SPEC-SUPPORT-BUNDLE](BITNET-SPEC-SUPPORT-BUNDLE.md)
 
-## Source-Of-Truth Authorities
-
-The support bundle composes existing surfaces:
-
-- `bitnet model status --device <device> --format json`;
-- `bitnet receipts explain <receipt> --format json`;
-- `ci/model-artifacts/model-coverage-matrix.toml`;
-- [Model readiness/status surface](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md);
-- [Receipt explain schema](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md);
-- [CUDA receipt triage guide](../tutorials/cuda-receipt-triage.md);
-- `.github/ISSUE_TEMPLATE/cuda-support.yml`.
-
-The bundle is a support envelope. It is not a receipt and is not proof by
-itself.
-
-## Top-Level JSON Contract
-
-`bitnet support bundle --latest --device <device> --format json` must emit an
-object with at least these fields:
-
-```text
-schema_version
-kind
-created_utc
-device
-summary
-binary
-runtime
-model_status
-latest_receipt
-```
-
-`kind` must identify the object as a support bundle. `created_utc` records when
-the bundle was assembled. `device` records the requested device label.
-
-## Summary Contract
-
-`summary` is the issue-triage front panel. It must include:
-
-```text
-model_coverage_row
-current_tier
-selected_backend
-selected_route
-fallback_used
-quality_gate
-server_ready
-server_ready_scope
-speedup_claim
-full_residency_claim
-bitnet_packed_i2s_qk256_proof
-dense_regular_llm_cuda_proof
-next_proof
-receipt_path
-```
-
-`summary` must be derived from `latest_receipt` and the corresponding
-`model_status` row when possible. It must not use stale docs prose or free-form
-string matching when the structured surfaces provide a value.
-
-## Binary Identity
-
-`binary` must include:
-
-```text
-name
-crate_version
-git_commit
-git_commit_source
-build_timestamp
-rustc_version
-target_triple
-```
-
-Unknown build fields may be `null`. They must not be replaced by placeholder
-values that look authoritative.
-
-## Runtime Identity
-
-`runtime` should include runtime identity when the latest receipt contains it:
-
-```text
-selected_backend
-runtime_api
-device_name
-driver_version
-cuda_runtime_version
-cuda_driver_version
-source
-```
-
-Runtime identity may be `null` on CPU-only or older receipts. A missing CUDA
-driver/runtime field must not be interpreted as CPU fallback, CUDA failure, or
-successful CUDA proof.
-
-## Embedded Status And Receipt Objects
-
-`model_status` must preserve the full model status dashboard shape from
-[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md).
-
-`latest_receipt` must preserve the full receipt explanation shape from
-[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md).
-
-The bundle may add fields in future versions, but it must not remove these
-embedded objects without a schema-version bump.
-
-## No New Inference
-
-Support bundle generation must be read-only:
-
-- it may read the model coverage matrix;
-- it may read a receipt path or resolve `--latest`;
-- it may inspect build/runtime identity already available locally;
-- it must not download models;
-- it must not run ask, chat, bench, serve, or hardware probes;
-- it must not create a new inference receipt.
-
-This keeps support collection cheap and safe for users filing issues.
-
-## Proof-Family And Claim Boundaries
-
-The bundle must preserve the same hard boundaries as status and receipt
-explanation:
-
-- `speedup_claim=false` remains false unless an exact-profile benchmark review
-  accepted it.
-- `full_residency_claim=false` remains false unless per-phase residency proof
-  accepted it.
-- Exact-profile server readiness must show its scope.
-- Dense CUDA proof must not satisfy BitNet packed I2_S/QK256 proof.
-- BitNet QK256 proof must not satisfy dense SLM proof.
-- Qwen2.5 proof must not satisfy Qwen3 proof.
-
-## Issue Template Contract
-
-CUDA support issue templates should ask for the support bundle JSON before
-free-form environment prose. If the command fails, the template should ask for
-the failed command, stderr, and any available receipt path.
-
-## Proof Commands
-
-Current contract validation:
-
-```bash
-cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli support_bundle
-cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
-cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
-git diff --check
-```
-
-## Non-Goals
-
-- Do not make the support bundle an immutable receipt.
-- Do not run inference, model verification, benchmarks, server requests, or
-  hardware probes while assembling a bundle.
-- Do not promote any model, server, speedup, residency, or proof-family claim.
-- Do not require CUDA-only runtime fields for non-CUDA support bundles.
-
-## Related Policy Or Manifest Sources
-
-- `ci/model-artifacts/model-coverage-matrix.toml`
-- `docs/tutorials/cuda-receipt-triage.md`
-- `.github/ISSUE_TEMPLATE/cuda-support.yml`
-- `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Do not add new support-bundle requirements here. Update the canonical spec so
+schema, CLI output, issue templates, and contract tests remain in one place.

--- a/docs/specs/BITNET-SPEC-SUPPORT-BUNDLE.md
+++ b/docs/specs/BITNET-SPEC-SUPPORT-BUNDLE.md
@@ -1,0 +1,206 @@
+# BITNET-SPEC-SUPPORT-BUNDLE
+
+Status: proposed
+Owner: BitNet-rs maintainers
+Created: 2026-05-19
+Linked proposal:
+[BITNET-PROP-0003](../proposals/BITNET-PROP-0003-native-rust-inference-product.md)
+Linked specs:
+[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md),
+[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md),
+[BITNET-SPEC-CUDA-SUPPORT-ISSUE](BITNET-SPEC-CUDA-SUPPORT-ISSUE.md)
+Linked ADRs:
+[BITNET-ADR-0005](../adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md)
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: support bundles expose existing claim boundaries only
+Policy impact: none
+
+## Purpose
+
+`bitnet support bundle --latest --device <device> --format json` is the
+pasteable support artifact for local inference issues. It lets a user or agent
+answer from one JSON object:
+
+```text
+Can I run this model?
+On which backend?
+What is proven?
+What is explicitly not proven?
+What command generated the proof?
+What should I paste into an issue if it fails?
+What is the next blocker?
+```
+
+The bundle is a support envelope. It is not a receipt and does not run
+inference.
+
+## Source-Of-Truth Authorities
+
+The support bundle composes these structured sources:
+
+- `bitnet model status --device <device> --format json`;
+- `bitnet receipts explain <receipt> --format json`;
+- `ci/model-artifacts/model-coverage-matrix.toml`;
+- the latest local receipt selected by `--latest` or by an explicit path;
+- build identity available in the compiled binary;
+- runtime identity already present in the receipt.
+
+The bundle must not derive claims from stale docs prose, free-form issue text,
+or filename heuristics when structured status or receipt fields exist.
+
+## Top-Level JSON Contract
+
+The JSON object must include:
+
+```text
+schema_version
+kind
+created_utc
+device
+summary
+binary
+runtime
+model_status
+latest_receipt
+```
+
+`kind` must be `bitnet_support_bundle`. `schema_version` is currently `1`.
+Adding optional fields is compatible with schema version `1`; removing or
+renaming fields requires a schema-version bump.
+
+## Summary Contract
+
+`summary` is the issue-triage front panel. It must include:
+
+```text
+model_coverage_row
+current_tier
+selected_backend
+selected_route
+fallback_used
+quality_gate
+server_ready
+server_ready_scope
+speedup_claim
+full_residency_claim
+bitnet_packed_i2s_qk256_proof
+dense_regular_llm_cuda_proof
+next_proof
+claim_boundary
+receipt_path
+```
+
+`summary.claim_boundary` must carry the structured model-status or receipt
+claim boundary when available. If no structured boundary is available, it may be
+`null`; it must not be replaced by a broad support claim.
+
+## Binary Identity
+
+`binary` must include:
+
+```text
+name
+crate_version
+git_commit
+git_commit_source
+build_timestamp
+rustc_version
+target_triple
+```
+
+Unknown build fields may be `null`. They must not be filled with placeholder
+values that look authoritative.
+
+## Runtime Identity
+
+`runtime` should include runtime identity already present in the receipt:
+
+```text
+selected_backend
+runtime_api
+device_name
+driver_version
+cuda_runtime_version
+cuda_driver_version
+source
+```
+
+Missing runtime identity means unknown. It must not be interpreted as CPU
+fallback, CUDA failure, or successful CUDA proof.
+
+## Embedded Status And Receipt Objects
+
+`model_status` must preserve the full dashboard shape defined by
+[BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE](BITNET-SPEC-MODEL-READINESS-STATUS-SURFACE.md).
+
+`latest_receipt` must preserve the full explanation shape defined by
+[BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA](BITNET-SPEC-RECEIPT-EXPLAIN-SCHEMA.md).
+
+The embedded objects are intentionally redundant with `summary`. `summary`
+helps issue triage; embedded objects preserve audit detail.
+
+## No New Inference
+
+Support bundle generation is read-only:
+
+- it may read the model coverage matrix;
+- it may resolve or read a receipt path;
+- it may inspect build identity already compiled into the binary;
+- it must not download models;
+- it must not run `ask`, `chat`, `bench`, `serve`, or hardware probes;
+- it must not create a new inference receipt.
+
+## Claim Boundaries
+
+The bundle must preserve these boundaries:
+
+- diagnostic evidence is not semantic quality;
+- route visibility is not selected execution;
+- Qwen2.5 proof is not Qwen3 proof;
+- dense CUDA proof is not BitNet packed I2_S/QK256 proof;
+- one exact-profile server receipt is not broad server readiness;
+- microbench evidence is not product speedup;
+- missing fallback data is unknown, not false proof of strict execution.
+
+## CUDA Issue Contract
+
+CUDA issue templates must ask for support bundle JSON before free-form
+environment prose. See
+[BITNET-SPEC-CUDA-SUPPORT-ISSUE](BITNET-SPEC-CUDA-SUPPORT-ISSUE.md).
+
+If bundle generation fails, the issue template or triage path should ask for:
+
+```text
+failed command
+stderr
+receipt path, if available
+GPU / driver / runtime version, if the bundle did not capture it
+```
+
+## Proof Commands
+
+Current contract validation:
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli support_bundle
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cuda_support_issue_template
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard
+git diff --check
+```
+
+## Non-Goals
+
+- Do not make the support bundle an immutable receipt.
+- Do not run inference, model verification, benchmarks, server requests, or
+  hardware probes while assembling a bundle.
+- Do not promote model, server, speedup, residency, or proof-family claims.
+- Do not require CUDA-only runtime fields for non-CUDA support bundles.
+
+## Compatibility Alias
+
+[BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA](BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md)
+is a stable compatibility URL for older references. This file owns the current
+support-bundle contract.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -13,10 +13,15 @@ model readiness, receipt explanation, or support bundles:
    - Defines the normalized `bitnet receipts explain --format json` shape,
      flat support aliases, nested diagnostic objects, unknown-vs-false
      semantics, and promotion warnings.
-3. [Support Bundle Schema](BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md)
+3. [Support Bundle](BITNET-SPEC-SUPPORT-BUNDLE.md)
    - Defines `bitnet support bundle --latest --device <device> --format json`
      as a read-only issue artifact that embeds model status and receipt
-     explanation without promoting claims.
+     explanation without promoting claims. The older
+     [Support Bundle Schema](BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md) URL remains
+     as a compatibility pointer.
+4. [CUDA Support Issue](BITNET-SPEC-CUDA-SUPPORT-ISSUE.md)
+   - Defines the receipt-backed CUDA issue template contract, required support
+     bundle field, JSON rendering, and claim-boundary checklist.
 
 Do not remove or repurpose support JSON fields without a schema-version bump.
 Do not let status, receipt explanation, or support bundles infer speedup,


### PR DESCRIPTION
## Summary

- add the canonical `BITNET-SPEC-SUPPORT-BUNDLE` contract and keep the older schema URL as a compatibility pointer
- add `BITNET-SPEC-CUDA-SUPPORT-ISSUE` for the receipt-backed CUDA issue template contract
- expose `summary.claim_boundary` in support bundle JSON and lock the CUDA issue template with a YAML parser regression test

## Scope

Support bundle schema/docs and issue-template tests only. Changed files:

- `.github/ISSUE_TEMPLATE/cuda-support.yml`
- `crates/bitnet-cli/src/commands/support.rs`
- `docs/specs/BITNET-SPEC-CUDA-SUPPORT-ISSUE.md`
- `docs/specs/BITNET-SPEC-SUPPORT-BUNDLE-SCHEMA.md`
- `docs/specs/BITNET-SPEC-SUPPORT-BUNDLE.md`
- `docs/specs/INDEX.md`

## Claim boundary

This is a support/schema/test hardening PR only. It does not run inference, promote CUDA speedup, full residency, broad server readiness, Qwen3, or BitNet packed I2_S/QK256 claims.

## Validation

- PASS: `cargo fmt -p bitnet-cli -- --check`
- PASS: `git diff --check origin/main..HEAD`
- PASS: `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli support_bundle`
- PASS: `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cuda_support_issue_template`
- PASS: `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli receipts_explain`
- PASS: `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli model_status_dashboard`

## Generated files

None.

## Follow-up / supersedes

- Rebased after #6021 to remove stale tracker churn from the original PR base.
- Supersedes no open PR.
