### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts for generation prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-24 - Visual Keyboard Shortcuts
+**Learning:** Adding visual keyboard shortcut hints (like `<kbd>Ctrl</kbd> + <kbd>Enter</kbd>`) inside labels can cause screen readers to announce confusing or redundant text when focusing the input. The visual hint should be explicitly hidden from screen readers.
+**Action:** Always use `aria-hidden="true"` on the visual hint container, and add `aria-keyshortcuts="Control+Enter"` directly to the interactive input element itself to ensure the shortcut is cleanly and semantically announced by screen readers.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -261,6 +261,25 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            display: inline-flex;
+            align-items: center;
+            margin-left: 8px;
+            font-weight: normal;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+            color: #495057;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 11px;
+            padding: 2px 5px;
+            white-space: nowrap;
+        }
     </style>
 </head>
 <body>
@@ -298,8 +317,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">
+                    Prompt:
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +365,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">
+                    Prompt:
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +417,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">
+                    Prompt:
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -722,6 +723,29 @@ function setupTabNavigation() {
             const nextTab = tabs[nextIndex];
             nextTab.focus();
             nextTab.click(); // Activate the tab
+        }
+    });
+}
+
+function setupKeyboardShortcuts() {
+    const textareas = [
+        { id: 'prompt', btnId: 'generate' },
+        { id: 'streaming-prompt', btnId: 'start-streaming' },
+        { id: 'worker-prompt', btnId: 'worker-generate' }
+    ];
+
+    textareas.forEach(({ id, btnId }) => {
+        const textarea = document.getElementById(id);
+        if (textarea) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(btnId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
         }
     });
 }

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -261,6 +261,25 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            display: inline-flex;
+            align-items: center;
+            margin-left: 8px;
+            font-weight: normal;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+            color: #495057;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 11px;
+            padding: 2px 5px;
+            white-space: nowrap;
+        }
     </style>
 </head>
 <body>
@@ -298,8 +317,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">
+                    Prompt:
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +365,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">
+                    Prompt:
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +417,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">
+                    Prompt:
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -722,6 +723,29 @@ function setupTabNavigation() {
             const nextTab = tabs[nextIndex];
             nextTab.focus();
             nextTab.click(); // Activate the tab
+        }
+    });
+}
+
+function setupKeyboardShortcuts() {
+    const textareas = [
+        { id: 'prompt', btnId: 'generate' },
+        { id: 'streaming-prompt', btnId: 'start-streaming' },
+        { id: 'worker-prompt', btnId: 'worker-generate' }
+    ];
+
+    textareas.forEach(({ id, btnId }) => {
+        const textarea = document.getElementById(id);
+        if (textarea) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(btnId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
         }
     });
 }


### PR DESCRIPTION
### 💡 What
Added visual keyboard shortcuts (`Ctrl+Enter` / `Cmd+Enter`) to the prompt textareas for Basic, Streaming, and Worker generation tabs, allowing users to submit prompts without moving to the mouse.

### 🎯 Why
Power users expect to be able to quickly submit text using standard keyboard shortcuts. This saves time and provides a more seamless, keyboard-focused interaction model.

### 📸 Before/After
Added small, styled visual hints (e.g., `Ctrl + Enter`) next to the "Prompt:" labels, and wired up event listeners to trigger the respective "Generate" buttons when pressed.

### ♿ Accessibility
The visual `<kbd>` elements are hidden from screen readers using `aria-hidden="true"`, while the actual textareas receive the `aria-keyshortcuts="Control+Enter"` attribute, ensuring the shortcut is properly announced to assistive technologies without redundant readouts.

---
*PR created automatically by Jules for task [10044416537031858994](https://jules.google.com/task/10044416537031858994) started by @EffortlessSteven*