### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts for text generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-25 - Keyboard Shortcuts and Accessibility
+**Learning:** Adding visual keyboard shortcuts (like `<kbd>Ctrl+Enter</kbd>`) directly inside interactive elements (like buttons) can cause screen readers to redundantly or confusingly read out the shortcut text alongside the primary label. Additionally, the text input element where the shortcut is actually triggered needs semantic context.
+**Action:** Always add `aria-hidden="true"` to visual `<kbd>` shortcut hints so they are ignored by screen readers. Simultaneously, add `aria-keyshortcuts="Control+Enter"` directly to the interactive input element (e.g., the `textarea`) where the user actually performs the keystroke, ensuring screen reader users are properly informed of the available shortcut.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -261,6 +261,15 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut {
+            font-size: 11px;
+            background: rgba(255, 255, 255, 0.2);
+            padding: 2px 6px;
+            border-radius: 3px;
+            margin-left: 8px;
+            vertical-align: middle;
+        }
     </style>
 </head>
 <body>
@@ -299,12 +308,12 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
                 <button id="load-model" onclick="loadModel()">Load Model</button>
-                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text</button>
+                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text <kbd aria-hidden="true" class="shortcut">Ctrl+Enter</kbd></button>
                 <button id="clear-output" onclick="clearOutput()">Clear Output</button>
             </div>
 
@@ -344,11 +353,11 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
-                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming</button>
+                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming <kbd aria-hidden="true" class="shortcut">Ctrl+Enter</kbd></button>
                 <button id="stop-streaming" onclick="stopStreaming()" disabled title="No stream is running">Stop Streaming</button>
                 <button id="clear-streaming" onclick="clearStreaming()">Clear</button>
             </div>
@@ -387,13 +396,13 @@
 
             <div class="controls">
                 <button id="init-worker" onclick="initWorker()">Initialize Worker</button>
-                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker</button>
+                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker <kbd aria-hidden="true" class="shortcut">Ctrl+Enter</kbd></button>
                 <button id="terminate-worker" onclick="terminateWorker()" disabled title="Initialize the worker first">Terminate Worker</button>
             </div>
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,30 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+function setupKeyboardShortcuts() {
+    const prompts = [
+        { id: 'prompt', buttonId: 'generate' },
+        { id: 'streaming-prompt', buttonId: 'start-streaming' },
+        { id: 'worker-prompt', buttonId: 'worker-generate' }
+    ];
+
+    prompts.forEach(({ id, buttonId }) => {
+        const textarea = document.getElementById(id);
+        const button = document.getElementById(buttonId);
+
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!button.disabled) {
+                        button.click();
+                    }
+                }
+            });
+        }
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -261,6 +261,15 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut {
+            font-size: 11px;
+            background: rgba(255, 255, 255, 0.2);
+            padding: 2px 6px;
+            border-radius: 3px;
+            margin-left: 8px;
+            vertical-align: middle;
+        }
     </style>
 </head>
 <body>
@@ -299,12 +308,12 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
                 <button id="load-model" onclick="loadModel()">Load Model</button>
-                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text</button>
+                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text <kbd aria-hidden="true" class="shortcut">Ctrl+Enter</kbd></button>
                 <button id="clear-output" onclick="clearOutput()">Clear Output</button>
             </div>
 
@@ -344,11 +353,11 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
-                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming</button>
+                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming <kbd aria-hidden="true" class="shortcut">Ctrl+Enter</kbd></button>
                 <button id="stop-streaming" onclick="stopStreaming()" disabled title="No stream is running">Stop Streaming</button>
                 <button id="clear-streaming" onclick="clearStreaming()">Clear</button>
             </div>
@@ -387,13 +396,13 @@
 
             <div class="controls">
                 <button id="init-worker" onclick="initWorker()">Initialize Worker</button>
-                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker</button>
+                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker <kbd aria-hidden="true" class="shortcut">Ctrl+Enter</kbd></button>
                 <button id="terminate-worker" onclick="terminateWorker()" disabled title="Initialize the worker first">Terminate Worker</button>
             </div>
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,30 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+function setupKeyboardShortcuts() {
+    const prompts = [
+        { id: 'prompt', buttonId: 'generate' },
+        { id: 'streaming-prompt', buttonId: 'start-streaming' },
+        { id: 'worker-prompt', buttonId: 'worker-generate' }
+    ];
+
+    prompts.forEach(({ id, buttonId }) => {
+        const textarea = document.getElementById(id);
+        const button = document.getElementById(buttonId);
+
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!button.disabled) {
+                        button.click();
+                    }
+                }
+            });
+        }
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Ctrl+Enter keyboard shortcuts to all prompt textareas (basic, streaming, and worker tabs) to trigger text generation. Also added visual `<kbd>` hints to the corresponding buttons.
🎯 Why: Keyboard shortcuts improve power-user experience and general usability by allowing users to generate text without needing to move their hand to the mouse after typing their prompt.
📸 Before/After: Added small "Ctrl+Enter" visual hints to the "Generate Text", "Start Streaming", and "Generate in Worker" buttons.
♿ Accessibility: Added `aria-keyshortcuts="Control+Enter"` to the textareas so screen readers can announce the available shortcut. Added `aria-hidden="true"` to the visual `<kbd>` hints to prevent redundant screen reader announcements.

---
*PR created automatically by Jules for task [18318588447062035113](https://jules.google.com/task/18318588447062035113) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example/demo UI and client-side event wiring only; no inference, auth, or data-path changes.
> 
> **Overview**
> Adds **Ctrl+Enter** (and **Cmd+Enter** on macOS) from the basic, streaming, and worker prompt textareas to run the same actions as **Generate Text**, **Start Streaming**, and **Generate in Worker**, only when those buttons are enabled.
> 
> The BitNet WASM browser demos (`crates/bitnet-wasm/examples/browser` and `examples/wasm/browser`) gain `setupKeyboardShortcuts()` on init, `.shortcut` styling for inline **Ctrl+Enter** hints on the action buttons, `aria-keyshortcuts="Control+Enter"` on the textareas, and `aria-hidden` on the visual `<kbd>` hints. `.jules/palette.md` documents this keyboard-shortcut accessibility pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e13031dbfe2b894d86810f2d987d36cf8061cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->