### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts for generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-24 - Keyboard Shortcuts for Primary Actions
+**Learning:** Adding keyboard shortcuts (like Ctrl+Enter to submit) significantly improves the experience for power users and keyboard-focused navigation, but users need to know they exist.
+**Action:** When adding keyboard shortcuts to form inputs, include a visual hint (e.g., using `<kbd>` tags) with `aria-hidden="true"` and add the corresponding `aria-keyshortcuts` attribute to the input element itself so screen readers can announce it without reading the visual hint verbatim.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -261,7 +261,19 @@
         .tab-content.active {
             display: block;
         }
+
+        kbd {
+            font-family: Consolas, Monaco, 'Andale Mono', monospace;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 2px 5px;
+            font-size: 0.85em;
+            color: #495057;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+        }
     </style>
+
 </head>
 <body>
     <div class="header">
@@ -298,8 +310,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <label for="prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +358,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <label for="streaming-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to stream</span>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +410,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <label for="worker-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -22,8 +22,57 @@ let copyFeedbackTimeout = null;
 // Initialize the application
 async function initApp() {
     try {
-        // Setup keyboard navigation for tabs
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    // Basic text generation
+    const promptArea = document.getElementById('prompt');
+    if (promptArea) {
+        promptArea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'Enter') {
+                e.preventDefault();
+                const generateBtn = document.getElementById('generate');
+                if (generateBtn && !generateBtn.disabled) {
+                    generateBtn.click();
+                }
+            }
+        });
+    }
+
+    // Streaming text generation
+    const streamingPromptArea = document.getElementById('streaming-prompt');
+    if (streamingPromptArea) {
+        streamingPromptArea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'Enter') {
+                e.preventDefault();
+                const startStreamingBtn = document.getElementById('start-streaming');
+                if (startStreamingBtn && !startStreamingBtn.disabled) {
+                    startStreamingBtn.click();
+                }
+            }
+        });
+    }
+
+    // Worker text generation
+    const workerPromptArea = document.getElementById('worker-prompt');
+    if (workerPromptArea) {
+        workerPromptArea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'Enter') {
+                e.preventDefault();
+                const workerGenerateBtn = document.getElementById('worker-generate');
+                if (workerGenerateBtn && !workerGenerateBtn.disabled) {
+                    workerGenerateBtn.click();
+                }
+            }
+        });
+    }
+}
+
+// Setup keyboard navigation for tabs
         setupTabNavigation();
+
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -261,7 +261,19 @@
         .tab-content.active {
             display: block;
         }
+
+        kbd {
+            font-family: Consolas, Monaco, 'Andale Mono', monospace;
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 2px 5px;
+            font-size: 0.85em;
+            color: #495057;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+        }
     </style>
+
 </head>
 <body>
     <div class="header">
@@ -298,8 +310,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <label for="prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +358,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <label for="streaming-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to stream</span>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +410,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <label for="worker-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -22,8 +22,57 @@ let copyFeedbackTimeout = null;
 // Initialize the application
 async function initApp() {
     try {
-        // Setup keyboard navigation for tabs
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    // Basic text generation
+    const promptArea = document.getElementById('prompt');
+    if (promptArea) {
+        promptArea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'Enter') {
+                e.preventDefault();
+                const generateBtn = document.getElementById('generate');
+                if (generateBtn && !generateBtn.disabled) {
+                    generateBtn.click();
+                }
+            }
+        });
+    }
+
+    // Streaming text generation
+    const streamingPromptArea = document.getElementById('streaming-prompt');
+    if (streamingPromptArea) {
+        streamingPromptArea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'Enter') {
+                e.preventDefault();
+                const startStreamingBtn = document.getElementById('start-streaming');
+                if (startStreamingBtn && !startStreamingBtn.disabled) {
+                    startStreamingBtn.click();
+                }
+            }
+        });
+    }
+
+    // Worker text generation
+    const workerPromptArea = document.getElementById('worker-prompt');
+    if (workerPromptArea) {
+        workerPromptArea.addEventListener('keydown', (e) => {
+            if (e.ctrlKey && e.key === 'Enter') {
+                e.preventDefault();
+                const workerGenerateBtn = document.getElementById('worker-generate');
+                if (workerGenerateBtn && !workerGenerateBtn.disabled) {
+                    workerGenerateBtn.click();
+                }
+            }
+        });
+    }
+}
+
+// Setup keyboard navigation for tabs
         setupTabNavigation();
+
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);


### PR DESCRIPTION
💡 What: Added `Ctrl+Enter` keyboard shortcuts to trigger generation in the Basic, Streaming, and Worker tabs, along with visual `<kbd>` hints for the user.
🎯 Why: Improves keyboard accessibility and efficiency for power users by eliminating the need to tab to or click the generate button after typing a prompt.
📸 Before/After: Added `<kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate` above the textareas.
♿ Accessibility: Used `aria-hidden="true"` on the visual hints and `aria-keyshortcuts="Control+Enter"` on the textareas to ensure screen readers announce the shortcut correctly.

---
*PR created automatically by Jules for task [16642122565560893677](https://jules.google.com/task/16642122565560893677) started by @EffortlessSteven*