### PR TITLE
fix(lunar-lake): clarify ask timing receipts

### DIFF
--- a/crates/bitnet-cli/src/commands/lunar_lake.rs
+++ b/crates/bitnet-cli/src/commands/lunar_lake.rs
@@ -11435,7 +11435,15 @@ fn route_not_selected_reasons(
     if route.status != "promoted" {
         reasons.push(format!("route status is `{}`", route.status));
     }
-    if !route.promoted_for.iter().any(|profile| profile == profile_id) {
+    let profile_superseded_by_accelerator = route.blocked_for.iter().any(|blocker| {
+        matches!(
+            profile_superseding_accelerator(blocker),
+            Some((_, blocker_profile)) if blocker_profile == profile_id
+        )
+    });
+    if !route.promoted_for.iter().any(|profile| profile == profile_id)
+        && !profile_superseded_by_accelerator
+    {
         reasons.push(format!("route is not promoted for profile `{profile_id}`"));
     }
     if route.fallback_used != Some(false) {
@@ -11473,6 +11481,15 @@ fn describe_route_missing_evidence(item: &str) -> String {
 }
 
 fn describe_route_blocker(blocker: &str, profile_id: &str) -> String {
+    if let Some((accelerator, promoted_profile)) = profile_superseding_accelerator(blocker) {
+        let evidence = match accelerator {
+            "OpenVINO GPU" => "benchmark-qualified route evidence",
+            _ => "route evidence",
+        };
+        return format!(
+            "{accelerator} is promoted for profile `{promoted_profile}` by {evidence}; this route is not auto-selected for `{profile_id}`"
+        );
+    }
     match blocker {
         "auto_default" => format!(
             "route blocker for profile `{profile_id}`: {blocker} (auto routing only selects routes explicitly promoted for this profile)"
@@ -11482,6 +11499,16 @@ fn describe_route_blocker(blocker: &str, profile_id: &str) -> String {
         ),
         _ => format!("route blocker for profile `{profile_id}`: {blocker}"),
     }
+}
+
+fn profile_superseding_accelerator(blocker: &str) -> Option<(&'static str, &str)> {
+    if let Some(profile) = blocker.strip_prefix("openvino_gpu_promoted_for_") {
+        return Some(("OpenVINO GPU", profile));
+    }
+    if let Some(profile) = blocker.strip_prefix("openvino_npu_promoted_for_") {
+        return Some(("OpenVINO NPU", profile));
+    }
+    None
 }
 
 fn route_blocker_applies_to_profile(blocker: &str, profile_id: &str) -> bool {
@@ -16154,6 +16181,78 @@ mod tests {
         assert_eq!(profile_scoped_route_status(&ask_short, &route, true), "promoted");
         assert_eq!(profile_scoped_route_status(&ask_short, &route, false), "blocked");
         assert_eq!(profile_scoped_route_status(&regression_tiny, &route, false), "candidate");
+    }
+
+    #[test]
+    fn route_not_selected_reasons_explain_profile_superseded_accelerator() {
+        let ledger = LunarLakeRoutePromotionLedger {
+            schema_version: "1.0.0".to_string(),
+            artifact_kind: "lunar_lake_route_promotion_ledger".to_string(),
+            proof_stage: "test".to_string(),
+            created_utc: "2026-05-19T04:30:00Z".to_string(),
+            machine_id: "intel-258v".to_string(),
+            artifact_root: "ci/hardware/intel-258v/2026-05-08".to_string(),
+            operator_receipt: "lunar-lake-operator-readiness.json".to_string(),
+            comparison_receipt: "lunar-lake-operator-comparison.json".to_string(),
+            promotion_ready: true,
+            default_route_id: DEFAULT_ASK_ROUTE.to_string(),
+            auto_route_policy: AutoRoutePolicy {
+                policy_stage: "test".to_string(),
+                default_route: DEFAULT_ASK_ROUTE.to_string(),
+                hidden_fallback_allowed: false,
+                cpu_default_until_profile_promoted: true,
+                candidate_routes_require_profile_promotion: true,
+                route_reason_required: true,
+                notes: vec![],
+            },
+            workload_profiles: vec![],
+            routes: vec![RoutePromotion {
+                route_id: DEFAULT_ASK_ROUTE.to_string(),
+                status: "promoted".to_string(),
+                promoted_for: vec!["regression_tiny".to_string(), "structured".to_string()],
+                blocked_for: vec!["openvino_gpu_promoted_for_ask_normal".to_string()],
+                required_evidence: vec![],
+                present_evidence: vec![],
+                missing_evidence: vec![],
+                selected_backend: "cpu-rust".to_string(),
+                runtime_api: "cpu".to_string(),
+                fallback_policy: "strict_no_fallback".to_string(),
+                answer_gate_evidence: None,
+                phase_evidence: None,
+                fallback_used: Some(false),
+                answer_gate_passed: Some(true),
+                phase_timing_present: Some(true),
+                speedup_claim: false,
+                acceleration_claim: false,
+                last_evidence_utc: "2026-05-19T04:30:00Z".to_string(),
+                reason: "CPU baseline superseded for ask_normal".to_string(),
+            }],
+            gaps: vec![],
+            claim_boundary: ClaimBoundary {
+                cpu_is_truth_path: true,
+                dense_slm_default_is_cpu_until_speedup_qualified: true,
+                openvino_gpu_npu_are_candidates_not_speedup_claims: true,
+                arc_bitnet_full_inference_claimed: false,
+                npu_bitnet_full_inference_claimed: false,
+                qk256_accelerator_decode_claimed: false,
+                hidden_fallback_allowed: false,
+            },
+        };
+
+        let reasons = route_not_selected_reasons(&ledger, DEFAULT_ASK_ROUTE, "ask_normal");
+
+        assert_eq!(reasons.len(), 1, "{reasons:?}");
+        assert!(
+            reasons[0].contains("OpenVINO GPU is promoted for profile `ask_normal`"),
+            "{reasons:?}"
+        );
+        assert!(reasons[0].contains("benchmark-qualified route evidence"), "{reasons:?}");
+        assert!(
+            !reasons
+                .iter()
+                .any(|reason| reason == "route is not promoted for profile `ask_normal`"),
+            "{reasons:?}"
+        );
     }
 
     #[test]

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -11342,6 +11342,7 @@ fn build_lunar_lake_operator_ask_receipt(ctx: LunarLakeAskReceiptContext<'_>) ->
         ctx.source_run_receipt,
         &["tokens.prompt", "prompt_policy.prompt_token_count"],
     );
+    let source_known_gaps = ctx.source_run_receipt["known_gaps"].clone();
     let openvino_candidate_executed = ctx.route.runtime_api == "openvino_genai";
     let proof_stage = if openvino_candidate_executed {
         "operator_candidate_route_executed_through_lunar_lake_ask"
@@ -11409,6 +11410,11 @@ fn build_lunar_lake_operator_ask_receipt(ctx: LunarLakeAskReceiptContext<'_>) ->
         "bitnet_qk256_i2s_claim": false,
         "arc_or_npu_execution_claim": false,
         "openvino_candidate_route_executed": openvino_candidate_executed,
+        "known_gaps": if source_known_gaps.is_null() {
+            serde_json::json!([])
+        } else {
+            source_known_gaps
+        },
         "route": {
             "route_id": ctx.route.route_id,
             "workload": ctx.route.workload,
@@ -14873,6 +14879,10 @@ mod tests {
             "quantization": "INT4_SYM",
             "prompt_template": "qwen2.5",
             "tokenizer_source": "hf_tokenizer_export",
+            "known_gaps": [
+                "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+                "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+            ],
             "model": {
                 "local_model_dir": "models/openvino/qwen2.5-0.5b-instruct-int4-sym"
             },
@@ -14893,7 +14903,26 @@ mod tests {
                 "passed": true,
                 "failed_rules": []
             },
-            "timing": {"generation_wall_ms": 301.0}
+            "timing": {
+                "pipeline_construct_wall_ms": 2200.0,
+                "generation_wall_ms": 301.0,
+                "generation_total_ms": 301.0,
+                "decode_total_ms": 301.0,
+                "prefill_ms": null,
+                "time_to_first_token_ms": 123.0,
+                "first_token_ms": 123.0,
+                "total_ms": 2501.0,
+                "cold_total_ms": 2501.0,
+                "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+                "decode_timing_source": "generation_wall_ms",
+                "known_gaps": [
+                    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+                    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+                ],
+                "openvino_perf_metrics": {
+                    "time_to_first_token": {"mean_ms": 123.0, "std_ms": 0.0}
+                }
+            }
         });
         validate_lunar_lake_ask_source_receipt(&source, &route)?;
         let answer = lunar_lake_source_answer_text(&source);
@@ -14933,6 +14962,10 @@ mod tests {
         assert_eq!(receipt["tokenizer_source"], "hf_tokenizer_export");
         assert_eq!(receipt["prompt"]["token_ids"], serde_json::json!([1, 2, 3]));
         assert_eq!(receipt["tokens"]["generated_count"], 9);
+        assert_eq!(receipt["timing"]["time_to_first_token_ms"], 123.0);
+        assert_eq!(receipt["timing"]["decode_total_ms"], 301.0);
+        assert!(receipt["timing"]["known_gaps"].as_array().is_some_and(|items| !items.is_empty()));
+        assert!(receipt["known_gaps"].as_array().is_some_and(|items| !items.is_empty()));
         assert_eq!(receipt["answer"]["normalized_text"], "2 + 2 equals 4.");
         Ok(())
     }

--- a/scripts/openvino_genai_operator_ask.py
+++ b/scripts/openvino_genai_operator_ask.py
@@ -157,6 +157,16 @@ def perf_metrics(result: Any) -> dict[str, Any]:
     }
 
 
+def metric_mean_ms(metrics: dict[str, Any], key: str) -> float | None:
+    value = metrics.get(key)
+    if not isinstance(value, dict):
+        return None
+    mean = value.get("mean_ms")
+    if not isinstance(mean, (int, float)) or mean < 0:
+        return None
+    return float(mean)
+
+
 def normalize_answer(text: str) -> str:
     return text.replace("<|im_end|>", "").replace("<|endoftext|>", "").strip()
 
@@ -242,6 +252,22 @@ def main() -> int:
     if first_chunk_at[0] is not None:
         first_chunk_ms = (first_chunk_at[0] - generation_start) * 1000.0
 
+    openvino_metrics = perf_metrics(result)
+    openvino_ttft_ms = metric_mean_ms(openvino_metrics, "time_to_first_token")
+    time_to_first_token_ms = openvino_ttft_ms if openvino_ttft_ms is not None else first_chunk_ms
+    first_token_timing_source = (
+        "openvino_perf_metrics.time_to_first_token.mean_ms"
+        if openvino_ttft_ms is not None
+        else "output.first_streamed_text_chunk_ms"
+        if first_chunk_ms is not None
+        else "unavailable"
+    )
+    cold_total_ms = pipeline_construct_wall_ms + generation_wall_ms
+    timing_known_gaps = [
+        "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+        "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum.",
+    ]
+
     created_utc = args.created_utc or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     receipt = {
         "schema_version": "1.0.0",
@@ -273,6 +299,7 @@ def main() -> int:
             "answer_gate_evidence": route.get("answer_gate_evidence"),
             "phase_evidence": route.get("phase_evidence"),
         },
+        "known_gaps": timing_known_gaps,
         "inputs": {
             "operator_receipt": operator_path.as_posix(),
             "artifact_root": args.artifact_root.as_posix(),
@@ -328,7 +355,17 @@ def main() -> int:
         "timing": {
             "pipeline_construct_wall_ms": pipeline_construct_wall_ms,
             "generation_wall_ms": generation_wall_ms,
-            "openvino_perf_metrics": perf_metrics(result),
+            "generation_total_ms": generation_wall_ms,
+            "decode_total_ms": generation_wall_ms,
+            "prefill_ms": None,
+            "time_to_first_token_ms": time_to_first_token_ms,
+            "first_token_ms": time_to_first_token_ms,
+            "total_ms": cold_total_ms,
+            "cold_total_ms": cold_total_ms,
+            "first_token_timing_source": first_token_timing_source,
+            "decode_timing_source": "generation_wall_ms",
+            "known_gaps": timing_known_gaps,
+            "openvino_perf_metrics": openvino_metrics,
         },
         "environment": {
             "python": platform.python_version(),
@@ -349,6 +386,7 @@ def main() -> int:
             "answer_gate_passed": gate["passed"],
             "fallback_used": False,
             "openvino_perf_metrics_recorded": True,
+            "standard_timing_aliases_recorded": True,
             "generated_token_ids_available_from_pipeline": True,
             "acceleration_claim": False,
         },


### PR DESCRIPTION
Summary:
- add standard timing aliases and known gaps to Lunar Lake OpenVINO ask receipts
- carry source known_gaps into the wrapper ask receipt
- replace raw profile-superseded ledger blocker tokens with readable route-selection explanations

Validation:
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::lunar_lake::tests::route_not_selected_reasons_explain_profile_superseded_accelerator -- --exact --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet tests::lunar_lake_operator_ask_receipt_accepts_openvino_source_shape -- --exact --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::lunar_lake::tests::auto_ask_no_promoted_profile_reports_route_blockers -- --exact --nocapture
- python -m py_compile scripts/openvino_genai_operator_ask.py
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device auto lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile ask_normal --route auto --question "What is 2+2? Answer with just the number." --expect-contains 4 --max-new-tokens 8 --json-out C:\Code\Rust\BitNet-rs\target\tmp\lunar-lake-ask-auto-ask-normal-timing-explanations.json
- rustfmt --check --edition 2024 crates/bitnet-cli/src/main.rs crates/bitnet-cli/src/commands/lunar_lake.rs
- git diff --check
- cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check