### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Request Size Limit Bypass via Chunked Encoding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** The `validate_model_request` function bypassed directory checks entirely when `allowed_model_directories` was empty. This allowed attackers to specify absolute paths (e.g., `/etc/passwd.gguf`) and bypass path restrictions.
 **Learning:** Checking for `..` and `~` is insufficient for path safety because absolute paths don't contain them. When an allowlist is intentionally empty, it is critical to explicitly deny absolute paths or deny all requests, rather than allowing any path.
 **Prevention:** Explicitly deny absolute paths if no specific allowed directories are configured.
+
+## 2026-07-02 - Request Size Limit Bypass via Chunked Encoding
+**Vulnerability:** The request sanitization middleware enforced payload size limits by solely checking the `Content-Length` header. This allowed attackers to bypass the size restriction by using `Transfer-Encoding: chunked`, as chunked requests do not require a predetermined content length.
+**Learning:** Checking `Content-Length` is insufficient for enforcing global request body size limits, as chunked transfer encoding fundamentally bypasses this check. However, demanding both `Content-Length` and `Transfer-Encoding: chunked` is an HTTP protocol violation that enables Request Smuggling.
+**Prevention:** Either reject `Transfer-Encoding: chunked` outright if the API requires predetermined lengths, or enforce global body size limits at the framework level (e.g., using `axum::extract::DefaultBodyLimit`).

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -493,6 +493,16 @@ pub async fn request_sanitization_middleware(
     // For inference requests, we'll validate in the handler
     // This middleware focuses on general request sanitization
 
+    // 🛡️ Sentinel: Reject chunked requests to prevent bypass of size limits which rely on Content-Length
+    if let Some(te) = request.headers().get(axum::http::header::TRANSFER_ENCODING) {
+        if let Ok(te_str) = te.to_str() {
+            if te_str.to_lowercase().contains("chunked") {
+                warn!("Chunked transfer encoding is not allowed");
+                return Err(StatusCode::LENGTH_REQUIRED);
+            }
+        }
+    }
+
     // Check request size
     if let Some(content_length) = request.headers().get("content-length")
         && let Ok(length_str) = content_length.to_str()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The request sanitization middleware enforced payload size limits by solely checking the `Content-Length` header. This allowed attackers to bypass the size restriction by using `Transfer-Encoding: chunked`.
🎯 Impact: Attackers could send arbitrarily large payloads, potentially causing memory exhaustion and Denial of Service (DoS).
🔧 Fix: Explicitly reject requests with `Transfer-Encoding: chunked` by returning a 411 Length Required status code.
✅ Verification: Ensure the server compilation, clippy, formatting and test suites pass.

---
*PR created automatically by Jules for task [7147768479353361255](https://jules.google.com/task/7147768479353361255) started by @EffortlessSteven*