### PR TITLE
chore(lunar-lake): refresh auto ask receipts

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-19T23:39:22Z",
+  "created_utc": "2026-05-26T11:32:26Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-gpu",
@@ -28,6 +28,10 @@
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-gpu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -171,7 +175,7 @@
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
     "generated_token_count": 8,
-    "first_streamed_text_chunk_ms": 253.75789997633547,
+    "first_streamed_text_chunk_ms": 249.45410003419966,
     "first_streamed_text_chunk": "2",
     "streamed_chunks_count": 7,
     "streamed_text": "2 + 2 equals 4."
@@ -183,37 +187,50 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 2224.170300003607,
-    "generation_wall_ms": 285.51780001726,
+    "pipeline_construct_wall_ms": 1903.2492000842467,
+    "generation_wall_ms": 278.5832000663504,
+    "generation_total_ms": 278.5832000663504,
+    "decode_total_ms": 278.5832000663504,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 158.34620666503906,
+    "first_token_ms": 158.34620666503906,
+    "total_ms": 2181.832400150597,
+    "cold_total_ms": 2181.832400150597,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 2202.0,
+      "load_time_ms": 1883.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 280.37701416015625,
+        "mean_ms": 273.47698974609375,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 277.18499755859375,
+        "mean_ms": 270.4429931640625,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 160.489501953125,
+        "mean_ms": 158.34620666503906,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 17.029386520385742,
-        "std_ms": 26.3677921295166
+        "mean_ms": 16.344369888305664,
+        "std_ms": 25.754940032958984
       },
       "inter_token_latency": {
-        "mean_ms": 34.9379997253418,
-        "std_ms": 53.44001007080078
+        "mean_ms": 34.07075119018555,
+        "std_ms": 52.75055694580078
       },
       "throughput": {
-        "mean_ms": 58.722023010253906,
-        "std_ms": 90.92342376708984
+        "mean_ms": 61.18314743041992,
+        "std_ms": 96.41046142578125
       },
       "detokenization": {
         "mean_ms": -1.0,
@@ -246,6 +263,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief.json
@@ -37,11 +37,15 @@
     "fallback_used": false,
     "openvino_candidate_route_executed": true
   },
-  "created_utc": "2026-05-19T23:39:22Z",
+  "created_utc": "2026-05-26T11:32:27Z",
   "dense_slm": null,
   "execution_coverage": null,
   "fallback_reason": null,
   "fallback_used": false,
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "machine_id": "intel-258v",
   "model": {
     "architecture": "qwen2",
@@ -217,8 +221,7 @@
     "selected_route": "dense_slm_openvino_gpu_candidate",
     "selection_source": "promotion_ledger_auto",
     "why_not_cpu": [
-      "route blocker for profile `ask_normal`: openvino_gpu_promoted_for_ask_normal",
-      "route is not promoted for profile `ask_normal`"
+      "OpenVINO GPU is promoted for profile `ask_normal` by benchmark-qualified route evidence; this route is not auto-selected for `ask_normal`"
     ],
     "why_not_gpu": [
       "dense_slm_openvino_gpu_candidate is promoted for profile ask_normal by benchmark-qualified route evidence"
@@ -262,7 +265,7 @@
         "Full BitNet inference works on Arc or NPU."
       ]
     },
-    "created_utc": "2026-05-19T23:39:22Z",
+    "created_utc": "2026-05-26T11:32:26Z",
     "environment": {
       "openvino": {
         "available_devices": [
@@ -286,6 +289,10 @@
       "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json"
     },
     "item": "LNL258V-ASK-004",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "machine_id": "intel-258v",
     "model": {
       "files": {
@@ -358,7 +365,7 @@
     "model_family": "qwen",
     "output": {
       "first_streamed_text_chunk": "2",
-      "first_streamed_text_chunk_ms": 253.75789997633547,
+      "first_streamed_text_chunk_ms": 249.45410003419968,
       "generated_text": "2 + 2 equals 4.",
       "generated_token_count": 8,
       "generated_token_ids": [
@@ -451,37 +458,47 @@
     "selected_backend": "openvino-gpu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-gpu0",
     "timing": {
-      "generation_wall_ms": 285.51780001726,
+      "cold_total_ms": 2181.832400150597,
+      "decode_timing_source": "generation_wall_ms",
+      "decode_total_ms": 278.5832000663504,
+      "first_token_ms": 158.34620666503906,
+      "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+      "generation_total_ms": 278.5832000663504,
+      "generation_wall_ms": 278.5832000663504,
+      "known_gaps": [
+        "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+        "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+      ],
       "openvino_perf_metrics": {
         "detokenization": {
           "mean_ms": -1.0,
           "std_ms": -1.0
         },
         "generate": {
-          "mean_ms": 280.37701416015625,
+          "mean_ms": 273.47698974609375,
           "std_ms": 0.0
         },
         "inference": {
-          "mean_ms": 277.18499755859375,
+          "mean_ms": 270.4429931640625,
           "std_ms": 0.0
         },
         "inter_token_latency": {
-          "mean_ms": 34.9379997253418,
-          "std_ms": 53.44001007080078
+          "mean_ms": 34.07075119018555,
+          "std_ms": 52.75055694580078
         },
-        "load_time_ms": 2202.0,
+        "load_time_ms": 1883.0,
         "num_generated_tokens": 8,
         "num_input_tokens": 39,
         "throughput": {
-          "mean_ms": 58.722023010253906,
-          "std_ms": 90.92342376708984
+          "mean_ms": 61.18314743041992,
+          "std_ms": 96.41046142578124
         },
         "time_per_output_token": {
-          "mean_ms": 17.029386520385742,
-          "std_ms": 26.3677921295166
+          "mean_ms": 16.344369888305664,
+          "std_ms": 25.754940032958984
         },
         "time_to_first_token": {
-          "mean_ms": 160.489501953125,
+          "mean_ms": 158.34620666503906,
           "std_ms": 0.0
         },
         "tokenization": {
@@ -489,7 +506,10 @@
           "std_ms": -1.0
         }
       },
-      "pipeline_construct_wall_ms": 2224.170300003607
+      "pipeline_construct_wall_ms": 1903.2492000842467,
+      "prefill_ms": null,
+      "time_to_first_token_ms": 158.34620666503906,
+      "total_ms": 2181.832400150597
     },
     "tokenizer_source": "hf_tokenizer_export",
     "verification": {
@@ -501,43 +521,54 @@
       "llmpipeline_constructed": true,
       "openvino_perf_metrics_recorded": true,
       "operator_ready": true,
-      "operator_route_validated": true
+      "operator_route_validated": true,
+      "standard_timing_aliases_recorded": true
     }
   },
   "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
-    "generation_wall_ms": 285.51780001726,
+    "cold_total_ms": 2181.832400150597,
+    "decode_timing_source": "generation_wall_ms",
+    "decode_total_ms": 278.5832000663504,
+    "first_token_ms": 158.34620666503906,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "generation_total_ms": 278.5832000663504,
+    "generation_wall_ms": 278.5832000663504,
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
       "detokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 280.37701416015625,
+        "mean_ms": 273.47698974609375,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 277.18499755859375,
+        "mean_ms": 270.4429931640625,
         "std_ms": 0.0
       },
       "inter_token_latency": {
-        "mean_ms": 34.9379997253418,
-        "std_ms": 53.44001007080078
+        "mean_ms": 34.07075119018555,
+        "std_ms": 52.75055694580078
       },
-      "load_time_ms": 2202.0,
+      "load_time_ms": 1883.0,
       "num_generated_tokens": 8,
       "num_input_tokens": 39,
       "throughput": {
-        "mean_ms": 58.722023010253906,
-        "std_ms": 90.92342376708984
+        "mean_ms": 61.18314743041992,
+        "std_ms": 96.41046142578124
       },
       "time_per_output_token": {
-        "mean_ms": 17.029386520385742,
-        "std_ms": 26.3677921295166
+        "mean_ms": 16.344369888305664,
+        "std_ms": 25.754940032958984
       },
       "time_to_first_token": {
-        "mean_ms": 160.489501953125,
+        "mean_ms": 158.34620666503906,
         "std_ms": 0.0
       },
       "tokenization": {
@@ -545,7 +576,10 @@
         "std_ms": -1.0
       }
     },
-    "pipeline_construct_wall_ms": 2224.170300003607
+    "pipeline_construct_wall_ms": 1903.2492000842467,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 158.34620666503906,
+    "total_ms": 2181.832400150597
   },
   "tokenizer_source": "hf_tokenizer_export",
   "tokens": {
@@ -563,8 +597,7 @@
     "prompt_count": 39
   },
   "why_not_cpu": [
-    "route blocker for profile `ask_normal`: openvino_gpu_promoted_for_ask_normal",
-    "route is not promoted for profile `ask_normal`"
+    "OpenVINO GPU is promoted for profile `ask_normal` by benchmark-qualified route evidence; this route is not auto-selected for `ask_normal`"
   ],
   "why_not_gpu": [
     "dense_slm_openvino_gpu_candidate is promoted for profile ask_normal by benchmark-qualified route evidence"

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-18T20:36:21Z",
+  "created_utc": "2026-05-26T11:32:37Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-gpu",
@@ -23,11 +23,15 @@
   "route_id": "dense_slm_openvino_gpu_candidate",
   "route": {
     "route_id": "dense_slm_openvino_gpu_candidate",
-    "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+    "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
     "acceleration_claim": false,
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-gpu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -108,7 +112,7 @@
       "do_sample": false,
       "num_beams": 1,
       "apply_chat_template": true,
-      "max_new_tokens": 16
+      "max_new_tokens": 8
     },
     "rendered_prompt": "<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n<|im_start|>user\nWhat is 2+2? Answer briefly.<|im_end|>\n<|im_start|>assistant\n",
     "rendered_sha256": "ebbdae27cd6294724f8d7e1568c236ed907b5d9346da1e6d6e80e7f0f296c99a",
@@ -166,15 +170,14 @@
       16819,
       220,
       19,
-      13,
-      151645
+      13
     ],
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
-    "generated_token_count": 9,
-    "first_streamed_text_chunk_ms": 247.7460000081919,
+    "generated_token_count": 8,
+    "first_streamed_text_chunk_ms": 240.94630009494722,
     "first_streamed_text_chunk": "2",
-    "streamed_chunks_count": 8,
+    "streamed_chunks_count": 7,
     "streamed_text": "2 + 2 equals 4."
   },
   "answer_gate": {
@@ -184,44 +187,57 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 1839.5443999907002,
-    "generation_wall_ms": 328.1204999948386,
+    "pipeline_construct_wall_ms": 1829.6804999699816,
+    "generation_wall_ms": 267.07480009645224,
+    "generation_total_ms": 267.07480009645224,
+    "decode_total_ms": 267.07480009645224,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 153.9051971435547,
+    "first_token_ms": 153.9051971435547,
+    "total_ms": 2096.755300066434,
+    "cold_total_ms": 2096.755300066434,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 1819.0,
+      "load_time_ms": 1809.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 322.71600341796875,
+        "mean_ms": 261.54998779296875,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 318.65899658203125,
+        "mean_ms": 258.72900390625,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 160.20199584960938,
+        "mean_ms": 153.9051971435547,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 20.22195053100586,
-        "std_ms": 21.793582916259766
+        "mean_ms": 15.28935718536377,
+        "std_ms": 24.817461013793945
       },
       "inter_token_latency": {
-        "mean_ms": 35.72022247314453,
-        "std_ms": 48.53548812866211
+        "mean_ms": 32.590126037597656,
+        "std_ms": 51.342750549316406
       },
       "throughput": {
-        "mean_ms": 49.45121383666992,
-        "std_ms": 53.294517517089844
+        "mean_ms": 65.40497589111328,
+        "std_ms": 106.16439056396484
       },
       "detokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "num_input_tokens": 39,
-      "num_generated_tokens": 9
+      "num_generated_tokens": 8
     }
   },
   "environment": {
@@ -247,6 +263,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief.json
@@ -37,11 +37,15 @@
     "fallback_used": false,
     "openvino_candidate_route_executed": true
   },
-  "created_utc": "2026-05-18T20:36:22Z",
+  "created_utc": "2026-05-26T11:32:38Z",
   "dense_slm": null,
   "execution_coverage": null,
   "fallback_reason": null,
   "fallback_used": false,
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "machine_id": "intel-258v",
   "model": {
     "architecture": "qwen2",
@@ -186,7 +190,7 @@
     "fallback_policy": "strict_no_fallback",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
     "route_id": "dense_slm_openvino_gpu_candidate",
-    "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+    "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-gpu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-gpu",
@@ -197,7 +201,7 @@
   "route_profile_blockers": [],
   "route_profile_comparison": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
   "route_profile_status": "promoted_route_ready",
-  "route_reason": "OpenVINO GPU is promoted only for benchmark-qualified dense Qwen profiles [ask_normal,ask_short] with fallback=false, passing corpus-v2 evidence, direct token visibility, profile-matched timing, and lower total response than the CPU baseline.",
+  "route_reason": "OpenVINO GPU is promoted only for benchmark-qualified dense Qwen profiles [ask_normal,ask_short,decode_heavy,prefill_heavy] with fallback=false, passing corpus-v2 evidence, direct token visibility, profile-matched timing, and lower total response than the CPU baseline.",
   "route_selection": {
     "candidate_routes": [
       "dense_slm_default_cpu",
@@ -211,22 +215,24 @@
     "route_profile_blockers": [],
     "route_profile_comparison": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
     "route_profile_status": "promoted_route_ready",
-    "route_reason": "OpenVINO GPU is promoted only for benchmark-qualified dense Qwen profiles [ask_normal,ask_short] with fallback=false, passing corpus-v2 evidence, direct token visibility, profile-matched timing, and lower total response than the CPU baseline.",
+    "route_reason": "OpenVINO GPU is promoted only for benchmark-qualified dense Qwen profiles [ask_normal,ask_short,decode_heavy,prefill_heavy] with fallback=false, passing corpus-v2 evidence, direct token visibility, profile-matched timing, and lower total response than the CPU baseline.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-gpu",
     "selected_route": "dense_slm_openvino_gpu_candidate",
     "selection_source": "promotion_ledger_auto",
     "why_not_cpu": [
-      "route is not promoted for profile `ask_short`"
+      "OpenVINO GPU is promoted for profile `ask_short` by benchmark-qualified route evidence; this route is not auto-selected for `ask_short`"
     ],
     "why_not_gpu": [
       "dense_slm_openvino_gpu_candidate is promoted for profile ask_short by benchmark-qualified route evidence"
     ],
     "why_not_npu": [
-      "missing evidence: benchmark_qualified_speedup_or_power_advantage",
-      "missing evidence: profile_regression_bundle",
-      "route is not promoted for profile `ask_short`",
-      "route status is `candidate`"
+      "route blocker for profile `ask_short`: ask_short_cold_start_blocked",
+      "route blocker for profile `ask_short`: auto_default (auto routing only selects routes explicitly promoted for this profile)",
+      "route blocker for profile `ask_short`: beam_search",
+      "route blocker for profile `ask_short`: dynamic_decode",
+      "route blocker for profile `ask_short`: parallel_sampling",
+      "route is not promoted for profile `ask_short`"
     ]
   },
   "runtime_api": "openvino_genai",
@@ -259,7 +265,7 @@
         "Full BitNet inference works on Arc or NPU."
       ]
     },
-    "created_utc": "2026-05-18T20:36:21Z",
+    "created_utc": "2026-05-26T11:32:37Z",
     "environment": {
       "openvino": {
         "available_devices": [
@@ -283,6 +289,10 @@
       "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json"
     },
     "item": "LNL258V-ASK-004",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "machine_id": "intel-258v",
     "model": {
       "files": {
@@ -355,9 +365,9 @@
     "model_family": "qwen",
     "output": {
       "first_streamed_text_chunk": "2",
-      "first_streamed_text_chunk_ms": 247.7460000081919,
+      "first_streamed_text_chunk_ms": 240.9463000949472,
       "generated_text": "2 + 2 equals 4.",
-      "generated_token_count": 9,
+      "generated_token_count": 8,
       "generated_token_ids": [
         17,
         488,
@@ -366,20 +376,19 @@
         16819,
         220,
         19,
-        13,
-        151645
+        13
       ],
       "generated_token_ids_available_from_pipeline": true,
       "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
       "normalized_answer": "2 + 2 equals 4.",
-      "streamed_chunks_count": 8,
+      "streamed_chunks_count": 7,
       "streamed_text": "2 + 2 equals 4."
     },
     "prompt_policy": {
       "generation_config": {
         "apply_chat_template": true,
         "do_sample": false,
-        "max_new_tokens": 16,
+        "max_new_tokens": 8,
         "num_beams": 1
       },
       "greedy": true,
@@ -440,7 +449,7 @@
       "answer_gate_evidence": "lunar-lake-openvino-operator-ask-gpu-math-brief.json",
       "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
       "route_id": "dense_slm_openvino_gpu_candidate",
-      "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded."
+      "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim."
     },
     "route_id": "dense_slm_openvino_gpu_candidate",
     "runtime_api": "openvino_genai",
@@ -449,37 +458,47 @@
     "selected_backend": "openvino-gpu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-gpu0",
     "timing": {
-      "generation_wall_ms": 328.1204999948386,
+      "cold_total_ms": 2096.755300066434,
+      "decode_timing_source": "generation_wall_ms",
+      "decode_total_ms": 267.07480009645224,
+      "first_token_ms": 153.9051971435547,
+      "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+      "generation_total_ms": 267.07480009645224,
+      "generation_wall_ms": 267.07480009645224,
+      "known_gaps": [
+        "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+        "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+      ],
       "openvino_perf_metrics": {
         "detokenization": {
           "mean_ms": -1.0,
           "std_ms": -1.0
         },
         "generate": {
-          "mean_ms": 322.71600341796875,
+          "mean_ms": 261.54998779296875,
           "std_ms": 0.0
         },
         "inference": {
-          "mean_ms": 318.65899658203125,
+          "mean_ms": 258.72900390625,
           "std_ms": 0.0
         },
         "inter_token_latency": {
-          "mean_ms": 35.72022247314453,
-          "std_ms": 48.53548812866211
+          "mean_ms": 32.590126037597656,
+          "std_ms": 51.342750549316406
         },
-        "load_time_ms": 1819.0,
-        "num_generated_tokens": 9,
+        "load_time_ms": 1809.0,
+        "num_generated_tokens": 8,
         "num_input_tokens": 39,
         "throughput": {
-          "mean_ms": 49.45121383666992,
-          "std_ms": 53.29451751708984
+          "mean_ms": 65.40497589111328,
+          "std_ms": 106.16439056396484
         },
         "time_per_output_token": {
-          "mean_ms": 20.22195053100586,
-          "std_ms": 21.79358291625977
+          "mean_ms": 15.28935718536377,
+          "std_ms": 24.817461013793945
         },
         "time_to_first_token": {
-          "mean_ms": 160.20199584960938,
+          "mean_ms": 153.9051971435547,
           "std_ms": 0.0
         },
         "tokenization": {
@@ -487,7 +506,10 @@
           "std_ms": -1.0
         }
       },
-      "pipeline_construct_wall_ms": 1839.5443999907
+      "pipeline_construct_wall_ms": 1829.6804999699816,
+      "prefill_ms": null,
+      "time_to_first_token_ms": 153.9051971435547,
+      "total_ms": 2096.755300066434
     },
     "tokenizer_source": "hf_tokenizer_export",
     "verification": {
@@ -499,43 +521,54 @@
       "llmpipeline_constructed": true,
       "openvino_perf_metrics_recorded": true,
       "operator_ready": true,
-      "operator_route_validated": true
+      "operator_route_validated": true,
+      "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
-    "generation_wall_ms": 328.1204999948386,
+    "cold_total_ms": 2096.755300066434,
+    "decode_timing_source": "generation_wall_ms",
+    "decode_total_ms": 267.07480009645224,
+    "first_token_ms": 153.9051971435547,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "generation_total_ms": 267.07480009645224,
+    "generation_wall_ms": 267.07480009645224,
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
       "detokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 322.71600341796875,
+        "mean_ms": 261.54998779296875,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 318.65899658203125,
+        "mean_ms": 258.72900390625,
         "std_ms": 0.0
       },
       "inter_token_latency": {
-        "mean_ms": 35.72022247314453,
-        "std_ms": 48.53548812866211
+        "mean_ms": 32.590126037597656,
+        "std_ms": 51.342750549316406
       },
-      "load_time_ms": 1819.0,
-      "num_generated_tokens": 9,
+      "load_time_ms": 1809.0,
+      "num_generated_tokens": 8,
       "num_input_tokens": 39,
       "throughput": {
-        "mean_ms": 49.45121383666992,
-        "std_ms": 53.29451751708984
+        "mean_ms": 65.40497589111328,
+        "std_ms": 106.16439056396484
       },
       "time_per_output_token": {
-        "mean_ms": 20.22195053100586,
-        "std_ms": 21.79358291625977
+        "mean_ms": 15.28935718536377,
+        "std_ms": 24.817461013793945
       },
       "time_to_first_token": {
-        "mean_ms": 160.20199584960938,
+        "mean_ms": 153.9051971435547,
         "std_ms": 0.0
       },
       "tokenization": {
@@ -543,11 +576,14 @@
         "std_ms": -1.0
       }
     },
-    "pipeline_construct_wall_ms": 1839.5443999907
+    "pipeline_construct_wall_ms": 1829.6804999699816,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 153.9051971435547,
+    "total_ms": 2096.755300066434
   },
   "tokenizer_source": "hf_tokenizer_export",
   "tokens": {
-    "generated_count": 9,
+    "generated_count": 8,
     "generated_ids": [
       17,
       488,
@@ -556,21 +592,22 @@
       16819,
       220,
       19,
-      13,
-      151645
+      13
     ],
     "prompt_count": 39
   },
   "why_not_cpu": [
-    "route is not promoted for profile `ask_short`"
+    "OpenVINO GPU is promoted for profile `ask_short` by benchmark-qualified route evidence; this route is not auto-selected for `ask_short`"
   ],
   "why_not_gpu": [
     "dense_slm_openvino_gpu_candidate is promoted for profile ask_short by benchmark-qualified route evidence"
   ],
   "why_not_npu": [
-    "missing evidence: benchmark_qualified_speedup_or_power_advantage",
-    "missing evidence: profile_regression_bundle",
-    "route is not promoted for profile `ask_short`",
-    "route status is `candidate`"
+    "route blocker for profile `ask_short`: ask_short_cold_start_blocked",
+    "route blocker for profile `ask_short`: auto_default (auto routing only selects routes explicitly promoted for this profile)",
+    "route blocker for profile `ask_short`: beam_search",
+    "route blocker for profile `ask_short`: dynamic_decode",
+    "route blocker for profile `ask_short`: parallel_sampling",
+    "route is not promoted for profile `ask_short`"
   ]
 }

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-19T09:56:25Z",
+  "created_utc": "2026-05-26T11:33:15Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-npu",
@@ -23,11 +23,15 @@
   "route_id": "dense_slm_openvino_npu_candidate",
   "route": {
     "route_id": "dense_slm_openvino_npu_candidate",
-    "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+    "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
     "acceleration_claim": false,
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-npu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -172,7 +176,7 @@
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
     "generated_token_count": 9,
-    "first_streamed_text_chunk_ms": 590.838200005237,
+    "first_streamed_text_chunk_ms": 330.2218000171706,
     "first_streamed_text_chunk": "2",
     "streamed_chunks_count": 8,
     "streamed_text": "2 + 2 equals 4."
@@ -184,37 +188,50 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 32032.17720001703,
-    "generation_wall_ms": 862.0865999837406,
+    "pipeline_construct_wall_ms": 28432.703899918124,
+    "generation_wall_ms": 484.3472000211477,
+    "generation_total_ms": 484.3472000211477,
+    "decode_total_ms": 484.3472000211477,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 233.73480224609375,
+    "first_token_ms": 233.73480224609375,
+    "total_ms": 28917.05109993927,
+    "cold_total_ms": 28917.05109993927,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 32010.0,
+      "load_time_ms": 28412.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 843.6229858398438,
+        "mean_ms": 467.13299560546875,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 838.22900390625,
+        "mean_ms": 463.9540100097656,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 324.7074890136719,
+        "mean_ms": 233.73480224609375,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 64.7959976196289,
-        "std_ms": 49.84443283081055
+        "mean_ms": 29.13617515563965,
+        "std_ms": 8.618219375610352
       },
       "inter_token_latency": {
-        "mean_ms": 93.13655853271484,
-        "std_ms": 93.45809936523438
+        "mean_ms": 51.550445556640625,
+        "std_ms": 64.39912414550781
       },
       "throughput": {
-        "mean_ms": 15.433052062988281,
-        "std_ms": 11.871901512145996
+        "mean_ms": 34.32159423828125,
+        "std_ms": 10.152020454406738
       },
       "detokenization": {
         "mean_ms": -1.0,
@@ -247,6 +264,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief.json
@@ -14,7 +14,7 @@
   "answer_gate_passed": true,
   "arc_or_npu_execution_claim": false,
   "artifact_kind": "lunar_lake_operator_ask",
-  "artifact_root": "ci\\hardware\\intel-258v\\2026-05-08",
+  "artifact_root": "ci/hardware/intel-258v/2026-05-08",
   "backend": {
     "backend_lane": "dense_slm_openvino_npu",
     "fallback_reason": null,
@@ -37,11 +37,15 @@
     "fallback_used": false,
     "openvino_candidate_route_executed": true
   },
-  "created_utc": "2026-05-19T09:56:26Z",
+  "created_utc": "2026-05-26T11:33:17Z",
   "dense_slm": null,
   "execution_coverage": null,
   "fallback_reason": null,
   "fallback_used": false,
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "machine_id": "intel-258v",
   "model": {
     "architecture": "qwen2",
@@ -124,7 +128,7 @@
   "model_architecture": "qwen2",
   "model_family": "qwen",
   "openvino_candidate_route_executed": true,
-  "operator_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-readiness.json",
+  "operator_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-readiness.json",
   "profile": null,
   "profile_id": "warm_resident",
   "promotion_status": "promoted",
@@ -186,7 +190,7 @@
     "fallback_policy": "strict_no_fallback",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
     "route_id": "dense_slm_openvino_npu_candidate",
-    "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+    "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-npu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-npu",
@@ -217,8 +221,7 @@
     "selected_route": "dense_slm_openvino_npu_candidate",
     "selection_source": "promotion_ledger_auto",
     "why_not_cpu": [
-      "route blocker for profile `warm_resident`: openvino_npu_promoted_for_warm_resident",
-      "route is not promoted for profile `warm_resident`"
+      "OpenVINO NPU is promoted for profile `warm_resident` by route evidence; this route is not auto-selected for `warm_resident`"
     ],
     "why_not_gpu": [
       "route is not promoted for profile `warm_resident`"
@@ -257,7 +260,7 @@
         "Full BitNet inference works on Arc or NPU."
       ]
     },
-    "created_utc": "2026-05-19T09:56:25Z",
+    "created_utc": "2026-05-26T11:33:15Z",
     "environment": {
       "openvino": {
         "available_devices": [
@@ -281,6 +284,10 @@
       "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json"
     },
     "item": "LNL258V-ASK-004",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "machine_id": "intel-258v",
     "model": {
       "files": {
@@ -353,7 +360,7 @@
     "model_family": "qwen",
     "output": {
       "first_streamed_text_chunk": "2",
-      "first_streamed_text_chunk_ms": 590.838200005237,
+      "first_streamed_text_chunk_ms": 330.2218000171706,
       "generated_text": "2 + 2 equals 4.",
       "generated_token_count": 9,
       "generated_token_ids": [
@@ -438,7 +445,7 @@
       "answer_gate_evidence": "lunar-lake-openvino-operator-ask-npu-math-brief.json",
       "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
       "route_id": "dense_slm_openvino_npu_candidate",
-      "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made."
+      "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim."
     },
     "route_id": "dense_slm_openvino_npu_candidate",
     "runtime_api": "openvino_genai",
@@ -447,37 +454,47 @@
     "selected_backend": "openvino-npu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-npu",
     "timing": {
-      "generation_wall_ms": 862.0865999837406,
+      "cold_total_ms": 28917.05109993927,
+      "decode_timing_source": "generation_wall_ms",
+      "decode_total_ms": 484.3472000211477,
+      "first_token_ms": 233.73480224609375,
+      "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+      "generation_total_ms": 484.3472000211477,
+      "generation_wall_ms": 484.3472000211477,
+      "known_gaps": [
+        "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+        "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+      ],
       "openvino_perf_metrics": {
         "detokenization": {
           "mean_ms": -1.0,
           "std_ms": -1.0
         },
         "generate": {
-          "mean_ms": 843.6229858398438,
+          "mean_ms": 467.1329956054687,
           "std_ms": 0.0
         },
         "inference": {
-          "mean_ms": 838.22900390625,
+          "mean_ms": 463.9540100097656,
           "std_ms": 0.0
         },
         "inter_token_latency": {
-          "mean_ms": 93.13655853271484,
-          "std_ms": 93.45809936523438
+          "mean_ms": 51.550445556640625,
+          "std_ms": 64.39912414550781
         },
-        "load_time_ms": 32010.0,
+        "load_time_ms": 28412.0,
         "num_generated_tokens": 9,
         "num_input_tokens": 39,
         "throughput": {
-          "mean_ms": 15.43305206298828,
-          "std_ms": 11.871901512145996
+          "mean_ms": 34.32159423828125,
+          "std_ms": 10.152020454406738
         },
         "time_per_output_token": {
-          "mean_ms": 64.7959976196289,
-          "std_ms": 49.84443283081055
+          "mean_ms": 29.13617515563965,
+          "std_ms": 8.618219375610352
         },
         "time_to_first_token": {
-          "mean_ms": 324.7074890136719,
+          "mean_ms": 233.73480224609375,
           "std_ms": 0.0
         },
         "tokenization": {
@@ -485,7 +502,10 @@
           "std_ms": -1.0
         }
       },
-      "pipeline_construct_wall_ms": 32032.17720001703
+      "pipeline_construct_wall_ms": 28432.703899918124,
+      "prefill_ms": null,
+      "time_to_first_token_ms": 233.73480224609375,
+      "total_ms": 28917.05109993927
     },
     "tokenizer_source": "hf_tokenizer_export",
     "verification": {
@@ -497,43 +517,54 @@
       "llmpipeline_constructed": true,
       "openvino_perf_metrics_recorded": true,
       "operator_ready": true,
-      "operator_route_validated": true
+      "operator_route_validated": true,
+      "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
-    "generation_wall_ms": 862.0865999837406,
+    "cold_total_ms": 28917.05109993927,
+    "decode_timing_source": "generation_wall_ms",
+    "decode_total_ms": 484.3472000211477,
+    "first_token_ms": 233.73480224609375,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "generation_total_ms": 484.3472000211477,
+    "generation_wall_ms": 484.3472000211477,
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
       "detokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 843.6229858398438,
+        "mean_ms": 467.1329956054687,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 838.22900390625,
+        "mean_ms": 463.9540100097656,
         "std_ms": 0.0
       },
       "inter_token_latency": {
-        "mean_ms": 93.13655853271484,
-        "std_ms": 93.45809936523438
+        "mean_ms": 51.550445556640625,
+        "std_ms": 64.39912414550781
       },
-      "load_time_ms": 32010.0,
+      "load_time_ms": 28412.0,
       "num_generated_tokens": 9,
       "num_input_tokens": 39,
       "throughput": {
-        "mean_ms": 15.43305206298828,
-        "std_ms": 11.871901512145996
+        "mean_ms": 34.32159423828125,
+        "std_ms": 10.152020454406738
       },
       "time_per_output_token": {
-        "mean_ms": 64.7959976196289,
-        "std_ms": 49.84443283081055
+        "mean_ms": 29.13617515563965,
+        "std_ms": 8.618219375610352
       },
       "time_to_first_token": {
-        "mean_ms": 324.7074890136719,
+        "mean_ms": 233.73480224609375,
         "std_ms": 0.0
       },
       "tokenization": {
@@ -541,7 +572,10 @@
         "std_ms": -1.0
       }
     },
-    "pipeline_construct_wall_ms": 32032.17720001703
+    "pipeline_construct_wall_ms": 28432.703899918124,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 233.73480224609375,
+    "total_ms": 28917.05109993927
   },
   "tokenizer_source": "hf_tokenizer_export",
   "tokens": {
@@ -560,8 +594,7 @@
     "prompt_count": 39
   },
   "why_not_cpu": [
-    "route blocker for profile `warm_resident`: openvino_npu_promoted_for_warm_resident",
-    "route is not promoted for profile `warm_resident`"
+    "OpenVINO NPU is promoted for profile `warm_resident` by route evidence; this route is not auto-selected for `warm_resident`"
   ],
   "why_not_gpu": [
     "route is not promoted for profile `warm_resident`"

--- a/scripts/openvino_genai_operator_ask.py
+++ b/scripts/openvino_genai_operator_ask.py
@@ -408,7 +408,7 @@ def main() -> int:
     }
 
     args.json_out.parent.mkdir(parents=True, exist_ok=True)
-    args.json_out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    args.json_out.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8", newline="\n")
     return 0 if gate["passed"] else 1
 
 


### PR DESCRIPTION
Summary:
- refresh committed promoted auto ask receipts for ask_normal, ask_short, and warm_resident through the current CLI
- record standard OpenVINO timing aliases, known gaps, and readable route-selection explanations in the committed receipts
- force LF JSON output from the OpenVINO ask helper so regenerated source-run receipts pass whitespace checks on Windows

Validation:
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device auto lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile ask_normal --route auto --question "What is 2+2? Answer briefly." --expect-contains 4 --max-new-tokens 8 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief.json
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device auto lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile ask_short --route auto --question "What is 2+2? Answer briefly." --expect-contains 4 --max-new-tokens 8 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief.json
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device auto lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile warm_resident --route auto --question "What is 2+2? Answer briefly." --expect-contains 4 --max-new-tokens 16 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief.json
- python -m py_compile scripts/openvino_genai_operator_ask.py
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake regress --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --json-out target/tmp/lunar-lake-regression-after-auto-ask-refresh.json --strict
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake compare --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --regression-bundle target/tmp/lunar-lake-regression-after-auto-ask-refresh.json --json-out target/tmp/lunar-lake-operator-comparison-after-auto-ask-refresh.json --strict
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check