### PR TITLE
docs: bound legacy hardware claim docs

### DIFF
--- a/docs/GPU_PERFORMANCE_EXPECTATIONS.md
+++ b/docs/GPU_PERFORMANCE_EXPECTATIONS.md
@@ -1,10 +1,16 @@
 # GPU Performance Expectations
 
+> Claim boundary: this page records historical targets and estimates, not
+> current speedup, CUDA readiness, server readiness, residency, or
+> product-readiness proof. Current hardware and model claims must come from
+> active model coverage, receipts, status docs, specs, and claim gates.
+
 Expected inference throughput targets and memory requirements for BitNet-rs
 GPU backends. These are **targets and estimates** — actual performance depends
 on model quantization format, batch size, prompt length, and driver version.
 
-> **Current status (v0.1.0-qna-mvp)**: CUDA is the production GPU backend.
+> **Historical status note (v0.1.0-qna-mvp)**: CUDA was treated as the planned
+> GPU backend in this older target document.
 > QK256 scalar kernels are ~0.1 tok/s (MVP limitation). I2_S BitNet32-F16
 > format is 10–20× faster. See [COMPATIBILITY.md](../COMPATIBILITY.md) and
 > [GPU_COMPATIBILITY_MATRIX.md](GPU_COMPATIBILITY_MATRIX.md) for backend status.

--- a/docs/explanation/cpp-wrapper-gpu-layer-config.md
+++ b/docs/explanation/cpp-wrapper-gpu-layer-config.md
@@ -7,16 +7,24 @@
 **Related Issues**: Socket 5 GPU Support
 **Date**: 2025-10-25
 
+> Claim boundary: this is a draft design specification. Expected speedups,
+> GPU-offload behavior, fallback behavior, and benchmark thresholds are design
+> targets until current-source receipts, model coverage, status docs, specs, and
+> claim gates prove them for an exact model/backend/profile.
+
 ---
 
 ## Executive Summary
 
 This specification defines the architecture for enabling GPU layer configuration in the BitNet-rs C++ FFI wrapper (`crossval/src/bitnet_cpp_wrapper.cc`). Currently, GPU layer offloading is disabled at lines 408-410, forcing all inference to run on CPU despite the infrastructure accepting an `n_gpu_layers` parameter. This represents a **MEDIUM-priority optimization opportunity** to unlock GPU acceleration for cross-validation workflows.
 
-**Key Impact**:
-- **Performance**: Expected 5-50× speedup for GPU-accelerated inference (model-size dependent)
-- **Memory**: GPU VRAM usage scales with layer count (estimate: ~100-500MB per billion parameters offloaded)
-- **Compatibility**: Graceful fallback to CPU when GPU unavailable or VRAM insufficient
+**Key Impact Targets**:
+- **Performance**: target 5-50× speedup for GPU-accelerated inference,
+  model-size dependent and receipt-gated
+- **Memory**: estimated GPU VRAM usage scales with layer count (~100-500MB per
+  billion parameters offloaded)
+- **Compatibility**: target graceful fallback to CPU when GPU unavailable or
+  VRAM insufficient, with explicit receipt evidence required
 
 **Scope**: This specification covers Socket 1 (Persistent Context API) GPU configuration only. Socket 5 (dedicated GPU API) remains a v0.3 future consideration.
 

--- a/docs/explanation/production-inference-server-architecture.md
+++ b/docs/explanation/production-inference-server-architecture.md
@@ -2,6 +2,11 @@
 
 Understanding the design principles and architectural decisions behind the BitNet-rs production inference server for enterprise neural network deployments.
 
+> Claim boundary: this is an architecture/design explanation, not a current
+> server-readiness proof. Current server readiness, backend route, fallback,
+> speed, residency, and product-readiness claims must come from active receipts,
+> model coverage, status docs, specs, and claim gates.
+
 ## Overview
 
 The BitNet-rs production inference server is designed as a comprehensive solution for deploying 1-bit neural network models in production environments. The architecture prioritizes **reliability, performance, and scalability** while maintaining **quantization accuracy** and **operational simplicity**.

--- a/docs/howto/production-server-docker-deployment.md
+++ b/docs/howto/production-server-docker-deployment.md
@@ -2,6 +2,11 @@
 
 This guide shows how to deploy the BitNet-rs production inference server using Docker containers for both CPU and GPU environments.
 
+> Claim boundary: this guide is deployment guidance, not proof that any current
+> model/backend combination is server-ready, CUDA-ready, speed-qualified, or
+> residency-qualified. Treat GPU and production examples as configuration
+> patterns until an exact receipt and model coverage row prove the claim.
+
 ## Prerequisites
 
 Before deploying, ensure you have:

--- a/docs/howto/quantization-optimization-and-performance.md
+++ b/docs/howto/quantization-optimization-and-performance.md
@@ -2,11 +2,18 @@
 
 This comprehensive guide shows you how to optimize BitNet-rs quantization performance for production workloads. You'll learn to configure device-aware quantization, enable strict mode to prevent mock fallbacks, tune performance parameters, and achieve realistic performance baselines with actual quantized computation.
 
+> Claim boundary: this guide gives optimization procedures and historical
+> examples. It does not prove current CUDA/GPU readiness, speedup, server
+> readiness, residency, fallback behavior, or product readiness. Use active
+> receipts, model coverage, status docs, specs, and claim gates for current
+> claims.
+
 ## Overview
 
 BitNet-rs provides advanced quantization optimization features:
 
-- **Device-Aware Quantization**: Automatic GPU acceleration with CPU fallback
+- **Device-Aware Quantization**: backend selection surfaces with explicit
+  fallback reporting
 - **Multiple Quantization Formats**: I2_S, TL1, TL2 quantization support
 - **SIMD Acceleration**: AVX2/AVX-512 (x86_64), NEON (ARM64) optimizations
 - **Memory Optimization**: Zero-copy operations and efficient memory layout

--- a/docs/mvp/qk256-mvp-validation-report.md
+++ b/docs/mvp/qk256-mvp-validation-report.md
@@ -1,5 +1,11 @@
 # QK256 MVP Validation Report
 
+> Claim boundary: this is a historical MVP validation report from 2025-10-17.
+> Its production-ready, speedup, GPU, and throughput wording records that older
+> report context only. Current BitNet-rs support, readiness, speed, residency,
+> fallback, and route claims must come from active model coverage, receipts,
+> status docs, specs, and claim gates.
+
 **Date:** 2025-10-17
 **Status:** ✅ **MVP COMPLETE - DEMO READY**
 **Version:** 1.0.0

--- a/docs/performance-benchmarking.md
+++ b/docs/performance-benchmarking.md
@@ -1,5 +1,10 @@
 # Performance Benchmarking and Regression Detection
 
+> Claim boundary: benchmark infrastructure and historical example numbers do
+> not prove current speedup, CUDA/GPU readiness, server readiness, residency, or
+> product readiness. Current performance claims require exact-profile receipts,
+> model coverage, status docs, specs, and claim gates.
+
 BitNet-rs includes a comprehensive performance benchmarking infrastructure designed to detect performance regressions, track improvements, and ensure consistent performance across platforms.
 
 ## 🚀 Quick Start

--- a/docs/performance-guide.md
+++ b/docs/performance-guide.md
@@ -2,6 +2,12 @@
 
 Comprehensive guide to optimizing BitNet-rs performance for different use cases and hardware configurations.
 
+> Claim boundary: this guide describes optimization surfaces and historical
+> targets. It does not prove current speedup, CUDA/GPU readiness, server
+> readiness, residency, fallback behavior, or product readiness for any model.
+> Current performance and hardware claims must come from active receipts, model
+> coverage, status docs, specs, and claim gates.
+
 ## Table of Contents
 
 - [Performance Overview](#performance-overview)
@@ -15,7 +21,7 @@ Comprehensive guide to optimizing BitNet-rs performance for different use cases 
 
 ## Performance Overview
 
-BitNet-rs is designed for high-performance inference with several optimization strategies:
+BitNet-rs contains several optimization surfaces:
 
 - **SIMD Kernels**: Vectorized operations for CPU (AVX2, NEON)
 - **GPU Acceleration**: CUDA kernels for parallel processing
@@ -23,7 +29,9 @@ BitNet-rs is designed for high-performance inference with several optimization s
 - **Memory Efficiency**: Zero-copy operations and memory pooling
 - **Async Processing**: Non-blocking I/O and concurrent execution
 
-### Performance Targets
+### Historical Performance Targets
+
+These targets are planning values, not current support or speedup claims.
 
 | Hardware | Model Size | Target Latency | Target Throughput |
 |----------|------------|----------------|-------------------|

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -2,6 +2,12 @@
 
 This document provides comprehensive API reference for BitNet Rust library and production inference server.
 
+> Claim boundary: API endpoints, feature flags, and examples in this reference
+> describe interface shape. They do not prove current server readiness, CUDA/GPU
+> support, speedup, residency, fallback behavior, or product readiness for any
+> model. Use active receipts, model coverage, status docs, specs, and claim
+> gates for current claims.
+
 ## Production Inference Server API
 
 The BitNet-rs production inference server provides enterprise-grade HTTP API endpoints for neural network inference with comprehensive model management, monitoring, and security features.

--- a/docs/reference/quantization-support.md
+++ b/docs/reference/quantization-support.md
@@ -1,15 +1,22 @@
 # Quantization Support
 
-This document describes the quantization formats and device-aware acceleration supported by BitNet-rs.
+This document describes BitNet-rs quantization formats and device-aware
+acceleration surfaces.
+
+> Claim boundary: feature flags, kernel names, and acceleration surfaces here do
+> not by themselves prove product readiness, speedup, server readiness, fallback
+> behavior, or full residency. Current hardware and model claims must be checked
+> against active model coverage, receipts, status docs, specs, and claim gates.
 
 ## Supported Quantization Formats
 
-BitNet-rs supports multiple quantization formats with advanced device-aware acceleration:
+BitNet-rs contains multiple quantization formats with device-aware acceleration
+surfaces:
 
 ### I2S - Native Rust Implementation (Issue #261)
 
-- Native Rust implementation with intelligent GPU/CPU selection and automatic fallback
-- Device-aware quantization with CUDA kernel acceleration (feature-gated) and CPU SIMD optimization
+- Native Rust implementation with device selection and explicit fallback reporting
+- Device-aware quantization surfaces with feature-gated CUDA kernels and CPU SIMD optimization
 - **Accuracy**: Target ≥99.8% correlation with FP32 reference (defined in test fixtures; formal measurement pending)
 - **Performance**: Hardware-dependent; SIMD-optimised. QK256 path uses scalar kernels (~0.1 tok/s for 2B models).
 - 2-bit signed quantization with optimized bit-packing (4 values per byte)

--- a/docs/reference/real-model-api-contracts.md
+++ b/docs/reference/real-model-api-contracts.md
@@ -1,5 +1,11 @@
 # Real BitNet Model Integration: API Contracts Reference
 
+> Claim boundary: these API contracts describe intended integration surfaces.
+> They do not prove model quality, tokenizer authority, backend execution,
+> speedup, server readiness, fallback behavior, or residency for current builds.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
+
 ## Overview
 
 This document defines the comprehensive API contracts for real BitNet model integration across the BitNet-rs neural network inference pipeline. These contracts ensure consistent interfaces for model loading, quantization, inference, and validation while maintaining backward compatibility and supporting device-aware execution.


### PR DESCRIPTION
## Summary
- add explicit claim-boundary notes to legacy/current-looking docs with GPU, CUDA, server, speed, throughput, residency, fallback, or product-readiness wording
- reword a few direct hardware/performance statements as historical targets, design targets, or acceleration surfaces
- point current claims back to active model coverage, receipts, status docs, specs, and claim gates

## Scope
Docs-only. No runtime, model coverage, receipt schema, CI workflow, generated dashboard, kernel, tokenizer, or benchmark behavior changes.

## Claim boundary
This PR does not promote CUDA/GPU support, server readiness, speedup, throughput, residency, fallback, model quality, or product readiness. It narrows legacy docs so those claims require current receipts and gates.

## Validation
- PASS: tk proxy git diff --check
- PASS: focused check that every changed Markdown file contains Claim boundary
- INFO: tk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc <changed docs> still reports existing legacy-doc formatting debt. The repo markdownlint workflow is informational/continue-on-error; this PR intentionally avoids whole-document reformatting.

## Generated files
None.

## Follow-up / supersedes
Follow-up to the #6142/#6143 historical claim-boundary cleanup. Does not affect #5092, which remains draft-held pending AVX2 product-route and exact-profile proof.