### PR TITLE
fix(lunar-lake): normalize ask receipt paths

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief.json
@@ -525,7 +525,7 @@
       "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cold_total_ms": 2181.832400150597,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief.json
@@ -525,7 +525,7 @@
       "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cold_total_ms": 2096.755300066434,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-math-brief.json
@@ -977,7 +977,7 @@
       "total": 47
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cuda_kernel_time_ms": null,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief.json
@@ -521,7 +521,7 @@
       "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cold_total_ms": 28917.05109993927,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-math-brief.json
@@ -887,7 +887,7 @@
       "total": 47
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cuda_kernel_time_ms": null,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-math.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-math.json
@@ -881,7 +881,7 @@
       "total": 44
     }
   },
-  "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-math-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-math-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cuda_kernel_time_ms": null,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief.json
@@ -518,7 +518,7 @@
       "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-openvino-gpu-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-gpu-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cold_total_ms": 2129.5089999912307,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief.json
@@ -524,7 +524,7 @@
       "standard_timing_aliases_recorded": true
     }
   },
-  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-openvino-npu-math-brief-source-run.json",
+  "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-openvino-npu-math-brief-source-run.json",
   "speedup_claim": false,
   "timing": {
     "cold_total_ms": 29580.4330999963,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-comparison.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-comparison.json
@@ -139,7 +139,7 @@
     "acceleration_claim": false,
     "bitnet_qk256_i2s_claim": false,
     "generated_token_ids_available": true,
-    "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
+    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
     "regression_ready": true,
     "gaps": []
   },
@@ -164,7 +164,7 @@
     "acceleration_claim": false,
     "bitnet_qk256_i2s_claim": false,
     "generated_token_ids_available": true,
-    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
+    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
     "regression_ready": true,
     "gaps": []
   },
@@ -189,7 +189,7 @@
     "acceleration_claim": false,
     "bitnet_qk256_i2s_claim": false,
     "generated_token_ids_available": true,
-    "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
+    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
     "regression_ready": true,
     "gaps": []
   },

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json
@@ -494,7 +494,7 @@
     "acceleration_claim": false,
     "bitnet_qk256_i2s_claim": false,
     "generated_token_ids_available": true,
-    "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
+    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json",
     "regression_ready": true,
     "gaps": []
   },
@@ -519,7 +519,7 @@
     "acceleration_claim": false,
     "bitnet_qk256_i2s_claim": false,
     "generated_token_ids_available": true,
-    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
+    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief-source-run.json",
     "regression_ready": true,
     "gaps": []
   },
@@ -544,7 +544,7 @@
     "acceleration_claim": false,
     "bitnet_qk256_i2s_claim": false,
     "generated_token_ids_available": true,
-    "source_run_receipt": "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
+    "source_run_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-npu-warm-resident-math-brief-source-run.json",
     "regression_ready": true,
     "gaps": []
   },

--- a/crates/bitnet-cli/src/commands/lunar_lake.rs
+++ b/crates/bitnet-cli/src/commands/lunar_lake.rs
@@ -5599,7 +5599,8 @@ fn inspect_operator_ask_regression(
                 "source_receipt.verification.generated_token_ids_available_from_pipeline",
             ],
         ) == Some(true);
-    let source_run_receipt = string_at(&receipt, "source_run_receipt");
+    let source_run_receipt =
+        string_at(&receipt, "source_run_receipt").map(|path| normalize_path_string(&path));
 
     if profile_id != expected.profile_id {
         gaps.push(format!(
@@ -16102,7 +16103,12 @@ fn value_at<'a>(json: &'a Value, dotted_path: &str) -> Option<&'a Value> {
 }
 
 fn path_string(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let path = path.to_string_lossy();
+    normalize_path_string(path.as_ref())
+}
+
+fn normalize_path_string(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 fn answer_preview(answer: &str) -> String {
@@ -21024,6 +21030,36 @@ mod tests {
         assert!(!summary.power_advantage_claim);
         assert!(!summary.acceleration_claim);
         assert!(!summary.bitnet_qk256_i2s_claim);
+        Ok(())
+    }
+
+    #[test]
+    fn operator_ask_regression_normalizes_source_run_receipt_path() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        write_ask_short_auto_gpu_ask(temp.path(), AUTO_GPU_ASK_SHORT_ASK_RECEIPT)?;
+        let path = temp.path().join(AUTO_GPU_ASK_SHORT_ASK_RECEIPT);
+        let mut receipt: Value = read_json_receipt(&path)?;
+        receipt["source_run_receipt"] = json!(
+            "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json"
+        );
+        fs::write(&path, serde_json::to_vec_pretty(&receipt)?)?;
+
+        let summary = inspect_operator_ask_regression(
+            &path,
+            OperatorAskRegressionExpectation {
+                label: "ask_short",
+                profile_id: "ask_short",
+                selected_route: "dense_slm_openvino_gpu_candidate",
+                selected_backend: "openvino-gpu",
+            },
+        )?;
+
+        assert_eq!(
+            summary.source_run_receipt.as_deref(),
+            Some(
+                "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-gpu-ask-short-math-brief-source-run.json"
+            )
+        );
         Ok(())
     }
 

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -11019,6 +11019,11 @@ fn source_run_receipt_path(receipt_path: &std::path::Path) -> std::path::PathBuf
 }
 
 #[cfg(feature = "full-cli")]
+fn lunar_lake_receipt_path_string(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(feature = "full-cli")]
 struct OpenVINOOperatorAskContext<'a> {
     artifact_root: &'a std::path::Path,
     operator_receipt_path: &'a std::path::Path,
@@ -11193,11 +11198,11 @@ fn build_lunar_lake_operator_ask_blocked_receipt(
     let promotion_ledger = ctx
         .route_selection
         .and_then(|selection| selection.promotion_ledger.clone())
-        .unwrap_or_else(|| ctx.promotion_ledger.display().to_string());
+        .unwrap_or_else(|| lunar_lake_receipt_path_string(ctx.promotion_ledger));
     let route_profile_comparison = ctx
         .route_selection
         .and_then(|selection| selection.route_profile_comparison.clone())
-        .unwrap_or_else(|| ctx.route_profile_comparison.display().to_string());
+        .unwrap_or_else(|| lunar_lake_receipt_path_string(ctx.route_profile_comparison));
     let operator_runbook = ctx
         .route_selection
         .and_then(|selection| selection.operator_runbook.clone())
@@ -11217,10 +11222,10 @@ fn build_lunar_lake_operator_ask_blocked_receipt(
         "proof_stage": "operator_route_selection_blocked_no_inference",
         "created_utc": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "machine_id": "intel-258v",
-        "artifact_root": ctx.artifact_root.display().to_string(),
-        "operator_receipt": ctx.operator_receipt.display().to_string(),
-        "promotion_ledger": ctx.promotion_ledger.display().to_string(),
-        "route_profile_comparison": ctx.route_profile_comparison.display().to_string(),
+        "artifact_root": lunar_lake_receipt_path_string(ctx.artifact_root),
+        "operator_receipt": lunar_lake_receipt_path_string(ctx.operator_receipt),
+        "promotion_ledger": lunar_lake_receipt_path_string(ctx.promotion_ledger),
+        "route_profile_comparison": lunar_lake_receipt_path_string(ctx.route_profile_comparison),
         "requested_device": ctx.requested_device,
         "requested_route": ctx.requested_route,
         "profile_id": ctx.profile_id,
@@ -11356,9 +11361,9 @@ fn build_lunar_lake_operator_ask_receipt(ctx: LunarLakeAskReceiptContext<'_>) ->
         "proof_stage": proof_stage,
         "created_utc": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         "machine_id": "intel-258v",
-        "artifact_root": ctx.artifact_root.display().to_string(),
-        "operator_receipt": ctx.operator_receipt_path.display().to_string(),
-        "source_run_receipt": ctx.source_run_path.display().to_string(),
+        "artifact_root": lunar_lake_receipt_path_string(ctx.artifact_root),
+        "operator_receipt": lunar_lake_receipt_path_string(ctx.operator_receipt_path),
+        "source_run_receipt": lunar_lake_receipt_path_string(ctx.source_run_path),
         "requested_device": ctx.route_selection.requested_device,
         "requested_route": ctx.route_selection.requested_route,
         "profile_id": ctx.route_selection.profile_id,
@@ -14758,6 +14763,7 @@ mod tests {
             "runtime_api": "cpu",
             "fallback_used": false,
             "fallback_reason": null,
+            "backend_lane": "dense_slm_cpu",
             "kernel": {"kernel_id": "dense-qwen-cpu-reference"},
             "model": {
                 "path": "models/qwen2.5.gguf",
@@ -14770,6 +14776,7 @@ mod tests {
                 "loader_mode": "real_gguf",
                 "fallback_loader_used": false
             },
+            "prompt_template": "qwen2.5",
             "prompt_render": "<|im_start|>user\n2+2?<|im_end|>\n<|im_start|>assistant\n",
             "tokens": {
                 "prompt_ids": [1, 2, 3],
@@ -14785,9 +14792,13 @@ mod tests {
         });
         let gate = evaluate_lunar_lake_answer_gate("4", Some("4"));
         let receipt = build_lunar_lake_operator_ask_receipt(LunarLakeAskReceiptContext {
-            artifact_root: std::path::Path::new("ci/hardware/intel-258v/2026-05-08"),
-            operator_receipt_path: std::path::Path::new("lunar-lake-operator-readiness.json"),
-            source_run_path: std::path::Path::new("lunar-lake-operator-ask-source-run.json"),
+            artifact_root: std::path::Path::new("ci\\hardware\\intel-258v\\2026-05-08"),
+            operator_receipt_path: std::path::Path::new(
+                "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-readiness.json",
+            ),
+            source_run_path: std::path::Path::new(
+                "ci\\hardware\\intel-258v\\2026-05-08\\lunar-lake-operator-ask-source-run.json",
+            ),
             route: &route,
             route_selection: &route_selection,
             question: "2+2?",
@@ -14798,6 +14809,15 @@ mod tests {
             source_run_receipt: &source,
         });
 
+        assert_eq!(receipt["artifact_root"], "ci/hardware/intel-258v/2026-05-08");
+        assert_eq!(
+            receipt["operator_receipt"],
+            "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json"
+        );
+        assert_eq!(
+            receipt["source_run_receipt"],
+            "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-source-run.json"
+        );
         assert_eq!(receipt["requested_backend"], "cpu");
         assert_eq!(receipt["selected_backend"], "cpu-rust");
         assert_eq!(receipt["runtime_api"], "cpu");


### PR DESCRIPTION
## Summary
- normalize `lunar-lake ask` wrapper path fields to forward slashes before serializing receipts
- normalize imported operator-ask `source_run_receipt` paths in regression summaries
- refresh committed Lunar Lake ask, regression, and comparison receipts so path metadata is stable on Windows rebuilds

## Validation
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet tests::lunar_lake_operator_ask_receipt_has_top_level_identity -- --exact --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::lunar_lake::tests::operator_ask_regression_normalizes_source_run_receipt_path -- --exact --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet tests::lunar_lake_operator_ask_receipt_accepts_openvino_source_shape -- --exact --nocapture`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake regress --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --json-out target/tmp/lunar-lake-regression-normalized-paths.json --created-utc 2026-05-21T06:49:14Z --strict`
- `git diff --no-index --stat ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json target/tmp/lunar-lake-regression-normalized-paths.json` (no diff)
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- lunar-lake compare --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --regression-bundle lunar-lake-regression-bundle-v2.json --json-out target/tmp/lunar-lake-comparison-normalized-paths.json --created-utc 2026-05-21T06:49:14Z --strict`
- `git diff --no-index --stat ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-comparison.json target/tmp/lunar-lake-comparison-normalized-paths.json` (no diff)
- `cargo fmt -p bitnet-cli --check`
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`