### PR TITLE
docs(lunar-lake): correct audit refresh timestamp

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-excellence-audit.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-excellence-audit.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "artifact_kind": "lunar_lake_excellence_audit",
   "proof_stage": "completion_audit_no_inference",
-  "created_utc": "2026-05-20T13:10:00Z",
+  "created_utc": "2026-05-20T04:17:12Z",
   "machine_id": "intel-258v",
   "source_revision": "5265445b4e9a5cd4f70679ec62c9bdd47036a5a8",
   "audited_goal": "Profile-aware Lunar Lake local inference appliance with Qwen CPU control route, earned OpenVINO GPU/NPU routes, protected BitNet CPU reference, strict regression, and explicit claim boundaries.",

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-goal-artifact-checklist.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-goal-artifact-checklist.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "artifact_kind": "lunar_lake_goal_artifact_checklist",
   "proof_stage": "objective_artifact_mapping_no_inference",
-  "created_utc": "2026-05-20T13:10:00Z",
+  "created_utc": "2026-05-20T04:17:12Z",
   "machine_id": "intel-258v",
   "source_revision": "5265445b4e9a5cd4f70679ec62c9bdd47036a5a8",
   "audited_objective": "Make Lunar Lake an excellent profile-aware local inference appliance with a reliable dense Qwen route, earned OpenVINO GPU/NPU route promotion, protected BitNet CPU reference behavior, strict regression, and explicit claim boundaries.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-20T041712Z-LNL258V-GOAL-AUDIT-007-in-progress.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-20T041712Z-LNL258V-GOAL-AUDIT-007-in-progress.toml
@@ -1,4 +1,4 @@
-timestamp = "2026-05-20T13:10:00Z"
+timestamp = "2026-05-20T04:17:12Z"
 campaign = "intel-258v-platform"
 item = "LNL258V-GOAL-AUDIT-007"
 event = "in_progress"


### PR DESCRIPTION
## Summary
- corrects the LNL258V-GOAL-AUDIT-007 audit refresh timestamp that landed in #6082 from future 13:10Z to the PR open-time window 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal metadata timestamps across audit and tracking systems. No user-facing functionality has been modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/6084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->