### PR TITLE
docs(a770): record selected receipt identity

### DIFF
--- a/ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-selected-device-receipt-identity.json
+++ b/ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-selected-device-receipt-identity.json
@@ -1,0 +1,60 @@
+{
+  "campaign": "intel-a770",
+  "work_item": "A770-007",
+  "proof_family": "a770_selected_device_receipt_identity",
+  "proof_stage": "selected_device_receipt_identity_recorded",
+  "identity_consistent": true,
+  "requested_backend": "intel-arc-a770",
+  "selected_backend": "intel-arc-a770-opencl",
+  "runtime_api": "opencl",
+  "runtime_device": "Intel(R) Arc(TM) A770 Graphics",
+  "platform_index": 0,
+  "device_index": 0,
+  "platform_name": "Intel(R) OpenCL Graphics",
+  "vendor": "Intel(R) Corporation",
+  "driver_version": "32.0.101.8801",
+  "receipt_paths": [
+    "ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-opencl-tiny-smoke.json",
+    "ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-opencl-matmul-i2s-parity.json"
+  ],
+  "proofs": [
+    {
+      "work_item": "A770-005",
+      "proof_family": "a770_opencl_tiny_vector_add_smoke",
+      "proof_stage": "kernel_smoke_tested",
+      "kernel_name": "tiny_vector_add",
+      "fallback_used": false,
+      "claim_allowed": false,
+      "diagnostic_only": true
+    },
+    {
+      "work_item": "A770-006",
+      "proof_family": "a770_opencl_matmul_i2s_cpu_parity",
+      "proof_stage": "cpu_opencl_parity_tested",
+      "kernel_name": "matmul_i2s",
+      "fallback_used": false,
+      "claim_allowed": false,
+      "diagnostic_only": true
+    }
+  ],
+  "fallback_used": false,
+  "cpu_fallback_allowed": false,
+  "bitnet_inference": false,
+  "qk256_decode": false,
+  "claim_allowed": false,
+  "diagnostic_only": true,
+  "performance_claim": false,
+  "full_residency_claim": false,
+  "trusted_partial_acceleration_claim": false,
+  "selected_attention_residency_claim": false,
+  "resident_kv_decode_claim": false,
+  "model_family": null,
+  "must_not_claim": [
+    "A770 trusted partial acceleration is claim-grade",
+    "BitNet inference works on A770",
+    "Official BitNet QK256 production semantics are proven",
+    "Full A770 residency is proven",
+    "Performance speedup is proven"
+  ],
+  "next_gate": "A770-008 benchmark baseline remains blocked until receipt identity is accepted and no performance claim is made from diagnostic smoke/parity alone."
+}

--- a/docs/reports/2026-05-20-a770-selected-device-receipt-identity.md
+++ b/docs/reports/2026-05-20-a770-selected-device-receipt-identity.md
@@ -1,0 +1,74 @@
+# A770 Selected-Device Receipt Identity
+
+Status: diagnostic
+Owner: intel-a770 campaign
+Created: 2026-05-20
+Linked proposal: n/a
+Linked specs: `docs/specs/intel-arc-a770-gpu-roadmap.md`, `docs/specs/a770-bitnet-claim-boundary.md`
+Linked ADRs: n/a
+Linked plan: `docs/tracking/campaigns/intel-a770/active.toml`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: No public support-tier promotion.
+Policy impact: No policy exception.
+
+## Purpose
+
+This report records selected-device receipt identity for the committed A770
+native OpenCL smoke and parity path before any benchmark, trusted partial
+acceleration, full residency, or BitNet inference claim.
+
+## Receipt Index
+
+| Work item | Receipt | Proof family | Kernel | Stage |
+| --- | --- | --- | --- | --- |
+| A770-005 | `ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-opencl-tiny-smoke.json` | `a770_opencl_tiny_vector_add_smoke` | `tiny_vector_add` | `kernel_smoke_tested` |
+| A770-006 | `ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-opencl-matmul-i2s-parity.json` | `a770_opencl_matmul_i2s_cpu_parity` | `matmul_i2s` | `cpu_opencl_parity_tested` |
+| A770-007 | `ci/hardware/amd-5700x-intel-a770/2026-05-20/a770-selected-device-receipt-identity.json` | `a770_selected_device_receipt_identity` | n/a | `selected_device_receipt_identity_recorded` |
+
+## Selected Device
+
+The committed smoke and parity receipts agree on the selected route identity:
+
+```text
+requested_backend = intel-arc-a770
+selected_backend = intel-arc-a770-opencl
+runtime_api = opencl
+runtime_device = Intel(R) Arc(TM) A770 Graphics
+platform_index = 0
+device_index = 0
+platform_name = Intel(R) OpenCL Graphics
+vendor = Intel(R) Corporation
+driver_version = 32.0.101.8801
+fallback_used = false
+```
+
+## What This Proves
+
+This proves only that selected-device A770 OpenCL receipt identity exists for
+the committed diagnostic smoke/parity path:
+
+- A770-005 executed a tiny vector-add OpenCL smoke on the selected A770 route.
+- A770-006 executed the existing `bitnet-kernels` `matmul_i2s` OpenCL source on
+  the selected A770 route and matched the CPU reference with `max_abs_error=0`.
+- Both receipts preserve `fallback_used=false`.
+
+## Claim Boundary
+
+The A770-007 receipt identity report does not promote:
+
+- A770 trusted partial acceleration;
+- BitNet inference on A770;
+- official BitNet QK256 production semantics;
+- selected attention residency;
+- resident KV decode;
+- attention score, softmax, or value-mix residency;
+- full A770 residency;
+- A770 performance speedup;
+- completion.
+
+## Next Gate
+
+A770-008 may create a benchmark baseline for the validated diagnostic
+kernel/subgraph. It must remain diagnostic until quality, model, route,
+fallback, resource, and history gates are satisfied by later receipts.

--- a/docs/tracking/campaigns/intel-a770/active.toml
+++ b/docs/tracking/campaigns/intel-a770/active.toml
@@ -214,7 +214,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "A770-007"
-status = "proposed"
+status = "in_progress"
 branch = "codex/intel-a770/A770-007-receipt-identity"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/intel-a770/events/2026-05-20T064900Z-A770-007-in-progress.toml
+++ b/docs/tracking/campaigns/intel-a770/events/2026-05-20T064900Z-A770-007-in-progress.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-20T06:49:00Z"
+campaign = "intel-a770"
+item = "A770-007"
+event = "in_progress"
+branch = "codex/intel-a770/A770-007-receipt-identity"
+actor = "codex"
+
+notes = [
+  "Started A770-007 after A770-006 landed selected-device OpenCL matmul_i2s CPU parity evidence.",
+  "This slice records selected-device receipt identity across the committed A770-005 smoke and A770-006 parity receipts.",
+  "The report remains diagnostic-only and does not promote trusted-partial acceleration, BitNet inference, official QK256 production semantics, residency, performance, or completion.",
+]

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -14,7 +14,7 @@
 | A770-004 | merged | #5971 | `codex/intel-a770/A770-004-runtime-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add A770 runtime probe evidence without promoting OpenCL execution or BitNet inference claims. |
 | A770-005 | merged | #6072 | `codex/intel-a770/A770-005-opencl-smoke` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run a tiny selected-device OpenCL smoke with fallback_used=false and CPU parity, without BitNet inference claims. |
 | A770-006 | merged | #6110 | `codex/intel-a770/A770-006-opencl-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add CPU/OpenCL parity for a minimal kernel or subgraph without promoting official BitNet QK256 inference. |
-| A770-007 | proposed | TBD | `codex/intel-a770/A770-007-receipt-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record selected-device receipt identity for the validated smoke/parity path before any performance or trusted-partial claim. |
+| A770-007 | in_progress | TBD | `codex/intel-a770/A770-007-receipt-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record selected-device receipt identity for the validated smoke/parity path before any performance or trusted-partial claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -454,7 +454,7 @@
 | intel-a770 | A770-004 | A770-003 | merged |
 | intel-a770 | A770-005 | A770-004 | merged |
 | intel-a770 | A770-006 | A770-005 | merged |
-| intel-a770 | A770-007 | A770-006 | proposed |
+| intel-a770 | A770-007 | A770-006 | in_progress |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -37,7 +37,7 @@
 | falcon3-family | F3-000 | TBD | ready | none | Do not commit model binaries. |
 | i2s | I2S-DOCS-000 | #5880 | merged | none | Do not change runtime code in docs-only I2_S tracker slices. |
 | intel-258v-platform | LNL258V-POWER-006 | TBD | blocked | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
-| intel-a770 | A770-007 | TBD | proposed | none | OpenCL-first for native A770 proof. |
+| intel-a770 | A770-007 | TBD | in_progress | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-013 | #5903 | merged | none | Device-node detection is not inference. |
 | llama3-8b-158 | LLAMA3-158-000 | TBD | ready | LLAMA3-158-001 | Do not commit model binaries. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary

- adds a selected-device receipt identity JSON index for the committed A770-005 smoke and A770-006 matmul_i2s parity receipts
- adds a short report tying both receipts to the same selected A770 OpenCL route, runtime device, driver, and fallback boundary
- marks A770-007 in progress with a campaign event

## Claim Boundary

This PR may claim only that selected-device receipt identity exists for the validated A770 smoke/parity path.

It does not claim:

- A770 trusted partial acceleration is claim-grade
- BitNet inference works on A770
- official BitNet QK256 production semantics are proven
- selected attention or resident KV
- attention score, softmax, or value-mix residency
- full A770 residency
- performance speedup
- completion

## Validation

Passed locally:

```text
Get-Content ci\hardware\amd-5700x-intel-a770\2026-05-20\a770-selected-device-receipt-identity.json | ConvertFrom-Json
markdownlint docs\reports\2026-05-20-a770-selected-device-receipt-identity.md
git diff --check
```

Receipt identity summary:

```text
identity_consistent=true
selected_backend=intel-arc-a770-opencl
runtime_device=Intel(R) Arc(TM) A770 Graphics
fallback_used=false
claim_allowed=false
performance_claim=false
full_residency_claim=false
```

Not run locally:

```text
cargo run --locked -p xtask --no-default-features -- campaign check intel-a770
```

Local blocker: xtask compilation on this Windows host timed out in the broader native dependency graph around `sentencepiece-sys` / `cl`. Generated tracking was not hand-edited.