### PR TITLE
🎨 Palette: Add keyboard shortcuts for prompt generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-06-28 - Keyboard Shortcuts for Text Generation
+**Learning:** Users naturally attempt to use `Ctrl+Enter` or `Cmd+Enter` to submit prompts in AI interfaces. Providing this shortcut along with visual hints in the UI creates a smoother, more efficient interaction loop than requiring a mouse click on the 'Generate' button.
+**Action:** Always map `Ctrl+Enter` / `Cmd+Enter` to the primary submission action within prompt textareas, and display a semantic `<kbd>` visual hint to teach users this shortcut.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -139,6 +139,22 @@
             font-size: 12px;
         }
 
+        .text-hint {
+            font-size: 12px;
+            color: #6c757d;
+            font-weight: normal;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 1px 4px;
+            font-family: 'Courier New', monospace;
+            font-size: 11px;
+            color: #495057;
+        }
+
         textarea {
             resize: vertical;
             min-height: 100px;
@@ -298,7 +314,10 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
+                <div class="range-header">
+                    <label for="prompt">Prompt:</label>
+                    <span class="text-hint">Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to generate</span>
+                </div>
                 <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
@@ -343,7 +362,10 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
+                <div class="range-header">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="text-hint">Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to generate</span>
+                </div>
                 <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
@@ -392,7 +414,10 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
+                <div class="range-header">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="text-hint">Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to generate</span>
+                </div>
                 <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup textarea shortcuts
+        setupTextareaShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupTextareaShortcuts() {
+    const handleShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        if (!textarea) return;
+
+        textarea.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                const btn = document.getElementById(buttonId);
+                if (btn && !btn.disabled) {
+                    btn.click();
+                }
+            }
+        });
+    };
+
+    handleShortcut('prompt', 'generate');
+    handleShortcut('streaming-prompt', 'start-streaming');
+    handleShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -139,6 +139,22 @@
             font-size: 12px;
         }
 
+        .text-hint {
+            font-size: 12px;
+            color: #6c757d;
+            font-weight: normal;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 1px 4px;
+            font-family: 'Courier New', monospace;
+            font-size: 11px;
+            color: #495057;
+        }
+
         textarea {
             resize: vertical;
             min-height: 100px;
@@ -298,7 +314,10 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
+                <div class="range-header">
+                    <label for="prompt">Prompt:</label>
+                    <span class="text-hint">Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to generate</span>
+                </div>
                 <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
@@ -343,7 +362,10 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
+                <div class="range-header">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span class="text-hint">Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to generate</span>
+                </div>
                 <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
@@ -392,7 +414,10 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
+                <div class="range-header">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span class="text-hint">Press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to generate</span>
+                </div>
                 <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup textarea shortcuts
+        setupTextareaShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupTextareaShortcuts() {
+    const handleShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        if (!textarea) return;
+
+        textarea.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                const btn = document.getElementById(buttonId);
+                if (btn && !btn.disabled) {
+                    btn.click();
+                }
+            }
+        });
+    };
+
+    handleShortcut('prompt', 'generate');
+    handleShortcut('streaming-prompt', 'start-streaming');
+    handleShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added `Ctrl+Enter` / `Cmd+Enter` keyboard shortcuts to all prompt textareas to trigger generation, and added visual hints using the `<kbd>` tag to communicate this functionality to the user.
🎯 Why: Users naturally attempt to use `Ctrl+Enter` to submit prompts in chat interfaces and textareas. Requiring them to move from the keyboard to the mouse to click "Generate" breaks their workflow and creates a slower, less pleasant interaction loop.
📸 Before/After: Before, users had to click the generate buttons. After, they can use `Ctrl+Enter` while focused on any textarea, with visual hints indicating this is possible.
♿ Accessibility: Improved keyboard accessibility by providing a direct submission method for keyboard users without needing to tab to the generate buttons. Used semantic `<kbd>` tags for the shortcut hints.

---
*PR created automatically by Jules for task [2502005657431976728](https://jules.google.com/task/2502005657431976728) started by @EffortlessSteven*