### PR TITLE
🎨 Palette: Add keyboard shortcuts for prompt generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-06-11 - Add Keyboard Shortcuts for Prompts
+**Learning:** Adding keyboard shortcuts (like Ctrl+Enter) to textareas is essential for power users, but they are often invisible.
+**Action:** Always include a visual hint (like a <kbd> tag) above or within the input, make it `aria-hidden="true"`, and add the `aria-keyshortcuts` attribute to the interactive input itself for screen reader compatibility.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -298,8 +298,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="range-header">
+                    <label for="prompt">Prompt:</label>
+                    <kbd aria-hidden="true" class="range-value" style="border: 1px solid #ccc; color: #555;">Ctrl+Enter</kbd>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +346,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="range-header">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <kbd aria-hidden="true" class="range-value" style="border: 1px solid #ccc; color: #555;">Ctrl+Enter</kbd>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +398,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="range-header">
+                    <label for="worker-prompt">Prompt:</label>
+                    <kbd aria-hidden="true" class="range-value" style="border: 1px solid #ccc; color: #555;">Ctrl+Enter</kbd>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    const handleCtrlEnter = (id, buttonId) => {
+        const el = document.getElementById(id);
+        if (el) {
+            el.addEventListener('keydown', (e) => {
+                if (e.ctrlKey && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(buttonId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    };
+
+    handleCtrlEnter('prompt', 'generate');
+    handleCtrlEnter('streaming-prompt', 'start-streaming');
+    handleCtrlEnter('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -298,8 +298,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="range-header">
+                    <label for="prompt">Prompt:</label>
+                    <kbd aria-hidden="true" class="range-value" style="border: 1px solid #ccc; color: #555;">Ctrl+Enter</kbd>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +346,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="range-header">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <kbd aria-hidden="true" class="range-value" style="border: 1px solid #ccc; color: #555;">Ctrl+Enter</kbd>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +398,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="range-header">
+                    <label for="worker-prompt">Prompt:</label>
+                    <kbd aria-hidden="true" class="range-value" style="border: 1px solid #ccc; color: #555;">Ctrl+Enter</kbd>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    const handleCtrlEnter = (id, buttonId) => {
+        const el = document.getElementById(id);
+        if (el) {
+            el.addEventListener('keydown', (e) => {
+                if (e.ctrlKey && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(buttonId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    };
+
+    handleCtrlEnter('prompt', 'generate');
+    handleCtrlEnter('streaming-prompt', 'start-streaming');
+    handleCtrlEnter('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/verify2.py
+++ b/verify2.py
@@ -1,0 +1,9 @@
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto("http://localhost:8000")
+    page.wait_for_selector("#prompt")
+    page.screenshot(path="verify2.png")
+    browser.close()


### PR DESCRIPTION
💡 What: Added `Ctrl+Enter` keyboard shortcuts to all prompt textareas to trigger generation, including visual `<kbd>` hints.
🎯 Why: Users expect quick keyboard shortcuts in chat and generation interfaces. This prevents having to move the mouse to click the generate button.
📸 Before/After: Visual shortcut hints are now displayed above each prompt input.
♿ Accessibility: The visual `<kbd>` hints use `aria-hidden="true"`, and the interactive `textarea` elements have `aria-keyshortcuts="Control+Enter"` to properly expose the shortcuts to assistive technologies.

---
*PR created automatically by Jules for task [8065076057498264799](https://jules.google.com/task/8065076057498264799) started by @EffortlessSteven*