### PR TITLE
archive: bound CI/docs report claims

### DIFF
--- a/archive/reports/CI_EXPLORATION_INDEX.md
+++ b/archive/reports/CI_EXPLORATION_INDEX.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # BitNet-rs CI Infrastructure Exploration - Complete Index
 
 **Date**: 2025-10-23

--- a/archive/reports/CI_EXPLORATION_SUMMARY.md
+++ b/archive/reports/CI_EXPLORATION_SUMMARY.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # BitNet-rs CI Infrastructure Exploration Summary
 
 **Date**: 2025-10-23

--- a/archive/reports/CI_GAPS_ANALYSIS.md
+++ b/archive/reports/CI_GAPS_ANALYSIS.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # BitNet-rs CI Configuration Gap Analysis Report
 
 **Analysis Date**: 2025-10-23  

--- a/archive/reports/CI_INTEGRATION_ACTION_PLAN.md
+++ b/archive/reports/CI_INTEGRATION_ACTION_PLAN.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Integration Action Plan
 
 **Date**: 2025-10-23

--- a/archive/reports/CI_INTEGRATION_CHECKLIST.md
+++ b/archive/reports/CI_INTEGRATION_CHECKLIST.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Integration Checklist
 
 **Date**: 2025-10-23  

--- a/archive/reports/CI_INTEGRATION_EXECUTION_SUMMARY.md
+++ b/archive/reports/CI_INTEGRATION_EXECUTION_SUMMARY.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Integration Execution Summary
 
 **Date**: 2025-10-23

--- a/archive/reports/CI_INTEGRATION_INDEX.md
+++ b/archive/reports/CI_INTEGRATION_INDEX.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Integration Documentation Index
 
 **Last Updated**: 2025-10-23

--- a/archive/reports/CI_INTEGRATION_QUICK_START.md
+++ b/archive/reports/CI_INTEGRATION_QUICK_START.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Integration Quick Start
 
 **Last Updated**: 2025-10-23

--- a/archive/reports/CI_INTEGRATION_READINESS_REPORT.md
+++ b/archive/reports/CI_INTEGRATION_READINESS_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Integration Readiness Report
 
 **Report Date**: 2025-10-23  

--- a/archive/reports/CI_INTEGRATION_SUMMARY.txt
+++ b/archive/reports/CI_INTEGRATION_SUMMARY.txt
@@ -1,3 +1,10 @@
+ARCHIVED CI/DOCS REPORT CLAIM BOUNDARY:
+This file is a historical CI/docs report from active development. Status,
+ready, validated, merge, production, backend, performance, and publication
+wording below is historical context only and is not a current project,
+support, CI, quality, release, backend, performance, or publication claim.
+Current claims must come from active docs, trackers, receipts, specs, and
+claim gates.
 ================================================================================
 CI INTEGRATION READINESS - QUICK SUMMARY
 ================================================================================

--- a/archive/reports/CI_JOBS_INTEGRATION_SUMMARY.md
+++ b/archive/reports/CI_JOBS_INTEGRATION_SUMMARY.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # CI Jobs Integration Summary
 
 **Date**: 2025-10-23

--- a/archive/reports/CI_JOB_DEPENDENCY_GRAPH.txt
+++ b/archive/reports/CI_JOB_DEPENDENCY_GRAPH.txt
@@ -1,3 +1,10 @@
+ARCHIVED CI/DOCS REPORT CLAIM BOUNDARY:
+This file is a historical CI/docs report from active development. Status,
+ready, validated, merge, production, backend, performance, and publication
+wording below is historical context only and is not a current project,
+support, CI, quality, release, backend, performance, or publication claim.
+Current claims must come from active docs, trackers, receipts, specs, and
+claim gates.
 ================================================================================
                   BITNET.RS CI JOB DEPENDENCY GRAPH
 ================================================================================

--- a/archive/reports/CI_LINK_CHECK_AND_DAG_ANALYSIS.md
+++ b/archive/reports/CI_LINK_CHECK_AND_DAG_ANALYSIS.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # BitNet-rs CI Infrastructure Analysis
 
 ## 1. Link-Check Configuration

--- a/archive/reports/DOCS_ARCHIVE_ACTION_PLAN.md
+++ b/archive/reports/DOCS_ARCHIVE_ACTION_PLAN.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Docs/Reports Archive Migration - Action Plan
 
 **Date**: 2025-10-23

--- a/archive/reports/DOCS_ARCHIVE_MIGRATION_INDEX.md
+++ b/archive/reports/DOCS_ARCHIVE_MIGRATION_INDEX.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Docs/Reports Archive Migration - Complete Index
 
 **Status**: Ready for Implementation  

--- a/archive/reports/DOCS_ARCHIVE_QUICK_REFERENCE.md
+++ b/archive/reports/DOCS_ARCHIVE_QUICK_REFERENCE.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Docs/Reports Archive Migration - Quick Reference
 
 **Status**: Ready to Execute  

--- a/archive/reports/DOCS_ARCHIVE_STATUS_REPORT.md
+++ b/archive/reports/DOCS_ARCHIVE_STATUS_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Docs/Reports Archive Migration Status Report
 
 **Date**: 2025-10-23  

--- a/archive/reports/DOCS_LINK_VALIDATION_REPORT.md
+++ b/archive/reports/DOCS_LINK_VALIDATION_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Documentation Link Validation Report
 
 > **Note**: References to `docs/archive/reports/` point to historical archived documentation.

--- a/archive/reports/DOCS_NAVIGATION_IMPLEMENTATION_COMPLETE.md
+++ b/archive/reports/DOCS_NAVIGATION_IMPLEMENTATION_COMPLETE.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Documentation Navigation Implementation - Complete Report
 
 **Date:** 2025-10-23

--- a/archive/reports/DOCS_REPORTS_AUDIT.md
+++ b/archive/reports/DOCS_REPORTS_AUDIT.md
@@ -1,3 +1,11 @@
+> **Archived CI/docs report claim boundary**
+>
+> This file is a historical CI/docs report from active development. Status,
+> ready, validated, merge, production, backend, performance, and publication
+> wording below is historical context only and is not a current project,
+> support, CI, quality, release, backend, performance, or publication claim.
+> Current claims must come from active docs, trackers, receipts, specs, and
+> claim gates.
 # Documentation Reports Directory Audit
 **Date**: 2025-10-23  
 **Scope**: `/home/steven/code/Rust/BitNet-rs/docs/reports/`


### PR DESCRIPTION
## Summary
- add archived-report claim-boundary banners to `archive/reports/CI_*` and `archive/reports/DOCS_*`
- cover old status/ready/validated/merge/production/backend/performance/publication wording as historical context only
- leave report bodies unchanged aside from the top-of-file boundary

## Scope
- archive/report documentation only
- no workflow routing change
- no runtime/model/backend change
- no current CI, release, quality, backend, or performance claim promotion

## Claim boundary
Historical archive reports only. Current claims must come from active docs, trackers, receipts, specs, and claim gates.

## Validation
- `git diff --check`
- focused banner check over all 20 edited files
- focused risky-claim scan confirming all 20 in-scope files are banner-bounded
- `npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc "archive/reports/{CI,DOCS}_*.md"` *(fails on 607 pre-existing archive formatting issues in the report bodies; banner-only diff left intact)*

## Generated files
None.

## Follow-up / supersedes
- Continues the archived claim-boundary cleanup after #6159.
- Does not sweep broader `archive/reports/**` surfaces.