### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcuts to text inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-05-15 - Adding keyboard shortcuts to textareas
+**Learning:** While adding power-user shortcuts like Cmd/Ctrl+Enter increases efficiency, it introduces a hidden accessibility trap if not visually communicated and properly linked to the input.
+**Action:** Always pair such keyboard shortcuts with an accessible visual hint (e.g., using `<kbd>` tags) and explicitly link the hint to the input field using the `aria-describedby` attribute to ensure screen reader users are aware of the shortcut without cluttering the primary label.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -261,6 +261,21 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            font-size: 11px;
+            padding: 2px 4px;
+            font-family: inherit;
+        }
     </style>
 </head>
 <body>
@@ -298,8 +313,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span id="prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-describedby="prompt-shortcut" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +361,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span id="streaming-prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="streaming-prompt" aria-describedby="streaming-prompt-shortcut" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +413,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span id="worker-prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-describedby="worker-prompt-shortcut" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,38 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
+    // Update hint text for Mac users
+    if (isMac) {
+        document.querySelectorAll('kbd').forEach(kbd => {
+            if (kbd.textContent === 'Ctrl') {
+                kbd.textContent = 'Cmd';
+            }
+        });
+    }
+
+    const handleShortcut = (id, buttonId) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                const btn = document.getElementById(buttonId);
+                if (btn) {
+                    btn.click();
+                }
+            }
+        });
+    };
+
+    handleShortcut('prompt', 'generate');
+    handleShortcut('streaming-prompt', 'start-streaming');
+    handleShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -261,6 +261,21 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.2);
+            font-size: 11px;
+            padding: 2px 4px;
+            font-family: inherit;
+        }
     </style>
 </head>
 <body>
@@ -298,8 +313,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span id="prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-describedby="prompt-shortcut" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +361,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span id="streaming-prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="streaming-prompt" aria-describedby="streaming-prompt-shortcut" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +413,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span id="worker-prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-describedby="worker-prompt-shortcut" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,38 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
+    // Update hint text for Mac users
+    if (isMac) {
+        document.querySelectorAll('kbd').forEach(kbd => {
+            if (kbd.textContent === 'Ctrl') {
+                kbd.textContent = 'Cmd';
+            }
+        });
+    }
+
+    const handleShortcut = (id, buttonId) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                const btn = document.getElementById(buttonId);
+                if (btn) {
+                    btn.click();
+                }
+            }
+        });
+    };
+
+    handleShortcut('prompt', 'generate');
+    handleShortcut('streaming-prompt', 'start-streaming');
+    handleShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Cmd/Ctrl+Enter keyboard shortcuts to submit prompts across Basic, Streaming, and Web Worker tabs, paired with visual hints.
🎯 Why: Improves power-user efficiency by allowing quick prompt submission without taking hands off the keyboard.
📸 Before/After: N/A
♿ Accessibility: The visual shortcut hint is explicitly linked to the textarea using `aria-describedby`, ensuring screen readers announce the shortcut gracefully without cluttering the main label. OS-specific formatting (Cmd vs Ctrl) is automatically applied based on the user's platform.

---
*PR created automatically by Jules for task [10467047601474793995](https://jules.google.com/task/10467047601474793995) started by @EffortlessSteven*