### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Content-Length Limit Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+
+## 2024-11-13 - [Content-Length Limit Bypass via Chunked Transfer Encoding]
+**Vulnerability:** The request validation middleware relied solely on the `content-length` header to enforce maximum request payload sizes. A malicious client could send requests with `Transfer-Encoding: chunked`, omitting the `content-length` header and completely bypassing the size restrictions. This exposed the server to Denial of Service (DoS) attacks via memory exhaustion (OOM).
+**Learning:** When implementing request size limits in HTTP middleware, checking the `content-length` header is insufficient against chunked requests. Furthermore, demanding both `Transfer-Encoding: chunked` and `Content-Length` simultaneously is an HTTP protocol violation (RFC 9112) that enables Request Smuggling.
+**Prevention:** Either reject `Transfer-Encoding: chunked` outright if the API requires predetermined lengths, or enforce global body size limits using framework-provided mechanisms like `axum::extract::DefaultBodyLimit`.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -1949,6 +1949,12 @@ async fn request_validation_middleware(
     next: Next,
 ) -> Result<Response, StatusCode> {
     // Check request size limits
+    // 🛡️ Sentinel: Reject chunked transfer encoding as it bypasses the content-length limit check, leading to potential DoS.
+    if request.headers().contains_key("transfer-encoding") {
+        warn!("Chunked transfer encoding is not allowed");
+        return Err(StatusCode::LENGTH_REQUIRED);
+    }
+
     if let Some(content_length) = request.headers().get("content-length")
         && let Ok(length_str) = content_length.to_str()
         && let Ok(length) = length_str.parse::<usize>()

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -494,6 +494,12 @@ pub async fn request_sanitization_middleware(
     // This middleware focuses on general request sanitization
 
     // Check request size
+    // 🛡️ Sentinel: Reject chunked transfer encoding as it bypasses the content-length limit check, leading to potential DoS.
+    if request.headers().contains_key("transfer-encoding") {
+        warn!("Chunked transfer encoding is not allowed");
+        return Err(StatusCode::LENGTH_REQUIRED);
+    }
+
     if let Some(content_length) = request.headers().get("content-length")
         && let Ok(length_str) = content_length.to_str()
         && let Ok(length) = length_str.parse::<usize>()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The request validation middleware relied solely on the `content-length` header to enforce maximum request payload sizes. A malicious client could send requests with `Transfer-Encoding: chunked`, omitting the `content-length` header and bypassing the size restrictions.
🎯 Impact: Exposes the server to memory exhaustion and Denial of Service (DoS) attacks.
🔧 Fix: Rejected `Transfer-Encoding: chunked` outright in the request size validation middleware to enforce strict `content-length` limits.
✅ Verification: Verified compilation, ran `cargo clippy` and test suite, and documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2814229269089629804](https://jules.google.com/task/2814229269089629804) started by @EffortlessSteven*