### PR TITLE
test(receipts): require device sampler for Qwen D2H reduction

### DIFF
--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -452,7 +452,7 @@ forbidden_claims = [
   "global_dense_gguf_inference",
   "global_speedup",
 ]
-next_proof = "Post-OPS-003 requalification review keeps benchmark_qualified=false, speedup_claim=false, and full_residency_claim=false because reviewed CUDA profiles remain slower than same-artifact CPU means, H2D remains a model-load wall-clock envelope, and logits-transfer accounting still records full-logits D2H until device top-k sampling exists. Next proof is a refreshed exact-profile comparator with reduced D2H or device top-k sampling, pure H2D timing, and phase residency."
+  next_proof = "Post-OPS-003 requalification review keeps benchmark_qualified=false, speedup_claim=false, and full_residency_claim=false because reviewed CUDA profiles remain slower than same-artifact CPU means, H2D remains a model-load wall-clock envelope, and logits-transfer accounting still records full-logits D2H until device top-k sampling exists. Next proof is a device-side top-k or greedy sampler receipt with reduced D2H, then a refreshed exact-profile comparator with pure H2D timing and phase residency."
 claim_boundary = "Qwen2.5 0.5B Q8_0 is the first dense CUDA SLM answer lane and has exact-profile RTX 5070 Ti server readiness for the refreshed non-streaming shared-engine chat-completions receipt only. Its post-OPS requalification review does not promote benchmark-qualified speed, speedup, full residency, broad dense GGUF readiness, or BitNet packed I2_S/QK256 proof."
 
   [entry.claims]

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -5407,8 +5407,14 @@ fn validate_dense_qwen_logits_transfer_reduction(
 
     require_u64_eq(reduction, "schema", 1)?;
     require_string_eq(reduction, "scope", "dense_qwen_logits_top_k_transfer")?;
-    require_string_non_empty(reduction, "transfer_mode")?;
-    require_string_non_empty(reduction, "sampling_location")?;
+    let transfer_mode = required_string(reduction, "transfer_mode")?;
+    if transfer_mode.trim().is_empty() {
+        return Err(anyhow!("field `transfer_mode` must not be empty"));
+    }
+    let sampling_location = required_string(reduction, "sampling_location")?;
+    if sampling_location.trim().is_empty() {
+        return Err(anyhow!("field `sampling_location` must not be empty"));
+    }
     let requested_top_k = required_u64(reduction, "requested_top_k")?;
     if requested_top_k == 0 {
         return Err(anyhow!("logits_transfer_reduction.requested_top_k must be positive"));
@@ -5494,6 +5500,23 @@ fn validate_dense_qwen_logits_transfer_reduction(
         .ok_or_else(|| anyhow!("field `device_to_host_bytes_reduced` must be a bool"))?;
     let bytes_saved = required_u64(reduction, "bytes_saved_vs_full_logits")?;
     if reduced {
+        if !matches!(transfer_mode, "device_top_k_cuda_sampler" | "device_greedy_cuda_sampler") {
+            return Err(anyhow!(
+                "logits_transfer_reduction.device_to_host_bytes_reduced requires a device_top_k_cuda_sampler or device_greedy_cuda_sampler transfer_mode"
+            ));
+        }
+        if sampling_location != "cuda_device" {
+            return Err(anyhow!(
+                "logits_transfer_reduction.device_to_host_bytes_reduced requires sampling_location=cuda_device"
+            ));
+        }
+        if let Some(blocker) = reduction.get("reduction_blocker") {
+            if !blocker.is_null() {
+                return Err(anyhow!(
+                    "logits_transfer_reduction.reduction_blocker must be omitted or null when device_to_host_bytes_reduced is true"
+                ));
+            }
+        }
         if actual_device_to_host_bytes >= full_logits_download_bytes {
             return Err(anyhow!(
                 "logits_transfer_reduction.device_to_host_bytes_reduced requires actual_device_to_host_bytes < full_logits_download_bytes"
@@ -5506,6 +5529,7 @@ fn validate_dense_qwen_logits_transfer_reduction(
         }
     } else {
         require_string_eq(reduction, "transfer_mode", "full_logits_download_cpu_sampler")?;
+        require_string_eq(reduction, "sampling_location", "cpu")?;
         require_string_non_empty(reduction, "reduction_blocker")?;
         if actual_device_to_host_bytes != full_logits_download_bytes {
             return Err(anyhow!(

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -5510,12 +5510,12 @@ fn validate_dense_qwen_logits_transfer_reduction(
                 "logits_transfer_reduction.device_to_host_bytes_reduced requires sampling_location=cuda_device"
             ));
         }
-        if let Some(blocker) = reduction.get("reduction_blocker") {
-            if !blocker.is_null() {
-                return Err(anyhow!(
-                    "logits_transfer_reduction.reduction_blocker must be omitted or null when device_to_host_bytes_reduced is true"
-                ));
-            }
+        if let Some(blocker) = reduction.get("reduction_blocker")
+            && !blocker.is_null()
+        {
+            return Err(anyhow!(
+                "logits_transfer_reduction.reduction_blocker must be omitted or null when device_to_host_bytes_reduced is true"
+            ));
         }
         if actual_device_to_host_bytes >= full_logits_download_bytes {
             return Err(anyhow!(

--- a/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
+++ b/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
@@ -2055,6 +2055,60 @@ fn dense_gguf_qwen_short_decode_rejects_malformed_full_logits_byte_accounting()
     Ok(())
 }
 
+fn mark_short_decode_transfer_reduced(receipt: &mut Value, actual_device_to_host_bytes: u64) {
+    let full_logits_download_bytes =
+        receipt["logits_transfer_reduction"]["full_logits_download_bytes"]
+            .as_u64()
+            .expect("test fixture full logits bytes must be a u64");
+    assert!(
+        actual_device_to_host_bytes < full_logits_download_bytes,
+        "test fixture must model a reduced D2H transfer"
+    );
+    receipt["kernel_stats"][0]["device_to_host_bytes"] = json!(actual_device_to_host_bytes);
+    receipt["timing"]["device_to_host_bytes"] = json!(actual_device_to_host_bytes);
+    receipt["tensor_residency"]["transfer_accounting"]["device_to_host_bytes"] =
+        json!(actual_device_to_host_bytes);
+    receipt["logits_transfer_reduction"]["actual_device_to_host_bytes"] =
+        json!(actual_device_to_host_bytes);
+    receipt["logits_transfer_reduction"]["device_to_host_bytes_reduced"] = json!(true);
+    receipt["logits_transfer_reduction"]["bytes_saved_vs_full_logits"] =
+        json!(full_logits_download_bytes - actual_device_to_host_bytes);
+}
+
+#[test]
+fn dense_gguf_qwen_short_decode_rejects_reduced_transfer_without_device_sampler()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
+    mark_short_decode_transfer_reduced(&mut receipt, 192);
+
+    let err = match validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt) {
+        Ok(()) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "validator accepted reduced D2H bytes with the CPU full-logits sampler",
+            )
+            .into());
+        }
+        Err(err) => err.to_string(),
+    };
+
+    assert!(err.contains("transfer_mode"), "unexpected error: {err}");
+    Ok(())
+}
+
+#[test]
+fn dense_gguf_qwen_short_decode_accepts_device_top_k_reduced_transfer_contract()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
+    mark_short_decode_transfer_reduced(&mut receipt, 192);
+    receipt["logits_transfer_reduction"]["transfer_mode"] = json!("device_top_k_cuda_sampler");
+    receipt["logits_transfer_reduction"]["sampling_location"] = json!("cuda_device");
+    receipt["logits_transfer_reduction"]["reduction_blocker"] = Value::Null;
+
+    validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt)?;
+    Ok(())
+}
+
 #[test]
 fn dense_gguf_qwen_short_decode_rejects_chat_speedup_full_residency_and_bitnet_claims() {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();

--- a/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
+++ b/crates/bitnet-receipts/tests/cuda_receipt_validation.rs
@@ -2055,15 +2055,26 @@ fn dense_gguf_qwen_short_decode_rejects_malformed_full_logits_byte_accounting()
     Ok(())
 }
 
-fn mark_short_decode_transfer_reduced(receipt: &mut Value, actual_device_to_host_bytes: u64) {
+fn mark_short_decode_transfer_reduced(
+    receipt: &mut Value,
+    actual_device_to_host_bytes: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let full_logits_download_bytes =
-        receipt["logits_transfer_reduction"]["full_logits_download_bytes"]
-            .as_u64()
-            .expect("test fixture full logits bytes must be a u64");
-    assert!(
-        actual_device_to_host_bytes < full_logits_download_bytes,
-        "test fixture must model a reduced D2H transfer"
-    );
+        receipt["logits_transfer_reduction"]["full_logits_download_bytes"].as_u64().ok_or_else(
+            || {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "test fixture full logits bytes must be a u64",
+                )
+            },
+        )?;
+    if actual_device_to_host_bytes >= full_logits_download_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "test fixture must model a reduced D2H transfer",
+        )
+        .into());
+    }
     receipt["kernel_stats"][0]["device_to_host_bytes"] = json!(actual_device_to_host_bytes);
     receipt["timing"]["device_to_host_bytes"] = json!(actual_device_to_host_bytes);
     receipt["tensor_residency"]["transfer_accounting"]["device_to_host_bytes"] =
@@ -2073,13 +2084,14 @@ fn mark_short_decode_transfer_reduced(receipt: &mut Value, actual_device_to_host
     receipt["logits_transfer_reduction"]["device_to_host_bytes_reduced"] = json!(true);
     receipt["logits_transfer_reduction"]["bytes_saved_vs_full_logits"] =
         json!(full_logits_download_bytes - actual_device_to_host_bytes);
+    Ok(())
 }
 
 #[test]
 fn dense_gguf_qwen_short_decode_rejects_reduced_transfer_without_device_sampler()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
-    mark_short_decode_transfer_reduced(&mut receipt, 192);
+    mark_short_decode_transfer_reduced(&mut receipt, 192)?;
 
     let err = match validate_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt_json(&receipt) {
         Ok(()) => {
@@ -2100,7 +2112,7 @@ fn dense_gguf_qwen_short_decode_rejects_reduced_transfer_without_device_sampler(
 fn dense_gguf_qwen_short_decode_accepts_device_top_k_reduced_transfer_contract()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut receipt = valid_dense_gguf_qwen_short_decode_strict_cuda_proof_receipt();
-    mark_short_decode_transfer_reduced(&mut receipt, 192);
+    mark_short_decode_transfer_reduced(&mut receipt, 192)?;
     receipt["logits_transfer_reduction"]["transfer_mode"] = json!("device_top_k_cuda_sampler");
     receipt["logits_transfer_reduction"]["sampling_location"] = json!("cuda_device");
     receipt["logits_transfer_reduction"]["reduction_blocker"] = Value::Null;

--- a/docs/reports/CUDA_DENSE_QWEN25_OPS_004_LOGITS_TRANSFER_REDUCTION_CONTRACT.md
+++ b/docs/reports/CUDA_DENSE_QWEN25_OPS_004_LOGITS_TRANSFER_REDUCTION_CONTRACT.md
@@ -1,0 +1,69 @@
+# CUDA-DENSE-QWEN25-OPS-004 Logits Transfer Reduction Contract
+
+Date: 2026-05-20
+Work item: CUDA-DENSE-QWEN25-OPS-004
+Platform: Windows 9950X3D + RTX 5070 Ti
+Model: qwen2.5-0.5b-instruct-q8_0
+Coverage row: `dense_qwen25_05b_q8_cuda`
+Linked plan: `plans/native-rust-inference/dense-qwen25.md`
+Linked spec: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+
+## Summary
+
+CUDA-DENSE-QWEN25-PERF-007 rejected Qwen2.5 speed and full-residency
+promotion because the reviewed CUDA profiles remain slower than same-artifact
+CPU means, pure H2D timing is unavailable, and logits transfer still downloads
+full logits to the CPU sampler.
+
+This slice tightens the receipt contract for the next optimization. A receipt
+can no longer claim `device_to_host_bytes_reduced=true` only by lowering byte
+counts. It must also prove that selection moved to a CUDA device-side sampler
+path.
+
+## Contract
+
+A dense Qwen logits-transfer reduction receipt remains valid without a
+reduction section for legacy receipts. When the section is present:
+
+- non-reduced receipts must use `transfer_mode=full_logits_download_cpu_sampler`,
+  `sampling_location=cpu`, full-logits D2H byte accounting, a non-empty
+  `reduction_blocker`, selected-token equality, preserved top-k evidence, and
+  unchanged quality receipts;
+- reduced receipts must use `transfer_mode=device_top_k_cuda_sampler` or
+  `transfer_mode=device_greedy_cuda_sampler`;
+- reduced receipts must use `sampling_location=cuda_device`;
+- reduced receipts must record `actual_device_to_host_bytes <
+  full_logits_download_bytes`;
+- `bytes_saved_vs_full_logits` must equal the measured byte reduction;
+- `reduction_blocker` must be omitted or null after reduction is claimed;
+- selected-token equality, top-k evidence, and quality receipts must remain
+  preserved.
+
+## Claim Boundary
+
+May claim:
+
+- the receipt validator now rejects fake reduced-D2H receipts that still name
+  the CPU full-logits sampler;
+- future reduced-D2H Qwen2.5 receipts must carry device-side sampler identity
+  and measured byte reduction.
+
+Must not claim:
+
+- Qwen2.5 speedup;
+- `benchmark_qualified=true`;
+- full CUDA residency;
+- pure H2D event copy timing;
+- a runtime device top-k sampler exists;
+- broad dense GGUF server readiness;
+- BitNet packed I2_S/QK256 proof from dense CUDA evidence.
+
+## Validation
+
+```powershell
+rtk cargo test --locked -p bitnet-receipts --test cuda_receipt_validation --no-default-features dense_gguf_qwen_short_decode
+rtk cargo run --locked -p xtask --no-default-features -- check-model-coverage
+rtk cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+rtk cargo run --locked -p xtask --no-default-features -- campaign generate --check
+rtk git diff --check
+```

--- a/docs/status/CUDA_CAPABILITY_MATRIX.md
+++ b/docs/status/CUDA_CAPABILITY_MATRIX.md
@@ -68,7 +68,7 @@ bitnet receipts explain --latest
 | Row | Next proof |
 | --- | --- |
 | `bitnet_official_2b_i2s_qk256` | Profile-specific speedup qualification and deeper residency/transfer timing. |
-| `dense_qwen25_05b_q8_cuda` | Post-OPS requalification keeps speedup, benchmark-qualified speed, and full residency false. Next proof is a refreshed exact-profile comparator with reduced D2H or device top-k sampling, pure H2D timing, and phase residency; exact-profile server readiness remains limited to `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-17/server-strict-dense-qwen25-q8-smoke.json`. |
+| `dense_qwen25_05b_q8_cuda` | Post-OPS requalification keeps speedup, benchmark-qualified speed, and full residency false. The next reduced-D2H proof must use a CUDA device top-k or greedy sampler receipt, then a refreshed exact-profile comparator with pure H2D timing and phase residency; exact-profile server readiness remains limited to `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-17/server-strict-dense-qwen25-q8-smoke.json`. |
 | `dense_qwen3_06b_q8_candidate` | Exact-profile server readiness is promoted by `ci/hardware/windows-9950x3d-rtx5070ti/2026-05-19/server-strict-dense-qwen3-q8-smoke.json`; the `qwen3_cuda_repeated_comparator` contract and generator exist, but hardware aggregate comparator evidence and a separate review remain required before speed or benchmark-qualified claims. |
 | `dense_smollm2_360m_candidate` | Same-prompt SmolLM2 first-token/top-k or checkpoint comparator capture using the SLM-CPU-022 contract. |
 | Later dense SLM / small-LLM candidates | Artifact contract, tokenizer/prompt authority, CPU answer sanity, all-layer plan, boundary fixtures, strict CUDA proof, warm session, and benchmark review. |

--- a/plans/native-rust-inference/dense-qwen25.md
+++ b/plans/native-rust-inference/dense-qwen25.md
@@ -9,7 +9,7 @@ Status: merged
 Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
 Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
 Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
-Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Campaign: `nvidia-5070ti`
 Blocks: CUDA-DENSE-QWEN25-OPS-002
 Blocked by: none
 
@@ -173,3 +173,54 @@ git diff --check
 
 Revert the review report and restore the previous next-proof text. No claim
 booleans were promoted by this work item.
+
+## Work item: CUDA-DENSE-QWEN25-OPS-004
+
+Status: in_progress
+Linked proposal: `docs/proposals/BITNET-PROP-0003-native-rust-inference-product.md`
+Linked specs: `docs/specs/BITNET-SPEC-0014-runtime-performance-contract.md`
+Linked ADRs: `docs/adr/BITNET-ADR-0005-proof-families-are-not-interchangeable.md`
+Campaign: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+Blocks: device top-k implementation and refreshed exact-profile comparator
+Blocked by: CUDA-DENSE-QWEN25-PERF-007
+
+### Goal
+
+Harden the Qwen2.5 logits-transfer reduction contract before runtime work can
+claim reduced D2H bytes.
+
+### Production delta
+
+Dense Qwen short-decode and warm-session receipt validation must reject a
+`device_to_host_bytes_reduced=true` claim unless the receipt also proves a
+CUDA device-side top-k or greedy sampler path, `sampling_location=cuda_device`,
+measured D2H bytes below the full-logits envelope, selected-token equality,
+top-k evidence preservation, and unchanged quality receipts.
+
+### Non-goals
+
+No runtime sampler, CUDA kernel, benchmark requalification, speedup promotion,
+full-residency promotion, server-readiness change, or BitNet proof change.
+
+### Acceptance
+
+Reduced-transfer receipts with the CPU full-logits sampler fail validation.
+Reduced-transfer receipts with `device_top_k_cuda_sampler` or
+`device_greedy_cuda_sampler`, `sampling_location=cuda_device`, correct byte
+math, selected-token equality, top-k evidence, and unchanged quality receipts
+can validate.
+
+### Proof commands
+
+```bash
+cargo test --locked -p bitnet-receipts --test cuda_receipt_validation --no-default-features dense_gguf_qwen_short_decode
+cargo run --locked -p xtask --no-default-features -- check-model-coverage
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+### Rollback
+
+Revert the receipt-validator tightening and this work item. Existing Qwen2.5
+product CLI and exact-profile server readiness evidence remains unchanged.


### PR DESCRIPTION
## Summary
- require reduced Qwen D2H receipts to name a CUDA device top-k or greedy sampler with sampling_location=cuda_device
- keep full-logits CPU sampler receipts valid only as non-reduced receipts with a blocker
- update Qwen2.5 next-proof status, plan, and report without promoting speed, residency, server, or BitNet proof claims
- replace the new reduced-transfer test fixture .expect(...) with explicit Result error handling so the no-panic policy gate can pass

## Claim boundary
- receipt validation and docs/status/plan only
- no runtime CUDA implementation change
- no speedup claim
- no full-residency claim
- no server-readiness claim
- no BitNet packed I2_S/QK256 proof claim
- no Qwen3 claim

## Validation
- PASS: rtk cargo fmt -p bitnet-receipts-core -p bitnet-receipts -- --check
- PASS: rtk cargo test --locked -p bitnet-receipts --test cuda_receipt_validation --no-default-features dense_gguf_qwen_short_decode
- PASS: rtk cargo test --locked -p bitnet-receipts --test cuda_receipt_validation --no-default-features transfer_reduction
- PASS: rtk git diff --check origin/main..HEAD
- PASS: rtk git diff --check
- PASS: local search confirms the new test fixture full logits bytes path no longer uses .expect(...)
- BLOCKED local: rtk cargo run --locked -p xtask --no-default-features -- check-model-coverage timed out in sentencepiece-sys build-script before running the checker
- BLOCKED local: rtk cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports and retry via rtk err failed locally while compiling sentencepiece-sys; hosted Policy is the authority for the no-panic gate

## Generated files
None.

## Follow-up / supersedes
- fixes the hosted Policy failure from the new .expect(test fixture full logits bytes must be a u64) in crates/bitnet-receipts/tests/cuda_receipt_validation.rs