### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability in request sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,7 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+## 2026-06-19 - DoS via Chunked Encoding
+**Vulnerability:** The request sanitization middleware (`request_sanitization_middleware`) bypassed payload size limits (`max_prompt_length * 2`) when a request omitted the `content-length` header. A malicious actor could exploit this by sending a `Transfer-Encoding: chunked` payload of unbounded size, causing the server to consume excessive memory leading to a Denial of Service (DoS) or Out of Memory (OOM) crash.
+**Learning:** Checking payload constraints based exclusively on the presence of a `Content-Length` header is insufficient for HTTP/1.1 traffic, as chunked encoding intentionally streams requests with an unknown total length.
+**Prevention:** Always mandate a `Content-Length` header or explicitly reject `Transfer-Encoding: chunked` if streaming requests are not supported or if the body parser handles them by buffering entirely in memory.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -503,6 +503,14 @@ pub async fn request_sanitization_middleware(
         return Err(StatusCode::PAYLOAD_TOO_LARGE);
     }
 
+    // 🛡️ Sentinel: Reject chunked requests without content-length to prevent unbounded memory consumption (DoS risk)
+    if request.headers().get("content-length").is_none()
+        && request.headers().get("transfer-encoding").is_some()
+    {
+        warn!("Rejecting chunked request without content-length to prevent DoS");
+        return Err(StatusCode::LENGTH_REQUIRED);
+    }
+
     // Check Content-Type for JSON endpoints
     let content_type = request.headers().get("content-type").and_then(|ct| ct.to_str().ok());
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing size constraint on chunked requests without Content-Length.
🎯 Impact: Attackers can send unbounded chunked payloads to consume memory and cause a Denial of Service (DoS).
🔧 Fix: Reject chunked requests without Content-Length header.
✅ Verification: Ran `cargo test -p bitnet-server` to verify no regressions were introduced.

---
*PR created automatically by Jules for task [1631792681056322214](https://jules.google.com/task/1631792681056322214) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens request handling on a security-critical path; legitimate clients that send chunked bodies without Content-Length will get 411 until they send a length or the server adds streaming limits.
> 
> **Overview**
> Closes a **DoS gap** in `request_sanitization_middleware`: body size was only enforced when `Content-Length` was present, so **chunked** requests could grow without bound in memory.
> 
> The middleware now returns **`411 Length Required`** when `Transfer-Encoding` is set but **`Content-Length` is missing**, before content-type checks run. A Sentinel journal entry documents the chunked-encoding lesson and mitigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfba58fafecd2fbc35bac8fdf52b15fefeca4c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->