### PR TITLE
🎨 Palette: Add keyboard shortcuts for generating text

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-06-23 - Keyboard Shortcuts for Forms
+**Learning:** Adding `aria-keyshortcuts` to inputs and displaying visual hints `<kbd>` improves keyboard accessibility and power user UX. Adding an event listener that maps Ctrl+Enter to the primary action significantly speeds up workflow.
+**Action:** Always add keyboard shortcuts for primary actions on textareas, and use `aria-hidden="true"` on the visual hints to prevent screen readers from reading them redundantly when `aria-keyshortcuts` is present on the input itself.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -298,8 +298,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;"><kbd aria-hidden="true">Ctrl</kbd> + <kbd aria-hidden="true">Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +346,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;"><kbd aria-hidden="true">Ctrl</kbd> + <kbd aria-hidden="true">Enter</kbd> to generate</span>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +398,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;"><kbd aria-hidden="true">Ctrl</kbd> + <kbd aria-hidden="true">Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const handleCtrlEnter = (id, buttonId) => {
+        const el = document.getElementById(id);
+        if (el) {
+            el.addEventListener('keydown', (e) => {
+                if (e.ctrlKey && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(buttonId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    };
+
+    handleCtrlEnter('prompt', 'generate');
+    handleCtrlEnter('streaming-prompt', 'start-streaming');
+    handleCtrlEnter('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -298,8 +298,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;"><kbd aria-hidden="true">Ctrl</kbd> + <kbd aria-hidden="true">Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +346,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;"><kbd aria-hidden="true">Ctrl</kbd> + <kbd aria-hidden="true">Enter</kbd> to generate</span>
+                </div>
+                <textarea id="streaming-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +398,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span style="font-size: 12px; color: #6c757d;"><kbd aria-hidden="true">Ctrl</kbd> + <kbd aria-hidden="true">Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-keyshortcuts="Control+Enter" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const handleCtrlEnter = (id, buttonId) => {
+        const el = document.getElementById(id);
+        if (el) {
+            el.addEventListener('keydown', (e) => {
+                if (e.ctrlKey && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(buttonId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    };
+
+    handleCtrlEnter('prompt', 'generate');
+    handleCtrlEnter('streaming-prompt', 'start-streaming');
+    handleCtrlEnter('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Ctrl+Enter keyboard shortcut to all textareas to trigger the generation process. Added visual hints and aria-keyshortcuts attributes.
🎯 Why: Improves power user experience and keyboard accessibility by reducing the need to tab to or click the "Generate" button.
📸 Before/After: N/A
♿ Accessibility: Added `aria-keyshortcuts` to textareas and visual hints using `<kbd aria-hidden="true">` to ensure screen readers properly announce the shortcut without redundant reading of the visual text.

---
*PR created automatically by Jules for task [7130246165382215772](https://jules.google.com/task/7130246165382215772) started by @EffortlessSteven*