### PR TITLE
ci(intel-gpu): scope cpu feature matrix

### DIFF
--- a/.github/workflows/intel-gpu-feature-matrix.yml
+++ b/.github/workflows/intel-gpu-feature-matrix.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         include:
           - label: cpu
-            flags: "--workspace --no-default-features --features cpu"
+            flags: "-p bitnet-kernels -p bitnet-common -p bitnet-device-probe --no-default-features --features cpu"
             test_filter: "opencl"
           - label: cpu+oneapi
             # oneapi is a crate-level feature, not workspace-level


### PR DESCRIPTION
## Summary
- scope the Intel GPU Feature Matrix `cpu` lane to the GPU/probe crates it is meant to cover
- keep the lane from linting unrelated workspace crates such as `xtask` during Intel GPU PRs
- leave `cpu+oneapi`, `gpu`, and `gpu+oneapi` behavior unchanged

## Validation
- `cargo check --locked -p bitnet-kernels -p bitnet-common -p bitnet-device-probe --no-default-features --features cpu`
- `cargo clippy --locked -p bitnet-kernels -p bitnet-common -p bitnet-device-probe --no-default-features --features cpu -- -D warnings`
- `git diff --check`

Unblocks #6072, where the current `cpu` lane failed on unrelated `xtask` clippy baseline warnings.