### PR TITLE
docs(a770): close out A770-005 smoke

### DIFF
--- a/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-a770/CAMPAIGN.md
@@ -33,7 +33,7 @@ Make the Intel Arc A770 a receipt-backed OpenCL-first BitNet acceleration lane. 
 | A770-000 | merged | Reconcile committed tracker, matrices, claim ledger, and model contract before runtime work. |
 | A770-003 | merged | Preserve selected-device identity after reconciliation. |
 | A770-004 | merged | Add runtime probe. |
-| A770-005 | blocked | Run OpenCL smoke; requires real A770 DEV_56A0 selected-device host. |
+| A770-005 | merged | Run selected-device OpenCL smoke on real A770 DEV_56A0 host. |
 | A770-006 | proposed | Add CPU/OpenCL parity. |
 | A770-007 | proposed | Record receipt identity. |
 

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -142,8 +142,10 @@ must_not_claim = [
 
 [[work_item]]
 id = "A770-005"
-status = "in_progress"
+status = "merged"
 pr = 6072
+head_sha = "f2e137d17ae9a52bb761c336e254b0e4bf8a63db"
+merge_sha = "b995c5110866d1920538fff2d9019fcd3803e3c5"
 branch = "codex/intel-a770/A770-005-opencl-smoke"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-20T033149Z-A770-005-merged.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-20T033149Z-A770-005-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-20T03:31:49Z"
+campaign = "intel-a770"
+item = "A770-005"
+event = "merged"
+actor = "codex"
+pr = 6072
+branch = "codex/intel-a770/A770-005-opencl-smoke"
+head_sha = "f2e137d17ae9a52bb761c336e254b0e4bf8a63db"
+merge_sha = "b995c5110866d1920538fff2d9019fcd3803e3c5"
+summary = "Merged PR #6072 with selected-device Intel Arc A770 OpenCL tiny vector-add smoke evidence."
+notes = [
+  "The committed receipt records Intel(R) Arc(TM) A770 Graphics selected through native OpenCL with fallback_used=false for the tiny vector-add smoke.",
+  "A770-005 proves only a tiny selected-device OpenCL smoke; it does not prove BitNet inference, packed QK256 execution, trusted-partial acceleration, residency, performance, or completion.",
+  "A770-006 remains the next proposed boundary for CPU/OpenCL parity on a minimal kernel or subgraph without promoting official BitNet QK256 inference.",
+]


### PR DESCRIPTION
## Summary
- Marks A770-005 as merged after PR #6072 landed the selected-device A770 OpenCL tiny vector-add smoke.
- Records the #6072 head and merge SHAs in the A770 campaign manifest.
- Adds a merged event that keeps A770-005 scoped to tiny OpenCL smoke evidence and leaves A770-006 as the next CPU/OpenCL parity boundary.

## Claim boundary
- A770-005 proves only a tiny selected-device OpenCL vector-add smoke with `fallback_used=false`.
- No BitNet inference, packed QK256 execution, trusted-partial acceleration, selected attention, resident KV, support-op residency, full residency, performance, or completion claim is promoted.
- This PR is tracker/source closeout only. It does not close or dispose old A770 PRs.

## Validation
- `python - <<tomllib check>>` parsed `docs/tracking/campaigns/intel-a770/active.toml` and the new merged event.
- `git diff --check`

## Local unavailable commands
- `cargo run --locked -p xtask --no-default-features -- campaign generate` timed out locally after 20 minutes with no diagnostic output.
- `cargo -vv check --locked -p xtask --no-default-features` also timed out locally before compiler output.
- Stale local Cargo processes from those timed-out commands were stopped. Generated tracking is not hand-edited in this PR; hosted CI/generator is the authority.