### PR TITLE
docs: bound legacy validation report claims

### DIFF
--- a/docs/reports/COMPREHENSIVE_VALIDATION_REPORT.md
+++ b/docs/reports/COMPREHENSIVE_VALIDATION_REPORT.md
@@ -1,5 +1,11 @@
 # Comprehensive End-to-End Inference Validation Report
 
+> Claim boundary: this is a historical validation report from an older branch.
+> Ready-for-integration, performance, AVX2, GPU, receipt, correctness, and
+> inference-working wording records that dated context only. Current support,
+> speed, backend execution, quality, and product-readiness claims must come
+> from active receipts, model coverage, status docs, specs, and claim gates.
+
 **Date:** 2025-10-24
 **Branch:** `feat/comprehensive-integration-qk256-envguard-receipts-strict-avx2`
 **Validation Goal:** Prove inference works correctly with all optimizations applied

--- a/docs/reports/INFERENCE_VALIDATION_RECEIPTS.md
+++ b/docs/reports/INFERENCE_VALIDATION_RECEIPTS.md
@@ -1,5 +1,11 @@
 # Inference Validation Receipts
 
+> Claim boundary: this is a historical receipt summary from an older branch.
+> Real-inference, deterministic, performance, AVX2, and protected wording
+> records that dated context only. Current support, speed, backend execution,
+> quality, and product-readiness claims must come from active receipts, model
+> coverage, status docs, specs, and claim gates.
+
 **Date:** 2025-10-24
 **Branch:** `feat/comprehensive-integration-qk256-envguard-receipts-strict-avx2`
 **Commit:** Latest

--- a/docs/reports/PHASE2_COMPLETION_REPORT.md
+++ b/docs/reports/PHASE2_COMPLETION_REPORT.md
@@ -1,5 +1,11 @@
 # Phase 2 FMA Tiling - Implementation Completion Report
 
+> Claim boundary: this is a historical implementation report from an older
+> optimization branch. Complete, performance, AVX2, speedup, and benchmark
+> wording records that dated context only. Current support, speed, backend
+> execution, quality, and product-readiness claims must come from active
+> receipts, model coverage, status docs, specs, and claim gates.
+
 **Implementation Date:** 2025-10-24
 **Phase:** 2 of 4 (QK256 AVX2 Optimization Roadmap)
 **Status:** ✅ **COMPLETE** (Foundation Ready)

--- a/docs/reports/PHASE2_FMA_IMPLEMENTATION_SUMMARY.md
+++ b/docs/reports/PHASE2_FMA_IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,11 @@
 # Phase 2 FMA Tiling Implementation - Summary Report
 
+> Claim boundary: this is a historical implementation summary from an older
+> optimization branch. FMA, AVX2, theoretical speedup, combined speedup, and
+> ready-for-review wording records that dated context only. Current support,
+> speed, backend execution, quality, and product-readiness claims must come
+> from active receipts, model coverage, status docs, specs, and claim gates.
+
 **Date:** 2025-10-24
 **Implementer:** Claude Code Assistant
 **Status:** ✅ IMPLEMENTED (Foundation Complete)

--- a/docs/reports/SYSTEMATIC_DEBUGGING_PLAN.md
+++ b/docs/reports/SYSTEMATIC_DEBUGGING_PLAN.md
@@ -1,5 +1,11 @@
 # Systematic Debugging Plan for BitNet-rs Garbling Issue
 
+> Claim boundary: this is a historical diagnostic plan. Production-ready,
+> trace, cross-validation, corruption, performance, and debugging-status wording
+> records that dated diagnostic context only. Current support, speed, backend
+> execution, quality, and product-readiness claims must come from active
+> receipts, model coverage, status docs, specs, and claim gates.
+
 **Date**: 2025-10-24
 **Analysis Session**: Agent-based systematic exploration
 **Status**: Partial diagnosis complete, C++ comparison required for definitive answer

--- a/docs/reports/VALIDATION_INDEX.md
+++ b/docs/reports/VALIDATION_INDEX.md
@@ -1,5 +1,11 @@
 # BitNet-rs Validation Documentation Index
 
+> Claim boundary: this is a historical validation index from an older branch.
+> Ready-for-integration, performance, AVX2, receipt, correctness, and
+> inference-working wording records that dated context only. Current support,
+> speed, backend execution, quality, and product-readiness claims must come
+> from active receipts, model coverage, status docs, specs, and claim gates.
+
 **Date:** 2025-10-24
 **Branch:** `feat/comprehensive-integration-qk256-envguard-receipts-strict-avx2`
 **Overall Status:** ✅ **READY FOR INTEGRATION**

--- a/docs/reports/VALIDATION_SUMMARY.md
+++ b/docs/reports/VALIDATION_SUMMARY.md
@@ -1,5 +1,11 @@
 # Comprehensive Validation Summary
 
+> Claim boundary: this is a historical validation summary from an older branch.
+> Ready-for-integration, performance, AVX2, receipt, correctness, and
+> inference-working wording records that dated context only. Current support,
+> speed, backend execution, quality, and product-readiness claims must come
+> from active receipts, model coverage, status docs, specs, and claim gates.
+
 **Status:** ✅ **ALL VALIDATIONS PASSED**
 **Date:** 2025-10-24
 **Branch:** `feat/comprehensive-integration-qk256-envguard-receipts-strict-avx2`

--- a/docs/reports/WORKING_INFERENCE_SUMMARY.md
+++ b/docs/reports/WORKING_INFERENCE_SUMMARY.md
@@ -1,5 +1,11 @@
 # Working Inference - Implementation Summary
 
+> Claim boundary: this is a historical implementation summary from an older
+> branch. Inference-working, performance, AVX2, baseline, receipt, and
+> mock-elimination wording records that dated context only. Current support,
+> speed, backend execution, quality, and product-readiness claims must come
+> from active receipts, model coverage, status docs, specs, and claim gates.
+
 **Date:** 2025-10-24
 **Completion Status:** ✅ All tasks complete
 **Branch:** `feat/comprehensive-integration-qk256-envguard-receipts-strict-avx2`

--- a/docs/reports/sprint-2-kickoff-2025-11-11.md
+++ b/docs/reports/sprint-2-kickoff-2025-11-11.md
@@ -1,5 +1,11 @@
 # Sprint-2 Kickoff - BitNet-rs MVP v0.1.0
 
+> Claim boundary: this is a historical planning report. Ready-to-execute,
+> CUDA, AVX2, speedup, throughput, MVP, and performance-target wording records
+> that dated planning context only. Current support, speed, backend execution,
+> quality, and product-readiness claims must come from active receipts, model
+> coverage, status docs, specs, and claim gates.
+
 **Date**: November 11, 2025
 **Status**: Ready to Execute
 **Milestone**: MVP v0.1.0 (due 2025-12-31)

--- a/docs/reports/sprint-2-lockdown-complete-2025-11-11.md
+++ b/docs/reports/sprint-2-lockdown-complete-2025-11-11.md
@@ -1,5 +1,11 @@
 # Sprint-2 Lockdown Complete - BitNet-rs MVP v0.1.0
 
+> Claim boundary: this is a historical planning closeout. Ready-to-execute,
+> CUDA, AVX2, speedup, throughput, MVP, and performance-target wording records
+> that dated planning context only. Current support, speed, backend execution,
+> quality, and product-readiness claims must come from active receipts, model
+> coverage, status docs, specs, and claim gates.
+
 **Date**: November 11, 2025
 **Status**: ✅ All tasks complete, Sprint-2 ready to execute
 **Milestone**: MVP v0.1.0 (2025-12-31)


### PR DESCRIPTION
## Summary
- add claim-boundary notes to ten legacy validation, inference, FMA, debugging, and Sprint-2 report docs
- clarify that old ready-for-integration, inference-working, AVX2, CUDA, speedup, throughput, receipt, and performance wording is historical context only

## Scope
- docs/reports Markdown only
- no runtime, model, CI workflow, receipt schema, tracker, generated dashboard, or claim-gate behavior changes

## Claim boundary
- no current support, speed, backend execution, quality, release, GPU/CUDA, AVX, or product-readiness claim is promoted
- current claims remain owned by active receipts, model coverage, status docs, specs, and claim gates

## Validation
- tk git diff --check
- focused check: all changed report files include Claim boundary

## Generated files
- none

## Validation gap
- markdownlint-cli2 on the changed legacy report files still reports pre-existing formatting debt; this PR intentionally does not broaden into formatting cleanup.

## Follow-up / supersedes
- follows #6147 and #6149 claim-boundary cleanup waves and reduces the docs/reports audit gap identified by the review sidecar