### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts to textareas

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-28 - Keyboard Shortcuts for Textareas
+**Learning:** For multi-line textareas like prompts where users frequently need to submit, adding a Ctrl+Enter keyboard shortcut improves UX significantly. However, users need a visual hint to discover this, and screen readers need the `aria-keyshortcuts` attribute on the interactive input itself to announce it, rather than just relying on visual `<kbd>` tags.
+**Action:** Always add visual `<kbd>` hints with `aria-hidden="true"` and apply the `aria-keyshortcuts` attribute directly to the associated textarea to ensure both visual and screen-reader accessibility when implementing submit shortcuts.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -130,6 +130,28 @@
             margin-bottom: 0;
         }
 
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            color: #495057;
+            display: inline-block;
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 11px;
+            font-weight: 600;
+            line-height: 1;
+            padding: 2px 4px;
+            white-space: nowrap;
+        }
+
+        .shortcut-hint {
+            color: #6c757d;
+            font-size: 12px;
+            margin-left: 8px;
+            font-weight: normal;
+        }
+
         .range-value {
             font-weight: 500;
             color: #0056b3;
@@ -298,8 +320,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +368,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to start streaming</span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +420,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate in worker</span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts for textareas
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,29 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const attachShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!button.disabled) {
+                        button.click();
+                    }
+                }
+            });
+        }
+    };
+
+    attachShortcut('prompt', 'generate');
+    attachShortcut('streaming-prompt', 'start-streaming');
+    attachShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -130,6 +130,28 @@
             margin-bottom: 0;
         }
 
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            color: #495057;
+            display: inline-block;
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 11px;
+            font-weight: 600;
+            line-height: 1;
+            padding: 2px 4px;
+            white-space: nowrap;
+        }
+
+        .shortcut-hint {
+            color: #6c757d;
+            font-size: 12px;
+            margin-left: 8px;
+            font-weight: normal;
+        }
+
         .range-value {
             font-weight: 500;
             color: #0056b3;
@@ -298,8 +320,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +368,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to start streaming</span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +420,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate in worker</span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts for textareas
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,29 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const attachShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!button.disabled) {
+                        button.click();
+                    }
+                }
+            });
+        }
+    };
+
+    attachShortcut('prompt', 'generate');
+    attachShortcut('streaming-prompt', 'start-streaming');
+    attachShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What
Added Ctrl+Enter (or Cmd+Enter on Mac) keyboard shortcuts to trigger the primary action for the prompt textareas across the browser examples.

🎯 Why
Typing a prompt and then having to move the mouse to click the 'Generate' button breaks the user's flow. Allowing users to submit their prompts directly from the keyboard makes the interface feel much more responsive and efficient.

📸 Before/After
Before: Textareas had a simple label. Users had to manually click buttons to submit.
After: Textareas now show a visual hint `<kbd>Ctrl</kbd> + <kbd>Enter</kbd>` next to the label. Pressing this shortcut triggers the associated action.

♿ Accessibility
Added visual shortcut hints with `aria-hidden="true"` and applied `aria-keyshortcuts="Control+Enter"` directly to the `textarea` elements so screen readers can announce the available shortcuts to users.

---
*PR created automatically by Jules for task [15574934180529244084](https://jules.google.com/task/15574934180529244084) started by @EffortlessSteven*