### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Request Smuggling and DoS via Chunked Encoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+
+## 2025-03-08 - Fix Request Smuggling and DoS via Chunked Encoding
+**Vulnerability:** The application's global request size limit middleware relied exclusively on the `Content-Length` header. This allows an attacker to omit the header and use `Transfer-Encoding: chunked` to bypass the limit entirely (DoS). Furthermore, accepting both headers concurrently is an HTTP protocol violation that enables Request Smuggling attacks.
+**Learning:** Axum's `Content-Length` inspection alone is insufficient against chunked streams in custom sanitization middleware.
+**Prevention:** Explicitly reject `Transfer-Encoding: chunked` (e.g., returning `411 Length Required`) before falling back to `Content-Length` checks when using manual payload size validation in custom middleware, or utilize built-in extractors like `axum::extract::DefaultBodyLimit`.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -493,6 +493,14 @@ pub async fn request_sanitization_middleware(
     // For inference requests, we'll validate in the handler
     // This middleware focuses on general request sanitization
 
+    // 🛡️ Sentinel: Reject chunked requests to prevent body size limit bypass and Request Smuggling vulnerabilities.
+    if let Some(te) = request.headers().get("transfer-encoding")
+        && let Ok(te_str) = te.to_str()
+            && te_str.to_lowercase().contains("chunked") {
+                warn!("Chunked transfer encoding is not allowed");
+                return Err(StatusCode::LENGTH_REQUIRED);
+            }
+
     // Check request size
     if let Some(content_length) = request.headers().get("content-length")
         && let Ok(length_str) = content_length.to_str()

--- a/crates/bitnet-tokenizers/tests/cross_validation_tests.rs
+++ b/crates/bitnet-tokenizers/tests/cross_validation_tests.rs
@@ -3,7 +3,6 @@
 //! Tests feature spec: issue-249-tokenizer-discovery-neural-network-spec.md#ac6-cross-validation-tests
 
 use bitnet_common::{BitNetError, Result};
-use bitnet_tests::support::env_guard::EnvScope;
 use bitnet_tokenizers::{BasicTokenizer, Tokenizer};
 #[allow(unused_imports)]
 use serial_test::serial;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `request_sanitization_middleware` relies solely on the `content-length` header to restrict request sizes. This allows an attacker to send requests with `Transfer-Encoding: chunked` to bypass the size limit and perform a Denial of Service (DoS). Additionally, accepting both `Content-Length` and `Transfer-Encoding: chunked` is an HTTP protocol violation that enables Request Smuggling.
🎯 Impact: Attackers can send maliciously large payloads to exhaust server memory (DoS) or craft smuggled requests to bypass security controls and access unauthorized endpoints or data.
🔧 Fix: Added a check in `request_sanitization_middleware` to explicitly reject any requests containing `Transfer-Encoding: chunked` by returning a `411 Length Required` response.
✅ Verification: Ran `cargo check -p bitnet-server` and `cargo test -p bitnet-server` to verify compilation and confirm that existing functionality is not broken.

---
*PR created automatically by Jules for task [17745598949279554494](https://jules.google.com/task/17745598949279554494) started by @EffortlessSteven*