### PR TITLE
🎨 Palette: Add Ctrl+Enter keyboard shortcuts for form submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-05-24 - Confirm Destructive Actions
 **Learning:** Destructive actions that result in data loss or immediate page reloads (like resetting settings) must have a confirmation prompt to prevent accidental activation and poor UX.
 **Action:** Always add a confirmation step (e.g., using `confirm()`) or a custom confirmation modal before executing destructive actions or operations that force a full page reload.
+
+## 2024-07-04 - Keyboard Shortcuts for Form Submission
+**Learning:** Adding power-user keyboard shortcuts (like Ctrl/Cmd + Enter) to textareas significantly speeds up interaction, but the shortcut must be visibly communicated to users and accessible to screen readers.
+**Action:** When adding form submission shortcuts, always include a visual hint below the input using `<kbd>` tags, and link it to the textarea using `aria-describedby` so screen reader users hear the hint when focusing the input.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -104,6 +104,22 @@
             outline-offset: 2px;
         }
 
+        .keyboard-hint {
+            font-size: 12px;
+            color: #6c757d;
+            margin-top: 6px;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #ced4da;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+            padding: 2px 4px;
+            font-size: 11px;
+            font-family: monospace;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 8px 12px;
@@ -299,7 +315,8 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-hint">Hello, I am a BitNet model running in your browser!</textarea>
+                <div id="prompt-hint" class="keyboard-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (or <kbd>Cmd</kbd> + <kbd>Enter</kbd>) to generate</div>
             </div>
 
             <div class="controls">
@@ -344,7 +361,8 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-prompt-hint">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div id="streaming-prompt-hint" class="keyboard-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (or <kbd>Cmd</kbd> + <kbd>Enter</kbd>) to start streaming</div>
             </div>
 
             <div class="controls">
@@ -393,7 +411,8 @@
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-prompt-hint">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div id="worker-prompt-hint" class="keyboard-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (or <kbd>Cmd</kbd> + <kbd>Enter</kbd>) to generate</div>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -689,6 +690,26 @@ document.getElementById('top-p').addEventListener('input', function() {
 });
 
 // Setup keyboard navigation for tabs
+
+function setupKeyboardShortcuts() {
+    const setupTextarea = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    button.click();
+                }
+            });
+        }
+    };
+
+    setupTextarea('prompt', 'generate');
+    setupTextarea('streaming-prompt', 'start-streaming');
+    setupTextarea('worker-prompt', 'worker-generate');
+}
+
 function setupTabNavigation() {
     const tabsContainer = document.querySelector('.tabs');
     if (!tabsContainer) return;

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -104,6 +104,22 @@
             outline-offset: 2px;
         }
 
+        .keyboard-hint {
+            font-size: 12px;
+            color: #6c757d;
+            margin-top: 6px;
+        }
+
+        kbd {
+            background-color: #f8f9fa;
+            border: 1px solid #ced4da;
+            border-radius: 3px;
+            box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+            padding: 2px 4px;
+            font-size: 11px;
+            font-family: monospace;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 8px 12px;
@@ -299,7 +315,8 @@
 
             <div class="input-group">
                 <label for="prompt">Prompt:</label>
-                <textarea id="prompt" placeholder="Enter your prompt here...">Hello, I am a BitNet model running in your browser!</textarea>
+                <textarea id="prompt" placeholder="Enter your prompt here..." aria-describedby="prompt-hint">Hello, I am a BitNet model running in your browser!</textarea>
+                <div id="prompt-hint" class="keyboard-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (or <kbd>Cmd</kbd> + <kbd>Enter</kbd>) to generate</div>
             </div>
 
             <div class="controls">
@@ -344,7 +361,8 @@
 
             <div class="input-group">
                 <label for="streaming-prompt">Prompt:</label>
-                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming...">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <textarea id="streaming-prompt" placeholder="Enter your prompt for streaming..." aria-describedby="streaming-prompt-hint">Once upon a time, in a world where AI models run in browsers,</textarea>
+                <div id="streaming-prompt-hint" class="keyboard-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (or <kbd>Cmd</kbd> + <kbd>Enter</kbd>) to start streaming</div>
             </div>
 
             <div class="controls">
@@ -393,7 +411,8 @@
 
             <div class="input-group">
                 <label for="worker-prompt">Prompt:</label>
-                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing...">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <textarea id="worker-prompt" placeholder="Enter prompt for worker processing..." aria-describedby="worker-prompt-hint">This text is being generated in a Web Worker to keep the main thread responsive.</textarea>
+                <div id="worker-prompt-hint" class="keyboard-hint">Press <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (or <kbd>Cmd</kbd> + <kbd>Enter</kbd>) to generate</div>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -24,6 +24,7 @@ async function initApp() {
     try {
         // Setup keyboard navigation for tabs
         setupTabNavigation();
+        setupKeyboardShortcuts();
 
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
@@ -689,6 +690,26 @@ document.getElementById('top-p').addEventListener('input', function() {
 });
 
 // Setup keyboard navigation for tabs
+
+function setupKeyboardShortcuts() {
+    const setupTextarea = (textareaId, buttonId) => {
+        const textarea = document.getElementById(textareaId);
+        const button = document.getElementById(buttonId);
+        if (textarea && button) {
+            textarea.addEventListener('keydown', (e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    button.click();
+                }
+            });
+        }
+    };
+
+    setupTextarea('prompt', 'generate');
+    setupTextarea('streaming-prompt', 'start-streaming');
+    setupTextarea('worker-prompt', 'worker-generate');
+}
+
 function setupTabNavigation() {
     const tabsContainer = document.querySelector('.tabs');
     if (!tabsContainer) return;


### PR DESCRIPTION
### 💡 What
Added `Ctrl+Enter` (or `Cmd+Enter` on Mac) keyboard shortcuts for form submissions across the Browser WebAssembly example textareas (Basic Inference, Streaming, and Web Workers tabs).

### 🎯 Why
Power users often prefer to keep their hands on the keyboard rather than switching back to a mouse/trackpad just to hit "Generate" after typing a prompt. This speeds up the iteration cycle when testing models.

### 📸 Before/After
**Before:** Users had to type their prompt, then click the "Generate Text" / "Start Streaming" / "Generate in Worker" button manually.
**After:** Users can now just hit `Ctrl+Enter` directly from the text area. We've also added a helpful, subtle visual hint using `<kbd>` tags below each prompt box so users are aware of the shortcut.

### ♿ Accessibility
The visual hints are correctly linked to the text areas via `aria-describedby`, ensuring that screen readers will announce the availability of the shortcut to visually impaired users when they focus the input fields. The JavaScript natively invokes the underlying button's `.click()` method, respecting all disabled states and existing keyboard focuses.

---
*PR created automatically by Jules for task [2052964073197282982](https://jules.google.com/task/2052964073197282982) started by @EffortlessSteven*