### PR TITLE
fix(lunar-lake): mark visible thermal zone without readings

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-power-thermal-context.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-power-thermal-context.json
@@ -2,11 +2,11 @@
   "schema_version": "1.0.0",
   "artifact_kind": "lunar_lake_power_thermal_context",
   "proof_stage": "live_telemetry_context_captured_no_promotion_change",
-  "created_utc": "2026-05-19T09:30:00Z",
+  "created_utc": "2026-05-26T08:00:00Z",
   "machine_id": "intel-258v",
   "telemetry_scope": "current_machine_runtime_telemetry",
-  "memory_context": "source=sysinfo;total_bytes=33873780736;available_bytes=11462389760;used_bytes=22411390976",
-  "power_context": "source=os_power_probe;active_scheme=Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced);battery_status=BatteryStatus=2;EstimatedChargeRemaining=100;ac_power_inferred=true",
+  "memory_context": "source=sysinfo;total_bytes=33873780736;available_bytes=12632371200;used_bytes=21241409536",
+  "power_context": "source=os_power_probe;active_scheme=Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced);battery_status=BatteryStatus=2;EstimatedChargeRemaining=98;ac_power_inferred=true",
   "thermal_context": "source=windows_perf_thermal_zone;thermal_zones_visible=1;temperatures_celsius=unavailable",
   "availability": {
     "memory_context_recorded": true,
@@ -16,19 +16,26 @@
   "memory": {
     "source": "sysinfo",
     "total_bytes": 33873780736,
-    "available_bytes": 11462389760,
-    "used_bytes": 22411390976
+    "available_bytes": 12632371200,
+    "used_bytes": 21241409536
   },
   "power": {
     "source": "os_power_probe",
     "active_scheme": "Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  (Balanced)",
-    "battery_status": "BatteryStatus=2;EstimatedChargeRemaining=100",
+    "battery_status": "BatteryStatus=2;EstimatedChargeRemaining=98",
     "ac_power_inferred": true
   },
   "thermal": {
     "source": "windows_perf_thermal_zone",
     "thermal_zones_visible": 1,
     "temperatures_celsius": []
+  },
+  "capture_requirements": {
+    "battery_mode_required": false,
+    "battery_mode_sample_recorded": false,
+    "requirement_satisfied": true,
+    "status": "not_required",
+    "gaps": []
   },
   "sources": [
     {
@@ -44,10 +51,11 @@
     {
       "source": "windows_perf_thermal_zone",
       "available": true,
-      "status": "captured"
+      "status": "zone_visible_temperature_readings_unavailable"
     }
   ],
   "gaps": [
+    "thermal zone visibility is recorded, but temperature readings are unavailable from the current OS telemetry probe",
     "power context is recorded for routing evidence, but no speedup or power-advantage claim is made"
   ],
   "claim_boundary": {

--- a/crates/bitnet-cli/src/commands/lunar_lake.rs
+++ b/crates/bitnet-cli/src/commands/lunar_lake.rs
@@ -8509,6 +8509,11 @@ fn build_telemetry_context_from_parts(
             "thermal sensor context is not available from the current OS telemetry probe"
                 .to_string(),
         );
+    } else if thermal.temperatures_celsius.is_empty() {
+        gaps.push(
+            "thermal zone visibility is recorded, but temperature readings are unavailable from the current OS telemetry probe"
+                .to_string(),
+        );
     }
     gaps.push(
         "power context is recorded for routing evidence, but no speedup or power-advantage claim is made"
@@ -8547,11 +8552,7 @@ fn build_telemetry_context_from_parts(
         TelemetrySourceStatus {
             source: thermal.source.clone(),
             available: thermal_context_recorded,
-            status: if thermal_context_recorded {
-                "captured".to_string()
-            } else {
-                "unavailable".to_string()
-            },
+            status: thermal_source_status(&thermal, thermal_context_recorded),
         },
     ];
 
@@ -9469,6 +9470,19 @@ fn format_thermal_context(thermal: &TelemetryThermalContext) -> String {
             )
         }
         _ => "thermal_context_unavailable".to_string(),
+    }
+}
+
+fn thermal_source_status(
+    thermal: &TelemetryThermalContext,
+    thermal_context_recorded: bool,
+) -> String {
+    if !thermal_context_recorded {
+        "unavailable".to_string()
+    } else if thermal.temperatures_celsius.is_empty() {
+        "zone_visible_temperature_readings_unavailable".to_string()
+    } else {
+        "captured".to_string()
     }
 }
 
@@ -19653,6 +19667,42 @@ mod tests {
             "source=windows_perf_thermal_zone;thermal_zones_visible=1;temperatures_celsius=unavailable"
         ));
         assert!(thermal_context_is_unavailable("thermal_context_unavailable"));
+    }
+
+    #[test]
+    fn telemetry_context_marks_visible_thermal_zone_without_temperature_readings() {
+        let receipt = build_telemetry_context_from_parts(
+            "2026-05-26T08:00:00Z".to_string(),
+            TelemetryMemoryContext {
+                source: "test_memory".to_string(),
+                total_bytes: Some(16 * 1024 * 1024),
+                available_bytes: Some(8 * 1024 * 1024),
+                used_bytes: Some(8 * 1024 * 1024),
+            },
+            TelemetryPowerContext {
+                source: "test_power".to_string(),
+                active_scheme: Some("Balanced".to_string()),
+                battery_status: Some("BatteryStatus=2;EstimatedChargeRemaining=98".to_string()),
+                ac_power_inferred: Some(true),
+            },
+            TelemetryThermalContext {
+                source: "windows_perf_thermal_zone".to_string(),
+                thermal_zones_visible: Some(1),
+                temperatures_celsius: Vec::new(),
+            },
+            false,
+        );
+
+        assert!(receipt.availability.thermal_context_recorded);
+        assert!(
+            receipt.gaps.iter().any(|gap| gap.contains("temperature readings are unavailable"))
+        );
+        let thermal_source = receipt
+            .sources
+            .iter()
+            .find(|source| source.source == "windows_perf_thermal_zone")
+            .map(|source| (source.available, source.status.as_str()));
+        assert_eq!(thermal_source, Some((true, "zone_visible_temperature_readings_unavailable")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- mark visible thermal zones with no usable readings as `zone_visible_temperature_readings_unavailable` instead of generic captured telemetry
- add an explicit telemetry gap when thermal zone visibility exists but temperature readings are unavailable
- refresh the committed Lunar Lake power/thermal context receipt with the new status while preserving AC-only, no-promotion claim boundaries

## Validation
- rustfmt --check --config skip_children=true,newline_style=Unix --edition 2024 crates/bitnet-cli/src/commands/lunar_lake.rs
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::lunar_lake::tests::telemetry_context_marks_visible_thermal_zone_without_temperature_readings -- --exact --nocapture
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake telemetry-context --artifact-root ci/hardware/intel-258v/2026-05-08 --json-out target/tmp/lunar-lake-thermal-gap-live.json --created-utc 2026-05-26T08:00:00Z --strict
- target/debug/bitnet.exe lunar-lake telemetry-context --artifact-root ci/hardware/intel-258v/2026-05-08 --json-out lunar-lake-power-thermal-context.json --created-utc 2026-05-26T08:00:00Z --strict
- target/debug/bitnet.exe lunar-lake validate --artifact-root ci/hardware/intel-258v/2026-05-08 --json-out C:\Code\Rust\BitNet-rs\target\tmp\lunar-lake-validate-thermal-gap-final.json --created-utc 2026-05-26T08:00:00Z --strict
- target/debug/bitnet.exe lunar-lake regress --artifact-root ci/hardware/intel-258v/2026-05-08 --json-out C:\Code\Rust\BitNet-rs\target\tmp\lunar-lake-regress-thermal-gap-final.json --created-utc 2026-05-26T08:00:00Z --strict
- target/debug/bitnet.exe lunar-lake compare --artifact-root ci/hardware/intel-258v/2026-05-08 --regression-bundle C:\Code\Rust\BitNet-rs\target\tmp\lunar-lake-regress-thermal-gap-final.json --json-out C:\Code\Rust\BitNet-rs\target\tmp\lunar-lake-compare-thermal-gap-final.json --created-utc 2026-05-26T08:00:00Z --strict
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Claim boundary
- no Lunar Lake inference, route promotion, speedup, power advantage, native accelerator, Qwen3, or BitNet behavior claim
- POWER-006 remains blocked: Win32_Battery reports BatteryStatus=2, so no battery-mode low_power evidence was collected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thermal diagnostics to detect when thermal zones are visible but temperature readings are unavailable.

* **Improvements**
  * Enhanced Lunar Lake power and thermal telemetry data collection with updated context values and expanded metadata.
  * Improved thermal zone detection and status reporting in diagnostic output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/6213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->