### PR TITLE
fix(lunar-lake): auto-route default ask

### DIFF
--- a/crates/bitnet-cli/src/commands/lunar_lake.rs
+++ b/crates/bitnet-cli/src/commands/lunar_lake.rs
@@ -91,6 +91,7 @@ const AUTO_NPU_WARM_RESIDENT_ASK_RECEIPT: &str =
 const ANSWER_CORPUS_V2: &str = "ci/quality/lunar-lake-answer-corpus-v2.yaml";
 const REGRESSION_V2_SURFACE_ID: &str = "lunar_lake_regression_v2";
 pub const DEFAULT_ASK_ROUTE: &str = "dense_slm_default_cpu";
+const DEFAULT_ASK_CLI_ROUTE: &str = "auto";
 
 const REQUIRED_CORPUS_V2_PROFILES: &[&str] = &[
     "regression_tiny",
@@ -886,7 +887,7 @@ pub enum LunarLakeAction {
         /// Operator route to execute, or auto to select from the promotion ledger.
         /// Auto selection only uses ledger-promoted routes; OpenVINO candidate routes require
         /// an explicit --route plus matching --device request.
-        #[arg(long, default_value = DEFAULT_ASK_ROUTE)]
+        #[arg(long, default_value = DEFAULT_ASK_CLI_ROUTE)]
         route: String,
 
         /// Dense Qwen model path. When omitted, the ask path resolves the local model path from

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -13875,6 +13875,40 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "full-cli")]
+    fn lunar_lake_ask_cli_defaults_to_auto_route_for_profile_selection() -> Result<()> {
+        let handle = std::thread::Builder::new()
+            .name("lunar-lake-ask-clap-parse".to_string())
+            .stack_size(64 * 1024 * 1024)
+            .spawn(|| -> Result<(String, String)> {
+                let cli = Cli::try_parse_from([
+                    "bitnet",
+                    "lunar-lake",
+                    "ask",
+                    "--question",
+                    "What is 2+2?",
+                ])
+                .context("lunar-lake ask defaults should parse")?;
+
+                let Some(Commands::LunarLake(LunarLakeCommand {
+                    action: LunarLakeAction::Ask { profile, route, .. },
+                })) = cli.command
+                else {
+                    anyhow::bail!("expected lunar-lake ask command");
+                };
+
+                Ok((profile, route))
+            })
+            .map_err(|err| anyhow::anyhow!("spawn clap parse thread: {err}"))?;
+        let (profile, route) =
+            handle.join().map_err(|_| anyhow::anyhow!("clap parse thread panicked"))??;
+
+        assert_eq!(profile, "ask_normal");
+        assert_eq!(route, "auto");
+        Ok(())
+    }
+
+    #[test]
     #[cfg(feature = "cli-bench")]
     fn report_only_cuda_benchmark_receipt_skips_startup_backend_selection() {
         let report_command = Commands::Benchmark(BenchmarkCommand {


### PR DESCRIPTION
## Summary
- make `bitnet lunar-lake ask` default `--route` to `auto` so the default `ask_normal` profile follows the promotion ledger
- keep `DEFAULT_ASK_ROUTE` as the dense Qwen CPU baseline identity
- add a large-stack clap parsing regression test for the default route/profile pair

## Validation
- `cargo fmt -p bitnet-cli -- --check`
- `cargo test -p bitnet-cli --no-default-features --features cpu,full-cli lunar_lake_ask_cli_defaults_to_auto_route_for_profile_selection -- --nocapture`
- `cargo build --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet`
- `target/debug/bitnet.exe lunar-lake ask --help` shows `--route [default: auto]`
- scratch default `bitnet lunar-lake ask ...` selected `dense_slm_openvino_gpu_candidate`, `fallback_used=false`, `answer_gate_passed=true`
- `git diff --check`