### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability by enforcing request body limits independent of content-length headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+
+## 2024-05-28 - Payload Size Validation Bypass via Chunked Encoding
+**Vulnerability:** The request validation and sanitization middlewares relied solely on the `content-length` HTTP header to enforce payload size limits (`max_prompt_length * 2`). Attackers could bypass these limits by using Chunked Transfer Encoding, which omits the `content-length` header, potentially leading to Unbounded Memory Consumption and Denial of Service (DoS).
+**Learning:** Security controls that bound resource consumption must not depend on optional or malleable client-provided headers.
+**Prevention:** Enforce body size limits consistently at the framework level (e.g., using Axum's `DefaultBodyLimit`) rather than relying on manual header inspection in middleware.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -677,6 +677,10 @@ impl BitNetServer {
 
         // Add comprehensive middleware stack
         app = app
+            // 🛡️ Sentinel: Enforce strict body limit to prevent DoS via chunked transfer encoding bypassing content-length checks
+            .layer(axum::extract::DefaultBodyLimit::max(
+                self.config.security.max_prompt_length * 2,
+            ))
             .layer(middleware::from_fn(security_headers_middleware))
             .layer(middleware::from_fn_with_state(
                 self.security_validator.clone(),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The API relied solely on the `content-length` header to enforce maximum request payload sizes. An attacker could bypass this check by sending a request using Chunked Transfer Encoding (which does not provide a `content-length` header), leading to unbounded memory allocation and a potential Denial of Service (DoS).
🎯 Impact: Attackers could crash the server by sending excessively large payloads, causing OOM (Out of Memory) errors.
🔧 Fix: Added Axum's `DefaultBodyLimit` to the router middleware stack. This strictly enforces the body size limit (`max_prompt_length * 2`) regardless of whether the `content-length` header is present or if chunked encoding is used. Added security comments detailing the defense.
✅ Verification: Ran `cargo fmt`, `cargo clippy`, and `cargo test -p bitnet-server security` to ensure existing security tests and validation middleware continue to function correctly and code standards are met.

---
*PR created automatically by Jules for task [1200791602689912333](https://jules.google.com/task/1200791602689912333) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global request handling on all routes; misconfigured max_prompt_length could reject legitimate large payloads, but the limit matches existing security intent.
> 
> **Overview**
> Closes a **DoS** gap where oversized bodies could slip past checks that only looked at the optional **`content-length`** header (e.g. **chunked** requests with no header).
> 
> The router now applies **`DefaultBodyLimit::max(max_prompt_length * 2)`** at the top of the middleware stack so the framework caps body size while the stream is read, not only when a header is present. A **Sentinel** journal entry records the bypass pattern and the preference for framework-level limits over header-only middleware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19a47985f90b502cc1c3fb319c7dd09305e535d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->