### PR TITLE
ci: bound historical issue receipt claims

### DIFF
--- a/ci/receipts/issue-462/DIFF-REVIEW-COMPLETE.md
+++ b/ci/receipts/issue-462/DIFF-REVIEW-COMPLETE.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #462 Diff Review Complete - Pre-Publication Validation
 
 **Agent:** diff-reviewer

--- a/ci/receipts/issue-462/GENERATIVE-SUMMARY.md
+++ b/ci/receipts/issue-462/GENERATIVE-SUMMARY.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #462 Generative Analysis Summary
 
 **Date:** 2025-10-14

--- a/ci/receipts/issue-462/LEDGER.md
+++ b/ci/receipts/issue-462/LEDGER.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #462 Ledger - CPU Forward Pass with Real Inference
 
 **Flow:** Generative

--- a/ci/receipts/issue-462/PR-DESCRIPTION.md
+++ b/ci/receipts/issue-462/PR-DESCRIPTION.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 ## Summary
 
 Implements CPU forward pass with autoregressive generation, TL lookup table helper with overflow protection, and honest compute receipt validation enforcing CPU quantized kernel symmetry.

--- a/ci/receipts/issue-462/QUALITY-VALIDATION-COMPLETE.md
+++ b/ci/receipts/issue-462/QUALITY-VALIDATION-COMPLETE.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Quality Validation Complete - Issue #462
 
 **Date:** 2025-10-15

--- a/ci/receipts/issue-462/SPEC-FINALIZATION-SUMMARY.md
+++ b/ci/receipts/issue-462/SPEC-FINALIZATION-SUMMARY.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Spec Finalization Summary: Issue #462
 
 **Flow:** Generative (1.4/8 - spec-finalizer)

--- a/ci/receipts/issue-462/diff-reviewer-clippy-check-run.md
+++ b/ci/receipts/issue-462/diff-reviewer-clippy-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:clippy
 
 **Status:** ✅ PASS

--- a/ci/receipts/issue-462/diff-reviewer-format-check-run.md
+++ b/ci/receipts/issue-462/diff-reviewer-format-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:format
 
 **Status:** ✅ PASS

--- a/ci/receipts/issue-462/generative-gate-clippy-check-run.md
+++ b/ci/receipts/issue-462/generative-gate-clippy-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:clippy
 
 **Status:** ✅ pass

--- a/ci/receipts/issue-462/generative-gate-impl-check-run.md
+++ b/ci/receipts/issue-462/generative-gate-impl-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Implementation Gate Check Run
 **Gate:** `generative:gate:impl`
 **Status:** ✅ **PASS**

--- a/ci/receipts/issue-462/generative-gate-prep-check-run.md
+++ b/ci/receipts/issue-462/generative-gate-prep-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:prep
 
 **Status:** ✅ PASS

--- a/ci/receipts/issue-462/generative-gate-quality-finalizer-check-run.md
+++ b/ci/receipts/issue-462/generative-gate-quality-finalizer-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Quality Finalizer Check Run - Issue #462
 
 **Gate:** `generative:gate:quality-finalizer`

--- a/ci/receipts/issue-462/generative-gate-spec-check-run.md
+++ b/ci/receipts/issue-462/generative-gate-spec-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:spec
 
 **Issue:** #462 - Implement CPU Forward Pass with Real Inference (Cross MVP)

--- a/ci/receipts/issue-462/impl-to-refiner-handoff.md
+++ b/ci/receipts/issue-462/impl-to-refiner-handoff.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Implementation → Refiner Handoff
 **Issue:** #462 - CPU Forward Pass with Real Inference
 **From:** impl-finalizer

--- a/ci/receipts/issue-462/preparer-to-publisher-handoff.md
+++ b/ci/receipts/issue-462/preparer-to-publisher-handoff.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Branch Preparer → PR Publisher Handoff
 
 **Issue:** #462 - CPU Forward Pass with TL LUT Helper and Receipt Validation

--- a/ci/receipts/issue-462/refiner-progress-comment.md
+++ b/ci/receipts/issue-462/refiner-progress-comment.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # [GENERATIVE/code-refiner/clippy] Code quality improvements completed
 
 **Issue:** #462 - CPU Forward Pass with Real Inference

--- a/ci/receipts/issue-462/refiner-to-hardener-handoff.md
+++ b/ci/receipts/issue-462/refiner-to-hardener-handoff.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Handoff: code-refiner → test-hardener
 
 **Issue:** #462 - CPU Forward Pass with Real Inference

--- a/ci/receipts/issue-462/spec-finalizer-check-run.md
+++ b/ci/receipts/issue-462/spec-finalizer-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:spec (spec-finalizer)
 
 **Issue:** #462 - Implement CPU Forward Pass with Real Inference (Cross MVP)

--- a/ci/receipts/issue-465/DOCS-FINALIZATION-REPORT.md
+++ b/ci/receipts/issue-465/DOCS-FINALIZATION-REPORT.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Documentation Finalization Report - Issue #465
 
 **Flow**: Generative

--- a/ci/receipts/issue-465/DOCUMENTATION-VALIDATION-REPORT.md
+++ b/ci/receipts/issue-465/DOCUMENTATION-VALIDATION-REPORT.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Documentation Validation Report: Issue #465 CPU Path Followup
 
 **Date**: 2025-10-15

--- a/ci/receipts/issue-465/FINALIZATION-SUMMARY.md
+++ b/ci/receipts/issue-465/FINALIZATION-SUMMARY.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #465: CPU Path Followup - Finalization Summary
 
 **Date**: 2025-10-15

--- a/ci/receipts/issue-465/FUZZ-GATE-SUMMARY.md
+++ b/ci/receipts/issue-465/FUZZ-GATE-SUMMARY.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Fuzz Testing Gate Summary - Issue #465
 
 **Gate:** `generative:gate:fuzz`

--- a/ci/receipts/issue-465/LEDGER.md
+++ b/ci/receipts/issue-465/LEDGER.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #465 - CPU Path Followup: Ledger
 
 **Issue**: #465 CPU Path Followup

--- a/ci/receipts/issue-465/MUTATION-TESTING-REPORT.md
+++ b/ci/receipts/issue-465/MUTATION-TESTING-REPORT.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Mutation Testing Report: Issue #465 CPU Path Followup
 
 ## Executive Summary

--- a/ci/receipts/issue-465/PREP-FINALIZATION-REPORT.md
+++ b/ci/receipts/issue-465/PREP-FINALIZATION-REPORT.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #465 - CPU Path Followup: PR Preparation Finalization
 
 **Gate**: `generative:gate:prep`

--- a/ci/receipts/issue-465/SECURITY-VALIDATION-REPORT.md
+++ b/ci/receipts/issue-465/SECURITY-VALIDATION-REPORT.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Security Validation Report: Issue #465
 
 **Gate:** `security`

--- a/ci/receipts/issue-465/TEST-VALIDATION-REPORT.md
+++ b/ci/receipts/issue-465/TEST-VALIDATION-REPORT.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Issue #465 Test Infrastructure Validation Report
 
 **Date**: 2025-10-15T22:00:00Z

--- a/ci/receipts/issue-465/generative-gate-fuzz-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-fuzz-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Fuzz Testing Gate - Issue #465: CPU Path Followup
 
 **Flow:** Generative

--- a/ci/receipts/issue-465/generative-gate-mutation-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-mutation-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:mutation (Issue #465)
 
 **Gate:** `generative:gate:mutation`

--- a/ci/receipts/issue-465/generative-gate-prep-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-prep-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:prep
 
 **Status:** ✅ PASS

--- a/ci/receipts/issue-465/generative-gate-prep-final-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-prep-final-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # GitHub Check Run: generative:gate:prep (Final)
 
 **Check Name**: `generative:gate:prep`

--- a/ci/receipts/issue-465/generative-gate-publication-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-publication-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # GitHub Check Run: generative:gate:publication
 
 **Gate**: `generative:gate:publication`

--- a/ci/receipts/issue-465/generative-gate-security-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-security-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # GitHub Check Run: generative:gate:security
 
 **Status:** ✅ **SUCCESS**

--- a/ci/receipts/issue-465/generative-gate-spec-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-spec-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Check Run: generative:gate:spec
 
 **Gate**: `generative:gate:spec`

--- a/ci/receipts/issue-465/generative-gate-spec.md
+++ b/ci/receipts/issue-465/generative-gate-spec.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # Generative Gate: Spec Creation Receipt
 
 **Issue:** #465 - CPU Path Followup

--- a/ci/receipts/issue-465/generative-gate-tests-check-run.md
+++ b/ci/receipts/issue-465/generative-gate-tests-check-run.md
@@ -1,3 +1,10 @@
+> Historical CI receipt artifact only: this file is an archived issue receipt
+> from an older generated-validation or review-gate packet. Production-ready,
+> throughput, tok/s, GPU/CUDA/OpenCL/A770, AVX, receipt, quality,
+> and release-readiness wording here is historical context only and is not a
+> current support, speed, backend, quality, or release claim. Current claims
+> must come from active receipts, model coverage, status docs, specs, and claim gates.
+
 # GitHub Check Run: generative:gate:tests
 
 **Name**: `generative:gate:tests`


### PR DESCRIPTION
## Summary

- Add historical-only claim-boundary banners to archived issue receipt packets for issues 462 and 465.
- Keep old production-ready, throughput, GPU/CUDA/OpenCL/A770, AVX, receipt, quality, and release-readiness wording from reading as current BitNet-rs support evidence.

## Scope

- Documentation/receipt archive only: ci/receipts/issue-462/**/*.md and ci/receipts/issue-465/**/*.md.
- No runtime, model, kernel, workflow, generated dashboard, policy, or source-of-truth state changes.

## Claim boundary

This PR promotes no support, speed, backend, quality, release, A770, OpenCL, CUDA, AVX, server, or residency claim. The edited files are archived issue receipt artifacts; current claims must come from active receipts, model coverage, status docs, specs, and claim gates.

## Validation

- tk proxy git diff --check
- focused banner check over all 36 edited Markdown files
- focused archived-claim scan confirmed all risky issue receipt files in scope are covered by the banner

## Generated files

None.

## Validation gap

- tk npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc ci/receipts/issue-462/**/*.md ci/receipts/issue-465/**/*.md fails with 941 pre-existing archive formatting issues such as MD022, MD031, MD032, and MD040. The new banner is not the source of the reported lint contexts.

## Follow-up / supersedes

- Continues the legacy claim-boundary cleanup after #6147, #6149, and #6151.
- Does not change #5092 disposition; that PR remains draft-held pending perf and route proof.