### PR TITLE
docs(repo): define release repository boundary

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Active development issue
+    url: https://github.com/EffortlessMetrics/bitnet-rs-swarm/issues/new/choose
+    about: Open feature, hardware, performance, diagnostic, refactor, and proof-tooling issues in bitnet-rs-swarm.
+  - name: Release repository scope
+    url: https://github.com/EffortlessMetrics/BitNet-rs/blob/main/docs/development/DEVELOPMENT_REPO.md
+    about: Read the BitNet-rs release/publish repository intake rules before opening release or hotfix work here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,27 @@
 
 <!-- Brief description of what this PR accomplishes -->
 
+## Release-repo intake boundary
+
+<!--
+Active feature, hardware, performance, diagnostic, and refactor development has
+moved to EffortlessMetrics/bitnet-rs-swarm.
+
+PRs in this repository are accepted only for:
+- release promotion from bitnet-rs-swarm;
+- versioning, changelog, packaging, signing, or publish changes;
+- emergency security or release-blocking hotfixes;
+- documentation corrections needed for released artifacts.
+-->
+
+- [ ] This PR is a release promotion from `bitnet-rs-swarm`
+- [ ] This PR is versioning / changelog / packaging / signing / publish work
+- [ ] This PR is an emergency security or release-blocking hotfix
+- [ ] This PR is a documentation correction for released artifacts
+
+If none of these boxes applies, open the work in
+[`bitnet-rs-swarm`](https://github.com/EffortlessMetrics/bitnet-rs-swarm)
+instead.
 
 ## Source-of-truth links
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,33 @@
 
 Welcome to BitNet-rs! We appreciate your interest in contributing to our high-performance 1-bit neural network quantization and inference library for Rust.
 
+## Development Intake Has Moved
+
+Active development now happens in
+[`EffortlessMetrics/bitnet-rs-swarm`](https://github.com/EffortlessMetrics/bitnet-rs-swarm).
+This repository is the release and publish repository for BitNet-rs.
+
+Open normal feature, hardware-lane, performance, diagnostic, refactor, and
+proof-tooling work in `bitnet-rs-swarm`.
+
+PRs accepted here are limited to:
+
+- release promotion PRs from `bitnet-rs-swarm`;
+- versioning, changelog, packaging, signing, and publish changes;
+- emergency security or release-blocking hotfixes;
+- documentation corrections needed for released artifacts.
+
+Do not open new feature or hardware-lane PRs in this repository. Useful open
+development PRs should keep their identity when feasible and move only after a
+content-aware handoff; age, branch distance, and old-stack status are not close
+reasons.
+
 ## Quick Start for Contributors
 
 1. **Fork and Clone**
    ```bash
-   git clone https://github.com/your-username/BitNet-rs.git
-   cd BitNet-rs
+   git clone https://github.com/your-username/bitnet-rs-swarm.git
+   cd bitnet-rs-swarm
    ```
 
 2. **Setup Development Environment**

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@
 > answer quality is still under validation, so generated BitNet text should be
 > treated as diagnostic output until a strict proof lane accepts it.
 
+## Development Intake Has Moved
+
+Active feature, hardware, performance, diagnostic, and refactor work now happens
+in
+[`EffortlessMetrics/bitnet-rs-swarm`](https://github.com/EffortlessMetrics/bitnet-rs-swarm).
+This repository is the release and publish repository for BitNet-rs. Open normal
+development PRs in `bitnet-rs-swarm`; PRs here are limited to release promotion,
+versioning, changelog, packaging, signing, publish, emergency security or
+release-blocking hotfixes, and documentation corrections needed for released
+artifacts.
+
 ## What This Repo Is For
 
 BitNet-rs is moving toward a Rust-native local model runner with strict proof

--- a/docs/development/DEVELOPMENT_REPO.md
+++ b/docs/development/DEVELOPMENT_REPO.md
@@ -1,0 +1,92 @@
+# BitNet-rs Development Repository Cutover
+
+Active development has moved to:
+
+```text
+https://github.com/EffortlessMetrics/bitnet-rs-swarm
+```
+
+This repository is now the release and publish repository for BitNet-rs. Treat
+it as the stable source for public release history, tags, crates.io publish
+flow, release notes, package metadata, signed artifacts when present, stable
+release branches, and emergency release-blocking fixes.
+
+## Accepted Work Here
+
+Open or merge PRs in this repository only for:
+
+- release promotion PRs from `bitnet-rs-swarm`;
+- versioning, changelog, packaging, signing, and publish changes;
+- emergency security or release-blocking hotfixes;
+- documentation corrections needed for released artifacts.
+
+Do not open normal feature, hardware-lane, performance, diagnostic, refactor,
+or proof-tooling PRs here. Put that work in `bitnet-rs-swarm`.
+
+## PR Disposition Rules
+
+Closing is not backlog reduction. Do not close a PR because it is old, behind
+main, noisy, from an old branch chain, diagnostic-only, or needs restacking.
+
+Valid close reasons are limited to:
+
+- the exact useful content already landed;
+- the exact useful content was clean-ported and the successor landed;
+- the PR is a true duplicate of a named kept PR;
+- the PR is historical-only diagnostic evidence captured in a committed ledger
+  or report;
+- the idea was explicitly rejected after content review.
+
+If future work remains, keep the PR open or create and link a tracking issue
+before closing. Preserve PR identity where feasible; valid PR review history and
+comments are useful state.
+
+## Proof-Gated Work
+
+Draft and proof-gated PRs remain draft or proof-gated until their stated proof
+lands. In particular:
+
+- Windows BitNet.cpp fetch/build/install hardening remains proof-gated until a
+  full Windows fetch/build/install completes, or the PR is explicitly narrowed
+  to script-hardening-only.
+- AVX2 QK256 performance work remains proof-gated until official-shape parity,
+  hot-path counters, behavior receipts, and repeatable benchmark evidence
+  exist.
+- A770 runtime or diagnostic work remains content-bearing until exact
+  successor, duplicate, port, or historical ledger capture is proven.
+
+Current migrated proof-gated work:
+
+- `EffortlessMetrics/BitNet-rs#5092` was closed only after successor issue
+  `EffortlessMetrics/bitnet-rs-swarm#96` was created to carry the AVX2 QK256
+  GEMV LUT decode candidate and its proof checklist.
+
+## Swarm Continuation Lanes
+
+Move these lanes to `bitnet-rs-swarm`:
+
+- A770 diagnostic continuation;
+- A770 QK256 OpenCL implementation;
+- CPU and 5700X correctness and AVX2 proof;
+- behavior-suite runner;
+- benchmark runner;
+- device-history ledger;
+- model support matrix;
+- Rust-native proof tooling;
+- broad model-family expansion.
+
+## Guardrails
+
+Do not use this repository to make the queue look smaller. Use it to publish
+release-ready work and preserve traceable state.
+
+Avoid:
+
+- bulk closing, reopening, rebasing, or labeling;
+- recreating valid PRs by default;
+- running CI for queue archaeology;
+- promoting partial hardware or quality evidence;
+- turning drafts into merge candidates to tidy the queue.
+
+The release repository should be boring by design. Active execution belongs in
+`bitnet-rs-swarm`.

--- a/docs/policy/release-repo-boundary.md
+++ b/docs/policy/release-repo-boundary.md
@@ -1,0 +1,78 @@
+# Release Repository Boundary
+
+Status: active
+Owner: release maintainers
+Created: 2026-05-20
+Linked proposal: n/a
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: `docs/release/SWARM_PROMOTION.md`
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: release and publish intake only
+Policy impact: defines accepted PR classes for this repository
+
+## Purpose
+
+`EffortlessMetrics/BitNet-rs` is the release and publish repository for
+BitNet-rs. Active feature, hardware, performance, diagnostic, campaign,
+refactor, and proof-tooling work belongs in
+`EffortlessMetrics/bitnet-rs-swarm`.
+
+This boundary keeps `BitNet-rs` from becoming a second active development queue.
+
+## Allowed PR Classes
+
+PRs may target this repository only when they are one of:
+
+- `release-promotion`: a promotion from `bitnet-rs-swarm` into the release repo;
+- `release-hotfix`: a release-blocking fix needed before publish;
+- `publish-metadata`: versioning, changelog, packaging, signing, or publish
+  metadata;
+- `security-hotfix`: emergency security work;
+- `docs-for-current-release`: documentation corrections needed for released
+  artifacts.
+
+## Redirected PR Classes
+
+Open these in `bitnet-rs-swarm`, not here:
+
+- hardware lane work;
+- feature development;
+- performance experiments;
+- diagnostic receipt expansion;
+- refactor-only development;
+- campaign work;
+- generated proof dashboard work;
+- broad model-family expansion;
+- A770, CUDA, Apple, Lunar Lake, CPU AVX2, or server proof lanes.
+
+## Closure Rules
+
+Closing a PR is not backlog reduction. Do not close a PR because it is old,
+behind main, from an old branch chain, noisy, diagnostic-only, or needs a
+restack.
+
+Close only after content review proves one of:
+
+- the exact useful content already landed;
+- the exact useful content was clean-ported and the successor landed;
+- the PR is a true duplicate of a named kept PR;
+- the PR is historical-only evidence captured in a committed ledger or report;
+- the idea was explicitly rejected after content review.
+
+If future work remains, keep the PR open or create and link a tracking issue
+before closing. Preserve PR identity where feasible.
+
+## Initial Enforcement
+
+The initial policy is documentation-first. A future advisory check may reject
+obvious release-repo boundary violations, such as:
+
+- changes under `crates/**` or `ci/hardware/**` without a release-promotion or
+  release-hotfix label;
+- campaign dashboard changes made directly in this repository;
+- release-promotion PRs without a source `bitnet-rs-swarm` commit or PR list.
+
+Do not make the first check too broad. It should protect the release boundary
+without hiding valid migrated work or proof-gated source PRs.

--- a/docs/release/SWARM_PROMOTION.md
+++ b/docs/release/SWARM_PROMOTION.md
@@ -1,0 +1,111 @@
+# Swarm Promotion Contract
+
+Status: active
+Owner: release maintainers
+Created: 2026-05-20
+Linked proposal: n/a
+Linked specs: n/a
+Linked ADRs: n/a
+Linked plan: n/a
+Linked issues: n/a
+Linked PRs: n/a
+Support-tier impact: release promotion only
+Policy impact: defines the legal path from `bitnet-rs-swarm` to `BitNet-rs`
+
+## Purpose
+
+Active development lands in:
+
+```text
+EffortlessMetrics/bitnet-rs-swarm
+```
+
+Releases are promoted into:
+
+```text
+EffortlessMetrics/BitNet-rs
+```
+
+This document defines the one normal path from swarm development to release
+publication.
+
+## Required Promotion Metadata
+
+Every release-promotion PR must include:
+
+```text
+source_repo = EffortlessMetrics/bitnet-rs-swarm
+source_commit = <swarm main sha>
+source_prs = [<included swarm PR numbers>]
+release_target = patch | minor | prerelease
+version = <x.y.z or prerelease version>
+changelog = <summary or changelog path>
+proof_pack = <receipt or manifest path>
+excluded_work = <known swarm work intentionally not promoted>
+```
+
+If the promotion includes hardware, model, quality, performance, or residency
+claims, the proof pack must name the exact receipts and claim ledgers that allow
+those claims. Missing receipts mean the claim remains out of scope.
+
+## Release PR Acceptance
+
+A release-promotion PR should run release-grade package checks, not every swarm
+hardware lane by default.
+
+Expected checks include:
+
+```text
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+cargo package --workspace --allow-dirty
+cargo publish --dry-run, when applicable
+```
+
+When a command is unavailable or intentionally scoped down, the PR must record:
+
+- the unavailable command;
+- why it could not run;
+- substitute evidence, if any;
+- whether the missing proof blocks release.
+
+## Hardware and Performance Claims
+
+The release repo does not invent or broaden hardware claims. It consumes swarm
+proof manifests.
+
+For any promoted hardware/backend/profile claim, the release PR must preserve:
+
+- source swarm receipt paths;
+- selected backend;
+- selected device;
+- fallback status;
+- model and tokenizer identity;
+- quality gate;
+- benchmark profile;
+- explicit not-claims.
+
+Do not promote A770, CUDA, Apple, Lunar Lake, CPU AVX2, server, residency,
+speed, or broad model-family claims unless the swarm proof manifest explicitly
+allows them.
+
+## Excluded Work
+
+Promotion PRs must say what is not included. Examples:
+
+- draft or proof-gated PRs;
+- diagnostic-only receipts;
+- old PRs without content disposition;
+- hardware lanes that have not passed quality gates;
+- performance candidates without behavior-backed benchmarks.
+
+Excluded work should stay in `bitnet-rs-swarm` or remain linked to its original
+PR/issue. Do not close it in `BitNet-rs` merely because a release was promoted.
+
+## Publish Authority
+
+Tags, crates.io publication, release notes, signed artifacts when present, and
+stable release branches belong to `BitNet-rs`.
+
+Normal development belongs to `bitnet-rs-swarm`.


### PR DESCRIPTION
## Summary

Defines `BitNet-rs` as the release/publish repository and redirects normal feature, hardware, performance, diagnostic, campaign, and refactor development to `bitnet-rs-swarm`.

## Scope

- updates README and CONTRIBUTING with the cutover boundary
- updates the PR template so release-repo PRs must identify an allowed release/hotfix/publish/docs path
- disables blank issues and points active-development issues to `bitnet-rs-swarm`
- adds release-repo boundary policy and swarm promotion contract docs
- adds a development cutover note under `docs/development`
- records that BitNet-rs #5092 was closed only after swarm successor issue #96 was created

## Claim boundary

No runtime, model, hardware, A770, AVX2, quality, speed, residency, release, crates.io, or publish claim is added. This is repository-role documentation and intake guidance only.

## Validation

- `git diff --check`
- `markdownlint README.md .github\PULL_REQUEST_TEMPLATE.md docs\development\DEVELOPMENT_REPO.md docs\policy\release-repo-boundary.md docs\release\SWARM_PROMOTION.md`
- basic issue-template config scan for tabs

`CONTRIBUTING.md` has existing markdownlint findings outside this scoped insertion, so validation was limited to changed/new release-boundary surfaces plus whitespace checks.