### PR TITLE
test(qk256): salvage AVX2 position identity proof

### DIFF
--- a/crates/bitnet-models/tests/qk256_avx2_correctness.rs
+++ b/crates/bitnet-models/tests/qk256_avx2_correctness.rs
@@ -33,8 +33,6 @@ use bitnet_models::quant::i2s_qk256_avx2::gemv_qk256_avx2;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
-/// Code-to-weight mapping for QK256 format
-///
 /// Tolerance for floating-point comparison
 ///
 /// This is set to 1e-4 to account for:
@@ -51,7 +49,7 @@ const TOLERANCE: f32 = 1e-4;
 ///
 /// Each byte contains 4 codes in the format:
 /// ```text
-/// byte = code0 | (code1 << 2) | (code2 << 4) | (code3 << 6)
+/// byte = (code0 << 6) | (code1 << 4) | (code2 << 2) | code3
 /// ```
 ///
 /// # Arguments
@@ -73,7 +71,7 @@ fn generate_random_quantized_data(num_bytes: usize, seed: u64) -> Vec<u8> {
         let c2 = rng.random_range(0..4u8);
         let c3 = rng.random_range(0..4u8);
 
-        let byte = c0 | (c1 << 2) | (c2 << 4) | (c3 << 6);
+        let byte = (c0 << 6) | (c1 << 4) | (c2 << 2) | c3;
         data.push(byte);
     }
 
@@ -410,10 +408,10 @@ fn test_qk256_avx2_random_seeds() {
 ///
 /// This validates correctness for uniform quantized data.
 #[test]
-fn test_qk256_avx2_uniform_codes() {
+fn test_qk256_avx2_uniform_codes() -> Result<(), Box<dyn std::error::Error>> {
     if !is_x86_feature_detected!("avx2") {
         eprintln!("Skipping AVX2 test - not available");
-        return;
+        return Ok(());
     }
 
     const COLS: usize = 512;
@@ -432,8 +430,7 @@ fn test_qk256_avx2_uniform_codes() {
         let scalar_result = gemv_qk256_row(&qs_data, &x, COLS);
 
         let mut y_avx2 = vec![0.0f32; 1];
-        gemv_qk256_avx2(&qs_data, &x, &mut y_avx2, 1, COLS, BLOCKS * QK256_PACKED_BYTES)
-            .expect("AVX2 GEMV should succeed");
+        gemv_qk256_avx2(&qs_data, &x, &mut y_avx2, 1, COLS, BLOCKS * QK256_PACKED_BYTES)?;
         let avx2_result = y_avx2[0];
 
         // Compare scalar and AVX2 results
@@ -475,6 +472,7 @@ fn test_qk256_avx2_uniform_codes() {
     }
 
     println!("✅ Uniform codes test passed (all 4 code values)");
+    Ok(())
 }
 
 /// Test with zero input vector

--- a/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
+++ b/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
@@ -470,6 +470,58 @@ fn test_avx2_parity_requested_shape_pattern_matrix_1e4() {
 // ── Test 1: single row, all codes=2 (+1), uniform x=1.0 ──
 
 #[test]
+fn test_strict_avx2_full_block_position_identity() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("Skipping AVX2 position identity test - not x86_64");
+        return Ok(());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if !avx2_selection_available() {
+            eprintln!("Skipping AVX2 position identity test - AVX2/FMA unavailable");
+            return Ok(());
+        }
+
+        let rows = 1;
+        let cols = QK256_BLOCK;
+        let x: Vec<f32> = (0..cols).map(|idx| (idx as f32 + 0.25) / 17.0).collect();
+
+        for target_col in 0..cols {
+            for (code, expected_sign) in [(2u8, 1.0f32), (0u8, -1.0f32)] {
+                let mut codes = vec![1u8; cols];
+                codes[target_col] = code;
+                let (qs, stride) = build_qs_data(&[codes], cols);
+                let mut y = vec![0.0f32; rows];
+
+                let selection = gemv_qk256_with_kernel_selection(
+                    &qs,
+                    &x,
+                    &mut y,
+                    rows,
+                    cols,
+                    stride,
+                    Some(QK256_AVX2_GEMV_KERNEL_ID),
+                    true,
+                )?;
+
+                assert_eq!(selection.selected_kernel, QK256_AVX2_GEMV_KERNEL_ID);
+                assert!(!selection.fallback_used);
+                let expected = expected_sign * x[target_col];
+                assert!(
+                    (y[0] - expected).abs() <= 1e-6,
+                    "target_col={target_col} code={code}: expected={expected} actual={}",
+                    y[0]
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_gemv_single_row_all_ones() {
     let cols = 256;
     let codes = vec![2u8; cols]; // code 2 → +1.0


### PR DESCRIPTION
## Summary

- Port the test-only durable subset from draft PR #5092 onto a clean branch from current main.
- Correct the qk256 AVX2 correctness fixture packing documentation/data to match high-bit-first QK256 byte packing.
- Add a strict AVX2 full-block position identity test that verifies selected_kernel=qk256-avx2-gemv and fallback_used=false for isolated +1/-1 positions.

## Scope

- Test-only changes in bitnet-models and bitnet-quantization.
- No AVX2 runtime kernel changes.
- No model, tokenizer, server, CUDA/OpenCL/OpenVINO/NPU, speedup, residency, or product-readiness claim.

## Claim boundary

This PR preserves the #5092 runtime candidate as draft-held. It only lands reusable tests and fixture cleanup; it does not prove scaled BitNet I2_S x I8_S AVX2 execution, model answer readiness, generated-token parity, broad AVX2 readiness, or accepted speedup.

## Validation

- rustfmt --edition 2024 --check crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs crates/bitnet-models/tests/qk256_avx2_correctness.rs: PASS
- git diff --check --cached: PASS
- claim-wording scan across changed files for speed/perf/hardware/server/residency terms: PASS, no matches
- cargo test --locked -p bitnet-models --test qk256_avx2_correctness --no-default-features --features cpu test_qk256_avx2_uniform_codes -- --nocapture: local timeout after 10 minutes without assertion output while the shared workspace had many existing cargo/rustc processes; hosted CI is the proof path

## Generated files

None.

## Follow-up / supersedes

- Salvages the test-only subset from draft #5092.
- #5092 remains draft-held for runtime perf proof, receipt/counter evidence, exact-profile benchmark evidence, and claim-boundary review.