### PR TITLE
🎨 Palette: Add keyboard shortcuts for generation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2024-05-24 - Keyboard Shortcuts and Accessibility
+**Learning:** Adding power-user keyboard shortcuts (e.g., Cmd/Ctrl+Enter) to textareas must be paired with visible hints and proper accessibility. Using `aria-describedby` links the hint to the input, ensuring screen reader users are aware of the shortcut without cluttering the primary label.
+**Action:** When implementing global or input-specific keyboard shortcuts, always add a visual hint (using `<kbd>` tags for clarity) and link it to the relevant input using `aria-describedby`. Trigger the corresponding button's `click()` method rather than invoking the underlying action directly to natively respect the button's `disabled` state.

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -261,6 +261,26 @@
         .tab-content.active {
             display: block;
         }
+
+        .shortcut-hint {
+            font-size: 11px;
+            color: #6c757d;
+            margin-top: 4px;
+            display: flex;
+            justify-content: flex-end;
+            gap: 4px;
+            align-items: center;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 1px 4px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 10px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+        }
     </style>
 </head>
 <body>
@@ -299,7 +319,8 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-hint">Hello, I am a BitNet model running in your browser!</textarea>
+                <div id="prompt-hint" class="shortcut-hint">Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Enter</kbd> to generate</div>
             </div>
 
             <div class="controls">
@@ -344,7 +365,8 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-prompt-hint">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div id="streaming-prompt-hint" class="shortcut-hint">Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Enter</kbd> to generate</div>
             </div>
 
             <div class="controls">
@@ -393,7 +415,8 @@
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-prompt-hint">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div id="worker-prompt-hint" class="shortcut-hint">Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Enter</kbd> to generate</div>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -25,6 +25,9 @@ async function initApp() {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
 
+        // Setup keyboard shortcuts
+        setupKeyboardShortcuts();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -687,6 +690,33 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+function setupKeyboardShortcuts() {
+    const handleShortcut = (e, buttonId) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+            e.preventDefault();
+            const btn = document.getElementById(buttonId);
+            if (btn && !btn.disabled) {
+                btn.click();
+            }
+        }
+    };
+
+    const promptTextarea = document.getElementById('prompt');
+    if (promptTextarea) {
+        promptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'generate'));
+    }
+
+    const streamingPromptTextarea = document.getElementById('streaming-prompt');
+    if (streamingPromptTextarea) {
+        streamingPromptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'start-streaming'));
+    }
+
+    const workerPromptTextarea = document.getElementById('worker-prompt');
+    if (workerPromptTextarea) {
+        workerPromptTextarea.addEventListener('keydown', (e) => handleShortcut(e, 'worker-generate'));
+    }
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
### 💡 What
Added `Ctrl`/`Cmd` + `Enter` keyboard shortcuts to trigger text generation across all three main text areas (Basic, Streaming, and Web Workers) in the WASM browser example.

### 🎯 Why
In generative AI interfaces, users frequently write multi-line prompts and need a quick, ergonomic way to submit them without taking their hands off the keyboard to reach for the mouse.

### 📸 Before/After
Before: Users had to manually click "Generate Text" after typing a prompt.
After: Users can press `Ctrl+Enter` or `Cmd+Enter` to generate immediately. A subtle hint is displayed below the text areas.

### ♿ Accessibility
- Added visual hints using semantic `<kbd>` tags.
- Linked the hints to their respective textareas using `aria-describedby` so screen reader users are informed of the shortcut when the input is focused.
- The JavaScript implementation triggers the button's native `.click()` method, which automatically respects the button's `disabled` state (e.g., preventing parallel generations).

---
*PR created automatically by Jules for task [15821511369614704992](https://jules.google.com/task/15821511369614704992) started by @EffortlessSteven*