### PR TITLE
🎨 Palette: Add keyboard shortcuts to textareas

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,6 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+## 2024-11-20 - Keyboard Shortcuts Accessibility
+**Learning:** Adding keyboard shortcuts (e.g., Ctrl+Enter) to forms is a great UX improvement, but users with screen readers or those who cannot easily see the visual hint might miss them if not properly linked.
+**Action:** Use `aria-describedby` on the input/textarea element to link it to the visual keyboard shortcut hint so that screen readers announce the shortcut when the input is focused.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -130,6 +130,20 @@
             margin-bottom: 0;
         }
 
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 1px 4px;
+            font-family: inherit;
+            font-size: 11px;
+        }
+
         .range-value {
             font-weight: 500;
             color: #0056b3;
@@ -298,8 +312,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span id="prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-describedby="prompt-shortcut" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +360,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span id="streaming-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="streaming-prompt" aria-describedby="streaming-shortcut" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +412,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span id="worker-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-describedby="worker-shortcut" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,26 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const setupShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    button.click();
+                }
+            });
+        }
+    };
+
+    setupShortcut('prompt', 'generate');
+    setupShortcut('streaming-prompt', 'start-streaming');
+    setupShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -130,6 +130,20 @@
             margin-bottom: 0;
         }
 
+        .shortcut-hint {
+            font-size: 12px;
+            color: #6c757d;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 3px;
+            padding: 1px 4px;
+            font-family: inherit;
+            font-size: 11px;
+        }
+
         .range-value {
             font-weight: 500;
             color: #0056b3;
@@ -298,8 +312,11 @@
             </div>
 
             <div class="input-group">
-                <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="prompt">Prompt:</label>
+                    <span id="prompt-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="prompt" aria-describedby="prompt-shortcut" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
             </div>
 
             <div class="controls">
@@ -343,8 +360,11 @@
             <h3>Streaming Text Generation</h3>
 
             <div class="input-group">
-                <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="streaming-prompt">Prompt:</label>
+                    <span id="streaming-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="streaming-prompt" aria-describedby="streaming-shortcut" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
             </div>
 
             <div class="controls">
@@ -392,8 +412,11 @@
             </div>
 
             <div class="input-group">
-                <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                    <label for="worker-prompt">Prompt:</label>
+                    <span id="worker-shortcut" class="shortcut-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> to generate</span>
+                </div>
+                <textarea id="worker-prompt" aria-describedby="worker-shortcut" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -687,6 +688,26 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard shortcuts for textareas
+function setupKeyboardShortcuts() {
+    const setupShortcut = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    button.click();
+                }
+            });
+        }
+    };
+
+    setupShortcut('prompt', 'generate');
+    setupShortcut('streaming-prompt', 'start-streaming');
+    setupShortcut('worker-prompt', 'worker-generate');
+}
 
 // Setup keyboard navigation for tabs
 function setupTabNavigation() {


### PR DESCRIPTION
💡 What: Added Ctrl+Enter/Cmd+Enter keyboard shortcuts to trigger the generation buttons across all inference modes (Basic, Streaming, Worker).
🎯 Why: Allows users to submit their prompts without breaking their typing flow to reach for a mouse, a standard and expected UX pattern in LLM interfaces.
📸 Before/After: Textareas now display a visual hint ("Press Ctrl + Enter to generate").
♿ Accessibility: The visual hint is linked to the textarea using `aria-describedby`, ensuring screen readers announce the shortcut when the user focuses the input.

---
*PR created automatically by Jules for task [15247630246324102695](https://jules.google.com/task/15247630246324102695) started by @EffortlessSteven*