### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in rate limiter initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+
+## 2024-06-20 - TOCTOU in Rate Limiter Initialization
+**Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `get_or_create_ip_limiter`. Multiple concurrent requests from the same IP could bypass the initial read lock check, drop the lock, and then acquire a write lock to insert a new `RateLimitBucket`. This led to concurrent overwrites, leaking memory and resetting the rate limit state repeatedly under high concurrency.
+**Learning:** Using a separate read-lock block and write-lock block without re-checking the condition under the write lock creates a race condition window where state can change.
+**Prevention:** Use the double-checked locking pattern (check with read lock, acquire write lock, and then use `entry().or_insert_with()`) to safely initialize shared state under concurrent access without sacrificing fast-path read performance.

--- a/crates/bitnet-server/src/concurrency.rs
+++ b/crates/bitnet-server/src/concurrency.rs
@@ -343,6 +343,8 @@ impl ConcurrencyManager {
 
     /// Get or create rate limiter for IP
     async fn get_or_create_ip_limiter(&self, ip: IpAddr, limit: u64) -> Arc<RateLimitBucket> {
+        // 🛡️ Sentinel: Fix TOCTOU vulnerability during concurrent rate limiter initialization
+        // using the double-checked locking pattern to maintain fast read paths.
         {
             let limiters = self.per_ip_rate_limiters.read().await;
             if let Some(limiter) = limiters.get(&ip) {
@@ -350,13 +352,10 @@ impl ConcurrencyManager {
             }
         }
 
-        let new_limiter = Arc::new(RateLimitBucket::new(limit, limit));
-        {
-            let mut limiters = self.per_ip_rate_limiters.write().await;
-            limiters.insert(ip, Arc::clone(&new_limiter));
-        }
-
-        new_limiter
+        let mut limiters = self.per_ip_rate_limiters.write().await;
+        Arc::clone(
+            limiters.entry(ip).or_insert_with(|| Arc::new(RateLimitBucket::new(limit, limit))),
+        )
     }
 
     /// Record successful request completion


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability existed in `get_or_create_ip_limiter`. Multiple concurrent requests from the same IP could bypass the initial read check, create multiple limiters, and overwrite each other, causing memory leaks and losing rate-limit state.
🎯 Impact: Attackers could bypass per-IP rate limits by sending highly concurrent bursts of traffic.
🔧 Fix: Updated the initialization to use the double-checked locking pattern. It retains the fast read path for existing IPs and safely re-checks under a write lock before insertion, eliminating the TOCTOU gap without creating a concurrency bottleneck.
✅ Verification: Verified using unit tests and static analysis.

---
*PR created automatically by Jules for task [4170259055845406851](https://jules.google.com/task/4170259055845406851) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency-sensitive rate-limiting initialization; incorrect locking could still allow bypass or regress performance, but the fix is localized and follows a standard pattern.
> 
> **Overview**
> Fixes a **TOCTOU race** in `get_or_create_ip_limiter` where concurrent first-time requests for the same IP could each create a new `RateLimitBucket` and overwrite the map entry, leaking buckets and resetting limit state.
> 
> The slow path now takes a **write lock** and uses **`HashMap::entry(ip).or_insert_with(...)`** so only one bucket is created per IP while the existing **read-lock fast path** is unchanged. A **Sentinel journal** entry documents the vulnerability and the double-checked locking pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0bb70ec690b63cd4b1f3f4aeb6d391cf2aa525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->