### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts for textareas

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2025-02-23 - Keyboard Shortcuts in LLM Interfaces
+**Learning:** Text generation interfaces inherently trap keyboard focus in textareas, forcing users to reach for the mouse or hit Tab multiple times just to submit a prompt. Providing a visual `Ctrl+Enter` keyboard shortcut hint linked via `aria-describedby` significantly improves both power-user UX and accessibility.
+**Action:** Always add and visually document keyboard shortcuts (like Ctrl+Enter) for primary actions when users are typing in textareas, using semantic `<kbd>` tags and `aria-describedby` to ensure screen reader visibility.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,6 +92,25 @@
             margin: 15px 0;
         }
 
+        .helper-text {
+            font-size: 12px;
+            color: #6c757d;
+            margin-top: 5px;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            color: #495057;
+            font-size: 11px;
+            padding: 2px 4px;
+            font-family: monospace;
+        }
+
         label, .container-label {
             display: block;
             margin-bottom: 5px;
@@ -299,7 +318,8 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-help">Hello, I am a BitNet model running in your browser!</textarea>
+                <div id="prompt-help" class="helper-text">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</div>
             </div>
 
             <div class="controls">
@@ -344,7 +364,8 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-prompt-help">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div id="streaming-prompt-help" class="helper-text">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to start streaming</div>
             </div>
 
             <div class="controls">
@@ -393,7 +414,8 @@
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-prompt-help">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div id="worker-prompt-help" class="helper-text">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate in worker</div>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -747,5 +747,25 @@ window.resetSettings = resetSettings;
 window.exportSettings = exportSettings;
 window.importSettings = importSettings;
 
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId, actionFn) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(btnId);
+            if (btn && !btn.disabled) {
+                actionFn();
+            }
+        }
+    };
+
+    document.getElementById('prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'generate', generateText));
+    document.getElementById('streaming-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming', startStreaming));
+    document.getElementById('worker-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate', workerGenerate));
+}
+
 // Initialize the application when the page loads
-document.addEventListener('DOMContentLoaded', initApp);
+document.addEventListener('DOMContentLoaded', () => {
+    initApp();
+    setupKeyboardShortcuts();
+});

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -92,6 +92,25 @@
             margin: 15px 0;
         }
 
+        .helper-text {
+            font-size: 12px;
+            color: #6c757d;
+            margin-top: 5px;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            color: #495057;
+            font-size: 11px;
+            padding: 2px 4px;
+            font-family: monospace;
+        }
+
         label, .container-label {
             display: block;
             margin-bottom: 5px;
@@ -299,7 +318,8 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-help">Hello, I am a BitNet model running in your browser!</textarea>
+                <div id="prompt-help" class="helper-text">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</div>
             </div>
 
             <div class="controls">
@@ -344,7 +364,8 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-prompt-help">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div id="streaming-prompt-help" class="helper-text">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to start streaming</div>
             </div>
 
             <div class="controls">
@@ -393,7 +414,8 @@
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-prompt-help">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div id="worker-prompt-help" class="helper-text">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate in worker</div>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -747,5 +747,25 @@ window.resetSettings = resetSettings;
 window.exportSettings = exportSettings;
 window.importSettings = importSettings;
 
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, btnId, actionFn) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(btnId);
+            if (btn && !btn.disabled) {
+                actionFn();
+            }
+        }
+    };
+
+    document.getElementById('prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'generate', generateText));
+    document.getElementById('streaming-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming', startStreaming));
+    document.getElementById('worker-prompt')?.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate', workerGenerate));
+}
+
 // Initialize the application when the page loads
-document.addEventListener('DOMContentLoaded', initApp);
+document.addEventListener('DOMContentLoaded', () => {
+    initApp();
+    setupKeyboardShortcuts();
+});


### PR DESCRIPTION
💡 What: Added visual keyboard shortcut hints (Ctrl+Enter) with semantic `<kbd>` styling below all prompt textareas, and implemented the corresponding event listeners to trigger generation when pressed.
🎯 Why: Text generation interfaces often trap focus in the prompt textarea. Users shouldn't have to reach for their mouse or tab repeatedly just to submit their input. This small interaction improvement creates a smoother power-user experience.
📸 Before/After: Visual helper text reading "Press Ctrl + Enter to generate" appears beneath each textarea.
♿ Accessibility: Visual hints are linked to the textareas using `aria-describedby` so screen reader users are also informed of the available keyboard shortcuts, and semantic `<kbd>` tags are used for the key visual representations.

---
*PR created automatically by Jules for task [10990545034139240707](https://jules.google.com/task/10990545034139240707) started by @EffortlessSteven*