### PR TITLE
test(slm): require q8 payload tensor identity

### DIFF
--- a/ci/slm-cpu/intel-i5-8250u/2026-05-20/qwen3-payload-bearing-q8-sidecar-hook-contract.json
+++ b/ci/slm-cpu/intel-i5-8250u/2026-05-20/qwen3-payload-bearing-q8-sidecar-hook-contract.json
@@ -33,6 +33,7 @@
       "sidecar_payload_contract_valid"
     ],
     "payload_contract_valid_requires": [
+      "payload tensor_name matches descriptor tensor_name",
       "q8_block_size = 32",
       "q8_block_count = ceil(matrix_rows * matrix_cols / q8_block_size)",
       "packed_q8_bytes.len = q8_block_count * (2 + q8_block_size)",

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -146,7 +146,9 @@ impl DenseLinearRuntimeHookBoundary {
             sidecar_matrix_rows: payload.map(|payload| payload.matrix_rows),
             sidecar_matrix_cols: payload.map(|payload| payload.matrix_cols),
             sidecar_payload_contract_valid: payload.is_some_and(|payload| {
-                payload.shape_matches_matvec_contract() && payload.payload_len_matches_contract()
+                payload.tensor_name == descriptor.tensor_name
+                    && payload.shape_matches_matvec_contract()
+                    && payload.payload_len_matches_contract()
             }),
             runtime_compute_enabled: false,
             eager_f32_runtime_preserved: true,

--- a/crates/bitnet-transformer/tests/transformer_model_tests.rs
+++ b/crates/bitnet-transformer/tests/transformer_model_tests.rs
@@ -372,6 +372,47 @@ fn dense_linear_runtime_hook_boundary_can_carry_payload_without_enabling_compute
 }
 
 #[test]
+fn dense_linear_runtime_hook_boundary_rejects_payload_tensor_mismatch() -> anyhow::Result<()> {
+    let config = tiny_config(8, 16, 2);
+    let device = Device::Cpu;
+    let vb = VarBuilder::zeros(DType::F32, &device);
+    let payload_bytes = vec![0_u8; 68];
+    let mut hooks = DenseLinearRuntimeHookRegistry::default();
+    hooks.insert(
+        "layers.0.attention.q_proj.weight".to_string(),
+        DenseLinearRuntimeHookDescriptor {
+            tensor_name: "blk.0.attn_q.weight".to_string(),
+            role: "AttentionQ".to_string(),
+            sidecar_payload_sha256: Some("sha256:payload".to_string()),
+            packed_q8_payload: Some(DenseLinearPackedQ8Payload {
+                tensor_name: "blk.0.attn_k.weight".to_string(),
+                packed_q8_bytes: std::sync::Arc::from(payload_bytes.into_boxed_slice()),
+                q8_block_size: 32,
+                q8_block_count: 2,
+                matrix_rows: 8,
+                matrix_cols: 8,
+            }),
+            runtime_compute_enabled: true,
+        },
+    );
+    let model = TransformerModel::new_with_tensors_and_dense_linear_hooks(
+        config,
+        vb,
+        Default::default(),
+        hooks,
+    )?;
+
+    let boundary = model.dense_linear_runtime_hook_boundary("layers.0.attention.q_proj.weight");
+
+    assert!(boundary.sidecar_payload_bytes_available);
+    assert_eq!(boundary.sidecar_payload_bytes, Some(68));
+    assert!(!boundary.sidecar_payload_contract_valid);
+    assert!(!boundary.runtime_compute_enabled);
+    assert!(boundary.preserves_eager_f32());
+    Ok(())
+}
+
+#[test]
 fn dense_linear_runtime_hook_boundaries_report_sorted_receipt_identity() -> anyhow::Result<()> {
     let config = tiny_config(8, 16, 2);
     let device = Device::Cpu;


### PR DESCRIPTION
## Summary
- tighten the SLM-CPU-060 payload-bearing Q8 hook contract so a payload only reports `sidecar_payload_contract_valid=true` when its `tensor_name` matches the descriptor tensor
- add a negative transformer hook test for mismatched payload/descriptor tensor identity
- update the SLM-CPU-060 contract artifact with the tensor-identity invariant

## Claim Boundary
- contract/receipt-boundary tightening only
- no packed Q8 runtime compute enabled
- no generated-ID/text change
- no speedup or sustained-throughput claim
- no Q4/Q5, server, GPU/NPU/OpenVINO/UHD 620, Qwen3.5, or BitNet QK256 claim

## Validation
- PASS: `python -m json.tool ci/slm-cpu/intel-i5-8250u/2026-05-20/qwen3-payload-bearing-q8-sidecar-hook-contract.json`
- PASS: `cargo fmt -p bitnet-transformer -p bitnet-models -- --check`
- PASS: `cargo test --locked -p bitnet-transformer --no-default-features --features cpu dense_linear_runtime_hook -- --nocapture`
- PASS: `cargo test --locked -p bitnet-models --no-default-features --features cpu dense_gguf_q8 -- --nocapture`
- PASS: `git diff --check origin/main...HEAD`

## Follow-up
- Follow-up to #6085, which merged before this contract-tightening commit reached main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test validating payload tensor name matching in runtime hook boundaries, ensuring proper error handling for mismatched configurations.

* **Refactor**
  * Improved code organization and formatting of sidecar payload contract validation logic without altering runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/6096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->