### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts to generation actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-24 - Keyboard Shortcuts and ARIA Attributes
+**Learning:** Adding visual keyboard shortcuts (e.g., `<kbd>Ctrl+Enter</kbd>`) directly inside button labels without proper attributes can cause screen readers to read out the literal text, confusing users.
+**Action:** Always add `aria-hidden="true"` to visual shortcut hints (`<kbd>`) inside buttons, and place the `aria-keyshortcuts` attribute on the interactive input element (e.g., `<textarea>`) where the user is typing when the shortcut is triggered.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -258,6 +258,15 @@
             display: none;
         }
 
+        kbd.shortcut {
+            font-family: monospace;
+            background-color: rgba(0, 0, 0, 0.1);
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-size: 0.85em;
+            margin-left: 6px;
+        }
+
         .tab-content.active {
             display: block;
         }
@@ -299,12 +308,12 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
                 <button id="load-model" onclick="loadModel()">Load Model</button>
-                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text</button>
+                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></button>
                 <button id="clear-output" onclick="clearOutput()">Clear Output</button>
             </div>
 
@@ -344,11 +353,11 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
-                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming</button>
+                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></button>
                 <button id="stop-streaming" onclick="stopStreaming()" disabled title="No stream is running">Stop Streaming</button>
                 <button id="clear-streaming" onclick="clearStreaming()">Clear</button>
             </div>
@@ -387,13 +396,13 @@
 
             <div class="controls">
                 <button id="init-worker" onclick="initWorker()">Initialize Worker</button>
-                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker</button>
+                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></button>
                 <button id="terminate-worker" onclick="terminateWorker()" disabled title="Initialize the worker first">Terminate Worker</button>
             </div>
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,34 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const handleCtrlEnter = (e, buttonId) => {
+        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            const btn = document.getElementById(buttonId);
+            if (btn && !btn.disabled) {
+                btn.click();
+            }
+        }
+    };
+
+    const promptEl = document.getElementById('prompt');
+    if (promptEl) {
+        promptEl.addEventListener('keydown', (e) => handleCtrlEnter(e, 'generate'));
+    }
+
+    const streamingPromptEl = document.getElementById('streaming-prompt');
+    if (streamingPromptEl) {
+        streamingPromptEl.addEventListener('keydown', (e) => handleCtrlEnter(e, 'start-streaming'));
+    }
+
+    const workerPromptEl = document.getElementById('worker-prompt');
+    if (workerPromptEl) {
+        workerPromptEl.addEventListener('keydown', (e) => handleCtrlEnter(e, 'worker-generate'));
+    }
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -258,6 +258,15 @@
             display: none;
         }
 
+        kbd.shortcut {
+            font-family: monospace;
+            background-color: rgba(0, 0, 0, 0.1);
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-size: 0.85em;
+            margin-left: 6px;
+        }
+
         .tab-content.active {
             display: block;
         }
@@ -299,12 +308,12 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-keyshortcuts="Control+Enter">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
                 <button id="load-model" onclick="loadModel()">Load Model</button>
-                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text</button>
+                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></button>
                 <button id="clear-output" onclick="clearOutput()">Clear Output</button>
             </div>
 
@@ -344,11 +353,11 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-keyshortcuts="Control+Enter">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
-                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming</button>
+                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></button>
                 <button id="stop-streaming" onclick="stopStreaming()" disabled title="No stream is running">Stop Streaming</button>
                 <button id="clear-streaming" onclick="clearStreaming()">Clear</button>
             </div>
@@ -387,13 +396,13 @@
 
             <div class="controls">
                 <button id="init-worker" onclick="initWorker()">Initialize Worker</button>
-                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker</button>
+                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker <kbd class="shortcut" aria-hidden="true">Ctrl+Enter</kbd></button>
                 <button id="terminate-worker" onclick="terminateWorker()" disabled title="Initialize the worker first">Terminate Worker</button>
             </div>
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-keyshortcuts="Control+Enter">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,34 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const handleCtrlEnter = (e, buttonId) => {
+        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            const btn = document.getElementById(buttonId);
+            if (btn && !btn.disabled) {
+                btn.click();
+            }
+        }
+    };
+
+    const promptEl = document.getElementById('prompt');
+    if (promptEl) {
+        promptEl.addEventListener('keydown', (e) => handleCtrlEnter(e, 'generate'));
+    }
+
+    const streamingPromptEl = document.getElementById('streaming-prompt');
+    if (streamingPromptEl) {
+        streamingPromptEl.addEventListener('keydown', (e) => handleCtrlEnter(e, 'start-streaming'));
+    }
+
+    const workerPromptEl = document.getElementById('worker-prompt');
+    if (workerPromptEl) {
+        workerPromptEl.addEventListener('keydown', (e) => handleCtrlEnter(e, 'worker-generate'));
+    }
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Ctrl+Enter (or Cmd+Enter) keyboard shortcuts to trigger text generation from the prompt textareas.
🎯 Why: Users typing prompts previously had to reach for the mouse to click "Generate", which interrupted the typing flow. Now they can submit directly from the keyboard.
📸 Before/After: Visual <kbd>Ctrl+Enter</kbd> hints added to the "Generate Text", "Start Streaming", and "Generate in Worker" buttons.
♿ Accessibility:
  - Added `aria-keyshortcuts="Control+Enter"` to the `<textarea>` elements to notify screen readers of the available shortcut.
  - Added `aria-hidden="true"` to the visual `<kbd>` hints to prevent screen readers from redundantly reading the shortcut text aloud.

---
*PR created automatically by Jules for task [11517714998711934191](https://jules.google.com/task/11517714998711934191) started by @EffortlessSteven*