### PR TITLE
fix(lunar-lake): surface low-power power evidence gate

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-low-power-blocked.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-low-power-blocked.json
@@ -22,7 +22,7 @@
     "route_selection_blocked": true,
     "speedup_claim": false
   },
-  "created_utc": "2026-05-30T04:21:43Z",
+  "created_utc": "2026-05-30T05:03:25Z",
   "fallback_used": false,
   "machine_id": "intel-258v",
   "max_new_tokens": 4,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-comparison.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-comparison.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "artifact_kind": "lunar_lake_operator_comparison",
   "proof_stage": "operator_routes_compared",
-  "created_utc": "2026-05-30T04:17:30Z",
+  "created_utc": "2026-05-30T05:03:40Z",
   "machine_id": "intel-258v",
   "artifact_root": "ci/hardware/intel-258v/2026-05-08",
   "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
@@ -942,7 +942,7 @@
         "energy_proxy_source=energy_proxy_receipt",
         "thermal_context_recorded=true",
         "operator_runbook=docs/hardware/intel-258v-low-power-battery-runbook.md",
-        "next_required_evidence=record thermal temperatures if available; current thermal evidence is zone visibility only | only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass",
+        "next_required_evidence=collect benchmark-qualified low_power power-advantage evidence from battery-mode route samples or accepted energy proxy before promotion | record measured thermal temperatures if available or preserve thermal-unavailable as an explicit blocker | only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass",
         "claim_boundary_preserved=true",
         "blocker_count=5"
       ]

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "artifact_kind": "lunar_lake_operator_readiness",
   "proof_stage": "operator_routes_indexed",
-  "created_utc": "2026-05-30T04:17:10Z",
+  "created_utc": "2026-05-30T05:03:20Z",
   "machine_id": "intel-258v",
   "artifact_root": "ci/hardware/intel-258v/2026-05-08",
   "operator_ready": true,
@@ -237,7 +237,8 @@
     "thermal_context_recorded": true,
     "operator_runbook": "docs/hardware/intel-258v-low-power-battery-runbook.md",
     "next_required_evidence": [
-      "record thermal temperatures if available; current thermal evidence is zone visibility only",
+      "collect benchmark-qualified low_power power-advantage evidence from battery-mode route samples or accepted energy proxy before promotion",
+      "record measured thermal temperatures if available or preserve thermal-unavailable as an explicit blocker",
       "only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass"
     ],
     "claim_boundary_preserved": true,

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-power-profile-evidence.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-power-profile-evidence.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "artifact_kind": "lunar_lake_power_profile_evidence",
   "proof_stage": "low_power_evidence_indexed_no_promotion_change",
-  "created_utc": "2026-05-30T04:15:00Z",
+  "created_utc": "2026-05-30T05:03:10Z",
   "machine_id": "intel-258v",
   "artifact_root": "ci/hardware/intel-258v/2026-05-08",
   "route_profile_comparison_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-route-profile-comparison.json",
@@ -158,7 +158,8 @@
   ],
   "operator_runbook": "docs/hardware/intel-258v-low-power-battery-runbook.md",
   "next_required_evidence": [
-    "record thermal temperatures if available; current thermal evidence is zone visibility only",
+    "collect benchmark-qualified low_power power-advantage evidence from battery-mode route samples or accepted energy proxy before promotion",
+    "record measured thermal temperatures if available or preserve thermal-unavailable as an explicit blocker",
     "only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass"
   ],
   "claim_boundary": {

--- a/ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json
+++ b/ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "artifact_kind": "lunar_lake_regression_bundle",
   "proof_stage": "operator_regression_indexed",
-  "created_utc": "2026-05-30T04:17:20Z",
+  "created_utc": "2026-05-30T05:03:30Z",
   "machine_id": "intel-258v",
   "artifact_root": "ci/hardware/intel-258v/2026-05-08",
   "operator_receipt": "ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json",
@@ -443,7 +443,8 @@
     "thermal_context_recorded": true,
     "operator_runbook": "docs/hardware/intel-258v-low-power-battery-runbook.md",
     "next_required_evidence": [
-      "record thermal temperatures if available; current thermal evidence is zone visibility only",
+      "collect benchmark-qualified low_power power-advantage evidence from battery-mode route samples or accepted energy proxy before promotion",
+      "record measured thermal temperatures if available or preserve thermal-unavailable as an explicit blocker",
       "only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass"
     ],
     "claim_boundary_preserved": true,
@@ -887,7 +888,7 @@
         "energy_proxy_source=energy_proxy_receipt",
         "thermal_context_recorded=true",
         "operator_runbook=docs/hardware/intel-258v-low-power-battery-runbook.md",
-        "next_required_evidence=record thermal temperatures if available; current thermal evidence is zone visibility only | only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass",
+        "next_required_evidence=collect benchmark-qualified low_power power-advantage evidence from battery-mode route samples or accepted energy proxy before promotion | record measured thermal temperatures if available or preserve thermal-unavailable as an explicit blocker | only promote low_power after answer gates, fallback=false, stable timing, and power advantage all pass",
         "claim_boundary_preserved=true",
         "blocker_count=5"
       ]

--- a/crates/bitnet-cli/src/commands/lunar_lake.rs
+++ b/crates/bitnet-cli/src/commands/lunar_lake.rs
@@ -8752,6 +8752,13 @@ pub fn build_power_profile_evidence_with_created_utc(
     }
     let low_power_battery_samples_required =
         telemetry.battery_mode_sample_recorded || telemetry.energy_proxy_recorded;
+    let low_power_battery_route_samples_ready = !low_power_battery_route_samples.is_empty()
+        && LOW_POWER_BATTERY_ROUTE_IDS.iter().all(|route_id| {
+            low_power_battery_route_samples
+                .iter()
+                .any(|sample| sample.route_id.as_deref() == Some(*route_id))
+        })
+        && low_power_battery_route_samples.iter().all(|sample| sample.requirement_satisfied);
     if low_power_battery_samples_required && low_power_battery_route_samples.is_empty() {
         gaps.push(
             "low_power battery route ask receipts are missing from power-profile evidence"
@@ -8798,16 +8805,7 @@ pub fn build_power_profile_evidence_with_created_utc(
         && telemetry.power_context_recorded
         && input_claim_boundary_preserved
         && !low_power_routes.is_empty()
-        && (!low_power_battery_samples_required
-            || (!low_power_battery_route_samples.is_empty()
-                && LOW_POWER_BATTERY_ROUTE_IDS.iter().all(|route_id| {
-                    low_power_battery_route_samples
-                        .iter()
-                        .any(|sample| sample.route_id.as_deref() == Some(*route_id))
-                })
-                && low_power_battery_route_samples
-                    .iter()
-                    .all(|sample| sample.requirement_satisfied)));
+        && (!low_power_battery_samples_required || low_power_battery_route_samples_ready);
 
     let operator_runbook = Some(LOW_POWER_BATTERY_RUNBOOK.to_string());
     let mut next_required_evidence = Vec::new();
@@ -8819,17 +8817,19 @@ pub fn build_power_profile_evidence_with_created_utc(
             "record an energy or battery-drain proxy across repeated low_power runs".to_string(),
         );
     }
-    if low_power_battery_samples_required
-        && (low_power_battery_route_samples.is_empty()
-            || low_power_battery_route_samples.iter().any(|sample| !sample.requirement_satisfied)
-            || LOW_POWER_BATTERY_ROUTE_IDS.iter().any(|route_id| {
-                !low_power_battery_route_samples
-                    .iter()
-                    .any(|sample| sample.route_id.as_deref() == Some(*route_id))
-            }))
-    {
+    if low_power_battery_samples_required && !low_power_battery_route_samples_ready {
         next_required_evidence.push(
             "index fallback-free CPU/GPU/NPU low_power ask receipts with --low-power-ask-receipt before qualifying power advantage"
+                .to_string(),
+        );
+    }
+    if telemetry.battery_mode_sample_recorded
+        && telemetry.energy_proxy_recorded
+        && low_power_battery_route_samples_ready
+        && !power_advantage_proven
+    {
+        next_required_evidence.push(
+            "collect benchmark-qualified low_power power-advantage evidence from battery-mode route samples or accepted energy proxy before promotion"
                 .to_string(),
         );
     }
@@ -8840,7 +8840,7 @@ pub fn build_power_profile_evidence_with_created_utc(
         );
     } else if telemetry.thermal_temperature_count == 0 {
         next_required_evidence.push(
-            "record thermal temperatures if available; current thermal evidence is zone visibility only"
+            "record measured thermal temperatures if available or preserve thermal-unavailable as an explicit blocker"
                 .to_string(),
         );
     }
@@ -20514,6 +20514,28 @@ mod tests {
             receipt.gaps.iter().any(
                 |gap| gap.contains("no low_power route has benchmark-qualified power evidence")
             )
+        );
+        assert!(
+            receipt.next_required_evidence.iter().any(|item| item
+                .contains("benchmark-qualified low_power power-advantage evidence")),
+            "{:?}",
+            receipt.next_required_evidence
+        );
+        assert!(
+            !receipt
+                .next_required_evidence
+                .iter()
+                .any(|item| item.contains("telemetry-context --require-battery")),
+            "{:?}",
+            receipt.next_required_evidence
+        );
+        assert!(
+            receipt
+                .next_required_evidence
+                .iter()
+                .any(|item| item.contains("record measured thermal temperatures")),
+            "{:?}",
+            receipt.next_required_evidence
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Make lunar-lake power-profile evidence advance to the benchmark-qualified low_power power-advantage gate once battery telemetry, energy proxy, and CPU/GPU/NPU low_power ask samples are indexed.
- Preserve low_power as unpromoted and keep measured thermal availability as an explicit remaining blocker.
- Refresh power-profile, blocked ask, readiness, regression, and comparison receipts without changing route promotion or claim boundaries.

## Validation
- cargo build --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet
- target\\debug\\bitnet.exe lunar-lake power-profile --artifact-root ci/hardware/intel-258v/2026-05-08 --route-profile-comparison lunar-lake-route-profile-comparison.json --cold-warm-benchmark lunar-lake-cold-warm-profile-benchmark.json --telemetry-context lunar-lake-power-thermal-context.json --battery-telemetry-context lunar-lake-low-power-battery-after.json --energy-proxy lunar-lake-low-power-energy-proxy.json --low-power-ask-receipt lunar-lake-operator-ask-battery-low-power-cpu.json --low-power-ask-receipt lunar-lake-operator-ask-battery-low-power-gpu.json --low-power-ask-receipt lunar-lake-operator-ask-battery-low-power-npu.json --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-power-profile-evidence.json --created-utc 2026-05-30T05:03:10Z --strict
- target\\debug\\bitnet.exe lunar-lake ask --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --profile low_power --route auto --device auto --prompt "What is 2+2?" --max-new-tokens 4 --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-ask-auto-low-power-blocked.json (expected fail-closed)
- target\\debug\\bitnet.exe lunar-lake validate --artifact-root ci/hardware/intel-258v/2026-05-08 --route-promotion-ledger lunar-lake-route-promotion.json --route-profile-comparison lunar-lake-route-profile-comparison.json --power-profile-evidence lunar-lake-power-profile-evidence.json --thermal-temperature-availability lunar-lake-thermal-temperature-availability.json --blocked-ask-receipt lunar-lake-operator-ask-auto-low-power-blocked.json --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-readiness.json --created-utc 2026-05-30T05:03:20Z --strict
- target\\debug\\bitnet.exe lunar-lake regress --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --answer-corpus-v2 ci/quality/lunar-lake-answer-corpus-v2.yaml --route-profile-comparison lunar-lake-route-profile-comparison.json --cold-warm-benchmark lunar-lake-cold-warm-profile-benchmark.json --durability-bundle lunar-lake-durability-bundle.json --bitnet-semantic-intake lunar-lake-bitnet-semantic-intake.json --power-profile-evidence lunar-lake-power-profile-evidence.json --thermal-temperature-availability lunar-lake-thermal-temperature-availability.json --ask-short-ask-receipt lunar-lake-operator-ask-auto-gpu-ask-short-math-brief.json --ask-normal-ask-receipt lunar-lake-operator-ask-auto-gpu-ask-normal-math-brief.json --warm-resident-ask-receipt lunar-lake-operator-ask-auto-npu-warm-resident-math-brief.json --blocked-ask-receipt lunar-lake-operator-ask-auto-low-power-blocked.json --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-regression-bundle-v2.json --created-utc 2026-05-30T05:03:30Z --strict
- target\\debug\\bitnet.exe lunar-lake compare --artifact-root ci/hardware/intel-258v/2026-05-08 --operator-receipt lunar-lake-operator-readiness.json --regression-bundle lunar-lake-regression-bundle-v2.json --json-out ci/hardware/intel-258v/2026-05-08/lunar-lake-operator-comparison.json --created-utc 2026-05-30T05:03:40Z --strict
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet power_profile -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::lunar_lake::tests::auto_ask_low_power_guidance_advances_after_battery_samples_are_indexed -- --exact --nocapture
- rustfmt --check --config skip_children=true,newline_style=Unix --edition 2024 crates/bitnet-cli/src/commands/lunar_lake.rs
- cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check
- JSON parse and stale-guidance checks for refreshed receipts
- claim-boundary grep for refreshed receipts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified low-power promotion requirements to explicitly mandate benchmark-qualified power-advantage evidence from battery-mode samples before advancement.
  * Improved thermal temperature evidence handling to preserve unavailable status as a blocker when measurements aren't available.

* **Documentation**
  * Updated guidance for evidence collection to provide clearer prerequisite specifications for low-power profile validation.

* **Tests**
  * Updated validation tests to verify correct evidence requirement strings in readiness checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/6230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->