### PR TITLE
fix(lunar-lake): suppress generic ask backend warning

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -11619,6 +11619,18 @@ fn skips_startup_backend_selection(command: Option<&Commands>) -> bool {
     uses_report_only_cuda_benchmark_receipt(command)
         || uses_read_only_model_status(command)
         || uses_read_only_support_bundle(command)
+        || uses_lunar_lake_ask_runtime(command)
+}
+
+#[cfg(feature = "full-cli")]
+fn uses_lunar_lake_ask_runtime(command: Option<&Commands>) -> bool {
+    matches!(command, Some(Commands::LunarLake(cmd)) if matches!(&cmd.action, LunarLakeAction::Ask { .. }))
+}
+
+#[cfg(not(feature = "full-cli"))]
+fn uses_lunar_lake_ask_runtime(command: Option<&Commands>) -> bool {
+    let _ = command;
+    false
 }
 
 fn uses_report_only_cuda_benchmark_receipt(command: Option<&Commands>) -> bool {
@@ -13819,6 +13831,34 @@ mod tests {
         });
 
         assert!(uses_read_only_support_bundle(Some(&command)));
+        assert!(skips_startup_backend_selection(Some(&command)));
+        assert_eq!(default_log_level_for_command(Some(&command)), Some("warn"));
+    }
+
+    #[test]
+    #[cfg(feature = "full-cli")]
+    fn lunar_lake_ask_skips_startup_backend_selection() {
+        let command = Commands::LunarLake(LunarLakeCommand {
+            action: LunarLakeAction::Ask {
+                artifact_root: std::path::PathBuf::from("ci/hardware/intel-258v/2026-05-08"),
+                operator_receipt: std::path::PathBuf::from("lunar-lake-operator-readiness.json"),
+                promotion_ledger: std::path::PathBuf::from("lunar-lake-route-promotion.json"),
+                route_profile_comparison: std::path::PathBuf::from(
+                    "lunar-lake-route-profile-comparison.json",
+                ),
+                profile: "ask_normal".to_string(),
+                route: "dense_slm_openvino_gpu_candidate".to_string(),
+                model: None,
+                tokenizer: None,
+                question: Some("What is 2+2?".to_string()),
+                question_arg: None,
+                max_new_tokens: 8,
+                expect_contains: Some("4".to_string()),
+                json_out: None,
+            },
+        });
+
+        assert!(uses_lunar_lake_ask_runtime(Some(&command)));
         assert!(skips_startup_backend_selection(Some(&command)));
         assert_eq!(default_log_level_for_command(Some(&command)), Some("warn"));
     }

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -81,7 +81,7 @@ This document describes all environment variables used throughout BitNet-rs for 
 
 ### Lunar Lake OpenVINO Ask Runtime
 
-- `BITNET_LUNAR_LAKE_OPENVINO_MODEL_DIR`: OpenVINO IR directory used by `bitnet lunar-lake ask` when an auto-selected OpenVINO GPU/NPU route needs a local model and `--model` is omitted. This is intended for ignored local model exports such as `models/openvino/qwen2.5-0.5b-instruct-int4-sym`; it does not commit model binaries or change route promotion.
+- `BITNET_LUNAR_LAKE_OPENVINO_MODEL_DIR`: OpenVINO IR directory used by `bitnet lunar-lake ask` when a selected OpenVINO GPU/NPU route needs a local model and `--model` is omitted. This is intended for ignored local model exports such as `models/openvino/qwen2.5-0.5b-instruct-int4-sym`; it does not commit model binaries or change route promotion.
 - `BITNET_LUNAR_LAKE_OPENVINO_PYTHON`: Python executable used by the Lunar Lake OpenVINO GenAI helper. Set this when the checkout-local `.venv/Scripts/python.exe` is absent or does not include `openvino_genai`.
 
 ### Model Configuration (Environment Overrides)


### PR DESCRIPTION
## Summary
- skip the generic Rust startup backend selector for `lunar-lake ask`, which owns route/backend validation itself
- remove the misleading `--device gpu` warning when the OpenVINO GenAI helper executes the GPU route successfully
- clarify the OpenVINO model-dir env var applies to any selected OpenVINO ask route, not only auto selection

## Validation
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet tests::lunar_lake_ask_skips_startup_backend_selection -- --exact --nocapture`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device gpu lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile ask_normal --route dense_slm_openvino_gpu_candidate --question "What is 2+2? Answer with just the number." --expect-contains 4 --max-new-tokens 8 --json-out C:\Code\Rust\BitNet-rs\target\tmp\openvino-gpu-direct-ask-patched.json`
- `cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports`
- `cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `rustfmt --check --edition 2024 crates/bitnet-cli/src/main.rs`
- `git diff --check`

Live patched ask receipt: selected `dense_slm_openvino_gpu_candidate`, backend `openvino-gpu`, runtime `openvino_genai`, `fallback_used=false`, answer gate passed, `openvino_candidate_route_executed=true`, normalized answer `4`.
