### PR TITLE
M4-TREND-001: Publish seven-day trend history

### DIFF
--- a/ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.json
+++ b/ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.json
@@ -1,0 +1,345 @@
+{
+  "schema_version": "1.0.0",
+  "artifact_kind": "apple_m4_seven_day_trend_history",
+  "generated_at": "2026-05-22T05:30:00Z",
+  "campaign": "apple-m4-inference-excellence",
+  "work_item": "M4-TREND-001",
+  "machine": {
+    "id": "apple-m4-mac-mini",
+    "scope": "committed M4 Mac mini receipts only"
+  },
+  "lookback_window": {
+    "label": "7d",
+    "start": "2026-05-15T00:00:00Z",
+    "end": "2026-05-22T00:00:00Z",
+    "calendar_days": [
+      "2026-05-15",
+      "2026-05-16",
+      "2026-05-17",
+      "2026-05-18",
+      "2026-05-19",
+      "2026-05-20",
+      "2026-05-21"
+    ]
+  },
+  "source_artifacts": [
+    {
+      "kind": "report_refresh_manifest",
+      "path": "ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/report-refresh/report-refresh-manifest.json",
+      "sha256": "f573eaa03bc02239bc36c0f8a4d5fd5b1b577d9c04d311de935519d20e520ee9"
+    },
+    {
+      "kind": "regression_dashboard",
+      "path": "ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/regression-dashboard/regression-dashboard.json",
+      "sha256": "84b6b14070527a04911225aeb69896eb86b57a6398f3f38b6cacff8532015119"
+    },
+    {
+      "kind": "bitnet_repaired_eval_context_delta",
+      "path": "ci/hardware/apple-m4-mac-mini/2026-05-18T1806Z/bitnet-eval-250-repaired/regression-vs-2026-05-17T1903Z.json",
+      "sha256": "d4dd4c4ddcddf64c00d55b86f05ae8e38f058e0bf841a5deb1a99907b119f52a"
+    }
+  ],
+  "summary": {
+    "status": "ok",
+    "family_count": 5,
+    "matching_dashboard_groups": 9,
+    "ready_groups": 9,
+    "insufficient_history_groups": 0,
+    "advisory_warning_groups": 1,
+    "release_blocking_groups": 0,
+    "operator_envelope_impact": "No route class or public claim boundary changes. The current operator envelope remains tied to the retained matching dashboard groups; BitNet warm-session resident memory is an advisory follow-up, not a chat or serve enablement signal."
+  },
+  "families": [
+    {
+      "id": "dense_slm_eval_v2",
+      "evidence_family": "dense_slm",
+      "dashboard_status": "ready",
+      "report_count": 12,
+      "comparable_group_count": 3,
+      "groups": [
+        {
+          "model_id": "qwen2.5-0.5b-instruct-q4_k_m",
+          "report_count": 4,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/slm-eval-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-16T1711Z/slm-eval-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "quality": {
+              "cases_passed_delta": 0,
+              "cases_total": 500
+            },
+            "speed": {
+              "ttft_ms_p50_delta": -1.0,
+              "output_tok_s_p50_delta": 0.006
+            },
+            "memory": {
+              "peak_memory_mb_p50_delta": 0.0
+            }
+          },
+          "operator_envelope_impact": "No operator class change; retained as current dense SLM eval trend evidence for this exact identity."
+        },
+        {
+          "model_id": "qwen2.5-0.5b-instruct-q8_0",
+          "report_count": 4,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/slm-eval-v2/qwen2.5-0.5b-instruct-q8_0/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-16T1711Z/slm-eval-v2/qwen2.5-0.5b-instruct-q8_0/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "quality": {
+              "cases_passed_delta": 0,
+              "cases_total": 500
+            },
+            "speed": {
+              "ttft_ms_p50_delta": -2011.0,
+              "output_tok_s_p50_delta": 1.111
+            },
+            "memory": {
+              "peak_memory_mb_p50_delta": 0.0
+            }
+          },
+          "operator_envelope_impact": "No operator class change; retained as current dense SLM eval trend evidence for this exact identity."
+        },
+        {
+          "model_id": "qwen2.5-1.5b-instruct-q4_k_m",
+          "report_count": 4,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/slm-eval-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-16T1711Z/slm-eval-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "quality": {
+              "cases_passed_delta": 0,
+              "cases_total": 500
+            },
+            "speed": {
+              "ttft_ms_p50_delta": 85.0,
+              "output_tok_s_p50_delta": 0.003
+            },
+            "memory": {
+              "peak_memory_mb_p50_delta": 0.0
+            }
+          },
+          "operator_envelope_impact": "No operator class change; retained as current dense SLM eval trend evidence for this exact identity."
+        }
+      ]
+    },
+    {
+      "id": "dense_slm_benchmark_v2",
+      "evidence_family": "dense_slm",
+      "dashboard_status": "ready",
+      "report_count": 6,
+      "comparable_group_count": 3,
+      "groups": [
+        {
+          "model_id": "qwen2.5-0.5b-instruct-q4_k_m",
+          "report_count": 2,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-15T1845Z/slm-benchmark-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-15/slm-benchmark-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "speed": {
+              "ttft_ms_p50_delta": -1627.0,
+              "output_tok_s_p50_delta": 1.137
+            }
+          },
+          "operator_envelope_impact": "No operator class change; retained as current dense SLM benchmark trend evidence for this exact identity."
+        },
+        {
+          "model_id": "qwen2.5-0.5b-instruct-q8_0",
+          "report_count": 2,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-15T1845Z/slm-benchmark-v2/qwen2.5-0.5b-instruct-q8_0/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-15/slm-benchmark-v2/qwen2.5-0.5b-instruct-q8_0/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "speed": {
+              "ttft_ms_p50_delta": -1620.0,
+              "output_tok_s_p50_delta": 0.699
+            }
+          },
+          "operator_envelope_impact": "No operator class change; retained as current dense SLM benchmark trend evidence for this exact identity."
+        },
+        {
+          "model_id": "qwen2.5-1.5b-instruct-q4_k_m",
+          "report_count": 2,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-15T1845Z/slm-benchmark-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-15/slm-benchmark-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "speed": {
+              "ttft_ms_p50_delta": -6019.0,
+              "output_tok_s_p50_delta": 0.097
+            }
+          },
+          "operator_envelope_impact": "No operator class change; retained as current dense SLM benchmark trend evidence for this exact identity."
+        }
+      ]
+    },
+    {
+      "id": "bitnet_eval",
+      "evidence_family": "bitnet",
+      "dashboard_status": "ready",
+      "report_count": 2,
+      "comparable_group_count": 1,
+      "groups": [
+        {
+          "model_id": "microsoft-bitnet-b1.58-2B-4T-i2s",
+          "report_count": 2,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-15T2214Z/bitnet-eval/answer-corpus.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-15/bitnet-eval/answer-corpus.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "quality": {
+              "cases_passed_delta": 0,
+              "cases_total": 100
+            }
+          },
+          "operator_envelope_impact": "No BitNet route class change. This is BitNet eval evidence only and does not enable BitNet chat or serve."
+        }
+      ]
+    },
+    {
+      "id": "bitnet_benchmark",
+      "evidence_family": "bitnet",
+      "dashboard_status": "ready",
+      "report_count": 2,
+      "comparable_group_count": 1,
+      "groups": [
+        {
+          "model_id": "microsoft-bitnet-b1.58-2B-4T-i2s",
+          "report_count": 2,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-15T2214Z/bitnet-benchmark/summary.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-15/bitnet-benchmark/summary.json",
+          "threshold_outcome": {
+            "status": "within_threshold",
+            "warning_count": 0,
+            "speed": {
+              "ttft_ms_p50_delta": -2867.0,
+              "output_tok_s_p50_delta": 0.08
+            }
+          },
+          "operator_envelope_impact": "No BitNet route class change. This is BitNet benchmark evidence only and does not enable BitNet chat or serve."
+        }
+      ]
+    },
+    {
+      "id": "bitnet_variable_warm",
+      "evidence_family": "bitnet",
+      "dashboard_status": "ready_with_advisory",
+      "report_count": 2,
+      "comparable_group_count": 1,
+      "groups": [
+        {
+          "model_id": "microsoft-bitnet-b1.58-2B-4T-i2s",
+          "report_count": 2,
+          "dashboard_status": "ready",
+          "latest_report": "ci/hardware/apple-m4-mac-mini/2026-05-16T0626Z/bitnet-productization/variable-warm-session.json",
+          "baseline_report": "ci/hardware/apple-m4-mac-mini/2026-05-15/bitnet-productization/variable-warm-session.json",
+          "threshold_outcome": {
+            "status": "advisory_warning",
+            "warning_count": 1,
+            "quality": {
+              "quality_passed_latest": true,
+              "cases_total": 5
+            },
+            "speed": {
+              "ttft_ms_p50_delta": -29404.0,
+              "decode_tok_s_p50_delta": 1.651,
+              "total_wall_ms_p50_delta": -162610.084
+            },
+            "memory": {
+              "resident_memory_bytes_delta": 548552704,
+              "resident_memory_delta_percent": 25.63,
+              "threshold_percent": 10.0,
+              "direction": "higher_is_worse"
+            }
+          },
+          "operator_envelope_impact": "Keep BitNet warm-session evidence in advisory review for resident memory drift. This does not enable BitNet chat or serve."
+        }
+      ]
+    }
+  ],
+  "skipped_day_reasons": [
+    {
+      "date": "2026-05-15",
+      "status": "covered",
+      "reason": "Dense benchmark, BitNet eval, BitNet benchmark, and BitNet variable-warm baseline/latest receipts were retained in matching dashboard groups."
+    },
+    {
+      "date": "2026-05-16",
+      "status": "covered",
+      "reason": "Dense SLM eval-v2 and BitNet variable-warm receipts added matching-history refreshes."
+    },
+    {
+      "date": "2026-05-17",
+      "status": "covered",
+      "reason": "Dense SLM eval-v2 latest refresh and report-refresh/regression-dashboard summaries were committed; later BitNet 250-case eval evidence started a separate context."
+    },
+    {
+      "date": "2026-05-18",
+      "status": "skipped_for_matching_dashboard_trend",
+      "reason": "BitNet 250-case repaired eval was committed as a new context-only baseline with scoring-summary mismatch against the prior 250-case run; it is not a matching dashboard trend pair yet."
+    },
+    {
+      "date": "2026-05-19",
+      "status": "skipped_for_matching_dashboard_trend",
+      "reason": "Setup and benchmark-variance receipts were committed for separate operator surfaces, not as replacements for the five matching dashboard families summarized here."
+    },
+    {
+      "date": "2026-05-20",
+      "status": "skipped_for_matching_dashboard_trend",
+      "reason": "Context and reliability-drill receipts were committed for separate route and failure-mode evidence, not as matching trend refreshes for these dashboard groups."
+    },
+    {
+      "date": "2026-05-21",
+      "status": "skipped_for_matching_dashboard_trend",
+      "reason": "Serve failure-semantics evidence was committed for local-server behavior; it does not replace dense SLM or BitNet eval/benchmark/warm trend evidence."
+    }
+  ],
+  "non_trend_context": [
+    {
+      "path": "ci/hardware/apple-m4-mac-mini/2026-05-18T1806Z/bitnet-eval-250-repaired/regression-vs-2026-05-17T1903Z.json",
+      "reason": "The repaired 250-case BitNet eval changes scoring_summary.kinds, so the committed regression classifies it as context-only until a second repaired receipt exists."
+    }
+  ],
+  "claim_boundary": {
+    "dashboard_and_receipt_summary_only": true,
+    "source_receipts_remain_authoritative": true,
+    "no_live_model_run": true,
+    "no_model_download": true,
+    "does_not_replace_per_run_receipts": true,
+    "dense_slm_and_bitnet_evidence_separated": true,
+    "bitnet_chat_enabled": false,
+    "bitnet_serve_enabled": false,
+    "full_metal_inference_claimed": false,
+    "qk256_apple_claimed": false,
+    "neural_engine_execution_claimed": false,
+    "mpsgraph_inference_claimed": false,
+    "macbook_evidence": false,
+    "broad_apple_silicon_claim": false,
+    "broad_model_quality_claim": false,
+    "broad_performance_claim": false,
+    "speedup_claim": false,
+    "future_performance_proven": false
+  },
+  "verification_limits": {
+    "derived_from_committed_receipts": true,
+    "regression_dashboard_status_used": "ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/regression-dashboard/regression-dashboard.json",
+    "local_live_refresh_run": false,
+    "local_cargo_or_xtask_run": false,
+    "reason_local_cargo_or_xtask_not_run": "The local checkout has about 1.0 GiB free disk; this source artifact is intentionally committed-data only."
+  }
+}

--- a/ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.md
+++ b/ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.md
@@ -1,0 +1,61 @@
+# Apple M4 Seven-Day Trend History
+
+Generated: `2026-05-22T05:30:00Z`
+
+Work item: `M4-TREND-001`
+
+Source artifacts:
+
+| Kind | Path | SHA256 |
+|---|---|---|
+| report refresh manifest | `ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/report-refresh/report-refresh-manifest.json` | `f573eaa03bc02239bc36c0f8a4d5fd5b1b577d9c04d311de935519d20e520ee9` |
+| regression dashboard | `ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/regression-dashboard/regression-dashboard.json` | `84b6b14070527a04911225aeb69896eb86b57a6398f3f38b6cacff8532015119` |
+| BitNet repaired eval context delta | `ci/hardware/apple-m4-mac-mini/2026-05-18T1806Z/bitnet-eval-250-repaired/regression-vs-2026-05-17T1903Z.json` | `d4dd4c4ddcddf64c00d55b86f05ae8e38f058e0bf841a5deb1a99907b119f52a` |
+
+## Summary
+
+The committed seven-day window keeps five M4 dashboard families in matching-history
+state: dense SLM eval-v2, dense SLM benchmark-v2, BitNet eval, BitNet benchmark,
+and BitNet variable warm. The dashboard has nine matching groups and all nine are
+`ready` for latest-vs-baseline comparison.
+
+One advisory threshold needs operator attention: BitNet variable warm resident
+memory increased from `2140225536` bytes to `2688778240` bytes, a `25.63%`
+increase against the existing `10%` higher-is-worse resident-memory threshold.
+Quality remained passing and timing improved, so this is an advisory memory
+follow-up only. It does not enable BitNet chat or serve.
+
+## Dashboard Groups
+
+| Family | Model | Reports | Latest | Baseline | Threshold outcome | Operator impact |
+|---|---|---:|---|---|---|---|
+| `dense_slm_eval_v2` | `qwen2.5-0.5b-instruct-q4_k_m` | 4 | `2026-05-17T0045Z/slm-eval-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json` | `2026-05-16T1711Z/slm-eval-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json` | within threshold | no class change |
+| `dense_slm_eval_v2` | `qwen2.5-0.5b-instruct-q8_0` | 4 | `2026-05-17T0045Z/slm-eval-v2/qwen2.5-0.5b-instruct-q8_0/summary.json` | `2026-05-16T1711Z/slm-eval-v2/qwen2.5-0.5b-instruct-q8_0/summary.json` | within threshold | no class change |
+| `dense_slm_eval_v2` | `qwen2.5-1.5b-instruct-q4_k_m` | 4 | `2026-05-17T0045Z/slm-eval-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json` | `2026-05-16T1711Z/slm-eval-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json` | within threshold | no class change |
+| `dense_slm_benchmark_v2` | `qwen2.5-0.5b-instruct-q4_k_m` | 2 | `2026-05-15T1845Z/slm-benchmark-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json` | `2026-05-15/slm-benchmark-v2/qwen2.5-0.5b-instruct-q4_k_m/summary.json` | within threshold | no class change |
+| `dense_slm_benchmark_v2` | `qwen2.5-0.5b-instruct-q8_0` | 2 | `2026-05-15T1845Z/slm-benchmark-v2/qwen2.5-0.5b-instruct-q8_0/summary.json` | `2026-05-15/slm-benchmark-v2/qwen2.5-0.5b-instruct-q8_0/summary.json` | within threshold | no class change |
+| `dense_slm_benchmark_v2` | `qwen2.5-1.5b-instruct-q4_k_m` | 2 | `2026-05-15T1845Z/slm-benchmark-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json` | `2026-05-15/slm-benchmark-v2/qwen2.5-1.5b-instruct-q4_k_m/summary.json` | within threshold | no class change |
+| `bitnet_eval` | `microsoft-bitnet-b1.58-2B-4T-i2s` | 2 | `2026-05-15T2214Z/bitnet-eval/answer-corpus.json` | `2026-05-15/bitnet-eval/answer-corpus.json` | within threshold | BitNet eval only |
+| `bitnet_benchmark` | `microsoft-bitnet-b1.58-2B-4T-i2s` | 2 | `2026-05-15T2214Z/bitnet-benchmark/summary.json` | `2026-05-15/bitnet-benchmark/summary.json` | within threshold | BitNet benchmark only |
+| `bitnet_variable_warm` | `microsoft-bitnet-b1.58-2B-4T-i2s` | 2 | `2026-05-16T0626Z/bitnet-productization/variable-warm-session.json` | `2026-05-15/bitnet-productization/variable-warm-session.json` | advisory memory warning | no chat or serve enablement |
+
+## Skipped Days
+
+| Date | Status | Reason |
+|---|---|---|
+| 2026-05-15 | covered | Dense benchmark, BitNet eval, BitNet benchmark, and BitNet variable-warm baseline/latest receipts were retained in matching dashboard groups. |
+| 2026-05-16 | covered | Dense SLM eval-v2 and BitNet variable-warm receipts added matching-history refreshes. |
+| 2026-05-17 | covered | Dense SLM eval-v2 latest refresh and report-refresh/regression-dashboard summaries were committed. Later BitNet 250-case eval evidence started a separate context. |
+| 2026-05-18 | skipped for matching dashboard trend | BitNet 250-case repaired eval was committed as a new context-only baseline with scoring-summary mismatch against the prior 250-case run. |
+| 2026-05-19 | skipped for matching dashboard trend | Setup and benchmark-variance receipts were committed for separate operator surfaces, not as replacements for the five matching dashboard families. |
+| 2026-05-20 | skipped for matching dashboard trend | Context and reliability-drill receipts were committed for separate route and failure-mode evidence. |
+| 2026-05-21 | skipped for matching dashboard trend | Serve failure-semantics evidence was committed for local-server behavior and does not replace dense SLM or BitNet eval/benchmark/warm trend evidence. |
+
+## Claim Boundary
+
+This artifact is a dashboard and receipt summary only. The per-run receipts
+remain authoritative. It does not run live inference, download models, replace
+per-run receipts, enable BitNet chat, enable BitNet serve, prove full Metal,
+claim QK256, claim Neural Engine or MPSGraph inference, claim MacBook behavior,
+make broad Apple Silicon quality or performance claims, claim speedup, or prove
+future performance.

--- a/docs/slm/apple-m4-inference-excellence.md
+++ b/docs/slm/apple-m4-inference-excellence.md
@@ -1261,6 +1261,37 @@ not run a model, prove new dense SLM or BitNet quality, enable BitNet chat or
 serve, or widen Metal, QK256, Neural Engine, MPSGraph, MacBook, speedup, broad
 quality, or broad performance claims.
 
+`M4-TREND-001` publishes the first seven-day matching-history summary derived
+from retained receipts:
+
+```text
+ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.json
+ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.md
+```
+
+The summary covers the five current dashboard families from
+`2026-05-15T00:00:00Z` through `2026-05-22T00:00:00Z`: dense SLM eval-v2,
+dense SLM benchmark-v2, BitNet eval, BitNet benchmark, and BitNet variable warm.
+It records nine matching dashboard groups, all with `ready` history. Dense SLM
+eval and benchmark groups remain within the published threshold envelope for
+their retained latest-vs-baseline pairs. BitNet eval and benchmark also remain
+within threshold for their retained pairs.
+
+The only advisory trend issue is BitNet variable-warm resident memory: the
+retained latest run increased resident memory from `2140225536` bytes to
+`2688778240` bytes, a `25.63%` increase against the existing `10%`
+higher-is-worse advisory threshold. Timing improved and quality remained
+passing, so this is an operator follow-up, not a BitNet chat or serve enablement
+signal.
+
+Skipped-day reasons are explicit in the trend artifact. Later receipts in the
+window, including BitNet repaired 250-case eval, setup, variance, context,
+reliability, and serve failure-semantics evidence, remain separate route or
+context baselines unless a second matching receipt makes them trend-comparable.
+The trend summary does not replace per-run receipts, run live inference, prove
+future performance, or widen Metal, QK256, Neural Engine, MPSGraph, MacBook,
+speedup, broad quality, or broad performance claims.
+
 `M4-CONTEXT-001` implements long-context guardrails for the M4 operator routes.
 Dense SLM `mac ask`, dense `mac chat`, dense `mac chat-smoke`, and dense
 `mac serve` classify requests against the recorded short, `context_1k`, and

--- a/docs/slm/apple-m4-operator-envelope-v3.md
+++ b/docs/slm/apple-m4-operator-envelope-v3.md
@@ -270,6 +270,22 @@ whenever stale aging changes a route class, default model, supported-model
 state, BitNet artifact/tokenizer identity, route enablement, threshold result,
 context boundary, disk/cache floor, dashboard status, or claim-boundary wording.
 
+`M4-TREND-001` records the first committed seven-day trend summary under:
+
+```text
+ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.json
+ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.md
+```
+
+The summary keeps nine dashboard groups in `ready` matching-history state for
+dense SLM eval-v2, dense SLM benchmark-v2, BitNet eval, BitNet benchmark, and
+BitNet variable warm. It also records skipped-day reasons for days that produced
+setup, variance, context, reliability, serve, or repaired-eval evidence without
+a second matching receipt for the dashboard family. The only current advisory
+impact is BitNet variable-warm resident memory growth of `25.63%` against the
+`10%` higher-is-worse advisory threshold. No route class changes and no BitNet
+chat or serve enablement follow from this trend summary.
+
 ## Regression Thresholds
 
 The dashboard may compare reports only when the identity context matches:

--- a/docs/tracking/campaigns/apple-m4-inference-excellence/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-inference-excellence/CAMPAIGN.md
@@ -147,8 +147,8 @@ make the M4 Mac mini easier to operate and harder to overclaim.
 | M4-BENCH-007 | proposed | Calibrate the benchmark harness before timing envelopes are interpreted. |
 | M4-ROUTE-MATRIX-001 | merged | Publish the route-state matrix for dense SLM and BitNet command surfaces. |
 | M4-WORKLOAD-001 | merged | Add end-to-end operator workload receipts across enabled M4 routes. |
-| M4-EVIDENCE-REPLAY-001 | in_progress | Add replayable evidence bundles for dense SLM and BitNet refreshes. |
-| M4-TREND-001 | proposed | Publish seven-day matching-identity trend history and skipped-day reasons. |
+| M4-EVIDENCE-REPLAY-001 | merged | Add replayable evidence bundles for dense SLM and BitNet refreshes. |
+| M4-TREND-001 | in_progress | Publish seven-day matching-identity trend history and skipped-day reasons. |
 | M4-MODEL-LIFECYCLE-001 | proposed | Define supported-model lifecycle states and claim-boundary requirements. |
 | M4-COMPAT-001 | proposed | Define compatibility refresh receipts after OS, toolchain, binary, or manifest changes. |
 | M4-RELEASE-001 | proposed | Publish the M4 inference release go/no-go matrix. |

--- a/docs/tracking/campaigns/apple-m4-inference-excellence/events/2026-05-22T053000Z-M4-TREND-001-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4-inference-excellence/events/2026-05-22T053000Z-M4-TREND-001-pr-open.toml
@@ -1,0 +1,16 @@
+timestamp = "2026-05-22T05:30:00Z"
+campaign = "apple-m4-inference-excellence"
+item = "M4-TREND-001"
+event = "pr_open"
+actor = "codex"
+previous_status = "in_progress"
+new_status = "pr_open"
+branch = "codex/apple-m4-inference-excellence/M4-TREND-001-seven-day-history"
+pr = 6184
+head_sha = "04e2b25ef371f3ce4eaf9b2200f33291f04db27a"
+
+notes = [
+  "Opened PR #6184 to publish a committed seven-day trend history from retained M4 Mac mini receipts.",
+  "The trend artifact covers dense SLM eval-v2, dense SLM benchmark-v2, BitNet eval, BitNet benchmark, and BitNet variable-warm dashboard families with matching identity, skipped-day reasons, dashboard status, threshold outcomes, and operator-envelope impact.",
+  "The source slice is dashboard and receipt summary only; it does not run live inference, download models, replace per-run receipts, enable BitNet chat or serve, prove future performance, or widen Metal, QK256, Neural Engine, MPSGraph, MacBook, broad quality, broad performance, or speedup claims.",
+]


### PR DESCRIPTION
## Summary
- publish a committed seven-day M4 trend history artifact for the current dense SLM and BitNet dashboard families
- record matching identity, skipped-day reasons, dashboard status, threshold outcomes, and operator-envelope impact
- document the trend artifact in the M4 inference excellence and operator envelope docs
- update the human campaign table for the merged evidence replay item and active trend item

## Claim boundary
This is a dashboard and retained-receipt summary only. It does not run live inference, download models, replace per-run receipts, enable BitNet chat or serve, prove future performance, or widen Metal, QK256, Neural Engine, MPSGraph, MacBook, broad quality, broad performance, or speedup claims.

## Validation
- jq empty ci/hardware/apple-m4-mac-mini/2026-05-22T0530Z/trend/seven-day-history.json
- computed threshold check against ci/hardware/apple-m4-mac-mini/2026-05-17T0045Z/regression-dashboard/regression-dashboard.json
- git diff --check
- local cargo/xtask checks not run because this checkout has about 1.0 GiB free disk