### PR TITLE
🎨 Palette: Add keyboard shortcuts for prompt submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2026-06-25 - Adding keyboard shortcuts to interactive inputs
+**Learning:** When adding visual keyboard shortcuts (e.g., `<kbd>` tags) for primary actions associated with inputs, always use `aria-hidden="true"` on the visual hint and add the `aria-keyshortcuts` attribute (e.g., `aria-keyshortcuts="Control+Enter"`) directly to the interactive input element itself to ensure screen reader accessibility.
+**Action:** Use this pattern to improve efficiency for power users while maintaining a clear and accessible structure for screen readers.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -104,6 +104,29 @@
             outline-offset: 2px;
         }
 
+        .label-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 5px;
+        }
+        .label-row label {
+            margin-bottom: 0;
+        }
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            font-size: 11px;
+            padding: 2px 4px;
+            font-family: monospace;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 8px 12px;
@@ -298,8 +321,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="label-row">
+                    <label for="prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +369,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="label-row">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to start</span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +421,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="label-row">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -20,10 +20,25 @@ let benchmarkSuite = null;
 let copyFeedbackTimeout = null;
 
 // Initialize the application
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId) => {
+        if (e.ctrlKey && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(btnId);
+            if (!btn.disabled) btn.click();
+        }
+    };
+
+    document.getElementById('prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+    document.getElementById('streaming-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+    document.getElementById('worker-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+}
+
 async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -104,6 +104,29 @@
             outline-offset: 2px;
         }
 
+        .label-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 5px;
+        }
+        .label-row label {
+            margin-bottom: 0;
+        }
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            font-size: 11px;
+            padding: 2px 4px;
+            font-family: monospace;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 8px 12px;
@@ -298,8 +321,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="label-row">
+                    <label for="prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +369,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="label-row">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to start</span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +421,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="label-row">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="shortcut-hint" aria-hidden="true"><kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -20,10 +20,25 @@ let benchmarkSuite = null;
 let copyFeedbackTimeout = null;
 
 // Initialize the application
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId) => {
+        if (e.ctrlKey && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(btnId);
+            if (!btn.disabled) btn.click();
+        }
+    };
+
+    document.getElementById('prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+    document.getElementById('streaming-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+    document.getElementById('worker-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+}
+
 async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);


### PR DESCRIPTION
💡 What
Added Ctrl+Enter keyboard shortcuts to all prompt textareas to allow quick submission without reaching for the mouse.

🎯 Why
Improves efficiency and ease of use for power users and keyboard-centric workflows, ensuring users can iterate quickly on their prompts.

📸 Before/After
Before: Users had to click the generate button manually after typing.
After: Users can type their prompt and immediately hit Ctrl+Enter to submit. Added visual hint (kbd styling) next to the labels.

♿ Accessibility
Included `aria-keyshortcuts="Control+Enter"` on the textareas and hid the visual `<kbd>` hints with `aria-hidden="true"` to prevent redundant screen reader output, maintaining a clear and accessible structure.

---
*PR created automatically by Jules for task [10806822465389993609](https://jules.google.com/task/10806822465389993609) started by @EffortlessSteven*