### PR TITLE
🎨 Palette: Add keyboard shortcuts for text generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2026-06-29 - Keyboard Shortcuts in Prompt Textareas
+**Learning:** Adding keyboard shortcuts (Cmd/Ctrl+Enter) to submit forms from multi-line textareas greatly improves UX for power users, but it must be paired with visible hints and explicit `aria-describedby` links to ensure screen reader users are aware of the shortcut without cluttering the main label.
+**Action:** Always pair power-user shortcuts with accessible visual hints and ARIA descriptions when enhancing input fields.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -98,6 +98,23 @@
             font-weight: 500;
         }
 
+        .label-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 5px;
+        }
+
+        .label-row label {
+            margin-bottom: 0;
+        }
+
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+            font-weight: normal;
+        }
+
         .output:focus-visible,
         .streaming-output:focus-visible {
             outline: 2px solid #0066cc;
@@ -298,8 +315,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="label-row">
+                    <label for="prompt">Prompt:</label>
+                    <span id="prompt-hint" class="shortcut-hint">Cmd/Ctrl + Enter to generate</span>
+                </div>
+                <textarea id="prompt" aria-describedby="prompt-hint" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +363,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="label-row">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span id="streaming-prompt-hint" class="shortcut-hint">Cmd/Ctrl + Enter to start</span>
+                </div>
+                <textarea id="streaming-prompt" aria-describedby="streaming-prompt-hint" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +415,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="label-row">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span id="worker-prompt-hint" class="shortcut-hint">Cmd/Ctrl + Enter to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-describedby="worker-prompt-hint" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for text generation
+function setupKeyboardShortcuts() {
+    const bindShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        if (textarea) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(buttonId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    };
+
+    bindShortcut('prompt', 'generate');
+    bindShortcut('streaming-prompt', 'start-streaming');
+    bindShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -98,6 +98,23 @@
             font-weight: 500;
         }
 
+        .label-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 5px;
+        }
+
+        .label-row label {
+            margin-bottom: 0;
+        }
+
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+            font-weight: normal;
+        }
+
         .output:focus-visible,
         .streaming-output:focus-visible {
             outline: 2px solid #0066cc;
@@ -298,8 +315,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div class="label-row">
+                    <label for="prompt">Prompt:</label>
+                    <span id="prompt-hint" class="shortcut-hint">Cmd/Ctrl + Enter to generate</span>
+                </div>
+                <textarea id="prompt" aria-describedby="prompt-hint" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +363,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div class="label-row">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span id="streaming-prompt-hint" class="shortcut-hint">Cmd/Ctrl + Enter to start</span>
+                </div>
+                <textarea id="streaming-prompt" aria-describedby="streaming-prompt-hint" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +415,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div class="label-row">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span id="worker-prompt-hint" class="shortcut-hint">Cmd/Ctrl + Enter to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-describedby="worker-prompt-hint" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,28 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for text generation
+function setupKeyboardShortcuts() {
+    const bindShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        if (textarea) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    const btn = document.getElementById(buttonId);
+                    if (btn && !btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    };
+
+    bindShortcut('prompt', 'generate');
+    bindShortcut('streaming-prompt', 'start-streaming');
+    bindShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Cmd/Ctrl + Enter keyboard shortcuts to all prompt textareas to allow quick generation, along with visible hints and ARIA descriptions.
🎯 Why: Chat interfaces and prompt inputs are heavily keyboard-driven. Forcing users to click the "Generate" button after typing a multi-line prompt breaks the workflow for power users.
📸 Before/After: Visual hints added above textareas: "Cmd/Ctrl + Enter to generate" (and "start" for streaming).
♿ Accessibility: Used `aria-describedby` to programmatically associate the visual shortcut hints with the textareas, ensuring screen reader users are informed of the interaction without disrupting the primary label flow.

---
*PR created automatically by Jules for task [3089959980187481986](https://jules.google.com/task/3089959980187481986) started by @EffortlessSteven*