### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcut for prompt submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-25 - Keyboard Shortcuts for Text Areas
+**Learning:** Adding keyboard shortcuts (like Ctrl+Enter) to text areas significantly improves UX for power users, but standard keyboard accessibility (like ARIA descriptions) is required to ensure screen reader users are aware of these shortcuts.
+**Action:** When adding functional keyboard shortcuts, always include visual hints (e.g., `<kbd>`) and semantic attributes (e.g., `aria-keyshortcuts="Control+Enter"`) on the interactive element. Use `aria-hidden="true"` on the visual hints to prevent redundant/confusing announcements by screen readers.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -298,8 +298,8 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">Prompt: <kbd aria-hidden="true" style="font-size: 0.8em; color: #6c757d; background: #e9ecef; padding: 2px 6px; border-radius: 4px; border: 1px solid #dee2e6; margin-left: 8px;">Ctrl+Enter</kbd></label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +343,8 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">Prompt: <kbd aria-hidden="true" style="font-size: 0.8em; color: #6c757d; background: #e9ecef; padding: 2px 6px; border-radius: 4px; border: 1px solid #dee2e6; margin-left: 8px;">Ctrl+Enter</kbd></label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +392,8 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">Prompt: <kbd aria-hidden="true" style="font-size: 0.8em; color: #6c757d; background: #e9ecef; padding: 2px 6px; border-radius: 4px; border: 1px solid #dee2e6; margin-left: 8px;">Ctrl+Enter</kbd></label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupTextareaShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupTextareaShortcuts() {
+    document.querySelectorAll('textarea').forEach(textarea => {
+        textarea.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                let btnId;
+                if (textarea.id === 'prompt') btnId = 'generate';
+                else if (textarea.id === 'streaming-prompt') btnId = 'start-streaming';
+                else if (textarea.id === 'worker-prompt') btnId = 'worker-generate';
+
+                if (btnId) {
+                    const btn = document.getElementById(btnId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            }
+        });
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -298,8 +298,8 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">Prompt: <kbd aria-hidden="true" style="font-size: 0.8em; color: #6c757d; background: #e9ecef; padding: 2px 6px; border-radius: 4px; border: 1px solid #dee2e6; margin-left: 8px;">Ctrl+Enter</kbd></label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +343,8 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">Prompt: <kbd aria-hidden="true" style="font-size: 0.8em; color: #6c757d; background: #e9ecef; padding: 2px 6px; border-radius: 4px; border: 1px solid #dee2e6; margin-left: 8px;">Ctrl+Enter</kbd></label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +392,8 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">Prompt: <kbd aria-hidden="true" style="font-size: 0.8em; color: #6c757d; background: #e9ecef; padding: 2px 6px; border-radius: 4px; border: 1px solid #dee2e6; margin-left: 8px;">Ctrl+Enter</kbd></label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupTextareaShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupTextareaShortcuts() {
+    document.querySelectorAll('textarea').forEach(textarea => {
+        textarea.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                let btnId;
+                if (textarea.id === 'prompt') btnId = 'generate';
+                else if (textarea.id === 'streaming-prompt') btnId = 'start-streaming';
+                else if (textarea.id === 'worker-prompt') btnId = 'worker-generate';
+
+                if (btnId) {
+                    const btn = document.getElementById(btnId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            }
+        });
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 **What**: Added a `Ctrl+Enter` (and `Cmd+Enter`) keyboard shortcut to all prompt `<textarea>` elements in the browser WASM examples. Added an accessible `<kbd>` visual hint.
🎯 **Why**: Power users and developers generally prefer keeping their hands on the keyboard. Reaching for a mouse to click "Generate Text" or "Start Streaming" after typing a prompt breaks flow.
📸 **Before/After**: Visually, the "Prompt:" label now has a small `Ctrl+Enter` pill next to it.
♿ **Accessibility**: Added `aria-keyshortcuts="Control+Enter"` to the textareas so screen readers announce the shortcut correctly. Used `aria-hidden="true"` on the visual `<kbd>` pill to prevent redundant/confusing announcements by screen readers. Evaluated tab index and focus states, maintaining full keyboard navigability.

---
*PR created automatically by Jules for task [29277780104478190](https://jules.google.com/task/29277780104478190) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only UI and keyboard-handler changes; no inference, auth, or shared library behavior is modified.
> 
> **Overview**
> Adds **Ctrl+Enter** / **Cmd+Enter** on prompt textareas in both WASM browser demos so users can trigger the tab’s primary action without clicking **Generate**, **Start Streaming**, or **Generate in Worker**.
> 
> `setupTextareaShortcuts()` runs at init, prevents default on the chord, and programmatically clicks the mapped button only when it’s enabled. Labels gain a visual **Ctrl+Enter** `<kbd>` pill (`aria-hidden="true"`), and textareas get `aria-keyshortcuts="Control+Enter"`. The same HTML/JS updates are mirrored under `crates/bitnet-wasm/examples/browser/` and `examples/wasm/browser/`. `.jules/palette.md` documents the pattern for future textarea shortcuts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8059dcc0c63a0e292bf9817479b047808d8c806f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->