### PR TITLE
🎨 Palette: Add keyboard shortcuts for submitting prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-06-22 - Visual Hints for Keyboard Shortcuts
+**Learning:** When adding visual `<kbd>` hints for keyboard shortcuts to interactive elements, they can be read redundantly or confusingly by screen readers if left as plain text. Adding an `aria-keyshortcuts` attribute to the active input provides programmatic screen reader support, allowing the visual hint to be safely hidden with `aria-hidden="true"`.
+**Action:** Always pair `aria-keyshortcuts` on the active element with `aria-hidden="true"` on the visual hint tag.

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -119,6 +119,17 @@
             border-color: #007bff;
         }
 
+        kbd {
+            font-family: monospace;
+            font-size: 0.8em;
+            background-color: #f8f9fa;
+            padding: 2px 5px;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            color: #495057;
+            margin-left: 5px;
+        }
+
         .range-header {
             display: flex;
             justify-content: space-between;
@@ -298,8 +309,8 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <label for="prompt">Prompt: <kbd aria-hidden="true">Ctrl+Enter</kbd></label>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +354,8 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <label for="streaming-prompt">Prompt: <kbd aria-hidden="true">Ctrl+Enter</kbd></label>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +403,8 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <label for="worker-prompt">Prompt: <kbd aria-hidden="true">Ctrl+Enter</kbd></label>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -22,6 +22,9 @@ let copyFeedbackTimeout = null;
 // Initialize the application
 async function initApp() {
     try {
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
@@ -687,6 +690,31 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for text generation
+function setupKeyboardShortcuts() {
+    const shortcuts = [
+        { textareaId: 'prompt', buttonId: 'generate' },
+        { textareaId: 'streaming-prompt', buttonId: 'start-streaming' },
+        { textareaId: 'worker-prompt', buttonId: 'worker-generate' }
+    ];
+
+    shortcuts.forEach(({ textareaId, buttonId }) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!button.disabled) {
+                        button.click();
+                    }
+                }
+            });
+        }
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Ctrl+Enter (or Cmd+Enter) keyboard shortcuts to submit prompts across all text generation tabs. Added `<kbd>` visual hints to the input labels.
🎯 Why: Enhances power-user productivity by eliminating the need to move from keyboard to mouse to generate text.
📸 Before/After: Labels now show a visual shortcut hint.
♿ Accessibility: Added `aria-keyshortcuts="Control+Enter"` to the textareas, improving screen reader support. The visual hints use `aria-hidden="true"` to prevent redundant readouts.

---
*PR created automatically by Jules for task [5929321070429887768](https://jules.google.com/task/5929321070429887768) started by @EffortlessSteven*