### PR TITLE
🎨 Palette: Add accessible keyboard shortcuts for generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2025-03-09 - Accessible Keyboard Shortcuts
+**Learning:** Adding power-user keyboard shortcuts (Cmd/Ctrl+Enter) to textareas requires pairing them with accessible visual hints. Using `aria-describedby` links the hint to the input, ensuring screen reader users are aware of the shortcut without cluttering the primary label.
+**Action:** When adding keyboard shortcuts to inputs, always provide a visual hint (`<kbd>`) and link it via `aria-describedby` rather than just assuming users will discover it.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -298,8 +298,13 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px;">
+                    <label for="prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span id="prompt-hint" style="font-size: 0.75rem; color: #6c757d;">
+                        <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Cmd</kbd>/<kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Ctrl</kbd> + <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Enter</kbd> to generate
+                    </span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-hint">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +348,13 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px;">
+                    <label for="streaming-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span id="streaming-hint" style="font-size: 0.75rem; color: #6c757d;">
+                        <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Cmd</kbd>/<kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Ctrl</kbd> + <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Enter</kbd> to generate
+                    </span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-hint">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +402,13 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px;">
+                    <label for="worker-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span id="worker-hint" style="font-size: 0.75rem; color: #6c757d;">
+                        <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Cmd</kbd>/<kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Ctrl</kbd> + <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Enter</kbd> to generate
+                    </span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-hint">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts for textareas
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,31 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for prompts
+function setupKeyboardShortcuts() {
+    const textareas = [
+        { id: 'prompt', btnId: 'generate' },
+        { id: 'streaming-prompt', btnId: 'start-streaming' },
+        { id: 'worker-prompt', btnId: 'worker-generate' }
+    ];
+
+    textareas.forEach(({ id, btnId }) => {
+        const textarea = document.getElementById(id);
+        const btn = document.getElementById(btnId);
+
+        if (textarea && btn) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -298,8 +298,13 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px;">
+                    <label for="prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span id="prompt-hint" style="font-size: 0.75rem; color: #6c757d;">
+                        <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Cmd</kbd>/<kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Ctrl</kbd> + <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Enter</kbd> to generate
+                    </span>
+                </div>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-hint">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +348,13 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px;">
+                    <label for="streaming-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span id="streaming-hint" style="font-size: 0.75rem; color: #6c757d;">
+                        <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Cmd</kbd>/<kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Ctrl</kbd> + <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Enter</kbd> to generate
+                    </span>
+                </div>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-hint">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +402,13 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 5px;">
+                    <label for="worker-prompt" style="margin-bottom: 0;">Prompt:</label>
+                    <span id="worker-hint" style="font-size: 0.75rem; color: #6c757d;">
+                        <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Cmd</kbd>/<kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Ctrl</kbd> + <kbd style="background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 3px; box-shadow: 0 1px 1px rgba(0,0,0,0.2); font-family: monospace; padding: 1px 4px;">Enter</kbd> to generate
+                    </span>
+                </div>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-hint">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts for textareas
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,31 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for prompts
+function setupKeyboardShortcuts() {
+    const textareas = [
+        { id: 'prompt', btnId: 'generate' },
+        { id: 'streaming-prompt', btnId: 'start-streaming' },
+        { id: 'worker-prompt', btnId: 'worker-generate' }
+    ];
+
+    textareas.forEach(({ id, btnId }) => {
+        const textarea = document.getElementById(id);
+        const btn = document.getElementById(btnId);
+
+        if (textarea && btn) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!btn.disabled) {
+                        btn.click();
+                    }
+                }
+            });
+        }
+    });
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Cmd/Ctrl+Enter keyboard shortcuts to all prompt textareas with accessible visual hints.
🎯 Why: Power users expect to be able to submit text generation prompts using standard keyboard shortcuts without having to move their mouse to click the "Generate" buttons.
📸 Before/After: N/A - Added visual <kbd> hints next to textarea labels.
♿ Accessibility: The keyboard shortcut hint is properly linked to the textarea using aria-describedby, ensuring screen reader users are notified of the available shortcut.

---
*PR created automatically by Jules for task [11125627115706228330](https://jules.google.com/task/11125627115706228330) started by @EffortlessSteven*