### PR TITLE
🎨 Palette: Add keyboard shortcuts for text generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2024-05-24 - Keyboard Shortcut Hints and ARIA
+**Learning:** When adding visual keyboard shortcut hints (like `<kbd>Ctrl</kbd> + <kbd>Enter</kbd>`) next to inputs, they must be hidden from screen readers (`aria-hidden="true"`) to prevent redundant or confusing readout. The semantic connection is made by adding `aria-keyshortcuts="Control+Enter"` directly to the input element itself.
+**Action:** Always pair visually hidden `<kbd>` shortcut hints with `aria-keyshortcuts` on the interactive element to ensure proper screen reader support.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -261,6 +261,27 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            color: #495057;
+            display: inline-block;
+            font-size: 0.85em;
+            font-weight: 700;
+            line-height: 1;
+            padding: 2px 4px;
+            white-space: nowrap;
+            margin-left: 5px;
+        }
     </style>
 </head>
 <body>
@@ -298,8 +319,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="shortcut-hint">
+                    <label for="prompt">Prompt:</label>
+                    <span aria-hidden="true" style="font-size: 12px; color: #6c757d;"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +367,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="shortcut-hint">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span aria-hidden="true" style="font-size: 12px; color: #6c757d;"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to stream</span>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +419,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="shortcut-hint">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span aria-hidden="true" style="font-size: 12px; color: #6c757d;"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup prompt shortcuts
+        setupPromptShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,27 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup shortcuts for prompts
+function setupPromptShortcuts() {
+    const handleShortcut = (id, generateFunction, buttonId) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                const btn = document.getElementById(buttonId);
+                if (btn && !btn.disabled) {
+                    e.preventDefault();
+                    generateFunction();
+                }
+            }
+        });
+    };
+
+    handleShortcut('prompt', generateText, 'generate');
+    handleShortcut('streaming-prompt', startStreaming, 'start-streaming');
+    handleShortcut('worker-prompt', workerGenerate, 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -261,6 +261,27 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            color: #495057;
+            display: inline-block;
+            font-size: 0.85em;
+            font-weight: 700;
+            line-height: 1;
+            padding: 2px 4px;
+            white-space: nowrap;
+            margin-left: 5px;
+        }
     </style>
 </head>
 <body>
@@ -298,8 +319,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="shortcut-hint">
+                    <label for="prompt">Prompt:</label>
+                    <span aria-hidden="true" style="font-size: 12px; color: #6c757d;"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +367,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="shortcut-hint">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span aria-hidden="true" style="font-size: 12px; color: #6c757d;"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to stream</span>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +419,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="shortcut-hint">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span aria-hidden="true" style="font-size: 12px; color: #6c757d;"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup prompt shortcuts
+        setupPromptShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,27 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup shortcuts for prompts
+function setupPromptShortcuts() {
+    const handleShortcut = (id, generateFunction, buttonId) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                const btn = document.getElementById(buttonId);
+                if (btn && !btn.disabled) {
+                    e.preventDefault();
+                    generateFunction();
+                }
+            }
+        });
+    };
+
+    handleShortcut('prompt', generateText, 'generate');
+    handleShortcut('streaming-prompt', startStreaming, 'start-streaming');
+    handleShortcut('worker-prompt', workerGenerate, 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added `Ctrl+Enter` keyboard shortcuts to trigger generation in all text areas, along with visual `<kbd>` hints.
🎯 Why: Text generation often involves typing long prompts. Forcing the user to move to their mouse to click 'Generate' disrupts flow. A keyboard shortcut improves power-user efficiency.
📸 Before/After: Visual hints added next to 'Prompt:' labels.
♿ Accessibility: Visual hints are hidden from screen readers (`aria-hidden="true"`) and semantic `aria-keyshortcuts="Control+Enter"` is added directly to the textareas.

---
*PR created automatically by Jules for task [15575933090925917277](https://jules.google.com/task/15575933090925917277) started by @EffortlessSteven*