### PR TITLE
🎨 Palette: Add keyboard shortcuts for generation prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-28 - Keyboard Shortcut Accessibility
+**Learning:** Adding visual keyboard shortcuts (like `<kbd>Ctrl+Enter</kbd>`) next to inputs helps sighted users, but screen readers will redundantly read the text.
+**Action:** Always add `aria-hidden="true"` to visual shortcut elements and apply `aria-keyshortcuts="Control+Enter"` directly to the interactive element to ensure proper screen reader announcements.

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -98,6 +98,19 @@
             font-weight: 500;
         }
 
+        kbd.shortcut {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+            color: #495057;
+            font-family: inherit;
+            font-size: 0.8em;
+            padding: 1px 5px;
+            margin-left: 8px;
+            vertical-align: middle;
+        }
+
         .output:focus-visible,
         .streaming-output:focus-visible {
             outline: 2px solid #0066cc;
@@ -298,8 +311,8 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">Prompt: <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></label>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +356,8 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">Prompt: <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></label>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +405,8 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">Prompt: <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></label>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,34 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            const btn = document.getElementById(btnId);
+            if (btn && !btn.disabled) {
+                e.preventDefault();
+                btn.click();
+            }
+        }
+    };
+
+    const promptEl = document.getElementById('prompt');
+    if (promptEl) {
+        promptEl.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+    }
+
+    const streamingPromptEl = document.getElementById('streaming-prompt');
+    if (streamingPromptEl) {
+        streamingPromptEl.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+    }
+
+    const workerPromptEl = document.getElementById('worker-prompt');
+    if (workerPromptEl) {
+        workerPromptEl.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+    }
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added visual `<kbd>` elements indicating that `Ctrl+Enter` can be used to submit prompts, and implemented the keyboard event listeners to support this shortcut across the Basic Inference, Streaming, and Web Workers tabs.
🎯 Why: Textareas capture the `Enter` key for multiline input, meaning users have to switch from their keyboard to their mouse to click the "Generate" button. Adding a standard `Ctrl+Enter` shortcut makes the interface more keyboard-friendly and efficient.
📸 Before/After: Visual shortcuts (`Ctrl+Enter`) are now displayed next to the "Prompt" labels.
♿ Accessibility: The visual `<kbd>` elements are hidden from screen readers using `aria-hidden="true"`, while the actual textareas have been updated with `aria-keyshortcuts="Control+Enter"` to properly announce the shortcut to assistive technologies.

---
*PR created automatically by Jules for task [13938019123830368148](https://jules.google.com/task/13938019123830368148) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the WASM browser example UI and client-side event handlers; no inference, auth, or data-path changes.
> 
> **Overview**
> Adds **Ctrl+Enter** (and **Cmd+Enter** on macOS) to submit prompts from the WASM browser demo without leaving the keyboard, on the Basic, Streaming, and Web Worker tabs.
> 
> The demo shows a styled **Ctrl+Enter** hint next to each prompt label and wires `setupKeyboardShortcuts()` at startup so the shortcut clicks the same generate/stream/worker buttons when they are enabled. Textareas use `aria-keyshortcuts="Control+Enter"` while the visual `<kbd>` is `aria-hidden` so screen readers are not doubled up.
> 
> Documents the accessibility pattern in `.jules/palette.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a77ece5e2dccc1762eaf653919d5c8aaf3476b3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->