### PR TITLE
🎨 Palette: Add keyboard shortcuts for prompt submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-06-14 - Keyboard Shortcuts Accessibility
+**Learning:** When adding visual keyboard shortcuts (e.g., `<kbd>` tags) to form labels, screen readers may announce them confusingly as part of the label text.
+**Action:** Always add `aria-hidden="true"` to the visual shortcut hint element, and add the semantic `aria-keyshortcuts` attribute (e.g., `aria-keyshortcuts="Control+Enter"`) directly to the interactive input element itself to ensure proper screen reader accessibility.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -144,6 +144,24 @@
             min-height: 100px;
         }
 
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #ced4da;
+            border-radius: 3px;
+            box-shadow: inset 0 -1px 0 #ced4da;
+            color: #495057;
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.8em;
+            padding: 2px 4px;
+        }
+
+        .shortcut-hint {
+            float: right;
+            font-size: 0.85em;
+            color: #6c757d;
+            font-weight: normal;
+        }
+
         .progress-bar {
             width: 100%;
             height: 20px;
@@ -298,8 +316,8 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">Prompt: <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to submit</span></label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +361,8 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">Prompt: <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to submit</span></label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +410,8 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">Prompt: <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to submit</span></label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -724,6 +725,34 @@ function setupTabNavigation() {
             nextTab.click(); // Activate the tab
         }
     });
+}
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, buttonId) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const button = document.getElementById(buttonId);
+            if (button && !button.disabled) {
+                button.click();
+            }
+        }
+    };
+
+    const promptTextarea = document.getElementById('prompt');
+    if (promptTextarea) {
+        promptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+    }
+
+    const streamingPromptTextarea = document.getElementById('streaming-prompt');
+    if (streamingPromptTextarea) {
+        streamingPromptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+    }
+
+    const workerPromptTextarea = document.getElementById('worker-prompt');
+    if (workerPromptTextarea) {
+        workerPromptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+    }
 }
 
 // Make functions globally available

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -144,6 +144,24 @@
             min-height: 100px;
         }
 
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #ced4da;
+            border-radius: 3px;
+            box-shadow: inset 0 -1px 0 #ced4da;
+            color: #495057;
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.8em;
+            padding: 2px 4px;
+        }
+
+        .shortcut-hint {
+            float: right;
+            font-size: 0.85em;
+            color: #6c757d;
+            font-weight: normal;
+        }
+
         .progress-bar {
             width: 100%;
             height: 20px;
@@ -298,8 +316,8 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">Prompt: <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to submit</span></label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +361,8 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">Prompt: <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to submit</span></label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +410,8 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">Prompt: <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to submit</span></label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -724,6 +725,34 @@ function setupTabNavigation() {
             nextTab.click(); // Activate the tab
         }
     });
+}
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, buttonId) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const button = document.getElementById(buttonId);
+            if (button && !button.disabled) {
+                button.click();
+            }
+        }
+    };
+
+    const promptTextarea = document.getElementById('prompt');
+    if (promptTextarea) {
+        promptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+    }
+
+    const streamingPromptTextarea = document.getElementById('streaming-prompt');
+    if (streamingPromptTextarea) {
+        streamingPromptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+    }
+
+    const workerPromptTextarea = document.getElementById('worker-prompt');
+    if (workerPromptTextarea) {
+        workerPromptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+    }
 }
 
 // Make functions globally available


### PR DESCRIPTION
💡 What: Added visual hints and keyboard shortcut handlers (`Ctrl+Enter` or `Cmd+Enter`) to all prompt textareas (main, streaming, and worker) to allow quick submission without reaching for the mouse.

🎯 Why: Power users typically expect `Ctrl+Enter` to submit multi-line inputs in chat/generation interfaces. Clicking the "Generate Text" button each time disrupts the keyboard workflow.

📸 Before/After: Visual hints added to labels (e.g., 'Prompt: Ctrl + Enter to submit').

♿ Accessibility: Added `aria-hidden="true"` to the visual hints to prevent screen readers from reading them as part of the label, and added the semantic `aria-keyshortcuts="Control+Enter"` attribute directly to the textareas.

---
*PR created automatically by Jules for task [17852984369580490464](https://jules.google.com/task/17852984369580490464) started by @EffortlessSteven*