### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix content-length payload size bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+
+## 2025-06-03 - Payload Size Limit Bypass via Chunked Encoding
+**Vulnerability:** The `request_sanitization_middleware` relied solely on the `content-length` header to enforce maximum payload size. An attacker could bypass this by using `Transfer-Encoding: chunked` and omitting `Content-Length`, potentially causing a Denial of Service (DoS) due to unbounded memory allocation during payload parsing.
+**Learning:** Checking HTTP headers for payload size is insufficient if chunked encoding is permitted without strict downstream limits.
+**Prevention:** If restricting sizes via middleware based on headers, explicitly reject requests that use chunked encoding without a `Content-Length` header by returning `411 Length Required`. Alternatively, use framework-level body limiters (like Axum's `DefaultBodyLimit`).

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -494,13 +494,20 @@ pub async fn request_sanitization_middleware(
     // This middleware focuses on general request sanitization
 
     // Check request size
-    if let Some(content_length) = request.headers().get("content-length")
-        && let Ok(length_str) = content_length.to_str()
-        && let Ok(length) = length_str.parse::<usize>()
-        && length > validator.config.max_prompt_length * 2
-    {
-        warn!(content_length = length, "Request too large");
-        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    // 🛡️ Sentinel: Fix payload size limit bypass. Reject requests with missing content-length but chunked encoding, or requests exceeding the size limit.
+    if let Some(content_length) = request.headers().get("content-length") {
+        if let Ok(length_str) = content_length.to_str()
+            && let Ok(length) = length_str.parse::<usize>()
+            && length > validator.config.max_prompt_length * 2
+        {
+            warn!(content_length = length, "Request too large");
+            return Err(StatusCode::PAYLOAD_TOO_LARGE);
+        }
+    } else if request.headers().contains_key("transfer-encoding") {
+        warn!(
+            "Chunked transfer encoding without content-length is not allowed for size verification"
+        );
+        return Err(StatusCode::LENGTH_REQUIRED);
     }
 
     // Check Content-Type for JSON endpoints


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Attackers could bypass the payload size limit in `request_sanitization_middleware` by omitting `content-length` and using `transfer-encoding: chunked`.
🎯 Impact: Potential Denial of Service (DoS) due to processing excessively large payloads.
🔧 Fix: Explicitly reject requests that use chunked encoding without a `content-length` header.
✅ Verification: Verified by running the server test suite and lint checks.

---
*PR created automatically by Jules for task [1856699242819071939](https://jules.google.com/task/1856699242819071939) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-size enforcement on the HTTP edge; the change is narrow and reduces DoS risk, though clients that legitimately send chunked bodies without Content-Length will now be rejected.
> 
> **Overview**
> **Closes a DoS bypass** in `request_sanitization_middleware`: oversized bodies could slip past the header-based cap when `Content-Length` was omitted and the request used chunked transfer encoding.
> 
> The middleware still returns **413** when `Content-Length` exceeds `max_prompt_length * 2`. It now also returns **411 Length Required** when `Content-Length` is missing but `Transfer-Encoding` is present, so size cannot be asserted from headers alone. A Sentinel journal entry documents the issue and mitigation (header-only limits vs. framework body limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3666fa7a9c0db533052e1a7bde717ae6c554469d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->