### PR TITLE
chore(lunar-lake): refresh direct OpenVINO ask receipts

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-openvino-operator-ask-gpu-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-openvino-operator-ask-gpu-math-brief.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-19T02:30:00Z",
+  "created_utc": "2026-05-26T11:37:24Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-gpu",
@@ -23,11 +23,15 @@
   "route_id": "dense_slm_openvino_gpu_candidate",
   "route": {
     "route_id": "dense_slm_openvino_gpu_candidate",
-    "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+    "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
     "acceleration_claim": false,
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-gpu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -172,7 +176,7 @@
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
     "generated_token_count": 9,
-    "first_streamed_text_chunk_ms": 259.844600019278,
+    "first_streamed_text_chunk_ms": 240.69969996344298,
     "first_streamed_text_chunk": "2",
     "streamed_chunks_count": 8,
     "streamed_text": "2 + 2 equals 4."
@@ -184,37 +188,50 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 2160.025899996981,
-    "generation_wall_ms": 301.603800005978,
+    "pipeline_construct_wall_ms": 2110.415400005877,
+    "generation_wall_ms": 277.184100006707,
+    "generation_total_ms": 277.184100006707,
+    "decode_total_ms": 277.184100006707,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 151.88729858398438,
+    "first_token_ms": 151.88729858398438,
+    "total_ms": 2387.599500012584,
+    "cold_total_ms": 2387.599500012584,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 2133.0,
+      "load_time_ms": 2091.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 295.94000244140625,
+        "mean_ms": 272.16400146484375,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 292.5419921875,
+        "mean_ms": 268.9840087890625,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 161.78701782226562,
+        "mean_ms": 151.88729858398438,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 16.660799026489258,
-        "std_ms": 25.8302059173584
+        "mean_ms": 14.954262733459473,
+        "std_ms": 23.38774299621582
       },
       "inter_token_latency": {
-        "mean_ms": 32.76377868652344,
-        "std_ms": 51.67101287841797
+        "mean_ms": 30.14988899230957,
+        "std_ms": 48.32493209838867
       },
       "throughput": {
-        "mean_ms": 60.0211296081543,
-        "std_ms": 93.05425262451172
+        "mean_ms": 66.87056732177734,
+        "std_ms": 104.58232116699219
       },
       "detokenization": {
         "mean_ms": -1.0,
@@ -247,6 +264,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-openvino-operator-ask-npu-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-openvino-operator-ask-npu-math-brief.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-19T02:31:00Z",
+  "created_utc": "2026-05-26T11:38:02Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-npu",
@@ -23,11 +23,15 @@
   "route_id": "dense_slm_openvino_npu_candidate",
   "route": {
     "route_id": "dense_slm_openvino_npu_candidate",
-    "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+    "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
     "acceleration_claim": false,
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-npu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -172,7 +176,7 @@
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
     "generated_token_count": 9,
-    "first_streamed_text_chunk_ms": 342.5390999764204,
+    "first_streamed_text_chunk_ms": 348.13639998901635,
     "first_streamed_text_chunk": "2",
     "streamed_chunks_count": 8,
     "streamed_text": "2 + 2 equals 4."
@@ -184,37 +188,50 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 29396.27910000854,
-    "generation_wall_ms": 510.03449998097494,
+    "pipeline_construct_wall_ms": 28034.030199982226,
+    "generation_wall_ms": 500.78359991312027,
+    "generation_total_ms": 500.78359991312027,
+    "decode_total_ms": 500.78359991312027,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 230.57391357421875,
+    "first_token_ms": 230.57391357421875,
+    "total_ms": 28534.813799895346,
+    "cold_total_ms": 28534.813799895346,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 29373.0,
+      "load_time_ms": 28013.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 502.3110046386719,
+        "mean_ms": 483.718994140625,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 499.3179931640625,
+        "mean_ms": 481.27899169921875,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 241.01649475097656,
+        "mean_ms": 230.57391357421875,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 32.59922409057617,
-        "std_ms": 12.345602035522461
+        "mean_ms": 31.55837631225586,
+        "std_ms": 13.51181697845459
       },
       "inter_token_latency": {
-        "mean_ms": 55.47977828979492,
-        "std_ms": 66.42837524414062
+        "mean_ms": 53.47544479370117,
+        "std_ms": 63.76333236694336
       },
       "throughput": {
-        "mean_ms": 30.67557716369629,
-        "std_ms": 11.617100715637207
+        "mean_ms": 31.687307357788086,
+        "std_ms": 13.567020416259766
       },
       "detokenization": {
         "mean_ms": -1.0,
@@ -247,6 +264,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief-source-run.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief-source-run.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-18T19:44:35Z",
+  "created_utc": "2026-05-26T11:38:28Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-gpu",
@@ -23,11 +23,15 @@
   "route_id": "dense_slm_openvino_gpu_candidate",
   "route": {
     "route_id": "dense_slm_openvino_gpu_candidate",
-    "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+    "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
     "acceleration_claim": false,
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-gpu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -172,7 +176,7 @@
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
     "generated_token_count": 9,
-    "first_streamed_text_chunk_ms": 251.78049999522045,
+    "first_streamed_text_chunk_ms": 252.0730000687763,
     "first_streamed_text_chunk": "2",
     "streamed_chunks_count": 8,
     "streamed_text": "2 + 2 equals 4."
@@ -184,37 +188,50 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 2196.481599996332,
-    "generation_wall_ms": 286.98060000897385,
+    "pipeline_construct_wall_ms": 1839.7279999917373,
+    "generation_wall_ms": 289.78099999949336,
+    "generation_total_ms": 289.78099999949336,
+    "decode_total_ms": 289.78099999949336,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 162.13888549804688,
+    "first_token_ms": 162.13888549804688,
+    "total_ms": 2129.5089999912307,
+    "cold_total_ms": 2129.5089999912307,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 2175.0,
+      "load_time_ms": 1818.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 281.4020080566406,
+        "mean_ms": 284.5329895019531,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 278.2690124511719,
+        "mean_ms": 281.489990234375,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 160.48590087890625,
+        "mean_ms": 162.13888549804688,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 15.01463794708252,
-        "std_ms": 24.25859832763672
+        "mean_ms": 15.208287239074707,
+        "std_ms": 23.994169235229492
       },
       "inter_token_latency": {
-        "mean_ms": 31.15833282470703,
-        "std_ms": 51.09067153930664
+        "mean_ms": 31.513444900512695,
+        "std_ms": 51.38871765136719
       },
       "throughput": {
-        "mean_ms": 66.60166931152344,
-        "std_ms": 107.60587310791016
+        "mean_ms": 65.75362396240234,
+        "std_ms": 103.73973083496094
       },
       "detokenization": {
         "mean_ms": -1.0,
@@ -247,6 +264,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief.json
@@ -37,11 +37,15 @@
     "fallback_used": false,
     "openvino_candidate_route_executed": true
   },
-  "created_utc": "2026-05-18T19:44:35Z",
+  "created_utc": "2026-05-26T11:38:29Z",
   "dense_slm": null,
   "execution_coverage": null,
   "fallback_reason": null,
   "fallback_used": false,
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "machine_id": "intel-258v",
   "model": {
     "architecture": "qwen2",
@@ -186,7 +190,7 @@
     "fallback_policy": "strict_no_fallback",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
     "route_id": "dense_slm_openvino_gpu_candidate",
-    "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+    "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-gpu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-gpu",
@@ -194,12 +198,10 @@
     "workload": "dense_slm_acceleration_candidate"
   },
   "route_id": "dense_slm_openvino_gpu_candidate",
-  "route_profile_blockers": [
-    "route not promoted for profile ask_short"
-  ],
+  "route_profile_blockers": [],
   "route_profile_comparison": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
   "route_profile_status": "promoted_route_ready",
-  "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+  "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
   "route_selection": {
     "candidate_routes": [],
     "profile_id": "ask_short",
@@ -207,12 +209,10 @@
     "promotion_status": "direct_route_validated",
     "requested_device": "gpu",
     "requested_route": "dense_slm_openvino_gpu_candidate",
-    "route_profile_blockers": [
-      "route not promoted for profile ask_short"
-    ],
+    "route_profile_blockers": [],
     "route_profile_comparison": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
     "route_profile_status": "promoted_route_ready",
-    "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded.",
+    "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-gpu",
     "selected_route": "dense_slm_openvino_gpu_candidate",
@@ -257,7 +257,7 @@
         "Full BitNet inference works on Arc or NPU."
       ]
     },
-    "created_utc": "2026-05-18T19:44:35Z",
+    "created_utc": "2026-05-26T11:38:28Z",
     "environment": {
       "openvino": {
         "available_devices": [
@@ -281,6 +281,10 @@
       "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json"
     },
     "item": "LNL258V-ASK-004",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "machine_id": "intel-258v",
     "model": {
       "files": {
@@ -353,7 +357,7 @@
     "model_family": "qwen",
     "output": {
       "first_streamed_text_chunk": "2",
-      "first_streamed_text_chunk_ms": 251.78049999522045,
+      "first_streamed_text_chunk_ms": 252.0730000687763,
       "generated_text": "2 + 2 equals 4.",
       "generated_token_count": 9,
       "generated_token_ids": [
@@ -438,7 +442,7 @@
       "answer_gate_evidence": "lunar-lake-openvino-operator-ask-gpu-math-brief.json",
       "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
       "route_id": "dense_slm_openvino_gpu_candidate",
-      "route_reason": "Candidate route because Arc 140V OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false, but no benchmark-qualified speedup claim is recorded."
+      "route_reason": "OpenVINO GPU dense Qwen route is profile-scoped: it may be selected only for workload profiles promoted by the route ledger from fallback-free answer, token-visibility, profile timing, and benchmark-qualified latency evidence; low_power, structured, BitNet, and any unqualified profile remain blocked without separate evidence, and this receipt makes no native OpenCL or acceleration claim."
     },
     "route_id": "dense_slm_openvino_gpu_candidate",
     "runtime_api": "openvino_genai",
@@ -447,37 +451,47 @@
     "selected_backend": "openvino-gpu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-gpu0",
     "timing": {
-      "generation_wall_ms": 286.98060000897385,
+      "cold_total_ms": 2129.5089999912307,
+      "decode_timing_source": "generation_wall_ms",
+      "decode_total_ms": 289.78099999949336,
+      "first_token_ms": 162.13888549804688,
+      "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+      "generation_total_ms": 289.78099999949336,
+      "generation_wall_ms": 289.78099999949336,
+      "known_gaps": [
+        "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+        "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+      ],
       "openvino_perf_metrics": {
         "detokenization": {
           "mean_ms": -1.0,
           "std_ms": -1.0
         },
         "generate": {
-          "mean_ms": 281.4020080566406,
+          "mean_ms": 284.5329895019531,
           "std_ms": 0.0
         },
         "inference": {
-          "mean_ms": 278.2690124511719,
+          "mean_ms": 281.489990234375,
           "std_ms": 0.0
         },
         "inter_token_latency": {
-          "mean_ms": 31.15833282470703,
-          "std_ms": 51.09067153930664
+          "mean_ms": 31.513444900512695,
+          "std_ms": 51.38871765136719
         },
-        "load_time_ms": 2175.0,
+        "load_time_ms": 1818.0,
         "num_generated_tokens": 9,
         "num_input_tokens": 39,
         "throughput": {
-          "mean_ms": 66.60166931152344,
-          "std_ms": 107.60587310791016
+          "mean_ms": 65.75362396240234,
+          "std_ms": 103.73973083496094
         },
         "time_per_output_token": {
-          "mean_ms": 15.01463794708252,
-          "std_ms": 24.25859832763672
+          "mean_ms": 15.208287239074709,
+          "std_ms": 23.994169235229492
         },
         "time_to_first_token": {
-          "mean_ms": 160.48590087890625,
+          "mean_ms": 162.13888549804688,
           "std_ms": 0.0
         },
         "tokenization": {
@@ -485,7 +499,10 @@
           "std_ms": -1.0
         }
       },
-      "pipeline_construct_wall_ms": 2196.481599996332
+      "pipeline_construct_wall_ms": 1839.7279999917373,
+      "prefill_ms": null,
+      "time_to_first_token_ms": 162.13888549804688,
+      "total_ms": 2129.5089999912307
     },
     "tokenizer_source": "hf_tokenizer_export",
     "verification": {
@@ -497,43 +514,54 @@
       "llmpipeline_constructed": true,
       "openvino_perf_metrics_recorded": true,
       "operator_ready": true,
-      "operator_route_validated": true
+      "operator_route_validated": true,
+      "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-openvino-gpu-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-openvino-gpu-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
-    "generation_wall_ms": 286.98060000897385,
+    "cold_total_ms": 2129.5089999912307,
+    "decode_timing_source": "generation_wall_ms",
+    "decode_total_ms": 289.78099999949336,
+    "first_token_ms": 162.13888549804688,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "generation_total_ms": 289.78099999949336,
+    "generation_wall_ms": 289.78099999949336,
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
       "detokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 281.4020080566406,
+        "mean_ms": 284.5329895019531,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 278.2690124511719,
+        "mean_ms": 281.489990234375,
         "std_ms": 0.0
       },
       "inter_token_latency": {
-        "mean_ms": 31.15833282470703,
-        "std_ms": 51.09067153930664
+        "mean_ms": 31.513444900512695,
+        "std_ms": 51.38871765136719
       },
-      "load_time_ms": 2175.0,
+      "load_time_ms": 1818.0,
       "num_generated_tokens": 9,
       "num_input_tokens": 39,
       "throughput": {
-        "mean_ms": 66.60166931152344,
-        "std_ms": 107.60587310791016
+        "mean_ms": 65.75362396240234,
+        "std_ms": 103.73973083496094
       },
       "time_per_output_token": {
-        "mean_ms": 15.01463794708252,
-        "std_ms": 24.25859832763672
+        "mean_ms": 15.208287239074709,
+        "std_ms": 23.994169235229492
       },
       "time_to_first_token": {
-        "mean_ms": 160.48590087890625,
+        "mean_ms": 162.13888549804688,
         "std_ms": 0.0
       },
       "tokenization": {
@@ -541,7 +569,10 @@
         "std_ms": -1.0
       }
     },
-    "pipeline_construct_wall_ms": 2196.481599996332
+    "pipeline_construct_wall_ms": 1839.7279999917373,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 162.13888549804688,
+    "total_ms": 2129.5089999912307
   },
   "tokenizer_source": "hf_tokenizer_export",
   "tokens": {

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief-source-run.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief-source-run.json
@@ -3,7 +3,7 @@
   "artifact_kind": "lunar_lake_openvino_operator_ask",
   "campaign": "intel-258v-platform",
   "item": "LNL258V-ASK-004",
-  "created_utc": "2026-05-18T19:45:22Z",
+  "created_utc": "2026-05-26T11:39:09Z",
   "machine_id": "intel-258v",
   "proof_stage": "operator_candidate_route_executed",
   "requested_backend": "openvino-npu",
@@ -23,11 +23,15 @@
   "route_id": "dense_slm_openvino_npu_candidate",
   "route": {
     "route_id": "dense_slm_openvino_npu_candidate",
-    "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+    "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
     "acceleration_claim": false,
     "answer_gate_evidence": "lunar-lake-openvino-operator-ask-npu-math-brief.json",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json"
   },
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "inputs": {
     "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
     "artifact_root": "ci/hardware/intel-258v/2026-05-08",
@@ -172,7 +176,7 @@
     "generated_token_ids_available_from_pipeline": true,
     "generated_token_ids_source": "openvino_genai_encoded_results_tokens",
     "generated_token_count": 9,
-    "first_streamed_text_chunk_ms": 644.2006999859586,
+    "first_streamed_text_chunk_ms": 367.02439992222935,
     "first_streamed_text_chunk": "2",
     "streamed_chunks_count": 8,
     "streamed_text": "2 + 2 equals 4."
@@ -184,37 +188,50 @@
     "failed_rules": []
   },
   "timing": {
-    "pipeline_construct_wall_ms": 29129.048800008604,
-    "generation_wall_ms": 913.3272999897599,
+    "pipeline_construct_wall_ms": 29055.796200060286,
+    "generation_wall_ms": 524.6368999360129,
+    "generation_total_ms": 524.6368999360129,
+    "decode_total_ms": 524.6368999360129,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 235.67901611328125,
+    "first_token_ms": 235.67901611328125,
+    "total_ms": 29580.4330999963,
+    "cold_total_ms": 29580.4330999963,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "decode_timing_source": "generation_wall_ms",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
-      "load_time_ms": 29105.0,
+      "load_time_ms": 29024.0,
       "tokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 894.625,
+        "mean_ms": 504.9049987792969,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 889.833984375,
+        "mean_ms": 502.35101318359375,
         "std_ms": 0.0
       },
       "time_to_first_token": {
-        "mean_ms": 334.3456726074219,
+        "mean_ms": 235.67901611328125,
         "std_ms": 0.0
       },
       "time_per_output_token": {
-        "mean_ms": 69.94927215576172,
-        "std_ms": 54.59255599975586
+        "mean_ms": 33.606475830078125,
+        "std_ms": 17.745742797851562
       },
       "inter_token_latency": {
-        "mean_ms": 98.87044525146484,
-        "std_ms": 97.62153625488281
+        "mean_ms": 55.816776275634766,
+        "std_ms": 65.64060974121094
       },
       "throughput": {
-        "mean_ms": 14.296074867248535,
-        "std_ms": 11.157503128051758
+        "mean_ms": 29.75617027282715,
+        "std_ms": 15.712605476379395
       },
       "detokenization": {
         "mean_ms": -1.0,
@@ -247,6 +264,7 @@
     "answer_gate_passed": true,
     "fallback_used": false,
     "openvino_perf_metrics_recorded": true,
+    "standard_timing_aliases_recorded": true,
     "generated_token_ids_available_from_pipeline": true,
     "acceleration_claim": false
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief.json
@@ -37,11 +37,15 @@
     "fallback_used": false,
     "openvino_candidate_route_executed": true
   },
-  "created_utc": "2026-05-18T19:45:23Z",
+  "created_utc": "2026-05-26T11:39:11Z",
   "dense_slm": null,
   "execution_coverage": null,
   "fallback_reason": null,
   "fallback_used": false,
+  "known_gaps": [
+    "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+    "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+  ],
   "machine_id": "intel-258v",
   "model": {
     "architecture": "qwen2",
@@ -186,7 +190,7 @@
     "fallback_policy": "strict_no_fallback",
     "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
     "route_id": "dense_slm_openvino_npu_candidate",
-    "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+    "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-npu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-npu",
@@ -196,13 +200,11 @@
   "route_id": "dense_slm_openvino_npu_candidate",
   "route_profile_blockers": [
     "NPU cold start is openvino_pipeline_load_or_device_compile_dominated",
-    "benchmark_qualified_speedup_or_power_advantage",
-    "candidate route requires benchmark-qualified profile evidence",
     "route not promoted for profile ask_short"
   ],
   "route_profile_comparison": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
   "route_profile_status": "promoted_route_ready",
-  "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+  "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
   "route_selection": {
     "candidate_routes": [],
     "profile_id": "ask_short",
@@ -212,13 +214,11 @@
     "requested_route": "dense_slm_openvino_npu_candidate",
     "route_profile_blockers": [
       "NPU cold start is openvino_pipeline_load_or_device_compile_dominated",
-      "benchmark_qualified_speedup_or_power_advantage",
-      "candidate route requires benchmark-qualified profile evidence",
       "route not promoted for profile ask_short"
     ],
     "route_profile_comparison": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
     "route_profile_status": "promoted_route_ready",
-    "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made.",
+    "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim.",
     "runtime_api": "openvino_genai",
     "selected_backend": "openvino-npu",
     "selected_route": "dense_slm_openvino_npu_candidate",
@@ -263,7 +263,7 @@
         "Full BitNet inference works on Arc or NPU."
       ]
     },
-    "created_utc": "2026-05-18T19:45:22Z",
+    "created_utc": "2026-05-26T11:39:09Z",
     "environment": {
       "openvino": {
         "available_devices": [
@@ -287,6 +287,10 @@
       "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json"
     },
     "item": "LNL258V-ASK-004",
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "machine_id": "intel-258v",
     "model": {
       "files": {
@@ -359,7 +363,7 @@
     "model_family": "qwen",
     "output": {
       "first_streamed_text_chunk": "2",
-      "first_streamed_text_chunk_ms": 644.2006999859586,
+      "first_streamed_text_chunk_ms": 367.02439992222935,
       "generated_text": "2 + 2 equals 4.",
       "generated_token_count": 9,
       "generated_token_ids": [
@@ -444,7 +448,7 @@
       "answer_gate_evidence": "lunar-lake-openvino-operator-ask-npu-math-brief.json",
       "phase_evidence": "slm-openvino-cpu-gpu-npu-phase-runner.json",
       "route_id": "dense_slm_openvino_npu_candidate",
-      "route_reason": "Candidate route because Intel NPU OpenVINO GenAI bounded answer gates and phase metrics exist with fallback_used=false under INT4 symmetric constraints; no dynamic decode, beam, parallel sampling, packed QK256, or acceleration claim is made."
+      "route_reason": "OpenVINO NPU dense Qwen route is profile-scoped: warm_resident may be selected only when the route ledger promotes the resident-session path from fallback-free quality and timing evidence; cold one-off and low_power profiles remain blocked until separately qualified, with INT4 symmetric greedy constraints and no dynamic decode, beam, parallel sampling, packed QK256, native NPU, or acceleration claim."
     },
     "route_id": "dense_slm_openvino_npu_candidate",
     "runtime_api": "openvino_genai",
@@ -453,37 +457,47 @@
     "selected_backend": "openvino-npu",
     "selected_kernel_or_runtime": "openvino-genai-llmpipeline-npu",
     "timing": {
-      "generation_wall_ms": 913.32729998976,
+      "cold_total_ms": 29580.4330999963,
+      "decode_timing_source": "generation_wall_ms",
+      "decode_total_ms": 524.6368999360129,
+      "first_token_ms": 235.67901611328125,
+      "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+      "generation_total_ms": 524.6368999360129,
+      "generation_wall_ms": 524.6368999360129,
+      "known_gaps": [
+        "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+        "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+      ],
       "openvino_perf_metrics": {
         "detokenization": {
           "mean_ms": -1.0,
           "std_ms": -1.0
         },
         "generate": {
-          "mean_ms": 894.625,
+          "mean_ms": 504.9049987792969,
           "std_ms": 0.0
         },
         "inference": {
-          "mean_ms": 889.833984375,
+          "mean_ms": 502.35101318359375,
           "std_ms": 0.0
         },
         "inter_token_latency": {
-          "mean_ms": 98.87044525146484,
-          "std_ms": 97.6215362548828
+          "mean_ms": 55.816776275634766,
+          "std_ms": 65.64060974121094
         },
-        "load_time_ms": 29105.0,
+        "load_time_ms": 29024.0,
         "num_generated_tokens": 9,
         "num_input_tokens": 39,
         "throughput": {
-          "mean_ms": 14.296074867248535,
-          "std_ms": 11.157503128051758
+          "mean_ms": 29.75617027282715,
+          "std_ms": 15.712605476379396
         },
         "time_per_output_token": {
-          "mean_ms": 69.94927215576172,
-          "std_ms": 54.59255599975586
+          "mean_ms": 33.606475830078125,
+          "std_ms": 17.745742797851562
         },
         "time_to_first_token": {
-          "mean_ms": 334.3456726074219,
+          "mean_ms": 235.67901611328125,
           "std_ms": 0.0
         },
         "tokenization": {
@@ -491,7 +505,10 @@
           "std_ms": -1.0
         }
       },
-      "pipeline_construct_wall_ms": 29129.048800008604
+      "pipeline_construct_wall_ms": 29055.79620006029,
+      "prefill_ms": null,
+      "time_to_first_token_ms": 235.67901611328125,
+      "total_ms": 29580.4330999963
     },
     "tokenizer_source": "hf_tokenizer_export",
     "verification": {
@@ -503,43 +520,54 @@
       "llmpipeline_constructed": true,
       "openvino_perf_metrics_recorded": true,
       "operator_ready": true,
-      "operator_route_validated": true
+      "operator_route_validated": true,
+      "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-openvino-npu-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-openvino-npu-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
-    "generation_wall_ms": 913.32729998976,
+    "cold_total_ms": 29580.4330999963,
+    "decode_timing_source": "generation_wall_ms",
+    "decode_total_ms": 524.6368999360129,
+    "first_token_ms": 235.67901611328125,
+    "first_token_timing_source": "openvino_perf_metrics.time_to_first_token.mean_ms",
+    "generation_total_ms": 524.6368999360129,
+    "generation_wall_ms": 524.6368999360129,
+    "known_gaps": [
+      "OpenVINO GenAI operator ask does not expose a separate prefill_ms split; time_to_first_token_ms is recorded from OpenVINO perf metrics when available.",
+      "decode_total_ms uses generation_wall_ms for the bounded generate call and is not a per-token CPU-style decode-step sum."
+    ],
     "openvino_perf_metrics": {
       "detokenization": {
         "mean_ms": -1.0,
         "std_ms": -1.0
       },
       "generate": {
-        "mean_ms": 894.625,
+        "mean_ms": 504.9049987792969,
         "std_ms": 0.0
       },
       "inference": {
-        "mean_ms": 889.833984375,
+        "mean_ms": 502.35101318359375,
         "std_ms": 0.0
       },
       "inter_token_latency": {
-        "mean_ms": 98.87044525146484,
-        "std_ms": 97.6215362548828
+        "mean_ms": 55.816776275634766,
+        "std_ms": 65.64060974121094
       },
-      "load_time_ms": 29105.0,
+      "load_time_ms": 29024.0,
       "num_generated_tokens": 9,
       "num_input_tokens": 39,
       "throughput": {
-        "mean_ms": 14.296074867248535,
-        "std_ms": 11.157503128051758
+        "mean_ms": 29.75617027282715,
+        "std_ms": 15.712605476379396
       },
       "time_per_output_token": {
-        "mean_ms": 69.94927215576172,
-        "std_ms": 54.59255599975586
+        "mean_ms": 33.606475830078125,
+        "std_ms": 17.745742797851562
       },
       "time_to_first_token": {
-        "mean_ms": 334.3456726074219,
+        "mean_ms": 235.67901611328125,
         "std_ms": 0.0
       },
       "tokenization": {
@@ -547,7 +575,10 @@
         "std_ms": -1.0
       }
     },
-    "pipeline_construct_wall_ms": 29129.048800008604
+    "pipeline_construct_wall_ms": 29055.79620006029,
+    "prefill_ms": null,
+    "time_to_first_token_ms": 235.67901611328125,
+    "total_ms": 29580.4330999963
   },
   "tokenizer_source": "hf_tokenizer_export",
   "tokens": {


### PR DESCRIPTION
Summary:
- refresh direct OpenVINO GPU and NPU operator ask evidence with standard timing aliases and known gaps
- refresh direct CLI wrapper receipts for explicit GPU/NPU ask routes
- preserve fallback=false, bounded answer gates, and non-acceleration claim boundaries

Validation:
- .venv/Scripts/python.exe scripts/openvino_genai_operator_ask.py --model-dir models/openvino/qwen2.5-0.5b-instruct-int4-sym --device GPU.0 --question "What is 2+2? Answer briefly." --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --route-id dense_slm_openvino_gpu_candidate --max-new-tokens 16 --expect-contains 4 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-openvino-operator-ask-gpu-math-brief.json
- .venv/Scripts/python.exe scripts/openvino_genai_operator_ask.py --model-dir models/openvino/qwen2.5-0.5b-instruct-int4-sym --device NPU --question "What is 2+2? Answer briefly." --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --route-id dense_slm_openvino_npu_candidate --max-new-tokens 16 --expect-contains 4 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-openvino-operator-ask-npu-math-brief.json
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device gpu lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile ask_short --route dense_slm_openvino_gpu_candidate --question "What is 2+2? Answer briefly." --expect-contains 4 --max-new-tokens 16 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief.json
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --device npu lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile ask_short --route dense_slm_openvino_npu_candidate --question "What is 2+2? Answer briefly." --expect-contains 4 --max-new-tokens 16 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief.json
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake validate --artifact-root ci/hardware/intel-258v/2026-05-08 --json-out target/tmp/lunar-lake-operator-readiness-after-direct-openvino-refresh.json --strict
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake regress --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt target/tmp/lunar-lake-operator-readiness-after-direct-openvino-refresh.json --json-out target/tmp/lunar-lake-regression-after-direct-openvino-refresh.json --strict
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake compare --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt target/tmp/lunar-lake-operator-readiness-after-direct-openvino-refresh.json --regression-bundle target/tmp/lunar-lake-regression-after-direct-openvino-refresh.json --json-out target/tmp/lunar-lake-operator-comparison-after-direct-openvino-refresh.json --strict
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check