### PR TITLE
🎨 Palette: Add keyboard shortcuts for text generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2024-10-18 - Keyboard Shortcuts for Text Areas
+**Learning:** For chat-like or generative UI, requiring users to switch from keyboard to mouse to click "Generate" breaks the interaction flow. While screen readers have native ways to navigate, sighted power users greatly benefit from explicit keyboard shortcuts.
+**Action:** Always provide explicit keyboard shortcuts (e.g., Ctrl+Enter) for primary actions associated with large text inputs, visually indicate them using `<kbd>` tags (with `aria-hidden="true"` so they don't clutter screen reader output), and expose the shortcut semantically using the `aria-keyshortcuts` attribute on the input element itself.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,6 +92,30 @@
             margin: 15px 0;
         }
 
+        .input-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 5px;
+        }
+
+        .input-header label {
+            margin-bottom: 0;
+        }
+
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        kbd {
+            font-family: inherit;
+            background: #e9ecef;
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-size: 11px;
+        }
+
         label, .container-label {
             display: block;
             margin-bottom: 5px;
@@ -298,8 +322,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="input-header">
+                    <label for="prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd></span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +370,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="input-header">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd></span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +422,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="input-header">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd></span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Keyboard shortcuts for generation
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(btnId);
+            if (btn && !btn.disabled) {
+                btn.click();
+            }
+        }
+    };
+
+    const promptEl = document.getElementById('prompt');
+    if (promptEl) promptEl.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+
+    const streamingPromptEl = document.getElementById('streaming-prompt');
+    if (streamingPromptEl) streamingPromptEl.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+
+    const workerPromptEl = document.getElementById('worker-prompt');
+    if (workerPromptEl) workerPromptEl.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -92,6 +92,30 @@
             margin: 15px 0;
         }
 
+        .input-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 5px;
+        }
+
+        .input-header label {
+            margin-bottom: 0;
+        }
+
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        kbd {
+            font-family: inherit;
+            background: #e9ecef;
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-size: 11px;
+        }
+
         label, .container-label {
             display: block;
             margin-bottom: 5px;
@@ -298,8 +322,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="input-header">
+                    <label for="prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd></span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +370,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="input-header">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd></span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +422,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="input-header">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd></span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Keyboard shortcuts for generation
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(btnId);
+            if (btn && !btn.disabled) {
+                btn.click();
+            }
+        }
+    };
+
+    const promptEl = document.getElementById('prompt');
+    if (promptEl) promptEl.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+
+    const streamingPromptEl = document.getElementById('streaming-prompt');
+    if (streamingPromptEl) streamingPromptEl.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+
+    const workerPromptEl = document.getElementById('worker-prompt');
+    if (workerPromptEl) workerPromptEl.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What:
Added explicit keyboard shortcuts (Ctrl+Enter or Cmd+Enter) to trigger text generation from within the prompt text areas. Visually indicated the shortcut using `<kbd>` tags and exposed it semantically via `aria-keyshortcuts`.

🎯 Why:
For generative or chat-like interfaces, having to switch from keyboard to mouse to click the "Generate" button breaks the user's interaction flow and slows them down. Keyboard shortcuts make the primary action instantly accessible.

📸 Before/After:
Before: The text area simply had a label "Prompt:" and required clicking a button to submit.
After: The label includes a visually distinct hint (`Ctrl + Enter`) and pressing the shortcut immediately triggers the active generation context.

♿ Accessibility:
Used `aria-keyshortcuts="Control+Enter"` on the textareas to expose the shortcut to assistive technologies. Added `aria-hidden="true"` to the visual hint container to prevent screen readers from redundantly announcing "Control plus Enter" inline, relying instead on the semantic attribute.

---
*PR created automatically by Jules for task [9794641327182816779](https://jules.google.com/task/9794641327182816779) started by @EffortlessSteven*