### PR TITLE
chore(lunar-lake): allow POWER-006 battery ask receipts

### DIFF
--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -12071,6 +12071,9 @@ commands = [
 allowed_paths = [
   "ci/hardware/intel-258v/2026-05-08/lunar-lake-low-power-battery-before.json",
   "ci/hardware/intel-258v/2026-05-08/lunar-lake-low-power-battery-after.json",
+  "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-battery-low-power-cpu.json",
+  "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-battery-low-power-gpu.json",
+  "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-battery-low-power-npu.json",
   "ci/hardware/intel-258v/2026-05-08/lunar-lake-low-power-energy-proxy.json",
   "ci/hardware/intel-258v/2026-05-08/lunar-lake-power-profile-evidence.json",
   "ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json",


### PR DESCRIPTION
## Summary
- Add the three runbook-defined POWER-006 battery low_power ask receipt paths to the active item allowed_paths list.
- Keep LNL258V-POWER-006 blocked; this PR does not collect battery telemetry or claim low_power evidence.

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Notes
The physical battery-mode gate is still blocked while the 258V reports AC power. The strict before-telemetry receipt must still be collected before any POWER-006 evidence run.