### PR TITLE
archive: bound TDD sprint planning claims

### DIFF
--- a/archive/planning-docs/SPRINT_3_TDD_SCAFFOLD_COMPLETION.md
+++ b/archive/planning-docs/SPRINT_3_TDD_SCAFFOLD_COMPLETION.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # BitNet-rs TDD Scaffold Implementation Sprint #3 - Completion Report
 
 **Sprint Date**: 2025-10-20 (Sprint #3)

--- a/archive/planning-docs/SPRINT_4_TDD_SCAFFOLD_COMPLETION_REPORT.md
+++ b/archive/planning-docs/SPRINT_4_TDD_SCAFFOLD_COMPLETION_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # BitNet-rs TDD Scaffold Implementation Sprint #4 - Completion Report
 
 **Sprint Date**: 2025-10-20 (Sprint #4)

--- a/archive/planning-docs/SPRINT_COMPLETION_REPORT.md
+++ b/archive/planning-docs/SPRINT_COMPLETION_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # BitNet-rs TDD Scaffold Implementation Sprint - Completion Report
 
 **Sprint Date**: 2025-10-20

--- a/archive/planning-docs/SPRINT_FINAL_TDD_SCAFFOLD_COMPLETION.md
+++ b/archive/planning-docs/SPRINT_FINAL_TDD_SCAFFOLD_COMPLETION.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # BitNet-rs TDD Scaffold Implementation - Final Sprint Summary
 
 **Sprint Dates**: 2025-10-20 (Sprints #4 & #5)

--- a/archive/planning-docs/SPRINT_TDD_SCAFFOLD_COMPLETION_REPORT.md
+++ b/archive/planning-docs/SPRINT_TDD_SCAFFOLD_COMPLETION_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # BitNet-rs TDD Scaffold Implementation Sprint - Completion Report
 
 **Sprint Date**: 2025-10-20

--- a/archive/planning-docs/TDD_PERFORMANCE_PIPELINE_IMPLEMENTATION.md
+++ b/archive/planning-docs/TDD_PERFORMANCE_PIPELINE_IMPLEMENTATION.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Performance Pipeline Test Implementation
 
 **Issue**: #159 - GGUF Weight Loading Enhanced & Integration Tests

--- a/archive/planning-docs/TDD_SCAFFOLDS_COMPREHENSIVE_REPORT.md
+++ b/archive/planning-docs/TDD_SCAFFOLDS_COMPREHENSIVE_REPORT.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # BitNet-rs TDD Test Scaffolding: Comprehensive Implementation Report
 
 ## Executive Summary

--- a/archive/planning-docs/TDD_SCAFFOLDS_IMPLEMENTATION_COMPLETE.md
+++ b/archive/planning-docs/TDD_SCAFFOLDS_IMPLEMENTATION_COMPLETE.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffolds Implementation - Complete Summary
 
 ## Executive Summary

--- a/archive/planning-docs/TDD_SCAFFOLD_GGUF_PROPERTY_TESTS.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GGUF_PROPERTY_TESTS.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: GGUF Property Tests
 
 **Issue**: #159

--- a/archive/planning-docs/TDD_SCAFFOLD_GPU_QUANTIZATION.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GPU_QUANTIZATION.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: GPU Quantization Tests
 
 **File**: `crates/bitnet-kernels/tests/gpu_quantization.rs`

--- a/archive/planning-docs/TDD_SCAFFOLD_GUIDE_GGUF_ENHANCED_INTEGRATION.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GUIDE_GGUF_ENHANCED_INTEGRATION.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: GGUF Enhanced & Integration Tests
 
 **Issue**: #159  

--- a/archive/planning-docs/TDD_SCAFFOLD_GUIDE_GGUF_PROPERTY_TESTS.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GUIDE_GGUF_PROPERTY_TESTS.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: GGUF Property Tests
 
 **Issue**: #159  

--- a/archive/planning-docs/TDD_SCAFFOLD_GUIDE_GPU_TOKENIZER_OTHER.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GUIDE_GPU_TOKENIZER_OTHER.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: GPU, Tokenizer, and Other Tests
 
 **Files**: Multiple test suites across bitnet-kernels, bitnet-tokenizers, bitnet-cli, bitnet-common, bitnet-models

--- a/archive/planning-docs/TDD_SCAFFOLD_GUIDE_NEURAL_NETWORK_TESTS.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GUIDE_NEURAL_NETWORK_TESTS.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: Neural Network Tests
 
 **Issue**: #248 (COMPLETED - All ACs implemented)

--- a/archive/planning-docs/TDD_SCAFFOLD_GUIDE_QUANTIZATION_COMPREHENSIVE.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_GUIDE_QUANTIZATION_COMPREHENSIVE.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: Quantization Comprehensive Tests
 
 **File**: `crates/bitnet-quantization/tests/comprehensive_tests.rs`  

--- a/archive/planning-docs/TDD_SCAFFOLD_NEURAL_NETWORK.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_NEURAL_NETWORK.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: Neural Network Tests
 
 **Issue**: #248

--- a/archive/planning-docs/TDD_SCAFFOLD_QUANTIZATION_COMPREHENSIVE_TESTS.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_QUANTIZATION_COMPREHENSIVE_TESTS.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold: Quantization Comprehensive Tests Report
 
 **File**: `/home/steven/code/Rust/BitNet-rs/crates/bitnet-quantization/tests/comprehensive_tests.rs`

--- a/archive/planning-docs/TDD_SCAFFOLD_REAL_MODEL_LOADING.md
+++ b/archive/planning-docs/TDD_SCAFFOLD_REAL_MODEL_LOADING.md
@@ -1,3 +1,11 @@
+> **Archived planning-doc claim boundary**
+>
+> This file is a historical TDD/sprint planning or completion artifact from
+> active development. Complete, successful, ready, passing, implementation,
+> GPU, tokenizer, model-loading, performance, and production wording below is
+> historical context only and is not a current test, implementation, backend,
+> model, quality, performance, product, or release claim. Current claims must
+> come from active docs, trackers, receipts, specs, and claim gates.
 # TDD Scaffold Implementation Guide: Real Model Loading Tests
 
 **File**: `crates/bitnet-models/tests/real_model_loading.rs`


### PR DESCRIPTION
## Summary
- add archived planning-doc claim-boundary banners to `archive/planning-docs/TDD_*` and `archive/planning-docs/SPRINT_*`
- cover old complete/successful/ready/passing/implementation/GPU/tokenizer/model-loading/performance/production wording as historical context only
- leave planning and completion artifact bodies unchanged aside from the top-of-file boundary

## Scope
- archive/planning-docs documentation only
- no runtime/model/backend change
- no current test, implementation, quality, backend, performance, product, or release claim promotion

## Claim boundary
Historical TDD/sprint planning and completion artifacts only. Current claims must come from active docs, trackers, receipts, specs, and claim gates.

## Validation
- `git diff --check`
- focused banner check over all 18 edited files
- focused risky-claim scan confirming all 18 in-scope files are banner-bounded
- `npm exec --yes --package markdownlint-cli2@0.18.1 -- markdownlint-cli2 --config .markdownlint.jsonc "archive/planning-docs/{TDD,SPRINT}_*.md"` *(fails on 824 pre-existing archive formatting issues in the planning-doc bodies; banner-only diff left intact)*

## Generated files
None.

## Follow-up / supersedes
- Continues archived claim-boundary cleanup after #6160.
- Does not sweep broader archive or planning surfaces.