### PR TITLE
ci: bound exploration archive claims

### DIFF
--- a/ci/exploration/00_NEW_ANALYSIS_INDEX.md
+++ b/ci/exploration/00_NEW_ANALYSIS_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # New Test Analysis - Session Index
 
 **Generated**: October 22, 2025  

--- a/ci/exploration/00_START_HERE.md
+++ b/ci/exploration/00_START_HERE.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR Completeness Verification - START HERE
 
 **Last Updated**: 2025-10-22  

--- a/ci/exploration/00_START_STRICT_MODE_ANALYSIS.md
+++ b/ci/exploration/00_START_STRICT_MODE_ANALYSIS.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Strict Mode Test Failure Analysis - START HERE
 
 **Analysis Date**: 2025-10-22  

--- a/ci/exploration/00_TEST_ANALYSIS_FINAL_REPORT.md
+++ b/ci/exploration/00_TEST_ANALYSIS_FINAL_REPORT.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Final Test Analysis Report - BitNet-rs Workspace
 
 **Date**: October 22, 2025  

--- a/ci/exploration/ANALYSIS_SUMMARY.md
+++ b/ci/exploration/ANALYSIS_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Analysis Summary: Strict Mode Test Failure
 
 ## Location

--- a/ci/exploration/BLOCKING_ISSUES_INDEX.md
+++ b/ci/exploration/BLOCKING_ISSUES_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Blocking Issues Scan - Complete Index
 
 **Scan Date**: 2025-10-22  

--- a/ci/exploration/ENVGUARD_QUICK_FIX_GUIDE.md
+++ b/ci/exploration/ENVGUARD_QUICK_FIX_GUIDE.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # EnvGuard Compilation Issues - Quick Fix Guide
 
 **Last Updated**: 2025-10-22 | **Status**: Ready to Apply | **Est. Fix Time**: 15-30 minutes

--- a/ci/exploration/EXPLORATION_SUMMARY.md
+++ b/ci/exploration/EXPLORATION_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Test Fixture Exploration - Summary Report
 
 ## Overview

--- a/ci/exploration/FINDINGS_SUMMARY.md
+++ b/ci/exploration/FINDINGS_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Environment Variable Testing - Key Findings
 
 **Date**: 2025-10-22  

--- a/ci/exploration/INDEX.md
+++ b/ci/exploration/INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Exploration Analysis - Complete Index
 
 **Repository**: BitNet-rs  

--- a/ci/exploration/PR1_ANALYSIS_INDEX.md
+++ b/ci/exploration/PR1_ANALYSIS_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR1 Fixture Generation Analysis - Complete Index
 
 ## Documents in This Analysis

--- a/ci/exploration/PR1_INDEX.md
+++ b/ci/exploration/PR1_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR1 Verification Index
 
 **Date**: 2025-10-22  

--- a/ci/exploration/PR1_QUICK_REFERENCE.md
+++ b/ci/exploration/PR1_QUICK_REFERENCE.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR1 Fixture Implementation - Quick Reference
 
 ## TL;DR Summary

--- a/ci/exploration/PR1_fixture_implementation_plan.md
+++ b/ci/exploration/PR1_fixture_implementation_plan.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR1 Fixture Generation and GGUF Writer Integration Plan
 
 ## Executive Summary

--- a/ci/exploration/PR2_INDEX.md
+++ b/ci/exploration/PR2_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR2 EnvGuard Verification - Complete Index
 
 ## Quick Navigation

--- a/ci/exploration/PR2_SUMMARY.md
+++ b/ci/exploration/PR2_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR2 Analysis Summary: EnvGuard Migration & Serial Test Implementation
 
 ## Key Findings

--- a/ci/exploration/PR2_VERIFICATION_COMPLETE.md
+++ b/ci/exploration/PR2_VERIFICATION_COMPLETE.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR2 EnvGuard Verification - COMPLETE
 
 **Status**: ✅ VERIFICATION COMPLETE - READY FOR REVIEW AND MERGE (with pre-merge fix)

--- a/ci/exploration/PR2_envguard_migration_plan.md
+++ b/ci/exploration/PR2_envguard_migration_plan.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR2: EnvGuard Migration & Serial Test Implementation Plan
 
 **Document Status**: Analysis Complete  

--- a/ci/exploration/PR3_DELIVERY.md
+++ b/ci/exploration/PR3_DELIVERY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR3 Analysis Delivery Summary
 
 **Completion Date**: 2025-01-22

--- a/ci/exploration/PR3_perf_receipts_plan.md
+++ b/ci/exploration/PR3_perf_receipts_plan.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR3: Performance Receipts & CI Integration - Comprehensive Analysis
 
 **Objective**: Design and implement performance smoke tests with honest receipt generation and CI integration for non-gating observability of inference regressions.

--- a/ci/exploration/PR4_ANALYSIS_INDEX.md
+++ b/ci/exploration/PR4_ANALYSIS_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR4 Analysis Documentation Index
 
 **Test**: `test_strict_mode_enforcer_validates_fallback`  

--- a/ci/exploration/PR4_EXECUTIVE_SUMMARY.md
+++ b/ci/exploration/PR4_EXECUTIVE_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR4 Failing Inference Test - Executive Summary
 
 **Status**: DIAGNOSIS COMPLETE  

--- a/ci/exploration/PR4_VERIFICATION_INDEX.md
+++ b/ci/exploration/PR4_VERIFICATION_INDEX.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR4 Verification Index - Quick Reference
 
 ## Status Summary

--- a/ci/exploration/PR4_test_failure_diagnosis.md
+++ b/ci/exploration/PR4_test_failure_diagnosis.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR4 Failing Inference Test Diagnosis Report
 
 **Date**: 2025-10-22  

--- a/ci/exploration/README.md
+++ b/ci/exploration/README.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Strict Mode Test Failure Analysis - Complete Documentation
 
 This directory contains a comprehensive analysis of the `test_strict_mode_enforcer_validates_fallback` test and its refactoring.

--- a/ci/exploration/README_ENVGUARD.md
+++ b/ci/exploration/README_ENVGUARD.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # EnvGuard Compilation Errors - Analysis & Documentation
 
 **Created**: 2025-10-22  

--- a/ci/exploration/SCAN_RESULTS.md
+++ b/ci/exploration/SCAN_RESULTS.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Blocking Issues Scan - Executive Summary
 
 **Status**: ✅ CLEAR FOR PR

--- a/ci/exploration/SOLUTION_A_CODE_CHANGES.md
+++ b/ci/exploration/SOLUTION_A_CODE_CHANGES.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Solution A: Implementation Code Changes
 
 This document provides exact code changes needed to fix the flaky test.

--- a/ci/exploration/TEST_STATUS_SUMMARY.md
+++ b/ci/exploration/TEST_STATUS_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Test Status Summary - BitNet-rs Workspace
 
 **Date**: October 22, 2025  

--- a/ci/exploration/VERIFICATION_SUMMARY.md
+++ b/ci/exploration/VERIFICATION_SUMMARY.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR Verification Summary (Quick Reference)
 
 ## Status Overview

--- a/ci/exploration/blocking_issues_scan.md
+++ b/ci/exploration/blocking_issues_scan.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Blocking Issues Scan Report
 
 **Date**: 2025-10-22

--- a/ci/exploration/env_testing_patterns.md
+++ b/ci/exploration/env_testing_patterns.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Environment Variable Testing Patterns in BitNet-rs
 
 ## Executive Summary

--- a/ci/exploration/fixture_patterns.md
+++ b/ci/exploration/fixture_patterns.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # BitNet-rs Test Fixture Patterns and Architecture
 
 ## Executive Summary

--- a/ci/exploration/issue_envguard_compilation.md
+++ b/ci/exploration/issue_envguard_compilation.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # EnvGuard Compilation Error Analysis
 
 **Status**: Analysis Complete | **Severity**: High (Blocks Test Suite) | **Date**: 2025-10-22

--- a/ci/exploration/issue_markdownlint_formatting.md
+++ b/ci/exploration/issue_markdownlint_formatting.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Markdownlint Formatting Issues Analysis: MERGE_READY_SUMMARY.md
 
 **Analysis Date**: 2025-10-22

--- a/ci/exploration/issue_pr_completeness.md
+++ b/ci/exploration/issue_pr_completeness.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR Completeness Verification Report
 
 **Date**: 2025-10-22  

--- a/ci/exploration/issue_remaining_tests.md
+++ b/ci/exploration/issue_remaining_tests.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Remaining Test Issues Analysis - BitNet-rs
 
 **Date**: October 22, 2025

--- a/ci/exploration/issue_strict_mode_test_failure.md
+++ b/ci/exploration/issue_strict_mode_test_failure.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # Analysis: Strict Mode Test Failure `strict_mode_enforcer_validates_fallback`
 
 **Date**: 2025-10-22  

--- a/ci/exploration/pr1_fixture_parser_investigation.md
+++ b/ci/exploration/pr1_fixture_parser_investigation.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR1 Fixture Parser Investigation
 
 ## Problem

--- a/ci/exploration/pr1_fixtures_status.md
+++ b/ci/exploration/pr1_fixtures_status.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR1 Verification Report: GGUF Fixtures + QK256 Dual-Flavor Tests
 
 **Date**: 2025-10-22  

--- a/ci/exploration/pr2_envguard_status.md
+++ b/ci/exploration/pr2_envguard_status.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR2 EnvGuard + Environment Isolation - Status Report
 
 **Date**: 2025-10-22

--- a/ci/exploration/pr3_perf_receipts_status.md
+++ b/ci/exploration/pr3_perf_receipts_status.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR3 Verification Report: Performance Baselines + Receipt Verification + Nextest
 
 **Status**: READY FOR MERGE (All Components Verified)

--- a/ci/exploration/pr4_inference_guards_status.md
+++ b/ci/exploration/pr4_inference_guards_status.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # PR4 Strict Mode Runtime Guards - Complete Status Report
 
 **Status:** ✅ PRODUCTION READY FOR MERGE

--- a/ci/exploration/profiling_infrastructure.md
+++ b/ci/exploration/profiling_infrastructure.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # BitNet-rs Profiling Infrastructure
 
 **Status**: Exploration document for phase2_flamegraph integration

--- a/ci/exploration/xtask_receipt_verification.md
+++ b/ci/exploration/xtask_receipt_verification.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # xtask verify-receipt Implementation Verification
 
 **Date**: 2025-01-22

--- a/ci/exploration/xtask_receipt_verification_summary.md
+++ b/ci/exploration/xtask_receipt_verification_summary.md
@@ -1,3 +1,9 @@
+> Historical CI artifact only: this file is an archived exploration note from an
+> older CI/PR investigation. Production-ready, performance, AVX, GPU, CUDA,
+> receipt, strict-mode, and merge-readiness wording here is historical context
+> only and is not a current support, speed, backend, quality, or release claim.
+> Current claims must come from active receipts, model coverage, status docs,
+> specs, and claim gates.
 # xtask verify-receipt Implementation - Final Summary
 
 **Date**: 2025-01-22  


### PR DESCRIPTION
## Summary
- add a historical-only warning banner to every Markdown artifact under ci/exploration
- clarify that old production-ready, AVX, GPU/CUDA, throughput, receipt, strict-mode, and merge-readiness wording is archival context only

## Scope
- CI archive Markdown only
- no runtime, model, CI workflow, receipt schema, tracker, generated dashboard, or claim-gate behavior changes

## Claim boundary
- no current support, speed, backend, quality, release, GPU/CUDA, AVX, or product-readiness claim is promoted
- current claims remain owned by active receipts, model coverage, status docs, specs, and claim gates

## Validation
- tk git diff --check
- focused scan: ci/exploration unbounded risky markdown=0

## Generated files
- none

## Validation gap
- markdownlint-cli2 on the changed archive files still reports pre-existing legacy formatting debt; this PR intentionally does not broaden into formatting cleanup.

## Follow-up / supersedes
- follows #6143 top-level CI archive claim-boundary cleanup and reduces the subdirectory audit gap called out in the completion audit