### PR TITLE
docs(spec): define generated tracking conflict handling

### DIFF
--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -52,6 +52,9 @@ Roadmap
   `docs/adr/BITNET-ADR-0006-pr-closure-creates-backlog.md`,
   `docs/tracking/PR_QUEUE_DISPOSITION.md`, and
   `policy/pr-dispositions.toml`.
+- Generated tracking conflict rules belong in
+  `docs/specs/BITNET-SPEC-GENERATED-TRACKING.md` and
+  `policy/generated-tracking.toml`.
 
 ## Rules
 
@@ -60,7 +63,9 @@ Roadmap
 3. Specs define behavior; plans define sequencing.
 4. Proposals explain why; ADRs record durable decisions.
 5. Active goals tell agents what to do now and link to the plan/spec/ADR.
-6. Generated status is updated by tools, not by hand.
+6. Generated status is updated by tools, not by hand; conflicts are resolved by
+   repairing source manifests, events, generators, or checkers before
+   regenerating.
 7. Public claims require support-tier, hardware, model-artifact, or receipt proof.
 8. Policy exceptions require owner, reason, coverage, and review date.
 9. Closing a PR is a disposition event, not backlog reduction, unless the close

--- a/docs/specs/BITNET-SPEC-GENERATED-TRACKING.md
+++ b/docs/specs/BITNET-SPEC-GENERATED-TRACKING.md
@@ -1,0 +1,114 @@
+# BITNET-SPEC-GENERATED-TRACKING: Generated Tracking Conflict Handling
+
+Status: proposed
+Owner: release/ci
+Created: 2026-05-19
+Linked proposal: n/a
+Linked specs:
+[BITNET-SPEC-0001](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md),
+[BITNET-SPEC-PR-QUEUE-DISPOSITION](BITNET-SPEC-PR-QUEUE-DISPOSITION.md)
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: none
+Policy impact: `policy/generated-tracking.toml`
+
+## Purpose
+
+Generated campaign dashboards are derived status. They must not become a hand
+authored queue, claim ledger, or conflict-resolution surface. This spec defines
+how agents and maintainers handle generated tracking files when branches,
+rebases, campaign rows, or queue work collide.
+
+The rule is direct: fix the source manifest, event, generator, or checker, then
+regenerate. Do not edit generated output to make a conflict disappear.
+
+## Source-Of-Truth Authorities
+
+Generated tracking truth lives in:
+
+- campaign `active.toml` manifests;
+- campaign `events/*.toml` lifecycle records;
+- tracker infrastructure generator and checker code;
+- this spec;
+- `policy/generated-tracking.toml`;
+- [Tracker Model](../tracking/TRACKER_MODEL.md);
+- [Source Of Truth And Claim Boundaries](BITNET-SPEC-0001-source-of-truth-and-claim-boundaries.md).
+
+Generated files under `docs/tracking/generated/` and
+`docs/tracking/campaigns/*/generated/` are derived views. They can be committed
+when the generator produces them, but they do not own campaign state.
+
+## Generated Files Are Not Manually Authored
+
+Agents and maintainers must not hand-edit generated tracking files to:
+
+- remove a lane row;
+- mark a work item complete;
+- hide a skipped or blocked lane;
+- resolve a rebase conflict by choosing one branch's rendered table;
+- change claim wording;
+- close or supersede source PR work;
+- make campaign doctor pass without updating the source.
+
+If generated output is stale, run the generator. If generated output is wrong,
+fix the manifest, event source, generator, or checker.
+
+## Conflict Handling
+
+When a generated tracking file conflicts:
+
+1. Preserve every active row, lane, and work item that remains true.
+2. Inspect the relevant campaign `active.toml` and `events/*.toml` sources.
+3. Update the source manifest or event records, not the generated table.
+4. Run the generator or checker named by the affected campaign.
+5. Review the generated diff for source-faithful output.
+6. Do not hand-delete another lane's row to resolve the conflict.
+
+If two branches claim ownership of the same campaign item, stop the merge or
+port and resolve ownership in the source manifests before generating output.
+
+## Allowed Generated Diffs
+
+A generated tracking diff is allowed only when:
+
+- it was produced by the campaign generator;
+- it matches the committed campaign manifests and events;
+- it preserves active rows that remain true;
+- it does not promote product, support, hardware, runtime, or PR disposition
+  claims beyond the source data;
+- the PR records the generator or checker command used.
+
+## Acceptance Examples
+
+| Case | Required handling |
+| --- | --- |
+| Generated dashboard is stale after an `active.toml` edit | Run generator and commit generated output |
+| Generated dashboard conflicts during rebase | Reconcile manifest/event sources, then regenerate |
+| Another branch added a valid campaign row | Preserve the row unless the source says it closed |
+| A row looks inconvenient for queue burn-down | Keep it; queue disposition requires source proof |
+| Generator omits a true active row | Fix generator or source parsing, then regenerate |
+| Hand edit would make campaign doctor pass | Reject; fix source or generator |
+
+## Proof Commands
+
+Current generated-tracking validation:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+cargo run --locked -p xtask --no-default-features -- campaign doctor
+git diff --check
+```
+
+When a PR intentionally updates generated tracking, it must run the campaign
+generator without `--check` before the check form.
+
+## Non-Goals
+
+- Do not change campaign generator behavior in this spec.
+- Do not change today's campaign state.
+- Do not edit generated dashboards in this PR.
+- Do not encode current open PR order.
+- Do not use generated tracking as proof of support, speed, residency, or
+  product readiness without the underlying proof surface.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -38,10 +38,15 @@ PR queue state:
 2. [PR Write-Action CI Economics](BITNET-SPEC-PR-CI-ECONOMICS.md)
    - Defines queue write actions, no-CI-for-archaeology, bulk-write limits,
      rerun rules, and allowed CI spend during burn-down.
+3. [Generated Tracking](BITNET-SPEC-GENERATED-TRACKING.md)
+   - Defines generated dashboard ownership, conflict handling, source-first
+     regeneration, and no hand-authored status edits.
 
 Wrong base, stale stack, closed parent, and needs-restack are routing states,
 not close reasons. Queue writes should follow content review and should spend
 CI only on current merge candidates, clean ports, or required proof.
+Generated tracking conflicts should be fixed in campaign manifests, events,
+generators, or checkers before regenerating output.
 
 ## TL1 ARM-First Table-Lookup Route
 

--- a/policy/generated-tracking.toml
+++ b/policy/generated-tracking.toml
@@ -1,0 +1,51 @@
+schema_version = "1.0"
+policy = "generated-tracking"
+owner = "release/ci"
+status = "active"
+updated = "2026-05-19"
+
+# Generated tracking files are derived views. Source manifests, events,
+# generators, and checkers own campaign truth.
+
+[generated_paths]
+global = "docs/tracking/generated/"
+campaign = "docs/tracking/campaigns/*/generated/"
+
+[source_paths]
+campaign_active = "docs/tracking/campaigns/*/active.toml"
+campaign_events = "docs/tracking/campaigns/*/events/*.toml"
+tracker_model = "docs/tracking/TRACKER_MODEL.md"
+
+[rules]
+hand_edit_generated_tracking = false
+resolve_conflict_by_hand_edit = false
+delete_other_lane_row_to_resolve_conflict = false
+generated_output_owns_campaign_state = false
+generated_output_may_close_pr = false
+generated_output_may_promote_claim = false
+preserve_true_active_rows = true
+update_source_before_regenerate = true
+fix_generator_when_output_is_wrong = true
+record_generator_command_in_pr = true
+
+[required_commands]
+check = [
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "git diff --check",
+]
+regenerate = "cargo run --locked -p xtask --no-default-features -- campaign generate"
+
+[conflict_resolution]
+inspect_active_toml = true
+inspect_events = true
+preserve_rows_that_remain_true = true
+resolve_item_ownership_before_generating = true
+review_generated_diff_after_regenerate = true
+
+[allowed_generated_diffs]
+produced_by_generator = true
+matches_committed_sources = true
+preserves_true_active_rows = true
+no_claim_promotion = true
+no_pr_disposition_without_source = true


### PR DESCRIPTION
## Summary

- Adds BITNET-SPEC-GENERATED-TRACKING as the durable rule for generated dashboard ownership and conflict handling.
- Adds policy/generated-tracking.toml so the no-hand-edit/no-row-deletion rules are machine-readable.
- Links the generated tracking contract from the spec index and source-of-truth reference.

## Claim boundary

Docs/policy only. This does not change campaign state, generated dashboard output, runtime behavior, support claims, PR disposition, CI routing, model/backend readiness, speed, residency, server readiness, or A770 runtime behavior.

## Validation

- PASS: python tomllib parse of policy/generated-tracking.toml.
- PASS: git diff --check.
- PASS: git diff --cached --check.
- TIMEOUT: cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports timed out locally after 3 minutes on default target and after 5 minutes with isolated CARGO_TARGET_DIR while compiling xtask dependencies; hosted policy checks are required before merge.

## Generated files

None. This PR defines generated tracking conflict rules but intentionally does not edit generated dashboards.